### PR TITLE
Improved action check for InteractPacket

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2324,7 +2324,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
 				$cancelled = false;
 
-				if($packet->action === InteractPacket::ACTION_RIGHT_CLICK){
+				if($packet->action !== InteractPacket::ACTION_LEFT_CLICK){
 					// TODO handle
 					break;
 				}


### PR DESCRIPTION
As of 0.16, when a player highlights (right-click/tap) an entity, the client starts spamming InteractPackets with an action of 4. The server checks that it's not a right-click, and assumes it's left-click. Now the server only processes it as an attack when the action is 1 (left-click)