### PR TITLE
Make /timings command more verbose about errors

### DIFF
--- a/src/pocketmine/command/defaults/TimingsCommand.php
+++ b/src/pocketmine/command/defaults/TimingsCommand.php
@@ -114,7 +114,15 @@ class TimingsCommand extends VanillaCommand{
 				curl_setopt($ch, CURLOPT_HEADER, true);
 				curl_setopt($ch, CURLOPT_HTTPHEADER, ["User-Agent: " . $this->getName() . " " . $sender->getServer()->getPocketMineVersion()]);
 				curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-				$data = curl_exec($ch);
+				try{
+					$data = curl_exec($ch);
+					if($data === false){
+						throw new \Exception(curl_error($ch));
+					}
+				}catch(\Exception $e){
+					$sender->getServer()->getLogger()->logException($e);
+				}
+
 				curl_close($ch);
 				if(preg_match('#^Location: http://paste\\.ubuntu\\.com/([0-9]{1,})/#m', $data, $matches) == 0){
 					$sender->sendMessage(new TranslationContainer("pocketmine.command.timings.pasteError"));


### PR DESCRIPTION
It's highly irritating running /timings paste and getting that generic "An error happened..." message. This PR makes the command throw and log an exception with the error details if curl_exec fails.