### PR TITLE
Fix --disable-readline command-line option does not work, close #34

### DIFF
--- a/src/pocketmine/command/CommandReader.php
+++ b/src/pocketmine/command/CommandReader.php
@@ -31,6 +31,8 @@ class CommandReader extends Thread{
 
 	public function __construct(){
 		$this->buffer = new \Threaded;
+		$opts = getopt("", ["disable-readline"]);
+		$this->readline = extension_loaded("readline") and !isset($opts["disable-readline"]);
 		$this->start();
 	}
 
@@ -71,14 +73,10 @@ class CommandReader extends Thread{
 	}
 
 	public function run(){
-		$opts = getopt("", ["disable-readline"]);
-		if(extension_loaded("readline") and !isset($opts["disable-readline"])){
-			$this->readline = true;
-		}else{
+		if(!$this->readline){
 			global $stdin;
 			$stdin = fopen("php://stdin", "r");
 			stream_set_blocking($stdin, 0);
-			$this->readline = false;
 		}
 
 		$lastLine = microtime(true);

--- a/src/pocketmine/command/CommandReader.php
+++ b/src/pocketmine/command/CommandReader.php
@@ -32,7 +32,7 @@ class CommandReader extends Thread{
 	public function __construct(){
 		$this->buffer = new \Threaded;
 		$opts = getopt("", ["disable-readline"]);
-		$this->readline = extension_loaded("readline") and !isset($opts["disable-readline"]);
+		$this->readline = (extension_loaded("readline") and !isset($opts["disable-readline"]));
 		$this->start();
 	}
 


### PR DESCRIPTION
Global variables are thread-local. Calling getopt() in a thread will attempt to retrieve the arguments of the thread, _not_ the parent process. This PR fixes that by checking command-line arguments in the thread constructor instead of in the thread's run() method.