### PR TITLE
Safer anvil section requests, fix "top-of-the-map" spawn position crash

### DIFF
--- a/src/pocketmine/level/format/anvil/Chunk.php
+++ b/src/pocketmine/level/format/anvil/Chunk.php
@@ -82,12 +82,12 @@ class Chunk extends BaseChunk{
 		foreach($this->nbt->Sections as $section){
 			if($section instanceof CompoundTag){
 				$y = (int) $section["Y"];
-				if($y < 8){
+				if($y < self::SECTION_COUNT){
 					$sections[$y] = new ChunkSection($section);
 				}
 			}
 		}
-		for($y = 0; $y < 8; ++$y){
+		for($y = 0; $y < self::SECTION_COUNT; ++$y){
 			if(!isset($sections[$y])){
 				$sections[$y] = new EmptyChunkSection($y);
 			}
@@ -347,7 +347,7 @@ class Chunk extends BaseChunk{
 			$chunk->x = $chunkX;
 			$chunk->z = $chunkZ;
 
-			for($y = 0; $y < 8; ++$y){
+			for($y = 0; $y < self::SECTION_COUNT; ++$y){
 				$chunk->sections[$y] = new EmptyChunkSection($y);
 			}
 

--- a/src/pocketmine/level/format/generic/BaseChunk.php
+++ b/src/pocketmine/level/format/generic/BaseChunk.php
@@ -78,27 +78,27 @@ abstract class BaseChunk extends BaseFullChunk implements Chunk{
 	}
 
 	public function getFullBlock($x, $y, $z){
-		return $this->sections[$y >> 4]->getFullBlock($x, $y & 0x0f, $z);
+		return $this->getSection($y >> 4)->getFullBlock($x, $y & 0x0f, $z);
 	}
 
 	public function setBlock($x, $y, $z, $blockId = null, $meta = null){
 		try{
 			$this->hasChanged = true;
-			return $this->sections[$y >> 4]->setBlock($x, $y & 0x0f, $z, $blockId & 0xff, $meta & 0x0f);
+			return $this->getSection($y >> 4)->setBlock($x, $y & 0x0f, $z, $blockId & 0xff, $meta & 0x0f);
 		}catch(ChunkException $e){
 			$level = $this->getProvider();
 			$this->setInternalSection($Y = $y >> 4, $level::createChunkSection($Y));
-			return $this->sections[$y >> 4]->setBlock($x, $y & 0x0f, $z, $blockId & 0xff, $meta & 0x0f);
+			return $this->getSection($y >> 4)->setBlock($x, $y & 0x0f, $z, $blockId & 0xff, $meta & 0x0f);
 		}
 	}
 
 	public function getBlockId($x, $y, $z){
-		return $this->sections[$y >> 4]->getBlockId($x, $y & 0x0f, $z);
+		return $this->getSection($y >> 4)->getBlockId($x, $y & 0x0f, $z);
 	}
 
 	public function setBlockId($x, $y, $z, $id){
 		try{
-			$this->sections[$y >> 4]->setBlockId($x, $y & 0x0f, $z, $id);
+			$this->getSection($y >> 4)->setBlockId($x, $y & 0x0f, $z, $id);
 			$this->hasChanged = true;
 		}catch(ChunkException $e){
 			$level = $this->getProvider();
@@ -108,12 +108,12 @@ abstract class BaseChunk extends BaseFullChunk implements Chunk{
 	}
 
 	public function getBlockData($x, $y, $z){
-		return $this->sections[$y >> 4]->getBlockData($x, $y & 0x0f, $z);
+		return $this->getSection($y >> 4)->getBlockData($x, $y & 0x0f, $z);
 	}
 
 	public function setBlockData($x, $y, $z, $data){
 		try{
-			$this->sections[$y >> 4]->setBlockData($x, $y & 0x0f, $z, $data);
+			$this->getSection($y >> 4)->setBlockData($x, $y & 0x0f, $z, $data);
 			$this->hasChanged = true;
 		}catch(ChunkException $e){
 			$level = $this->getProvider();
@@ -123,12 +123,12 @@ abstract class BaseChunk extends BaseFullChunk implements Chunk{
 	}
 
 	public function getBlockSkyLight($x, $y, $z){
-		return $this->sections[$y >> 4]->getBlockSkyLight($x, $y & 0x0f, $z);
+		return $this->getSection($y >> 4)->getBlockSkyLight($x, $y & 0x0f, $z);
 	}
 
 	public function setBlockSkyLight($x, $y, $z, $data){
 		try{
-			$this->sections[$y >> 4]->setBlockSkyLight($x, $y & 0x0f, $z, $data);
+			$this->getSection($y >> 4)->setBlockSkyLight($x, $y & 0x0f, $z, $data);
 			$this->hasChanged = true;
 		}catch(ChunkException $e){
 			$level = $this->getProvider();
@@ -138,12 +138,12 @@ abstract class BaseChunk extends BaseFullChunk implements Chunk{
 	}
 
 	public function getBlockLight($x, $y, $z){
-		return $this->sections[$y >> 4]->getBlockLight($x, $y & 0x0f, $z);
+		return $this->getSection($y >> 4)->getBlockLight($x, $y & 0x0f, $z);
 	}
 
 	public function setBlockLight($x, $y, $z, $data){
 		try{
-			$this->sections[$y >> 4]->setBlockLight($x, $y & 0x0f, $z, $data);
+			$this->getSection($y >> 4)->setBlockLight($x, $y & 0x0f, $z, $data);
 			$this->hasChanged = true;
 		}catch(ChunkException $e){
 			$level = $this->getProvider();
@@ -155,7 +155,7 @@ abstract class BaseChunk extends BaseFullChunk implements Chunk{
 	public function getBlockIdColumn($x, $z){
 		$column = "";
 		for($y = 0; $y < Chunk::SECTION_COUNT; ++$y){
-			$column .= $this->sections[$y]->getBlockIdColumn($x, $z);
+			$column .= $this->getSection($y)->getBlockIdColumn($x, $z);
 		}
 
 		return $column;
@@ -164,7 +164,7 @@ abstract class BaseChunk extends BaseFullChunk implements Chunk{
 	public function getBlockDataColumn($x, $z){
 		$column = "";
 		for($y = 0; $y < Chunk::SECTION_COUNT; ++$y){
-			$column .= $this->sections[$y]->getBlockDataColumn($x, $z);
+			$column .= $this->getSection($y)->getBlockDataColumn($x, $z);
 		}
 
 		return $column;
@@ -173,7 +173,7 @@ abstract class BaseChunk extends BaseFullChunk implements Chunk{
 	public function getBlockSkyLightColumn($x, $z){
 		$column = "";
 		for($y = 0; $y < Chunk::SECTION_COUNT; ++$y){
-			$column .= $this->sections[$y]->getBlockSkyLightColumn($x, $z);
+			$column .= $this->getSection($y)->getBlockSkyLightColumn($x, $z);
 		}
 
 		return $column;
@@ -182,18 +182,18 @@ abstract class BaseChunk extends BaseFullChunk implements Chunk{
 	public function getBlockLightColumn($x, $z){
 		$column = "";
 		for($y = 0; $y < Chunk::SECTION_COUNT; ++$y){
-			$column .= $this->sections[$y]->getBlockLightColumn($x, $z);
+			$column .= $this->getSection($y)->getBlockLightColumn($x, $z);
 		}
 
 		return $column;
 	}
 
 	public function isSectionEmpty($fY){
-		return $this->sections[(int) $fY] instanceof EmptyChunkSection;
+		return $this->getSection($fY) instanceof EmptyChunkSection;
 	}
 
 	public function getSection($fY){
-		return $this->sections[(int) $fY];
+		return $this->sections[(int) $fY] ?? new EmptyChunkSection((int) $fY);
 	}
 
 	public function setSection($fY, ChunkSection $section){
@@ -217,7 +217,7 @@ abstract class BaseChunk extends BaseFullChunk implements Chunk{
 	public function getBlockIdArray(){
 		$blocks = "";
 		for($y = 0; $y < Chunk::SECTION_COUNT; ++$y){
-			$blocks .= $this->sections[$y]->getIdArray();
+			$blocks .= $this->getSection($y)->getIdArray();
 		}
 
 		return $blocks;
@@ -226,7 +226,7 @@ abstract class BaseChunk extends BaseFullChunk implements Chunk{
 	public function getBlockDataArray(){
 		$data = "";
 		for($y = 0; $y < Chunk::SECTION_COUNT; ++$y){
-			$data .= $this->sections[$y]->getDataArray();
+			$data .= $this->getSection($y)->getDataArray();
 		}
 
 		return $data;
@@ -235,7 +235,7 @@ abstract class BaseChunk extends BaseFullChunk implements Chunk{
 	public function getBlockSkyLightArray(){
 		$skyLight = "";
 		for($y = 0; $y < Chunk::SECTION_COUNT; ++$y){
-			$skyLight .= $this->sections[$y]->getSkyLightArray();
+			$skyLight .= $this->getSection($y)->getSkyLightArray();
 		}
 
 		return $skyLight;
@@ -244,7 +244,7 @@ abstract class BaseChunk extends BaseFullChunk implements Chunk{
 	public function getBlockLightArray(){
 		$blockLight = "";
 		for($y = 0; $y < Chunk::SECTION_COUNT; ++$y){
-			$blockLight .= $this->sections[$y]->getLightArray();
+			$blockLight .= $this->getSection($y)->getLightArray();
 		}
 
 		return $blockLight;


### PR DESCRIPTION
Fix the nasty crash described by @awzaw internally.

This required a a little maths on my part to work out how to reproduce, but the way to do it is to create a sandwich of blocks.

Create a flat **ANVIL** world with the below settings:
```
worlds:
 #These settings will override the generator set in server.properties and allows loading multiple levels
 #Example:
 world:
  seed: 404
  generator: FLAT:2;7,120x1,3x3,2;1;decoration(treecount=80 grasscount=45)
```
You will spawn at y = 125.
- Leave an empty 1-block gap, and build a solid layer.
- Stand on top of this layer and set the world spawn on top of it.
- Use /kill on yourself or quit/rejoin. You will see this error:
```
Notice: Undefined offset: 8 in C:\Users\Admin\Downloads\server\src\pocketmine\level\format\generic\BaseChunk.php on line 81
[11:35:57] [Server thread/CRITICAL]: Error: "Call to a member function getFullBlock() on null" (EXCEPTION) in "/src/pocketmine/level/format/generic/BaseChunk" at line 81
```

## Why this happens
Level->getSafeSpawn() misuses Chunk->getFullBlock() to skip retrieving the target chunk every time a block in the column is to be checked. While this is better for performance, there is a [point in the method ](https://github.com/pmmp/PocketMine-MP/blob/master/src/pocketmine/level/Level.php#L2609) where it will pass 127 to the next part. While this is fine, since players can spawn higher than this, the +1 in the next part checking headroom causes the method to request a block from a section which does not exist. 128 >> 4 = 8, but there are only indexes 0-7 of sections.

This could happen to any misused BaseChunk methods due to the lack of checks on the supplied Y coordinate. I expect @shoghicp didn't consider this because those methods are not API methods.

## Change details
Instead of accessing BaseChunk->sections directly, all methods which could encounter this issue now use BaseChunk->getSection(). getSection() has been altered to return a dummy EmptyChunkSection.

## Tests
This has been tested and confirmed that the described crash does not occur anymore.