### PR TITLE
Added options to load plugins of incompatible APIs

### DIFF
--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -211,7 +211,8 @@ class PluginManager{
 								continue;
 							}
 
-							$compatibility = 0;
+							// compatibility 1=outdated plugin, 2=outdated server, 4=minor, 8=normal
+  							$compatibility = 0;
 							//Check multiple dependencies
 							foreach($description->getCompatibleApis() as $versionString){
 								//Format: majorVersion.minorVersion.patch

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -212,7 +212,7 @@ class PluginManager{
 							}
 
 							// compatibility 1=outdated plugin, 2=outdated server, 4=minor, 8=normal
-  							$compatibility = 0;
+							$compatibility = 0;
 							//Check multiple dependencies
 							foreach($description->getCompatibleApis() as $versionString){
 								//Format: majorVersion.minorVersion.patch

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -211,8 +211,6 @@ class PluginManager{
 								continue;
 							}
 
-//							$compatible = false;
-							// compatibility 1=outdated plugin, 2=outdated server, 4=minor, 8=normal
 							$compatibility = 0;
 							//Check multiple dependencies
 							foreach($description->getCompatibleApis() as $versionString){
@@ -274,12 +272,6 @@ class PluginManager{
 									$this->server->getLogger()->warning($this->server->getLanguage()->translateString("pocketmine.plugin.incompatibleAPIWarning.majorTooOld", [$name]));
 								}
 							}
-
-
-//							if($compatibility === false){
-//								$this->server->getLogger()->error($this->server->getLanguage()->translateString("pocketmine.plugin.loadError", [$name, "%pocketmine.plugin.incompatibleAPI"]));
-//								continue;
-//							}
 
 							$plugins[$name] = $file;
 

--- a/src/pocketmine/resources/pocketmine.yml
+++ b/src/pocketmine/resources/pocketmine.yml
@@ -23,6 +23,16 @@ settings:
  #Set this approximately to your number of cores.
  #If set to auto, it'll try to detect the number of cores (or use 2)
  async-workers: auto
+ #Load plugins with incompatible API versions
+ #Enabling these options may result in the server loading plugins that are incompatible, hence crashing the server or causing other issues
+ incompatible-plugins:
+  plugin-too-new:
+   #Load plugins whose major API version is too new
+   major: false
+   #Load plugins whose minor API version is too new
+   minor: false
+  #Load plugins whose major API version is too old
+  plugin-too-old: false
 
 memory:
  #Global soft memory limit in megabytes. Set to 0 to disable


### PR DESCRIPTION
Please refer to PocketMine/PocketMine-MP#4109 for details
# Test

This branch has been tested against 7 script plugins. Except that the language file is not updated, the rest is working as expected. Test results as follow:

``` php
# cat plugins/*
<?php
/**
 * @name ApiNewMajor
 * @version v
 * @main ApiNewMajor
 * @api 3.0.0
 */

class ApiNewMajor extends \pocketmine\plugin\PluginBase{}

<?php
/**
 * @name ApiNewMinor
 * @version v
 * @main ApiNewMinor
 * @api 2.10.0
 */

class ApiNewMinor extends \pocketmine\plugin\PluginBase{}

<?php
/**
 * @name ApiNewPatch
 * @version v
 * @main ApiNewPatch
 * @api 2.0.10
 */

class ApiNewPatch extends \pocketmine\plugin\PluginBase{}

<?php
/**
 * @name ApiOldMajor
 * @version v
 * @main ApiOldMajor
 * @api -1.0.0
 */

class ApiOldMajor extends \pocketmine\plugin\PluginBase{}

<?php
/**
 * @name ApiOldMinor
 * @version v
 * @main ApiOldMinor
 * @api 2.-1.0
 */

class ApiOldMinor extends \pocketmine\plugin\PluginBase{}

<?php
/**
 * @name ApiOldPatch
 * @version v
 * @main ApiOldPatch
 * @api 2.0.-1
 */

class ApiOldPatch extends \pocketmine\plugin\PluginBase{}

<?php
/**
 * @name ApiSame
 * @version v
 * @main ApiSame
 * @api 2.0.0
 */

class ApiSame extends \pocketmine\plugin\PluginBase{}
```

```
# php src/pocketmine/PocketMine.php --enable-ansi --no-wizard --debug.level=2 --debug.commands=true
[16:34:45] [Server thread/WARNING]: Non-packaged PocketMine-MP installation detected, do not use on production.
[16:34:45] [Server thread/INFO]: Loading pocketmine.yml...
[16:34:45] [Server thread/INFO]: Loading server properties...
[16:34:45] [Server thread/INFO]: Selected English (eng) as the base language
[16:34:45] [Server thread/INFO]: Starting Minecraft: PE server version v0.14.0.0 alpha
[16:34:45] [Server thread/INFO]: Opening server on 0.0.0.0:19132
[16:34:45] [Server thread/DEBUG]: Server unique id: ---
[16:34:45] [Server thread/DEBUG]: Machine unique id: ---
[16:34:45] [Server thread/INFO]: This server is running PocketMine-MP version 1.6dev "[REDACTED]" (API 2.0.0)
[16:34:45] [Server thread/INFO]: PocketMine-MP is distributed under the LGPL License
[16:34:46] [Server thread/INFO]: Loading recipes...
[16:34:46] [Server thread/ERROR]: Could not load plugin 'ApiNewMajor': %pocketmine.plugin.incompatibleAPI.minorTooNew
[16:34:46] [Server thread/ERROR]: Could not load plugin 'ApiNewMinor': %pocketmine.plugin.incompatibleAPI.minorTooNew
[16:34:46] [Server thread/ERROR]: Could not load plugin 'ApiOldMajor': %pocketmine.plugin.incompatibleAPI.minorTooNew
[16:34:46] [Server thread/INFO]: Loading ApiNewPatch vv
[16:34:46] [Server thread/INFO]: Loading ApiOldMinor vv
[16:34:46] [Server thread/INFO]: Loading ApiOldPatch vv
[16:34:46] [Server thread/INFO]: Loading ApiSame vv
[16:34:46] [Server thread/INFO]: Preparing level "world"
[16:34:46] [Server thread/INFO]: Enabling ApiNewPatch vv
[16:34:46] [Server thread/INFO]: Enabling ApiOldMinor vv
[16:34:46] [Server thread/INFO]: Enabling ApiOldPatch vv
[16:34:46] [Server thread/INFO]: Enabling ApiSame vv
[16:34:46] [Server thread/INFO]: Starting GS4 status listener
[16:34:46] [Server thread/INFO]: Setting query port to 19132
[16:34:46] [Server thread/INFO]: Query running on 0.0.0.0:19132
[16:34:46] [Server thread/INFO]: Default game type: Survival Mode
[16:34:46] [Server thread/INFO]: Done (0.939s)! For help, type "help" or "?"
plugins
[16:34:53] [Server thread/INFO]: Plugins (4): ApiNewPatch vv, ApiOldMinor vv, ApiOldPatch vv, ApiSame vv
status
[16:34:54] [Server thread/INFO]: ---- Server status ----
[16:34:54] [Server thread/INFO]: Uptime: 8 seconds
[16:34:54] [Server thread/INFO]: Current TPS: 20 (0.55%)
[16:34:54] [Server thread/INFO]: Network upload: 0 kB/s
[16:34:54] [Server thread/INFO]: Network download: 0 kB/s
[16:34:54] [Server thread/INFO]: Thread count: 6
[16:34:54] [Server thread/INFO]: Main thread memory: 19 MB.
[16:34:54] [Server thread/INFO]: Total memory: 19 MB.
[16:34:54] [Server thread/INFO]: Total virtual memory: 22 MB.
[16:34:54] [Server thread/INFO]: Heap memory: 0 MB.
[16:34:54] [Server thread/INFO]: Maximum memory (system): 22 MB.
[16:34:54] [Server thread/INFO]: World "world": 0 chunks, 0 entities, 0 tiles. Time 0.03ms
stop
[16:34:57] [Server thread/INFO]: [CONSOLE: Stopping the server]
[16:34:57] [Server thread/DEBUG]: Disabling all plugins
[16:34:57] [Server thread/INFO]: Disabling ApiNewPatch vv
[16:34:57] [Server thread/INFO]: Disabling ApiOldMinor vv
[16:34:57] [Server thread/INFO]: Disabling ApiOldPatch vv
[16:34:57] [Server thread/INFO]: Disabling ApiSame vv
[16:34:57] [Server thread/DEBUG]: Unloading all levels
[16:34:57] [Server thread/INFO]: Unloading level "world"
[16:34:57] [Server thread/DEBUG]: Removing event handlers
[16:34:57] [Server thread/DEBUG]: Stopping all tasks
[16:34:58] [Server thread/DEBUG]: Saving properties
[16:34:58] [Server thread/DEBUG]: Closing console
[16:34:58] [Server thread/DEBUG]: Stopping network interfaces
[16:34:58] [Server thread/INFO]: Stopping other threads
[16:34:58] [Server thread/DEBUG]: Stopping CommandReader thread

[16:35:00] [Server thread/DEBUG]: Stopping AsyncWorker thread
[16:35:00] [Server thread/DEBUG]: Stopping AsyncWorker thread
```

With colors:

![image](https://cloud.githubusercontent.com/assets/19623715/19067695/e6cb3306-8a51-11e6-972b-f03935cebb0c.png)
