### PR TITLE
Added BatchBlockUpdateEvent and made updateAround() use it

### DIFF
--- a/src/pocketmine/event/block/BatchBlockEvent.php
+++ b/src/pocketmine/event/block/BatchBlockEvent.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link   http://www.pocketmine.net/
+ *
+ *
+ */
+
+/**
+ * Block events applying to more than one block at a time.
+ */
+namespace pocketmine\event\block;
+
+use pocketmine\block\Block;
+use pocketmine\event\Event;
+
+abstract class BatchBlockEvent extends BlockEvent{
+
+	/** @var \pocketmine\block\Block */
+	protected $blocks = [];
+
+	/**
+	 * @param Block[] $block
+	 */
+	public function __construct(array $blocks){
+		$this->blocks = $blocks;
+	}
+
+	/**
+	 * @return Block[]
+	 */
+	public function getBlockList(){
+		return $this->blocks;
+	}
+
+	/**
+	 * @param Block[]
+	 */
+	public function setBlockList(array $blocks){
+		$this->blocks = $blocks;
+	}
+
+	/**
+	 * @return null
+	 */
+	public function getBlock(){
+		return null;
+	}
+
+}

--- a/src/pocketmine/event/block/BatchBlockUpdateEvent.php
+++ b/src/pocketmine/event/block/BatchBlockUpdateEvent.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link   http://www.pocketmine.net/
+ *
+ *
+ */
+
+namespace pocketmine\event\block;
+
+use pocketmine\event\Cancellable;
+
+/**
+ * Called when a set of blocks try to be updated due to a neighbor change
+ */
+class BatchBlockUpdateEvent extends BatchBlockEvent implements Cancellable{
+	public static $handlerList = null;
+
+}

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -51,6 +51,7 @@ use pocketmine\entity\Arrow;
 use pocketmine\entity\Effect;
 use pocketmine\entity\Entity;
 use pocketmine\entity\Item as DroppedItem;
+use pocketmine\event\block\BatchBlockUpdateEvent;
 use pocketmine\event\block\BlockBreakEvent;
 use pocketmine\event\block\BlockPlaceEvent;
 use pocketmine\event\block\BlockUpdateEvent;
@@ -1013,34 +1014,19 @@ class Level implements ChunkManager, Metadatable{
 	 */
 	public function updateAround(Vector3 $pos){
 		$pos = $pos->floor();
-		$this->server->getPluginManager()->callEvent($ev = new BlockUpdateEvent($this->getBlock($this->temporalVector->setComponents($pos->x, $pos->y - 1, $pos->z))));
-		if(!$ev->isCancelled()){
-			$ev->getBlock()->onUpdate(self::BLOCK_UPDATE_NORMAL);
-		}
+		$this->server->getPluginManager()->callEvent($ev = new BatchBlockUpdateEvent([
+			$this->getBlock($this->temporalVector->setComponents($pos->x - 1, $pos->y,     $pos->z)),
+			$this->getBlock($this->temporalVector->setComponents($pos->x + 1, $pos->y,     $pos->z)),
+			$this->getBlock($this->temporalVector->setComponents($pos->x,     $pos->y - 1, $pos->z)),
+			$this->getBlock($this->temporalVector->setComponents($pos->x,     $pos->y + 1, $pos->z)),
+			$this->getBlock($this->temporalVector->setComponents($pos->x,     $pos->y,     $pos->z - 1)),
+			$this->getBlock($this->temporalVector->setComponents($pos->x,     $pos->y,     $pos->z + 1))
+		]));
 
-		$this->server->getPluginManager()->callEvent($ev = new BlockUpdateEvent($this->getBlock($this->temporalVector->setComponents($pos->x, $pos->y + 1, $pos->z))));
 		if(!$ev->isCancelled()){
-			$ev->getBlock()->onUpdate(self::BLOCK_UPDATE_NORMAL);
-		}
-
-		$this->server->getPluginManager()->callEvent($ev = new BlockUpdateEvent($this->getBlock($this->temporalVector->setComponents($pos->x - 1, $pos->y, $pos->z))));
-		if(!$ev->isCancelled()){
-			$ev->getBlock()->onUpdate(self::BLOCK_UPDATE_NORMAL);
-		}
-
-		$this->server->getPluginManager()->callEvent($ev = new BlockUpdateEvent($this->getBlock($this->temporalVector->setComponents($pos->x + 1, $pos->y, $pos->z))));
-		if(!$ev->isCancelled()){
-			$ev->getBlock()->onUpdate(self::BLOCK_UPDATE_NORMAL);
-		}
-
-		$this->server->getPluginManager()->callEvent($ev = new BlockUpdateEvent($this->getBlock($this->temporalVector->setComponents($pos->x, $pos->y, $pos->z - 1))));
-		if(!$ev->isCancelled()){
-			$ev->getBlock()->onUpdate(self::BLOCK_UPDATE_NORMAL);
-		}
-
-		$this->server->getPluginManager()->callEvent($ev = new BlockUpdateEvent($this->getBlock($this->temporalVector->setComponents($pos->x, $pos->y, $pos->z + 1))));
-		if(!$ev->isCancelled()){
-			$ev->getBlock()->onUpdate(self::BLOCK_UPDATE_NORMAL);
+			foreach($ev->getBlockList() as $block){
+				$block->onUpdate(self::BLOCK_UPDATE_NORMAL);
+			}
 		}
 	}
 


### PR DESCRIPTION
This pull request adds batch block update events.

### Why?
This is cleaner than the original method, and also better for performance since only one event is fired instead of six. The performance is the main reason to do this.

### Backwards incompatible changes
Plugins which use BlockUpdateEvent fired from updateAround() will no longer detect the event since a new one is used.

### Possible improvements
Adapt BlockEvent to allow it to handle block lists, instead of a separate event tree.