### PR TITLE
Moved the default mcr/mca worlds' spawn in the center of the r.0.0.mc* region file

### DIFF
--- a/src/pocketmine/level/format/mcregion/McRegion.php
+++ b/src/pocketmine/level/format/mcregion/McRegion.php
@@ -85,9 +85,9 @@ class McRegion extends BaseLevelProvider{
 			"initialized" => new ByteTag("initialized", 1),
 			"GameType" => new IntTag("GameType", 0),
 			"generatorVersion" => new IntTag("generatorVersion", 1), //2 in MCPE
-			"SpawnX" => new IntTag("SpawnX", 128),
+			"SpawnX" => new IntTag("SpawnX", 256),
 			"SpawnY" => new IntTag("SpawnY", 70),
-			"SpawnZ" => new IntTag("SpawnZ", 128),
+			"SpawnZ" => new IntTag("SpawnZ", 256),
 			"version" => new IntTag("version", 19133),
 			"DayTime" => new IntTag("DayTime", 0),
 			"LastPlayed" => new LongTag("LastPlayed", microtime(true) * 1000),


### PR DESCRIPTION
The default mcr/mca spawn was not centered in the 0,0 region causing the generation of not needed regions walking just a bit
