### PR TITLE
Added AsyncTask progress update API

### DIFF
--- a/src/pocketmine/scheduler/AsyncPool.php
+++ b/src/pocketmine/scheduler/AsyncPool.php
@@ -142,8 +142,13 @@ class AsyncPool{
 		Timings::$schedulerAsyncTimer->startTiming();
 
 		foreach($this->tasks as $task){
+			if($task->progressUpdates !== null){
+				if($task->progressUpdates->count() !== 0){
+					$progress = $task->progressUpdates->shift();
+					$task->onProgressUpdate($this->server, $progress);
+				}
+			}
 			if($task->isGarbage() and !$task->isRunning() and !$task->isCrashed()){
-
 				if(!$task->hasCancelledRun()){
 					$task->onCompletion($this->server);
 					$this->server->getScheduler()->removeLocalComplex($task);

--- a/src/pocketmine/scheduler/AsyncPool.php
+++ b/src/pocketmine/scheduler/AsyncPool.php
@@ -142,7 +142,7 @@ class AsyncPool{
 		Timings::$schedulerAsyncTimer->startTiming();
 
 		foreach($this->tasks as $task){
-			if($task->progressUpdates !== null){
+			if(!$task->isGarbage() and $task->progressUpdates !== null){
 				if($task->progressUpdates->count() !== 0){
 					$progress = $task->progressUpdates->shift();
 					$task->onProgressUpdate($this->server, $progress);

--- a/src/pocketmine/scheduler/AsyncPool.php
+++ b/src/pocketmine/scheduler/AsyncPool.php
@@ -142,11 +142,8 @@ class AsyncPool{
 		Timings::$schedulerAsyncTimer->startTiming();
 
 		foreach($this->tasks as $task){
-			if(!$task->isGarbage() and $task->progressUpdates !== null){
-				if($task->progressUpdates->count() !== 0){
-					$progress = $task->progressUpdates->shift();
-					$task->onProgressUpdate($this->server, $progress);
-				}
+			if(!$task->isGarbage()){
+				$task->checkProgressUpdates($this->server);
 			}
 			if($task->isGarbage() and !$task->isRunning() and !$task->isCrashed()){
 				if(!$task->hasCancelledRun()){

--- a/src/pocketmine/scheduler/AsyncTask.php
+++ b/src/pocketmine/scheduler/AsyncTask.php
@@ -27,6 +27,10 @@ use pocketmine\Server;
 /**
  * Class used to run async tasks in other threads.
  *
+ * An AsyncTask does not have its own thread. It is queued into an AsyncPool and executed if there is an async worker
+ * with no AsyncTask running. Therefore, an AsyncTask SHOULD NOT execute for more than a few seconds. For tasks that
+ * run for a long time or infinitely, start another {@link \pocketmine\Thread} instead.
+ *
  * WARNING: Do not call PocketMine-MP API methods, or save objects (and arrays cotaining objects) from/on other Threads!!
  */
 abstract class AsyncTask extends Collectable{

--- a/src/pocketmine/scheduler/AsyncTask.php
+++ b/src/pocketmine/scheduler/AsyncTask.php
@@ -35,7 +35,7 @@ abstract class AsyncTask extends Collectable{
 	public $worker = null;
 
 	/** @var \Threaded */
-	public $progressUpdates = null;
+	public $progressUpdates;
 
 	private $result = null;
 	private $serialized = false;
@@ -69,7 +69,6 @@ abstract class AsyncTask extends Collectable{
 	}
 
 	public function run(){
-		$this->progressUpdates = new \Threaded; // Do not move this to __construct for backwards compatibility.
 		$this->result = null;
 
 		if($this->cancelRun !== true){
@@ -180,6 +179,18 @@ abstract class AsyncTask extends Collectable{
 	 */
 	public function publishProgress($progress){
 		$this->progressUpdates[] = $progress;
+	}
+
+	/**
+	 * @internal Only call from AsyncPool.php on the main thread
+	 *
+	 * @param Server $server
+	 */
+	public function checkProgressUpdates(Server $server){
+		if($this->progressUpdates->count() !== 0){
+			$progress = $this->progressUpdates->shift();
+			$this->onProgressUpdate($server, $progress);
+		}
 	}
 
 	/**

--- a/src/pocketmine/scheduler/AsyncTask.php
+++ b/src/pocketmine/scheduler/AsyncTask.php
@@ -178,7 +178,7 @@ abstract class AsyncTask extends Collectable{
 	 * @param mixed $progress A value that can be safely serialize()'ed.
 	 */
 	public function publishProgress($progress){
-		$this->progressUpdates[] = $progress;
+		$this->progressUpdates[] = serialize($progress);
 	}
 
 	/**
@@ -187,9 +187,9 @@ abstract class AsyncTask extends Collectable{
 	 * @param Server $server
 	 */
 	public function checkProgressUpdates(Server $server){
-		if($this->progressUpdates->count() !== 0){
+		while($this->progressUpdates->count() !== 0){
 			$progress = $this->progressUpdates->shift();
-			$this->onProgressUpdate($server, $progress);
+			$this->onProgressUpdate($server, unserialize($progress));
 		}
 	}
 

--- a/src/pocketmine/scheduler/AsyncTask.php
+++ b/src/pocketmine/scheduler/AsyncTask.php
@@ -175,7 +175,7 @@ abstract class AsyncTask extends Collectable{
 	 * Call this method from {@link AsyncTask#onRun} (AsyncTask execution therad) to schedule a call to
 	 * {@link AsyncTask#onProgressUpdate} from the main thread with the given progress parameter.
 	 *
-	 * @param \Threaded|mixed $progress A Threaded object, or a value that can be safely serialize()'ed.
+	 * @param mixed $progress A value that can be safely serialize()'ed.
 	 */
 	public function publishProgress($progress){
 		$this->progressUpdates[] = $progress;
@@ -198,10 +198,9 @@ abstract class AsyncTask extends Collectable{
 	 * All {@link AsyncTask#publishProgress} calls should result in {@link AsyncTask#onProgressUpdate} calls before
 	 * {@link AsyncTask#onCompletion} is called.
 	 *
-	 * @param Server          $server
-	 * @param \Threaded|mixed $progress The parameter passed to {@link AsyncTask#publishProgress}. If it is not a
-	 *                                  Threaded object, it would be serialize()'ed and later unserialize()'ed, as if it
-	 *                                  has been cloned.
+	 * @param Server $server
+	 * @param mixed  $progress The parameter passed to {@link AsyncTask#publishProgress}. It is serialize()'ed
+	 *                         and then unserialize()'ed, as if it has been cloned.
 	 */
 	public function onProgressUpdate(Server $server, $progress){
 

--- a/src/pocketmine/scheduler/ServerScheduler.php
+++ b/src/pocketmine/scheduler/ServerScheduler.php
@@ -78,6 +78,7 @@ class ServerScheduler{
 	public function scheduleAsyncTask(AsyncTask $task){
 		$id = $this->nextId();
 		$task->setTaskId($id);
+		$task->progressUpdates = new \Threaded;
 		$this->asyncPool->submitTask($task);
 	}
 

--- a/src/pocketmine/scheduler/ServerScheduler.php
+++ b/src/pocketmine/scheduler/ServerScheduler.php
@@ -50,7 +50,7 @@ class ServerScheduler{
 	/** @var int */
 	protected $currentTick = 0;
 
-	/** @var \SplObjectStorage<AsyncTask> */
+	/** @var \SplObjectStorage<AsyncTask, object|array> */
 	protected $objectStore;
 
 	public function __construct(){
@@ -100,7 +100,7 @@ class ServerScheduler{
 	 *
 	 * @internal Only call from AsyncTask.php
 	 *
-	 * @param AsyncTask     $for
+	 * @param AsyncTask    $for
 	 * @param object|array $cmplx
 	 *
 	 * @throws \RuntimeException if this method is called twice for the same instance of AsyncTask
@@ -113,17 +113,39 @@ class ServerScheduler{
 	}
 
 	/**
-	 * Fetches data that must not be passed to other threads or be serialized, previously stored with {@link #storeLocalComplex}
+	 * Fetches data that must not be passed to other threads or be serialized, previously stored with
+	 * {@link ServerScheduler#storeLocalComplex}, without deletion of the data.
 	 *
 	 * @internal Only call from AsyncTask.php
 	 *
 	 * @param AsyncTask $for
 	 *
-	 * @throws \RuntimException if no data associated with this AsyncTask can be found
-	 */	
+	 * @return object|array
+	 *
+	 * @throws \RuntimeException if no data associated with this AsyncTask can be found
+	 */
+	public function peekLocalComplex(AsyncTask $for){
+		if(!isset($this->objectStore[$for])){
+			throw new \RuntimeException("No local complex stored for this AsyncTask");
+		}
+		return $this->objectStore[$for];
+	}
+
+	/**
+	 * Fetches data that must not be passed to other threads or be serialized, previously stored with
+	 * {@link ServerScheduler#storeLocalComplex}, and delete the data from the storage.
+	 *
+	 * @internal Only call from AsyncTask.php
+	 *
+	 * @param AsyncTask $for
+	 *
+	 * @return object|array
+	 *
+	 * @throws \RuntimeException if no data associated with this AsyncTask can be found
+	 */
 	public function fetchLocalComplex(AsyncTask $for){
 		if(!isset($this->objectStore[$for])){
-			throw new \RuntimeException("Attempt to fetch undefined complex");
+			throw new \RuntimeException("No local complex stored for this AsyncTask");
 		}
 		$cmplx = $this->objectStore[$for];
 		unset($this->objectStore[$for]);
@@ -138,7 +160,7 @@ class ServerScheduler{
 	 * @param AsyncTask $for
 	 *
 	 * @return bool returns false if any data are removed from this call, true otherwise
-	 */	
+	 */
 	public function removeLocalComplex(AsyncTask $for) : bool{
 		if(isset($this->objectStore[$for])){
 			Server::getInstance()->getLogger()->notice("AsyncTask " . get_class($for) . " stored local complex data but did not remove them after completion");

--- a/src/pocketmine/scheduler/ServerScheduler.php
+++ b/src/pocketmine/scheduler/ServerScheduler.php
@@ -93,6 +93,7 @@ class ServerScheduler{
 	public function scheduleAsyncTaskToWorker(AsyncTask $task, $worker){
 		$id = $this->nextId();
 		$task->setTaskId($id);
+		$task->progressUpdates = new \Threaded;
 		$this->asyncPool->submitTaskToWorker($task, $worker);
 	}
 


### PR DESCRIPTION
PocketMine AsyncTask lacks support for publishing progress in an AsyncTask.

## What is progress publish?
Refer to [Android's AsyncTask API](https://developer.android.com/reference/android/os/AsyncTask.html#publishProgress(Progress...)):
> This method can be invoked from doInBackground(Params...) to publish updates on the UI thread while the background computation is still running. Each call to this method will trigger the execution of onProgressUpdate(Progress...) on the UI thread. onProgressUpdate(Progress...) will not be called if the task has been canceled.

In simple words, the AsyncTask worker thread (the implementation of AsyncTask actually) can trigger a method called publishProgress. It will pass some primitive data (or Threaded objects) to the main thread. The main thread scheduler heartbeat will check for these calls (just like it checks to call onCompletion), and trigger a method onProgressUpdate on the AsyncTask from the main thread. Hence, with about half/one tick delay, an AsyncTask's progress can be published from the worker thread and correctly displayed to the main thread (hence sending messages to users, triggering server loggers, etc.).

Example: (the steps refer to the 4 steps in the Android AsyncTask API)
https://gist.github.com/006ad7d839697ff9044d7eb8cf16f2f8