### PR TITLE
Entity Effect Events

### DIFF
--- a/src/pocketmine/event/entity/EntityEffectAddEvent.php
+++ b/src/pocketmine/event/entity/EntityEffectAddEvent.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+namespace pocketmine\event\entity;
+
+use pocketmine\entity\Effect;
+use pocketmine\entity\Entity;
+
+class EntityEffectAddEvent extends EntityEffectEvent{
+	public static $handlerList = null;
+
+	/** @var bool */
+	private $modify;
+	/** @var Effect */
+	private $oldEffect;
+
+	public function __construct(Entity $entity, Effect $effect, $modify, $oldEffect){
+		parent::__construct($entity, $effect);
+		$this->modify = $modify;
+		$this->oldEffect = $oldEffect;
+	}
+
+	public function willModify() : bool{
+		return $this->modify;
+	}
+
+	public function setWillModify(bool $modify){
+		$this->modify = $modify;
+	}
+
+	public function hasOldEffect() : bool{
+		return $this->oldEffect instanceof Effect;
+	}
+
+	/**
+	 * @return Effect|null
+	 */
+	public function getOldEffect(){
+		return $this->oldEffect;
+	}
+
+
+}

--- a/src/pocketmine/event/entity/EntityEffectEvent.php
+++ b/src/pocketmine/event/entity/EntityEffectEvent.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+namespace pocketmine\event\entity;
+
+use pocketmine\entity\Effect;
+use pocketmine\entity\Entity;
+use pocketmine\event\Cancellable;
+
+class EntityEffectEvent extends EntityEvent implements Cancellable{
+
+	/** @var Effect */
+	private $effect;
+
+	public function __construct(Entity $entity, Effect $effect){
+		$this->entity = $entity;
+		$this->effect = $effect;
+	}
+
+	public function getEffect() : Effect{
+		return $this->effect;
+	}
+}

--- a/src/pocketmine/event/entity/EntityEffectRemoveEvent.php
+++ b/src/pocketmine/event/entity/EntityEffectRemoveEvent.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+namespace pocketmine\event\entity;
+
+class EntityEffectRemoveEvent extends EntityEffectEvent{
+	public static $handlerList = null;
+
+}


### PR DESCRIPTION
Add EntityEffectEvent class that the EntityEffectAddEvent and
EntityEffectRemoveEvent classes extend. Add event calls to Effect class.

This is purely an API addition that allows developers to modify the effect behaviour through the use of plugins.

I have tested this and it works as expected. Some more testing may need to be done to make sure the event's work as expect in all cases.