### PR TITLE
Improved varint write performance

### DIFF
--- a/src/pocketmine/utils/Binary.php
+++ b/src/pocketmine/utils/Binary.php
@@ -468,23 +468,19 @@ class Binary{
 		return self::writeUnsignedVarInt(($v << 1) ^ ($v >> (PHP_INT_SIZE === 8 ? 63 : 31)));
 	}
 
-	public static function writeUnsignedVarInt($v){
+	public static function writeUnsignedVarInt($value){
 		$buf = "";
-		$loops = 0;
-		do{
-			if($loops > 9){
-				throw new \InvalidArgumentException("Varint cannot be longer than 10 bytes!"); //for safety reasons
+		for($i = 0; $i < 10; ++$i){
+			if(($value >> 7) !== 0){
+				$buf .= chr($value | 0x80); //Let chr() take the last byte of this, it's faster than adding another & 0x7f.
+			}else{
+				$buf .= chr($value & 0x7f);
+				return $buf;
 			}
-			$w = $v & 0x7f;
-			if(($v >> 7) !== 0){
-				$w = $v | 0x80;
-			}
-			$buf .= self::writeByte($w);
-			$v = (($v >> 7) & (PHP_INT_MAX >> 6)); //PHP really needs a logical right-shift operator
-			++$loops;
-		}while($v);
 
-		return $buf;
+			$value = (($value >> 7) & (PHP_INT_MAX >> 6)); //PHP really needs a logical right-shift operator
+		}
+
+		throw new \InvalidArgumentException("Value too large to be encoded as a varint");
 	}
-
 }


### PR DESCRIPTION
Significantly faster especially for single values.

This has only been tested internally with 0.17 and has not been tested with 0.16 due to my current lack of a 0.16 test device. This can be merged as soon as it has been tested.