### PR TITLE
Removed some not needed code. Moved the default mcr/mca worlds' spawn in the center of the r.0.0.mc* region file

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1356,16 +1356,12 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
 			$this->move($dx, $dy, $dz);
 
-			$diffX = $this->x - $newPos->x;
-			$diffY = $this->y - $newPos->y;
-			$diffZ = $this->z - $newPos->z;
-
 			$yS = 0.5 + $this->ySize;
-			if($diffY >= -$yS or $diffY <= $yS){
-				$diffY = 0;
+			if(-$yS <= $dy or $dy <= $yS){
+				$dy = 0;
 			}
 
-			$diff = ($diffX ** 2 + $diffY ** 2 + $diffZ ** 2) / ($tickDiff ** 2);
+			$diff = ($dx ** 2 + $dy ** 2 + $dz ** 2) / ($tickDiff ** 2);
 
 			if($this->isSurvival()){
 				if(!$revert and !$this->isSleeping()){

--- a/src/pocketmine/level/format/mcregion/McRegion.php
+++ b/src/pocketmine/level/format/mcregion/McRegion.php
@@ -85,9 +85,9 @@ class McRegion extends BaseLevelProvider{
 			"initialized" => new ByteTag("initialized", 1),
 			"GameType" => new IntTag("GameType", 0),
 			"generatorVersion" => new IntTag("generatorVersion", 1), //2 in MCPE
-			"SpawnX" => new IntTag("SpawnX", 128),
+			"SpawnX" => new IntTag("SpawnX", 255),
 			"SpawnY" => new IntTag("SpawnY", 70),
-			"SpawnZ" => new IntTag("SpawnZ", 128),
+			"SpawnZ" => new IntTag("SpawnZ", 255),
 			"version" => new IntTag("version", 19133),
 			"DayTime" => new IntTag("DayTime", 0),
 			"LastPlayed" => new LongTag("LastPlayed", microtime(true) * 1000),


### PR DESCRIPTION
$diffX,Y,Z variables were not needed since they were the same as $dx,y,z with an opposite sign and were used as a power of 2 ( $diffX,Y,Z ** 2 ) that's always positive. $diffY was also used in a condition, to check if the value was inside the interval ( -$yS < $diffY < $yS ) , so, the sign is not needed to check if it's inside this interval.

The default mcr/mca spawn was not centered in the 0,0 region causing the generation of not needed regions walking just a bit