### PR TITLE
Fixed bugs related to #24 such as getName() on null

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -86,6 +86,7 @@ use pocketmine\level\Level;
 use pocketmine\level\Location;
 use pocketmine\level\Position;
 use pocketmine\level\sound\LaunchSound;
+use pocketmine\level\WeakPosition;
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Vector2;
 use pocketmine\math\Vector3;
@@ -228,7 +229,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	protected $viewDistance;
 	protected $chunksPerTick;
 	protected $spawnThreshold;
-	/** @var null|Position */
+	/** @var null|WeakPosition */
 	private $spawnPosition = null;
 
 	protected $inAirTicks = 0;
@@ -1038,7 +1039,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		}else{
 			$level = $pos->getLevel();
 		}
-		$this->spawnPosition = new Position($pos->x, $pos->y, $pos->z, $level);
+		$this->spawnPosition = new WeakPosition($pos->x, $pos->y, $pos->z, $level);
 		$pk = new SetSpawnPositionPacket();
 		$pk->x = (int) $this->spawnPosition->x;
 		$pk->y = (int) $this->spawnPosition->y;
@@ -1678,7 +1679,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		$this->dataPacket(new ResourcePacksInfoPacket());
 
 		if($this->spawnPosition === null and isset($this->namedtag->SpawnLevel) and ($level = $this->server->getLevelByName($this->namedtag["SpawnLevel"])) instanceof Level){
-			$this->spawnPosition = new Position($this->namedtag["SpawnX"], $this->namedtag["SpawnY"], $this->namedtag["SpawnZ"], $level);
+			$this->spawnPosition = new WeakPosition($this->namedtag["SpawnX"], $this->namedtag["SpawnY"], $this->namedtag["SpawnZ"], $level);
 		}
 
 		$spawnPosition = $this->getSpawn();
