### PR TITLE
Fix double permission recalculation on op status change, fixes double…

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -439,7 +439,6 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			$this->server->removeOp($this->getName());
 		}
 
-		$this->recalculatePermissions();
 		$this->sendSettings();
 	}
 


### PR DESCRIPTION
… sending of AvailableCommandsPacket

This call to recalculatePermissions() is unneeded, since this will already be called in Server->addOp() and removeOp(). As a result, this causes permissions to be recalculated twice on op status change.

I have tested this and confirmed that it works, however I am unsure if there are any circumstances under which this duplicate call would be needed. Please review.