### PR TITLE
Fixed #32

### DIFF
--- a/src/pocketmine/nbt/NBT.php
+++ b/src/pocketmine/nbt/NBT.php
@@ -107,7 +107,7 @@ class NBT{
 			return Item::get(0);
 		}
 
-		if($tag->id instanceof IntTag){
+		if($tag->id instanceof ShortTag){
 			$item = Item::get($tag->id->getValue(), !isset($tag->Damage) ? 0 : $tag->Damage->getValue(), $tag->Count->getValue());
 		}elseif($tag->id instanceof StringTag){ //PC item save format
 			$item = Item::fromString($tag->id->getValue());

--- a/src/pocketmine/nbt/NBT.php
+++ b/src/pocketmine/nbt/NBT.php
@@ -114,7 +114,7 @@ class NBT{
 			$item->setDamage(!isset($tag->Damage) ? 0 : $tag->Damage->getValue());
 			$item->setCount($tag->Count->getValue());
 		}else{
-			throw new \InvalidArgumentException("Item CompoundTag ID must be an instance of StringTag or IntTag, " . get_class($tag->id) . " given");
+			throw new \InvalidArgumentException("Item CompoundTag ID must be an instance of StringTag or ShortTag, " . get_class($tag->id) . " given");
 		}
 
 		if(isset($tag->tag) and $tag->tag instanceof CompoundTag){

--- a/src/pocketmine/nbt/NBT.php
+++ b/src/pocketmine/nbt/NBT.php
@@ -107,7 +107,13 @@ class NBT{
 			return Item::get(0);
 		}
 
-		$item = Item::get($tag->id->getValue(), !isset($tag->Damage) ? 0 : $tag->Damage->getValue(), $tag->Count->getValue());
+		if($tag->id instanceof IntTag){
+			$item = Item::get($tag->id->getValue(), !isset($tag->Damage) ? 0 : $tag->Damage->getValue(), $tag->Count->getValue());
+		}else{ //PC item save format
+			$item = Item::fromString($tag->id->getValue());
+			$item->setDamage(!isset($tag->Damage) ? 0 : $tag->Damage->getValue());
+			$item->setCount($tag->Count->getValue());
+		}
 
 		if(isset($tag->tag) and $tag->tag instanceof CompoundTag){
 			$item->setNamedTag($tag->tag);

--- a/src/pocketmine/nbt/NBT.php
+++ b/src/pocketmine/nbt/NBT.php
@@ -109,10 +109,12 @@ class NBT{
 
 		if($tag->id instanceof IntTag){
 			$item = Item::get($tag->id->getValue(), !isset($tag->Damage) ? 0 : $tag->Damage->getValue(), $tag->Count->getValue());
-		}else{ //PC item save format
+		}elseif($tag->id instanceof StringTag){ //PC item save format
 			$item = Item::fromString($tag->id->getValue());
 			$item->setDamage(!isset($tag->Damage) ? 0 : $tag->Damage->getValue());
 			$item->setCount($tag->Count->getValue());
+		}else{
+			throw new \InvalidArgumentException("Item CompoundTag ID must be an instance of StringTag or IntTag, " . get_class($tag->id) . " given");
 		}
 
 		if(isset($tag->tag) and $tag->tag instanceof CompoundTag){


### PR DESCRIPTION
Seems in some PC worlds item ID is a string in the format "minecraft:blah" instead of a numeric ID. (Possibly 1.11?) This causes the crash described in #32 .

This has not been tested as I'm unable to obtain such a world which causes this issue. Please test and review.