### PR TITLE
Better time ticking and sync

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -156,8 +156,6 @@ class Level implements ChunkManager, Metadatable{
 
 	private $cacheChunks = false;
 
-	private $sendTimeTicker = 0;
-
 	/** @var Server */
 	private $server;
 
@@ -640,11 +638,6 @@ class Level implements ChunkManager, Metadatable{
 		$this->timings->doTick->startTiming();
 
 		$this->checkTime();
-
-		if(++$this->sendTimeTicker === 200){
-			$this->sendTime();
-			$this->sendTimeTicker = 0;
-		}
 
 		$this->unloadChunks();
 

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -610,7 +610,7 @@ class Level implements ChunkManager, Metadatable{
 		if($this->stopTime === true){
 			return;
 		}else{
-			$this->time += 1;
+			$this->time += $this->tickRate;
 		}
 	}
 


### PR DESCRIPTION
There's no need to spam clients with SetTimePacket. It's just unnecessary extra overhead. Time progression is handled automatically by the client. All that needs to be done is to ensure that client/server time calculation is the same.
### Changes
- Removed SetTimePacket spam every 5 seconds
- Time ticking now uses the current level tick rate to ensure that it remains in sync even when the server is lagging.
### Tests

Tested in various circumstances, no issues found. Please review.
