### PR TITLE
Extra action on use of cURL in main thread

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -1404,6 +1404,7 @@ class Server{
 	public function __construct(\ClassLoader $autoloader, \ThreadedLogger $logger, $filePath, $dataPath, $pluginPath){
 		self::$instance = $this;
 		self::$sleeper = new \Threaded;
+		Utils::$mainThreadId = \Thread::getCurrentThreadId();
 		$this->autoloader = $autoloader;
 		$this->logger = $logger;
 
@@ -2040,7 +2041,9 @@ class Server{
 
 		$this->logger->info($this->getLanguage()->translateString("pocketmine.server.startFinished", [round(microtime(true) - \pocketmine\START_TIME, 3)]));
 
+		Utils::$serverRunning = true;
 		$this->tickProcessor();
+		Utils::$serverRunning = false;
 		$this->forceShutdown();
 	}
 

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -34,6 +34,7 @@ use pocketmine\permission\Permissible;
 use pocketmine\permission\Permission;
 use pocketmine\Server;
 use pocketmine\utils\PluginException;
+use pocketmine\utils\Utils;
 
 /**
  * Manages all the plugins, Permissions and Permissibles
@@ -148,7 +149,7 @@ class PluginManager{
 			if(preg_match($loader->getPluginFilters(), basename($path)) > 0){
 				$description = $loader->getPluginDescription($path);
 				if($description instanceof PluginDescription){
-					if(($plugin = $loader->loadPlugin($path)) instanceof Plugin){
+					if(($plugin = Utils::syncInternetAccess($this->server, [$loader, "loadPlugin"], $path)) instanceof Plugin){
 						$this->plugins[$plugin->getDescription()->getName()] = $plugin;
 
 						$pluginCommands = $this->parseYamlCommands($plugin);
@@ -558,7 +559,7 @@ class PluginManager{
 				foreach($plugin->getDescription()->getPermissions() as $perm){
 					$this->addPermission($perm);
 				}
-				$plugin->getPluginLoader()->enablePlugin($plugin);
+				Utils::syncInternetAccess($this->server, [$plugin->getPluginLoader(), "enablePlugin"], $plugin);
 			}catch(\Throwable $e){
 				$this->server->getLogger()->logException($e);
 				$this->disablePlugin($plugin);
@@ -629,7 +630,7 @@ class PluginManager{
 	public function disablePlugin(Plugin $plugin){
 		if($plugin->isEnabled()){
 			try{
-				$plugin->getPluginLoader()->disablePlugin($plugin);
+				Utils::syncInternetAccess($this->server, [$plugin->getPluginLoader(), "disablePlugin"], $plugin);
 			}catch(\Throwable $e){
 				$this->server->getLogger()->logException($e);
 			}

--- a/src/pocketmine/resources/pocketmine.yml
+++ b/src/pocketmine/resources/pocketmine.yml
@@ -32,6 +32,9 @@ settings:
  sync-internet-access:
   #For HTTP requests
   curl: warn
+  #If the plugin wants to suppress the actions specified above
+  #"empty" is not allowed in this option
+  suppressed: allow
 
 
 memory:

--- a/src/pocketmine/resources/pocketmine.yml
+++ b/src/pocketmine/resources/pocketmine.yml
@@ -23,6 +23,16 @@ settings:
  #Set this approximately to your number of cores.
  #If set to auto, it'll try to detect the number of cores (or use 2)
  async-workers: auto
+ #Allow plugins to access the Internet on the main thread (except during a plugin is loaded/unloaded).
+ #Plugins can still bypass this check if they specify that intentionally want to access the Internet on the main thread
+ #If set to deny, an exception will be thrown (you may see an error)
+ #If set to warn, a warning will be shown on console and Internet access continues
+ #If set to empty, a warning will be shown on console, and empty content is returned (will not download anything from the Internet).
+ #If set to allow, nothing will happen and Internet access continues
+ sync-internet-access:
+  #For HTTP requests
+  curl: warn
+
 
 memory:
  #Global soft memory limit in megabytes. Set to 0 to disable

--- a/src/pocketmine/utils/Utils.php
+++ b/src/pocketmine/utils/Utils.php
@@ -378,16 +378,24 @@ class Utils{
 	}
 
 	/**
-	 * @param Server|Plugin   $context
-	 * @param callable $function
-	 * @param mixed    ...$args
-	 * @return mixed
+	 * Avoid using this function. Consider using async tasks instead.
+	 *
+	 * This method executes a callable that requires Internet access <em>on the main thread</em>.
+	 *
+	 * Plugins that use this method are recommended to only include operations that transfer data with the Internet in
+	 * the callable so that a neat timings result can be produced.
+	 *
+	 * @param Server|Plugin $context  the context that is responsible for this API call (
+	 * @param callable      $function the function to execute
+	 * @param mixed         ...$args  arguments to pass to the function
+	 *
+	 * @return mixed any values returned by $function
 	 */
 	public static function syncInternetAccess($context, callable $function, ...$args){
 		Utils::$syncInternetAllowed = true;
 		// TODO timings on $context
 		if($context instanceof Plugin){
-			// TODO optionally show warnings on $context
+			Utils::warnSyncInternetAccess("suppressed");
 		}
 		try{
 			$result = $function(...$args);
@@ -422,6 +430,7 @@ class Utils{
 	 * @param array $extraHeaders
 	 *
 	 * @return bool|mixed
+	 * @throws \InvalidStateException if user
 	 */
 	public static function getURL($page, $timeout = 10, array $extraHeaders = []){
 		if(Utils::$online === false){

--- a/src/pocketmine/utils/Utils.php
+++ b/src/pocketmine/utils/Utils.php
@@ -406,7 +406,7 @@ class Utils{
 	}
 
 	private static function warnSyncInternetAccess(string $type) : bool{
-		if(Utils::$mainThreadId === \Thread::getCurrentThreadId() and !Utils::$syncInternetAllowed and Utils::$serverRunning){
+		if(Utils::isMainThread() and !Utils::$syncInternetAllowed and Utils::$serverRunning){
 			// safe to use Server::getInstance()
 			$action = Server::getInstance()->getProperty("settings.sync-internet-access.$type", "warn");
 			switch($action){


### PR DESCRIPTION
# Introduction

It is a very bad idea to access the Internet on the main thread, especially HTTP requests. They slow down the execution of the main thread and is highly discouraged in a production server.
# Description

This pull request adds the option to carry out extra action when the `Utils::getURL()` or `Utils::postURL()` methods are used (there should be more, but I can only think of these two functions right now; I am doubtful if it is possible to do it with others like mysqli).

Actions are listed in pocketmine.yml:

``` yaml
#If set to deny, an exception will be thrown (you may see an error)
#If set to warn, a warning will be shown on console and Internet access continues
#If set to empty, a warning will be shown on console, and empty content is returned (will not download anything from the Internet).
#If set to allow, nothing will happen and Internet access continues
```
# Changes
## For server admins

A new option in `pocketmine.yml` is added: map `settings.sync-internet-access`, including:
- enum string `settings.sync-internet-access.curl`
- enum string `settings.sync-internet-access.suppressed`

If pocketmine.yml is left unchanged, a warning is logged every time a plugin uses `Utils::getURL()` or `Utils::postURL()`.
## For developers

An `Utils::syncInternetAccess` method can be used for if you **really** want to access the Internet in the main thread.

Public static boolean method `Utils::isMainThread()` is added for checking whether the current context is in the main thread.
# To-do
- Language values `pocketmine.thread.useInternet.curl` and `pocketmine.thread.useInternet.suppressed` should be added.
# Possible enhancements

Add timings specific for syncInternetAccess calls.
# Tests

This script plugin has been used for testing this pull request:

``` php
<?php

/**
 * @name TestSyncInternet
 * @main TestSyncInternet\Main
 * @version 1.0.0
 * @api 2.0.0
 */

use pocketmine\utils\Utils;
use pocketmine\event\server\QueryRegenerateEvent as QRE;

class Main extends \pocketmine\plugin\PluginBase implements \pocketmine\event\Listener{
        public function onLoad(){
                echo "Load: ", strlen(Utils::getURL("http://example.com")), PHP_EOL;
        }

        public function onEnable(){
                echo "Enable: ", strlen(Utils::getURL("http://example.com")), PHP_EOL;
                $this->getServer()->getPluginManager()->registerEvents($this, $this);
                $this->getServer()->getScheduler()->scheduleDelayedTask(new class($this) extends \pocketmine\scheduler\PluginTask{
                        public function onRun($ticks){
                                $server = \pocketmine\Server::getInstance();
                                $server->getPluginManager()->callEvent(new QRE($server, 5));
                                $server->getScheduler()->scheduleAsyncTask(new class extends \pocketmine\scheduler\AsyncTask{
                                        public function onRun(){
                                                echo "Async: ", strlen(Utils::getURL("http://example.com")), PHP_EOL;
                                        }
                                });
                        }
                }, 10);
        }

        public function onDisable(){
                echo "Disable: ", strlen(Utils::getURL("http://example.com")), PHP_EOL;
        }

        public function e_regenEvent(QRE $e){
                echo "Regen.sync: ", strlen(Utils::syncInternetAccess($this, [Utils::class, "getURL"], "http://example.com")), PHP_EOL;
                echo "Regen: ", strlen(Utils::getURL("http://example.com")), PHP_EOL;
        }
}
```

Works as expected under different values for the new options in pocketmine.yml
