### PR TITLE
Fixed kicked for flying when walking on lily pads

### DIFF
--- a/src/pocketmine/block/Flowable.php
+++ b/src/pocketmine/block/Flowable.php
@@ -21,9 +21,6 @@
 
 namespace pocketmine\block;
 
-
-
-
 abstract class Flowable extends Transparent{
 
 	public function canBeFlowedInto(){
@@ -42,7 +39,7 @@ abstract class Flowable extends Transparent{
 		return false;
 	}
 
-	public function getBoundingBox(){
+	protected function recalculateBoundingBox(){
 		return null;
 	}
 }

--- a/src/pocketmine/block/WaterLily.php
+++ b/src/pocketmine/block/WaterLily.php
@@ -37,10 +37,6 @@ class WaterLily extends Flowable{
 		$this->meta = $meta;
 	}
 
-	public function isSolid(){
-		return false;
-	}
-
 	public function getName(){
 		return "Lily Pad";
 	}
@@ -49,18 +45,14 @@ class WaterLily extends Flowable{
 		return 0.6;
 	}
 
-	public function canPassThrough(){
-		return true;
-	}
-
 	protected function recalculateBoundingBox(){
 		return new AxisAlignedBB(
-			$this->x,
+			$this->x + 0.0625,
 			$this->y,
-			$this->z,
-			$this->x,
-			$this->y + 0.0625,
-			$this->z
+			$this->z + 0.0625,
+			$this->x + 0.9375,
+			$this->y + 0.015625,
+			$this->z + 0.9375
 		);
 	}
 


### PR DESCRIPTION
Standing on top of a lily pad for roughly 5 seconds currently causes players to be kicked for flying.

### Changes
- Changed Flowable to return null when _recalculating_ bounding boxes.
- Fixed lily pad bounding box (1/64 tall, #blamemojang for making it different in PE)
- Removed some redundant properties (already in parent class or not needed/incorrect)

### Tests
Walked on top of lily pads, the bug no longer occurs. Tested with various other flowables and found no issues.