### PR TITLE
Fixed clicking on fire to extinguish it

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2107,6 +2107,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 						$block = $target->getSide($packet->face);
 						if($block->getId() === Block::FIRE){
 							$this->level->setBlock($block, new Air());
+							break;
 						}
 						$this->lastBreak = microtime(true);
 						break;


### PR DESCRIPTION
Currently clicking on fire to put it out makes the fire _seem_ to disappear, but will still set fire to any players that walk through the place where the fire used to be. This is because the client sends what is currently known as ACTION_START_BREAK when clicking on fire, but does not send ACTION_ABORT_BREAK when letting off the click. This means that the lastBreak timer does not get reset and subsequent attempts to put fire out will fail until the player does some other action which causes lastBreak to be reset.

This pull request fixes the bug by breaking from the case statement before the timer is set if the player clicks on a block with fire attached.

This has been tested and confirmed to work with fire in creative and survival.