### PR TITLE
Deprecated and renamed Level::getName() to Level::getSavedName()

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1642,7 +1642,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
 		if(($level = $this->server->getLevelByName($nbt["Level"])) === null){
 			$this->setLevel($this->server->getDefaultLevel());
-			$nbt["Level"] = $this->level->getName();
+			$nbt["Level"] = $this->level->getSavedName();
 			$nbt["Pos"][0] = $this->level->getSpawnLocation()->x;
 			$nbt["Pos"][1] = $this->level->getSpawnLocation()->y;
 			$nbt["Pos"][2] = $this->level->getSpawnLocation()->z;
@@ -1730,7 +1730,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			$this->ip,
 			$this->port,
 			$this->id,
-			$this->level->getName(),
+			$this->level->getSavedName(),
 			round($this->x, 4),
 			round($this->y, 4),
 			round($this->z, 4)
@@ -3118,9 +3118,9 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
 		parent::saveNBT();
 		if($this->level instanceof Level){
-			$this->namedtag->Level = new StringTag("Level", $this->level->getName());
+			$this->namedtag->Level = new StringTag("Level", $this->level->getSavedName());
 			if($this->hasValidSpawnPosition()){
-				$this->namedtag["SpawnLevel"] = $this->spawnPosition->getLevel()->getName();
+				$this->namedtag["SpawnLevel"] = $this->spawnPosition->getLevel()->getSavedName();
 				$this->namedtag["SpawnX"] = (int) $this->spawnPosition->x;
 				$this->namedtag["SpawnY"] = (int) $this->spawnPosition->y;
 				$this->namedtag["SpawnZ"] = (int) $this->spawnPosition->z;

--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -720,7 +720,7 @@ class Server{
 				new DoubleTag(1, $spawn->y),
 				new DoubleTag(2, $spawn->z)
 			]),
-			new StringTag("Level", $this->getDefaultLevel()->getName()),
+			new StringTag("Level", $this->getDefaultLevel()->getSavedName()),
 			//new StringTag("SpawnLevel", $this->getDefaultLevel()->getName()),
 			//new IntTag("SpawnX", (int) $spawn->x),
 			//new IntTag("SpawnY", (int) $spawn->y),
@@ -2211,20 +2211,20 @@ class Server{
 						if($r > $this->baseTickRate){
 							$level->tickRateCounter = $level->getTickRate();
 						}
-						$this->getLogger()->debug("Raising level \"{$level->getName()}\" tick rate to {$level->getTickRate()} ticks");
+						$this->getLogger()->debug("Raising level \"{$level->getSavedName()}\" tick rate to {$level->getTickRate()} ticks");
 					}elseif($tickMs >= 50){
 						if($level->getTickRate() === $this->baseTickRate){
 							$level->setTickRate(max($this->baseTickRate + 1, min($this->autoTickRateLimit, floor($tickMs / 50))));
-							$this->getLogger()->debug(sprintf("Level \"%s\" took %gms, setting tick rate to %d ticks", $level->getName(), round($tickMs, 2), $level->getTickRate()));
+							$this->getLogger()->debug(sprintf("Level \"%s\" took %gms, setting tick rate to %d ticks", $level->getSavedName(), round($tickMs, 2), $level->getTickRate()));
 						}elseif(($tickMs / $level->getTickRate()) >= 50 and $level->getTickRate() < $this->autoTickRateLimit){
 							$level->setTickRate($level->getTickRate() + 1);
-							$this->getLogger()->debug(sprintf("Level \"%s\" took %gms, setting tick rate to %d ticks", $level->getName(), round($tickMs, 2), $level->getTickRate()));
+							$this->getLogger()->debug(sprintf("Level \"%s\" took %gms, setting tick rate to %d ticks", $level->getSavedName(), round($tickMs, 2), $level->getTickRate()));
 						}
 						$level->tickRateCounter = $level->getTickRate();
 					}
 				}
 			}catch(\Throwable $e){
-				$this->logger->critical($this->getLanguage()->translateString("pocketmine.level.tickError", [$level->getName(), $e->getMessage()]));
+				$this->logger->critical($this->getLanguage()->translateString("pocketmine.level.tickError", [$level->getSavedName(), $e->getMessage()]));
 				$this->logger->logException($e);
 			}
 		}

