### PR TITLE
Speed up region file creation by only using ftruncate().

### DIFF
--- a/src/pocketmine/level/format/mcregion/RegionLoader.php
+++ b/src/pocketmine/level/format/mcregion/RegionLoader.php
@@ -288,24 +288,14 @@ class RegionLoader{
 		fwrite($this->filePointer, Binary::writeInt($this->locationTable[$index][2]), 4);
 	}
 
-	protected function createBlank(){
-		fseek($this->filePointer, 0);
-		ftruncate($this->filePointer, 0);
-		$this->lastSector = 1;
-		$table = "";
-		for($i = 0; $i < 1024; ++$i){
-			$this->locationTable[$i] = [0, 0];
-			$table .= Binary::writeInt(0);
-		}
-
-		$time = time();
-		for($i = 0; $i < 1024; ++$i){
-			$this->locationTable[$i][2] = $time;
-			$table .= Binary::writeInt($time);
-		}
-
-		fwrite($this->filePointer, $table, 4096 * 2);
-	}
+    protected function createBlank(){
+        fseek($this->filePointer, 0);
+        ftruncate($this->filePointer, 8192); // this fills the file with the null byte
+        $this->lastSector = 1;
+        for($i = 0; $i < 1024; ++$i){
+            $this->locationTable[$i] = [0, 0, 0];
+        }
+    }
 
 	public function getX(){
 		return $this->x;

--- a/src/pocketmine/level/format/mcregion/RegionLoader.php
+++ b/src/pocketmine/level/format/mcregion/RegionLoader.php
@@ -290,7 +290,7 @@ class RegionLoader{
 
 	protected function createBlank(){
 		fseek($this->filePointer, 0);
- 		ftruncate($this->filePointer, 8192); // this fills the file with the null byte
+		ftruncate($this->filePointer, 8192); // this fills the file with the null byte
 		$this->lastSector = 1;
 		$this->locationTable = array_fill(0, 1024, [0, 0, 0]);
 	}

--- a/src/pocketmine/level/format/mcregion/RegionLoader.php
+++ b/src/pocketmine/level/format/mcregion/RegionLoader.php
@@ -292,9 +292,7 @@ class RegionLoader{
         fseek($this->filePointer, 0);
         ftruncate($this->filePointer, 8192); // this fills the file with the null byte
         $this->lastSector = 1;
-        for($i = 0; $i < 1024; ++$i){
-            $this->locationTable[$i] = [0, 0, 0];
-        }
+        $this->locationTable = array_fill(0, 1024, [0, 0, 0]);
     }
 
 	public function getX(){

--- a/src/pocketmine/level/format/mcregion/RegionLoader.php
+++ b/src/pocketmine/level/format/mcregion/RegionLoader.php
@@ -288,12 +288,12 @@ class RegionLoader{
 		fwrite($this->filePointer, Binary::writeInt($this->locationTable[$index][2]), 4);
 	}
 
-    protected function createBlank(){
-        fseek($this->filePointer, 0);
-        ftruncate($this->filePointer, 8192); // this fills the file with the null byte
-        $this->lastSector = 1;
-        $this->locationTable = array_fill(0, 1024, [0, 0, 0]);
-    }
+	protected function createBlank(){
+		fseek($this->filePointer, 0);
+ 		ftruncate($this->filePointer, 8192); // this fills the file with the null byte
+		$this->lastSector = 1;
+		$this->locationTable = array_fill(0, 1024, [0, 0, 0]);
+	}
 
 	public function getX(){
 		return $this->x;


### PR DESCRIPTION
This is intended to boost world generation speed slightly.

The old method was extremely slow (~200ms to create a single region file under very roughly simulated conditions), but the new one is much faster (in the order of ~15ms).

For reference, I used a Linode 2048 to get these numbers.