### PR TITLE
Fix #133

### DIFF
--- a/src/pocketmine/block/StillLava.php
+++ b/src/pocketmine/block/StillLava.php
@@ -21,9 +21,18 @@
 
 namespace pocketmine\block;
 
+use pocketmine\level\Level;
+
 class StillLava extends Lava{
 
 	protected $id = self::STILL_LAVA;
+
+	public function onUpdate($type){
+		if($type !== Level::BLOCK_UPDATE_SCHEDULED){
+			return parent::onUpdate($type);
+		}
+		return false;
+	}
 
 	public function getName(){
 		return "Still Lava";

--- a/src/pocketmine/block/StillWater.php
+++ b/src/pocketmine/block/StillWater.php
@@ -21,9 +21,18 @@
 
 namespace pocketmine\block;
 
+use pocketmine\level\Level;
+
 class StillWater extends Water{
 
 	protected $id = self::STILL_WATER;
+
+	public function onUpdate($type){
+		if($type !== Level::BLOCK_UPDATE_SCHEDULED){
+			return parent::onUpdate($type);
+		}
+		return false;
+	}
 
 	public function getName(){
 		return "Still Water";


### PR DESCRIPTION
Do not perform scheduled updates on still lava/water. This is in line with vanilla behaviour, where still water only starts to spread out when a neighbouring block is updated.

This has been tested and confirmed to fix the CPU leak described in #133 , however I am not sure this is the best way to fix the issue. Please review.

(Flow calculations really need a total rewrite, but that's a job for another time.)