### PR TITLE
Added ability to force literal gamemode checks for Player->isSurvival(), Player->isCreative() and Player->isAdventure()

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1186,28 +1186,58 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	}
 
 	/**
-	 * WARNING: This method does NOT return literal gamemode is survival, it will also return true for adventure mode players.
+	 * NOTE: Because Survival and Adventure Mode share some similar behaviour, this method will also return true if the player is
+	 * in Adventure Mode. Supply the $literal parameter as true to force a literal Survival Mode check.
+	 *
+	 * @param bool $literal whether a literal check should be performed
+	 *
+	 * @return bool
 	 */
-	public function isSurvival() : bool{
-		return ($this->gamemode & 0x01) === 0;
+	public function isSurvival(bool $literal = false) : bool{
+		if($literal){
+			return $this->gamemode === Player::SURVIVAL;
+		}else{
+			return ($this->gamemode & 0x01) === 0;
+		}
 	}
 
 	/**
-	 * WARNING: This method does NOT return literal gamemode is creative, it will also return true for spectator mode players.
+	 * NOTE: Because Creative and Spectator Mode share some similar behaviour, this method will also return true if the player is
+	 * in Spectator Mode. Supply the $literal parameter as true to force a literal Creative Mode check.
+	 *
+	 * @param bool $literal whether a literal check should be performed
+	 *
+	 * @return bool
 	 */
-	public function isCreative() : bool{
-		return ($this->gamemode & 0x01) === 1;
+	public function isCreative(bool $literal = false) : bool{
+		if($literal){
+			return $this->gamemode === Player::CREATIVE;
+		}else{
+			return ($this->gamemode & 0x01) === 1;
+		}
 	}
 
 	/**
-	 * WARNING: This method does NOT return literal gamemode is adventure, it will also return true for spectator mode players.
+	 * NOTE: Because Adventure and Spectator Mode share some similar behaviour, this method will also return true if the player is
+	 * in Spectator Mode. Supply the $literal parameter as true to force a literal Adventure Mode check.
+	 *
+	 * @param bool $literal whether a literal check should be performed
+	 *
+	 * @return bool
 	 */
-	public function isAdventure() : bool{
-		return ($this->gamemode & 0x02) > 0;
+	public function isAdventure(bool $literal = false) : bool{
+		if($literal){
+			return $this->gamemode === Player::ADVENTURE;
+		}else{
+			return ($this->gamemode & 0x02) > 0;
+		}
 	}
 
+	/**
+	 * @return bool
+	 */
 	public function isSpectator() : bool{
-		return $this->gamemode === 3;
+		return $this->gamemode === Player::SPECTATOR;
 	}
 
 	public function getDrops(){


### PR DESCRIPTION
I don't know about anyone else, but not realizing that these methods don't return the literal fact of the gamemode of a player can be a giant pain in the butt for developers, who then end up having to implement their own methods to perform literal checks or perform manual `if($player->getGamemode() === blah)`.

This PR adds the ability to request a literal result from `Player->isSurvival()`, `Player->isCreative()` and `Player->isAdventure()`.