--- a/src/pocketmine/command/defaults/StatusCommand.php
+++ b/src/pocketmine/command/defaults/StatusCommand.php
@@ -99,7 +99,7 @@ class StatusCommand extends VanillaCommand{
 		}
 
 		foreach($server->getLevels() as $level){
-			$levelName = $level->getFolderName() !== $level->getName() ? " (" . $level->getName() . ")" : "";
+			$levelName = $level->getFolderName() !== $level->getSavedName() ? " (" . $level->getSavedName() . ")" : "";
 			$timeColor = ($level->getTickRate() > 1 or $level->getTickRateTime() > 40) ? TextFormat::RED : TextFormat::YELLOW;
 			$tickRate = $level->getTickRate() > 1 ? " (tick rate " . $level->getTickRate() . ")" : "";
 			$sender->sendMessage(TextFormat::GOLD . "World \"{$level->getFolderName()}\"$levelName: " .

--- a/src/pocketmine/event/server/QueryRegenerateEvent.php
+++ b/src/pocketmine/event/server/QueryRegenerateEvent.php
@@ -66,7 +66,7 @@ class QueryRegenerateEvent extends ServerEvent{
 		$this->gametype = ($server->getGamemode() & 0x01) === 0 ? "SMP" : "CMP";
 		$this->version = $server->getVersion();
 		$this->server_engine = $server->getName() . " " . $server->getPocketMineVersion();
-		$this->map = $server->getDefaultLevel() === null ? "unknown" : $server->getDefaultLevel()->getName();
+		$this->map = $server->getDefaultLevel() === null ? "unknown" : $server->getDefaultLevel()->getSavedName();
 		$this->numPlayers = count($this->players);
 		$this->maxPlayers = $server->getMaxPlayers();
 		$this->whitelist = $server->hasWhitelist() ? "on" : "off";

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -86,7 +86,6 @@ use pocketmine\math\Vector3;
 use pocketmine\metadata\BlockMetadataStore;
 use pocketmine\metadata\Metadatable;
 use pocketmine\metadata\MetadataValue;
-use pocketmine\nbt\NBT;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\DoubleTag;
 use pocketmine\nbt\tag\FloatTag;
@@ -504,7 +503,7 @@ class Level implements ChunkManager, Metadatable{
 			return false;
 		}
 
-		$this->server->getLogger()->info($this->server->getLanguage()->translateString("pocketmine.level.unloading", [$this->getName()]));
+		$this->server->getLogger()->info($this->server->getLanguage()->translateString("pocketmine.level.unloading", [$this->getSavedName()]));
 		$defaultLevel = $this->server->getDefaultLevel();
 		foreach($this->getPlayers() as $player){
 			if($this === $defaultLevel or $defaultLevel === null){
@@ -2652,11 +2651,24 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * Returns the Level name
+	 * Returns the level name saved in the world, such as level.dat (may duplicate with other loaded worlds)
+	 *
+	 * @deprecated As this method is often misunderstood as the getter for the unique name of the level,
+	 *             it has been renamed to {@link Level#getSavedName()}. If a more reliable level identifier is desired,
+	 *             consider using {@link Level#getId()} or {@link Level#getFolderName()} instead.
 	 *
 	 * @return string
 	 */
 	public function getName() : string{
+		return $this->provider->getName();
+	}
+
+	/**
+	 * Returns the level name saved in the world, such as level.dat (may duplicate with other loaded worlds)
+	 *
+	 * @return string
+	 */
+	public function getSavedName() : string{
 		return $this->provider->getName();
 	}
 

--- a/src/pocketmine/level/Location.php
+++ b/src/pocketmine/level/Location.php
@@ -64,6 +64,6 @@ class Location extends Position{
 	}
 
 	public function __toString(){
-		return "Location (level=" . ($this->isValid() ? $this->getLevel()->getName() : "null") . ", x=$this->x, y=$this->y, z=$this->z, yaw=$this->yaw, pitch=$this->pitch)";
+		return "Location (level=" . ($this->isValid() ? $this->getLevel()->getSavedName() : "null") . ", x=$this->x, y=$this->y, z=$this->z, yaw=$this->yaw, pitch=$this->pitch)";
 	}
 }

--- a/src/pocketmine/level/Position.php
+++ b/src/pocketmine/level/Position.php
@@ -84,7 +84,7 @@ class Position extends Vector3{
 	}
 
 	public function __toString(){
-		return "Position(level=" . ($this->isValid() ? $this->getLevel()->getName() : "null") . ",x=" . $this->x . ",y=" . $this->y . ",z=" . $this->z . ")";
+		return "Position(level=" . ($this->isValid() ? $this->getLevel()->getSavedName() : "null") . ",x=" . $this->x . ",y=" . $this->y . ",z=" . $this->z . ")";
 	}
 
 	/**

--- a/src/pocketmine/metadata/BlockMetadataStore.php
+++ b/src/pocketmine/metadata/BlockMetadataStore.php
@@ -48,7 +48,7 @@ class BlockMetadataStore extends MetadataStore{
 		if($block->getLevel() === $this->owningLevel){
 			return parent::getMetadata($block, $metadataKey);
 		}else{
-			throw new \InvalidStateException("Block does not belong to world " . $this->owningLevel->getName());
+			throw new \InvalidStateException("Block does not belong to world " . $this->owningLevel->getSavedName());
 		}
 	}
 
@@ -59,7 +59,7 @@ class BlockMetadataStore extends MetadataStore{
 		if($block->getLevel() === $this->owningLevel){
 			return parent::hasMetadata($block, $metadataKey);
 		}else{
-			throw new \InvalidStateException("Block does not belong to world " . $this->owningLevel->getName());
+			throw new \InvalidStateException("Block does not belong to world " . $this->owningLevel->getSavedName());
 		}
 	}
 
@@ -70,7 +70,7 @@ class BlockMetadataStore extends MetadataStore{
 		if($block->getLevel() === $this->owningLevel){
 			parent::hasMetadata($block, $metadataKey, $owningPlugin);
 		}else{
-			throw new \InvalidStateException("Block does not belong to world " . $this->owningLevel->getName());
+			throw new \InvalidStateException("Block does not belong to world " . $this->owningLevel->getSavedName());
 		}
 	}
 
@@ -81,7 +81,7 @@ class BlockMetadataStore extends MetadataStore{
 		if($block->getLevel() === $this->owningLevel){
 			parent::setMetadata($block, $metadataKey, $newMetadatavalue);
 		}else{
-			throw new \InvalidStateException("Block does not belong to world " . $this->owningLevel->getName());
+			throw new \InvalidStateException("Block does not belong to world " . $this->owningLevel->getSavedName());
 		}
 	}
 }

--- a/src/pocketmine/metadata/LevelMetadataStore.php
+++ b/src/pocketmine/metadata/LevelMetadataStore.php
@@ -30,6 +30,6 @@ class LevelMetadataStore extends MetadataStore{
 			throw new \InvalidArgumentException("Argument must be a Level instance");
 		}
 
-		return strtolower($level->getName()) . ":" . $metadataKey;
+		return strtolower($level->getSavedName()) . ":" . $metadataKey;
 	}
 }


### PR DESCRIPTION
As this method is often misunderstood as the getter for the unique name of the level, it has been renamed to `Level::getSavedName()`. If a more reliable level identifier is desired, consider using `Level::getId()` or `Level::getFolderName()` instead.