### PR TITLE
Fix ServerKiller and make it less useless

### DIFF
--- a/src/pocketmine/PocketMine.php
+++ b/src/pocketmine/PocketMine.php
@@ -484,13 +484,13 @@ namespace pocketmine {
 
 	$logger->info("Stopping other threads");
 
+	$killer = new ServerKiller(8);
+	$killer->start();
+
 	foreach(ThreadManager::getInstance()->getAll() as $id => $thread){
 		$logger->debug("Stopping " . $thread->getThreadName() . " thread");
 		$thread->quit();
 	}
-
-	$killer = new ServerKiller(8);
-	$killer->start();
 
 	$logger->shutdown();
 	$logger->join();

--- a/src/pocketmine/utils/ServerKiller.php
+++ b/src/pocketmine/utils/ServerKiller.php
@@ -32,7 +32,7 @@ class ServerKiller extends Thread{
 	}
 
 	public function run(){
-		$start = time() + 1;
+		$start = time();
 		$this->synchronized(function(){
 			$this->wait($this->time * 1000000);
 		});


### PR DESCRIPTION
Currently the ServerKiller is totally useless due to a logical fail which ensures that the condition for killing the server is never met. It is _also_ only started AFTER everything _except_ the logger thread is closed, which is totally useless since it's almost always one of the other threads that hangs, for example Console thread on Windows.

This pull request starts the ServerKiller thread _before_ other thread shutdown is requested, so that if any of those threads fail to stop the server will commit suicide as expected. This also fixes an issue with the server taking an eternity to stop even after all other threads have exited, because the process will not exit until the timer on the ServerKiller runs out.