@@ -3081,7 +3082,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		parent::saveNBT();
 		if($this->level instanceof Level){
 			$this->namedtag->Level = new StringTag("Level", $this->level->getName());
-			if($this->spawnPosition instanceof Position and $this->spawnPosition->getLevel() instanceof Level){
+			if($this->spawnPosition instanceof WeakPosition and $this->spawnPosition->isValid()){
 				$this->namedtag["SpawnLevel"] = $this->spawnPosition->getLevel()->getName();
 				$this->namedtag["SpawnX"] = (int) $this->spawnPosition->x;
 				$this->namedtag["SpawnY"] = (int) $this->spawnPosition->y;

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -681,13 +681,20 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	 * @return Position
 	 */
 	public function getSpawn(){
-		if($this->spawnPosition instanceof Position and $this->spawnPosition->getLevel() instanceof Level){
+		if($this->hasValidSpawnPosition()){
 			return $this->spawnPosition;
 		}else{
 			$level = $this->server->getDefaultLevel();
 
 			return $level->getSafeSpawn();
 		}
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function hasValidSpawnPosition() : bool{
+		return $this->spawnPosition instanceof WeakPosition and $this->spawnPosition->isValid();
 	}
 
 	public function sendChunk($x, $z, $payload, $ordering = FullChunkDataPacket::ORDER_COLUMNS){
@@ -1678,7 +1685,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
 		$this->dataPacket(new ResourcePacksInfoPacket());
 
-		if($this->spawnPosition === null and isset($this->namedtag->SpawnLevel) and ($level = $this->server->getLevelByName($this->namedtag["SpawnLevel"])) instanceof Level){
+		if(!$this->hasValidSpawnPosition() and isset($this->namedtag->SpawnLevel) and ($level = $this->server->getLevelByName($this->namedtag["SpawnLevel"])) instanceof Level){
 			$this->spawnPosition = new WeakPosition($this->namedtag["SpawnX"], $this->namedtag["SpawnY"], $this->namedtag["SpawnZ"], $level);
 		}
 
@@ -3082,7 +3089,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		parent::saveNBT();
 		if($this->level instanceof Level){
 			$this->namedtag->Level = new StringTag("Level", $this->level->getName());
-			if($this->spawnPosition instanceof WeakPosition and $this->spawnPosition->isValid()){
+			if($this->hasValidSpawnPosition()){
 				$this->namedtag["SpawnLevel"] = $this->spawnPosition->getLevel()->getName();
 				$this->namedtag["SpawnX"] = (int) $this->spawnPosition->x;
 				$this->namedtag["SpawnY"] = (int) $this->spawnPosition->y;

--- a/src/pocketmine/level/Position.php
+++ b/src/pocketmine/level/Position.php
@@ -64,7 +64,7 @@ class Position extends Vector3{
 	 * @return bool
 	 */
 	public function isValid(){
-		return $this->getLevel() !== null;
+		return $this->getLevel() instanceof Level;
 	}
 
 	/**

--- a/src/pocketmine/level/WeakPosition.php
+++ b/src/pocketmine/level/WeakPosition.php
@@ -22,12 +22,10 @@
 namespace pocketmine\level;
 
 use pocketmine\math\Vector3;
+use pocketmine\Server;
 use pocketmine\utils\LevelException;
 
-class Position extends Vector3{
-
-	/** @var Level */
-	public $level = null;
+class WeakPosition extends Position{
 
 	/**
 	 * @param int   $x
@@ -39,32 +37,23 @@ class Position extends Vector3{
 		$this->x = $x;
 		$this->y = $y;
 		$this->z = $z;
-		$this->level = $level;
+		$this->levelId = ($level !== null ? $level->getId() : -1);
 	}
 
 	public static function fromObject(Vector3 $pos, Level $level = null){
-		return new Position($pos->x, $pos->y, $pos->z, $level);
+		return new WeakPosition($pos->x, $pos->y, $pos->z, $level);
 	}
 
 	/**
 	 * @return Level
 	 */
 	public function getLevel(){
-		return $this->level;
+		return Server::getInstance()->getLevel($this->levelId);
 	}
 
 	public function setLevel(Level $level){
-		$this->level = $level;
+		$this->levelId = ($level !== null ? $level->getId() : -1);
 		return $this;
-	}
-
-	/**
-	 * Checks if this object has a valid reference to a Level
-	 *
-	 * @return bool
-	 */
-	public function isValid(){
-		return $this->getLevel() !== null;
 	}
 
 	/**
@@ -73,32 +62,17 @@ class Position extends Vector3{
 	 * @param int $side
 	 * @param int $step
 	 *
-	 * @return Position
+	 * @return WeakPosition
 	 *
 	 * @throws LevelException
 	 */
 	public function getSide($side, $step = 1){
 		assert($this->isValid());
 
-		return Position::fromObject(parent::getSide($side, $step), $this->level);
+		return WeakPosition::fromObject(parent::getSide($side, $step), $this->level);
 	}
 
 	public function __toString(){
-		return "Position(level=" . ($this->isValid() ? $this->getLevel()->getName() : "null") . ",x=" . $this->x . ",y=" . $this->y . ",z=" . $this->z . ")";
+		return "Weak" . parent::__toString();
 	}
-
-	/**
-	 * @param $x
-	 * @param $y
-	 * @param $z
-	 *
-	 * @return Position
-	 */
-	public function setComponents($x, $y, $z){
-		$this->x = $x;
-		$this->y = $y;
-		$this->z = $z;
-		return $this;
-	}
-
 }

--- a/src/pocketmine/level/WeakPosition.php
+++ b/src/pocketmine/level/WeakPosition.php
@@ -45,7 +45,7 @@ class WeakPosition extends Position{
 	}
 
 	/**
-	 * @return Level
+	 * @return Level|null
 	 */
 	public function getLevel(){
 		return Server::getInstance()->getLevel($this->levelId);


### PR DESCRIPTION
This pull request fixes the leak described in #24 and a very large number of bugs that resulted from the issue.

Description of the actual issue can be seen in #24.

This pull request adds a new type of Position, WeakPosition, which instead of holding a Level _reference_, holds a level _ID_ instead. When WeakPosition::getLevel() is called, a Level reference is returned from Server ondemand, or null if the level has been unloaded.

WeakPosition is now used for player spawn positions, which was the primary cause of this bug. Now, instead of the famous crashes, the player will simply return to the server's default spawn point if the world in which the player's spawn point is set is not loaded.

### Possible improvements
- Use the level name instead of ID. This will allow spawnpoints to return to the world if it is reloaded. Using a Level ID is faster, but once the subject world is unloaded, the spawnpoint will never be re-validated until the server is restarted.