### PR TITLE
Partial fix for #83

### DIFF
--- a/src/pocketmine/command/defaults/GamemodeCommand.php
+++ b/src/pocketmine/command/defaults/GamemodeCommand.php
@@ -77,10 +77,10 @@ class GamemodeCommand extends VanillaCommand{
 			$sender->sendMessage("Game mode change for " . $target->getName() . " failed!");
 		}else{
 			if($target === $sender){
-				Command::broadcastCommandMessage($sender, new TranslationContainer("commands.gamemode.success.self", [Server::getGamemodeString($gameMode)]));
+				Command::broadcastCommandMessage($sender, new TranslationContainer("commands.gamemode.success.self", ['blame', 'mojang', Server::getGamemodeString($gameMode)]));
 			}else{
 				$target->sendMessage(new TranslationContainer("gameMode.changed"));
-				Command::broadcastCommandMessage($sender, new TranslationContainer("commands.gamemode.success.other", [$target->getName(), Server::getGamemodeString($gameMode)]));
+				Command::broadcastCommandMessage($sender, new TranslationContainer("commands.gamemode.success.other", ['blame mojang', $target->getName(), Server::getGamemodeString($gameMode)]));
 			}
 		}
 


### PR DESCRIPTION
Shows the correct message ingame but not in the console.
PocketMine doesn't handle the translation for gamemode changes, MCPE
does. No idea why but it requires the second and third parameter....

```
commands.gamemode.success.other=Set %2$s's game mode to %3$s
commands.gamemode.success.self=Set own game mode to %3$s
```

To solve the problem we have to change the language files and let
PocketMine-MP translate it.