### PR TITLE
Fix teleport command not accepting /tp 0 0 0

### DIFF
--- a/src/pocketmine/command/defaults/TeleportCommand.php
+++ b/src/pocketmine/command/defaults/TeleportCommand.php
@@ -44,7 +44,6 @@ class TeleportCommand extends VanillaCommand{
 			return true;
 		}
 
-		$args = array_filter($args);
 		if(count($args) < 1 or count($args) > 6){
 			$sender->sendMessage(new TranslationContainer("commands.generic.usage", [$this->usageMessage]));
 


### PR DESCRIPTION
This PR fixes the teleport command not accepting 0 0 0 (Player not found) through removing an useless array_filter. http://php.net/manual/en/function.array-filter.php