### PR TITLE
Fix trailing slashes in MOTD breaks server list, close #153

### DIFF
--- a/src/pocketmine/network/RakLibInterface.php
+++ b/src/pocketmine/network/RakLibInterface.php
@@ -170,7 +170,7 @@ class RakLibInterface implements ServerInstance, AdvancedSourceInterface{
 		$info = $this->server->getQueryInformation();
 
 		$this->interface->sendOption("name",
-			"MCPE;" . addcslashes($name, ";") . ";" .
+			"MCPE;" . rtrim(addcslashes($name, ";"), '\\') . ";" .
 			Info::CURRENT_PROTOCOL . ";" .
 			\pocketmine\MINECRAFT_VERSION_NETWORK . ";" .
 			$info->getPlayerCount() . ";" .


### PR DESCRIPTION
Cherry-picked from @PrimusLV 's PR to the old repository (PocketMine/PocketMine-MP#4131)

I have tested this and confirmed it works.

### Limitations and possible alternative solution
This removes all trailing slashes from the end of the server name, which might break some formatting. An alternative, slightly hackier way to do this was proposed [here](https://github.com/PocketMine/PocketMine-MP/issues/4083#issuecomment-200920496). This does in fact work well.