### PR TITLE
Sky light implementation

### DIFF
--- a/src/pocketmine/block/Block.php
+++ b/src/pocketmine/block/Block.php
@@ -282,6 +282,32 @@ class Block extends Position implements BlockIds, Metadatable{
 			}
 		}
 	}
+	
+	//SkyBlockLight SPECIAL blocks:
+	//WATER,ICE => -3
+	//solid => -INF
+	//transparent => -0 (this includes Lava!) [WHY]
+	/**
+	 * @param int $blockID
+	 *
+	 * @return int
+	*/
+	public static function getSkyLightResistance($blockID){
+		$block = new self::$list[$blockID]();
+		if(self::$transparent[$blockID]){
+			if($blockID == self::WATER){
+				return 3;
+			}else{
+				return 0;
+			}
+		}elseif(self::$solid[$blockID] === false){
+			switch($blockID){
+				self::
+			}
+			return 0;
+		}
+		return -1;
+	}
 
 	/**
 	 * @param int      $id

--- a/src/pocketmine/block/Block.php
+++ b/src/pocketmine/block/Block.php
@@ -293,7 +293,7 @@ class Block extends Position implements BlockIds, Metadatable{
 	 * @return int
 	*/
 	public static function getSkyLightResistance($blockID){
-		$block = new self::$list[$blockID]();
+		#$block = new self::$list[$blockID]();
 		if(self::$transparent[$blockID]){
 			if($blockID == self::WATER){
 				return 3;
@@ -301,10 +301,12 @@ class Block extends Position implements BlockIds, Metadatable{
 				return 0;
 			}
 		}elseif(self::$solid[$blockID] === false){
-			switch($blockID){
-				self::
-			}
+			#switch($blockID){
+			#	self::
+			#}
 			return 0;
+		}else{
+			return 15;
 		}
 		return -1;
 	}

--- a/src/pocketmine/block/Block.php
+++ b/src/pocketmine/block/Block.php
@@ -268,16 +268,16 @@ class Block extends Position implements BlockIds, Metadatable{
 							if($block instanceof Liquid or $block instanceof Ice){
 								self::$lightFilter[$id] = 2;
 							}else{
-								self::$lightFilter[$id] = 1;
+								self::$lightFilter[$id] = 0;
 							}
 						}else{
 							self::$lightFilter[$id] = 15;
 						}
 					}else{
-						self::$lightFilter[$id] = 1;
+						self::$lightFilter[$id] = 0;
 					}
 				}else{
-					self::$lightFilter[$id] = 1;
+					self::$lightFilter[$id] = 15;
 					for($data = 0; $data < 16; ++$data){
 						self::$fullList[($id << 4) | $data] = new Block($id, $data);
 					}
@@ -291,7 +291,7 @@ class Block extends Position implements BlockIds, Metadatable{
 	 *
 	 * @return int 0-15
 	*/
-	public static function getSkyLightVerticalFilter($blockID): int{
+	public static function getVerticalSkyLightFilter($blockID): int{
 		if(!self::$diffusesSkyLight[$blockID]){
 			return self::$lightFilter[$blockID];
 		}else{ //Diffusion
@@ -307,7 +307,7 @@ class Block extends Position implements BlockIds, Metadatable{
 	 * @return int 1-15
 	*/
 	public static function getHorizontalLightFilter($blockID): int{
-		return max(self::$lightFilter($blockID), 1);
+		return max(self::$lightFilter[$blockID], 1);
 	}
 
 	/**

--- a/src/pocketmine/block/Block.php
+++ b/src/pocketmine/block/Block.php
@@ -293,19 +293,18 @@ class Block extends Position implements BlockIds, Metadatable{
 	 * @return int
 	*/
 	public static function getSkyLightResistance($blockID){
+		echo("CurrBlock:".$blockID);
 		#$block = new self::$list[$blockID]();
 		if(self::$transparent[$blockID]){
 			if($blockID == self::WATER){
 				return 3;
-			}else{
-				return 0;
 			}
-		}elseif(self::$solid[$blockID] === false){
+			return 0;
+		}
+		if(self::$solid[$blockID]){
 			#switch($blockID){
 			#	self::
 			#}
-			return 0;
-		}else{
 			return 15;
 		}
 		return -1;

--- a/src/pocketmine/block/Block.php
+++ b/src/pocketmine/block/Block.php
@@ -309,6 +309,18 @@ class Block extends Position implements BlockIds, Metadatable{
 		}
 		return -1;
 	}
+	
+	
+	/**
+	 * @param int $blockID
+	 *
+	 * This function does always need to return values in range of 1-15.
+	 *
+	 * @return int
+	*/
+	public static function getVerticalSkyLightResistance($blockID){
+		return max(self::getSkyLightResistance($blockID), 1);
+	}
 
 	/**
 	 * @param int      $id

--- a/src/pocketmine/block/Block.php
+++ b/src/pocketmine/block/Block.php
@@ -293,18 +293,15 @@ class Block extends Position implements BlockIds, Metadatable{
 	 * @return int
 	*/
 	public static function getSkyLightResistance($blockID){
-		echo("CurrBlock:".$blockID);
+		#echo("CurrBlock:".$blockID); #DBG
 		#$block = new self::$list[$blockID]();
 		if(self::$transparent[$blockID]){
-			if($blockID == self::WATER){
+			if($blockID == self::WATER || $blockID == self::ICE){
 				return 3;
 			}
 			return 0;
 		}
 		if(self::$solid[$blockID]){
-			#switch($blockID){
-			#	self::
-			#}
 			return 15;
 		}
 		return -1;

--- a/src/pocketmine/block/Block.php
+++ b/src/pocketmine/block/Block.php
@@ -296,7 +296,6 @@ class Block extends Position implements BlockIds, Metadatable{
 		}
 	}
 	
-	
 	/**
 	 * @param int $blockID
 	 *

--- a/src/pocketmine/block/Block.php
+++ b/src/pocketmine/block/Block.php
@@ -288,18 +288,12 @@ class Block extends Position implements BlockIds, Metadatable{
 	 *
 	 * @return int 0-15
 	*/
-	public static function getSkyLightResistance($blockID){
-		#$block = new self::$list[$blockID]();
-		if(self::$transparent[$blockID]){
-			if($blockID == self::WATER || $blockID == self::ICE){
-				return 3;
-			}
-			return 0;
+	public static function getSkyLightResistance($blockID): int{
+		if($blockID != self::COWEB || $blockID != self::LEAVES){
+			return self::$lightFilter[$blockID];
+		}else{ //Diffusion
+			return -1;
 		}
-		if(self::$solid[$blockID]){
-			return 15;
-		}
-		return -1;
 	}
 	
 	
@@ -310,8 +304,8 @@ class Block extends Position implements BlockIds, Metadatable{
 	 *
 	 * @return int 1-15
 	*/
-	public static function getHorizontalSkyLightResistance($blockID){
-		return max(self::getSkyLightResistance($blockID), 1);
+	public static function getHorizontalSkyLightResistance($blockID): int{
+		return max(self::$lightFilter($blockID), 1);
 	}
 
 	/**

--- a/src/pocketmine/block/Block.php
+++ b/src/pocketmine/block/Block.php
@@ -53,6 +53,8 @@ class Block extends Position implements BlockIds, Metadatable{
 	/** @var \SplFixedArray */
 	public static $hardness = null;
 	/** @var \SplFixedArray */
+	public static $diffusesSkyLight = null;
+	/** @var \SplFixedArray */
 	public static $transparent = null;
 
 	protected $id;
@@ -259,6 +261,7 @@ class Block extends Position implements BlockIds, Metadatable{
 					self::$transparent[$id] = $block->isTransparent();
 					self::$hardness[$id] = $block->getHardness();
 					self::$light[$id] = $block->getLightLevel();
+					self::$diffusesSkyLight[$id] = $block->isDiffusingSkyLight();
 
 					if($block->isSolid()){
 						if($block->isTransparent()){
@@ -288,8 +291,8 @@ class Block extends Position implements BlockIds, Metadatable{
 	 *
 	 * @return int 0-15
 	*/
-	public static function getSkyLightResistance($blockID): int{
-		if($blockID != self::COWEB || $blockID != self::LEAVES){
+	public static function getSkyLightVerticalFilter($blockID): int{
+		if(!self::$diffusesSkyLight[$blockID]){
 			return self::$lightFilter[$blockID];
 		}else{ //Diffusion
 			return -1;
@@ -303,7 +306,7 @@ class Block extends Position implements BlockIds, Metadatable{
 	 *
 	 * @return int 1-15
 	*/
-	public static function getHorizontalSkyLightResistance($blockID): int{
+	public static function getHorizontalLightFilter($blockID): int{
 		return max(self::$lightFilter($blockID), 1);
 	}
 
@@ -441,6 +444,13 @@ class Block extends Position implements BlockIds, Metadatable{
 	 */
 	public function getLightLevel(){
 		return 0;
+	}
+	
+	/**
+	 * @return bool
+	 */
+	public function isDiffusingSkyLight(): bool{
+		return false;
 	}
 
 	/**

--- a/src/pocketmine/block/Block.php
+++ b/src/pocketmine/block/Block.php
@@ -283,17 +283,12 @@ class Block extends Position implements BlockIds, Metadatable{
 		}
 	}
 	
-	//SkyBlockLight SPECIAL blocks:
-	//WATER,ICE => -3
-	//solid => -INF
-	//transparent => -0 (this includes Lava!) [WHY]
 	/**
 	 * @param int $blockID
 	 *
-	 * @return int
+	 * @return int 0-15
 	*/
 	public static function getSkyLightResistance($blockID){
-		#echo("CurrBlock:".$blockID); #DBG
 		#$block = new self::$list[$blockID]();
 		if(self::$transparent[$blockID]){
 			if($blockID == self::WATER || $blockID == self::ICE){
@@ -311,11 +306,11 @@ class Block extends Position implements BlockIds, Metadatable{
 	/**
 	 * @param int $blockID
 	 *
-	 * This function does always need to return values in range of 1-15.
+	 * This function must always return values in range of 1-15, otherwise it could lead to a freeze.
 	 *
-	 * @return int
+	 * @return int 1-15
 	*/
-	public static function getVerticalSkyLightResistance($blockID){
+	public static function getHorizontalSkyLightResistance($blockID){
 		return max(self::getSkyLightResistance($blockID), 1);
 	}
 

--- a/src/pocketmine/block/Cobweb.php
+++ b/src/pocketmine/block/Cobweb.php
@@ -44,6 +44,10 @@ class Cobweb extends Flowable{
 	public function getHardness(){
 		return 4;
 	}
+	
+	public function isDiffusingSkyLight(): bool{
+		return true;
+	}
 
 	public function getToolType(){
 		return Tool::TYPE_SWORD;

--- a/src/pocketmine/block/Leaves.php
+++ b/src/pocketmine/block/Leaves.php
@@ -46,6 +46,10 @@ class Leaves extends Transparent{
 		return 0.2;
 	}
 
+	public function isDiffusingSkyLight(): bool{
+		return true;
+	}
+
 	public function getToolType(){
 		return Tool::TYPE_SHEARS;
 	}

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1410,7 +1410,7 @@ class Level implements ChunkManager, Metadatable{
 	private function findLightWays(int $x, int $y, int $z){
 		$lightWays = [];
 		$vec3 = new Vector3($x, $y, $z);
-		for($i = Vector3::SIDE_NORTH; $i <= Vector3::SIDE_EAST; $i++){
+		for($i = Vector3::SIDE_UP; $i <= Vector3::SIDE_EAST; $i++){
 			$newVec3 = $vec3->getSide($i);
 			if(Block::getHorizontalLightFilter($this->getBlockIdAt($newVec3->x, $newVec3->y, $newVec3->z)) < 15){
 				$lightWays[$i] = [$newVec3->x, $newVec3->y, $newVec3->z];

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1312,10 +1312,19 @@ class Level implements ChunkManager, Metadatable{
 	*/
 	private function getDirectSkyLight($x, $y, $z){
 		$chunk = $this->getChunk($x >> 4, $z >> 4, true);
+		if($highestBlock = $chunk->getHighestBlockAt($x & 0xf, $z & 0xf) < $y){
+			return 15;
+		}
 		
+		$diffusionBlocks = 0;
 		$directSkyLight = 15;
-		for($i = $y; $i <= 127; $i++){ //TODO:0.17
+		for($i = $y; $i <= $highestBlock; $i++){
 			$lightResistance = Block::getSkyLightResistance($chunk->getBlockId($x & 0x0f, $i & 0x7f, $z & 0x0f));
+			if($lightResistance == -1){ //diffusion
+				$diffusionBlocks++;
+				$lightResistance = 0;
+			}
+			$lightResiatance += $diffusionBlocks;
 			$directSkyLight -= $lightResistance;
 			if($directSkyLight <= 0){ //Skylight is 0 from above (No need to continue calculating)
 				return 0;

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1316,15 +1316,17 @@ class Level implements ChunkManager, Metadatable{
 			return 15;
 		}
 		
-		$diffusionBlocks = 0;
+		$diffused = false;
 		$directSkyLight = 15;
 		for($i = $y; $i <= $highestBlock; $i++){
 			$lightResistance = Block::getSkyLightResistance($chunk->getBlockId($x & 0x0f, $i & 0x7f, $z & 0x0f));
 			if($lightResistance == -1){ //diffusion
-				$diffusionBlocks++;
+				$diffused = true;
 				$lightResistance = 0;
 			}
-			$lightResiatance += $diffusionBlocks;
+			if($diffused){
+				$lightResiatance++;
+			}
 			$directSkyLight -= $lightResistance;
 			if($directSkyLight <= 0){ //Skylight is 0 from above (No need to continue calculating)
 				return 0;

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1224,7 +1224,7 @@ class Level implements ChunkManager, Metadatable{
 		$level = 0;
 		if($chunk !== null){
 			$level = $chunk->getBlockSkyLight($pos->x & 0x0f, $pos->y & Level::Y_MASK, $pos->z & 0x0f);
-			//do not decrease skylightlvl over day. MCPC and MCPE don't do this either.
+			//Do not decrease skylightlvl over day. MCPC and MCPE don't do this either.
 			if($level < 15){
 				$level = max($chunk->getBlockLight($pos->x & 0x0f, $pos->y & Level::Y_MASK, $pos->z & 0x0f));
 			}
@@ -1279,31 +1279,31 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 
-	//NO CALCULATION FROM LIGHT COMING FROM DOWN
-	//SkyBlockLight SPECIAL blocks:
-	//WATER,ICE => -3
-	//solid => -INF
-	//transparent => -0 (this includes Lava!) [WHY]
 	/**
-	 * Calculates the sky light level for $x $y $z. (TODO::SURROUNDINGBLOCKS)
+	 * Calculates the sky light level for $x $y $z.
 	*/
 	public function updateBlockSkyLight($x, $y, $z){
 		$chunk = $this->getChunk($x >> 4, $z >> 4, true);
 		
-		for($i = $y; $i => MAX_WORLD_HEIGHT; $i++){
-			if(Level::lightResistance($chunk->getBlockId($x & 0x0f, ($y+$i) & 0x7f, $z & 0x0f)) == 0){
+		$directSkyLight = 15;
+		for($i = $y; $i => self::MAX_WORLD_HEIGHT; $i++){
+			$lightResistance = Block::getSkyLightResistance($chunk->getBlockId($x & 0x0f, ($y+$i) & 0x7f, $z & 0x0f));
+			$directSkyLight - $lighResistance;
+			if($directSkyLight <= 0){ //Skylight is 0 from above
 				$directSkyLight = false;
+				break;
 			}
 		}
-		if($directSkyLight && !$this->findLightWay($x, $y, $z)){
+		if($directSkyLight === 15){ //No need to continue calculation, we already have full skylight from above!
 			$this->setBlockSkyLightAt($x, $y, $z, 15);
-			return;
 		}
-		$this->findLightWay($x, $y, $z)
-	}
-	
-	public static function lightResistance($blockID){
-		
+		if($directSkyLight == false && $lightWays = $this->findLightWay($x, $y, $z) === false){ //No skylight at all (nothing from above && nothing from below)
+			$this->setBlockSkyLightAt($x, $y, $z, 0);
+		}else{
+			foreach($lightWays as $lightWay){
+				if(isDirectLight)
+			}
+		}
 	}
 	
 	private function findLightWay($x, $y, $z){
@@ -1311,8 +1311,8 @@ class Level implements ChunkManager, Metadatable{
 		$vec3 = new Vector3($x, $y, $z);
 		for($i = Vector3::SIDE_NORTH; $i <= Vector3::SIDE_EAST; $i++){
 			$newVec3 = $vec3->getSide($i);
-			if(self::lightResistance($this->getBlockIdAt($newVec3->x, $newVec3->y, $newVec3->z) > 0){
-				$lightWays[$i] =
+			if(Block::getSkyLightResistance($this->getBlockIdAt($newVec3->x, $newVec3->y, $newVec3->z) > 0){
+				$lightWays[$i] = [$newVec3->x, $newVec3->y, $newVec3->z];
 			}
 		}
 		return $lightWays === [] ? false : $lightWays;

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1283,16 +1283,17 @@ class Level implements ChunkManager, Metadatable{
 	 * Calculates the sky light level for $x $y $z.
 	*/
 	public function updateBlockSkyLight($x, $y, $z){
-		$directSkyLight = getDirectSkyLight($x, $y, $z);
-		
-		if($directSkyLight =< 14){ //No need to continue calculation, we can't get higher skylight!
+		$directSkyLight = $this->getDirectSkyLight($x, $y, $z);
+		echo($directSkyLight."\n");
+		if($directSkyLight >= 14){ //No need to continue calculation, we can't get higher skylight!
 			$this->setBlockSkyLightAt($x, $y, $z, $directSkyLight);
 		}
 		
-		if($directSkyLight == 0 && $lightWays = $this->findLightWays($x, $y, $z) === false){ //No skylight at all (nothing from above && nothing from the sides)
+		$lightWays = $this->findLightWays($x, $y, $z);
+		if($directSkyLight == 0 && $lightWays === false){ //No skylight at all (nothing from above && nothing from the sides)
 			$this->setBlockSkyLightAt($x, $y, $z, 0); //repl 0 with $directSkyLight?
 		}else{
-			$this->$this->getSkyLightViaWays($lightWays, [$x, $y, $z]);
+			$this->getSkyLightViaWays($lightWays, [$x, $y, $z]);
 		}
 	}
 	
@@ -1300,7 +1301,7 @@ class Level implements ChunkManager, Metadatable{
 		$chunk = $this->getChunk($x >> 4, $z >> 4, true);
 		
 		$directSkyLight = 15;
-		for($i = $y; $i => self::MAX_WORLD_HEIGHT; $i++){
+		for($i = $y; $i >= 128; $i++){
 			$lightResistance = Block::getSkyLightResistance($chunk->getBlockId($x & 0x0f, ($y+$i) & 0x7f, $z & 0x0f));
 			$directSkyLight -= $lightResistance;
 			if($directSkyLight <= 0){ //Skylight is 0 from above
@@ -1316,7 +1317,7 @@ class Level implements ChunkManager, Metadatable{
 		foreach($lightWays as $dir => $lightWay){ //max 4
 			$directSkyLight = $this->getDirectSkyLight($lightWay[0], $lightWay[1], $lightWay[2]);
 			if($directSkyLight > 0){ //Found an origin of light in our current lightWay! (not THE origin, there can be up to 15*M_PI origins for one block)
-				if($directSkyLight =< 14){
+				if($directSkyLight >= 14){
 					$lightLvlsFromDir[$dir] = $directSkyLight;
 					continue;
 				}
@@ -1337,7 +1338,7 @@ class Level implements ChunkManager, Metadatable{
 		$vec3 = new Vector3($x, $y, $z);
 		for($i = Vector3::SIDE_NORTH; $i <= Vector3::SIDE_EAST; $i++){
 			$newVec3 = $vec3->getSide($i);
-			if(Block::getSkyLightResistance($this->getBlockIdAt($newVec3->x, $newVec3->y, $newVec3->z) > 0){
+			if(Block::getSkyLightResistance($this->getBlockIdAt($newVec3->x, $newVec3->y, $newVec3->z)) > 0){
 				$lightWays[$i] = [$newVec3->x, $newVec3->y, $newVec3->z];
 			}
 		}

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1337,14 +1337,14 @@ class Level implements ChunkManager, Metadatable{
 		var_dump($lightWays); #DBG
 		
 		foreach($lightWays as $dir => $lightWay){ //max 4
-			if(isset($visitedBlocks[Level::blockHash($lightWay[0], $lightWay[1], $lightWay[2])])){
-				continue;
-			}
-			$visitedBlocks[Level::blockHash($lightWay[0], $lightWay[1], $lightWay[2])] = true;
 			if($currWayResistance === -1){ //base
 				$calcWayResistance = 0;
 				$visitedBlocks = [];
 			}
+			if(isset($visitedBlocks[Level::blockHash($lightWay[0], $lightWay[1], $lightWay[2])])){
+				continue;
+			}
+			$visitedBlocks[Level::blockHash($lightWay[0], $lightWay[1], $lightWay[2])] = true;
 			$directSkyLight = $this->getDirectSkyLight($lightWay[0], $lightWay[1], $lightWay[2]);
 			$this->server->broadcastMessage("LightWay '".$dir."' (recCallLvl:'".$fncId."') has ".$directSkyLight." directSkyLight"); #DBG
 			
@@ -1368,7 +1368,7 @@ class Level implements ChunkManager, Metadatable{
 			$newWayResistance = $calcWayResistance + $currResistance;
 			$lightLvlsFromDir[$dir] = $this->getSkyLightViaWays($lightWay, $newLightWays, $origin, $newWayResistance, $origins, $visitedBlocks, $fncId + 1); //$fncId : DEBUG ONLY
 		}
-		$this->server->broadcastMessage("lightLvlDir for (".implode($calcBase, "/").") is '".max($lightLvlsFromDir)."'"); #DBG
+		#$this->server->broadcastMessage("lightLvlDir for (".implode($calcBase, "/").") is '".max($lightLvlsFromDir)."'"); #DBG
 		return max($lightLvlsFromDir) - $currResistance;
 	}
 		

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1224,7 +1224,7 @@ class Level implements ChunkManager, Metadatable{
 		$level = 0;
 		if($chunk !== null){
 			$level = $chunk->getBlockSkyLight($pos->x & 0x0f, $pos->y & Level::Y_MASK, $pos->z & 0x0f);
-			//TODO: decrease light level by time of day
+			//do not decrease skylightlvl over day. MCPC and MCPE don't do this either.
 			if($level < 15){
 				$level = max($chunk->getBlockLight($pos->x & 0x0f, $pos->y & Level::Y_MASK, $pos->z & 0x0f));
 			}
@@ -1278,8 +1278,44 @@ class Level implements ChunkManager, Metadatable{
 		$this->updateBlockLight($pos->x, $pos->y, $pos->z);
 	}
 
-	public function updateBlockSkyLight(int $x, int $y, int $z){
-		//TODO
+
+	//NO CALCULATION FROM LIGHT COMING FROM DOWN
+	//SkyBlockLight SPECIAL blocks:
+	//WATER,ICE => -3
+	//solid => -INF
+	//transparent => -0 (this includes Lava!) [WHY]
+	/**
+	 * Calculates the sky light level for $x $y $z. (TODO::SURROUNDINGBLOCKS)
+	*/
+	public function updateBlockSkyLight($x, $y, $z){
+		$chunk = $this->getChunk($x >> 4, $z >> 4, true);
+		
+		for($i = $y; $i => MAX_WORLD_HEIGHT; $i++){
+			if(Level::lightResistance($chunk->getBlockId($x & 0x0f, ($y+$i) & 0x7f, $z & 0x0f)) == 0){
+				$directSkyLight = false;
+			}
+		}
+		if($directSkyLight && !$this->findLightWay($x, $y, $z)){
+			$this->setBlockSkyLightAt($x, $y, $z, 15);
+			return;
+		}
+		$this->findLightWay($x, $y, $z)
+	}
+	
+	public static function lightResistance($blockID){
+		
+	}
+	
+	private function findLightWay($x, $y, $z){
+		$lightWays = [];
+		$vec3 = new Vector3($x, $y, $z);
+		for($i = Vector3::SIDE_NORTH; $i <= Vector3::SIDE_EAST; $i++){
+			$newVec3 = $vec3->getSide($i);
+			if(self::lightResistance($this->getBlockIdAt($newVec3->x, $newVec3->y, $newVec3->z) > 0){
+				$lightWays[$i] =
+			}
+		}
+		return $lightWays === [] ? false : $lightWays;
 	}
 
 	public function updateBlockLight(int $x, int $y, int $z){

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1311,18 +1311,23 @@ class Level implements ChunkManager, Metadatable{
 	}
 	
 	private function getSkyLightViaWays($lightWays, $origin){
-		$directSkyLightCache = [];
+		$origins = [];
 		$lightLvlsFromDir = [];
 		foreach($lightWays as $dir => $lightWay){ //max 4
-			$directSkyLightCache[Level::blockHash($lightWay[0], $lightWay[1], $lightWay[2])] = $directSkyLight = $this->getDirectSkyLight($lightWay[0], $lightWay[1], $lightWay[2]);
+			$directSkyLight = $this->getDirectSkyLight($lightWay[0], $lightWay[1], $lightWay[2]);
 			if($directSkyLight > 0){ //Found an origin of light in our current lightWay! (not THE origin, there can be up to 15*M_PI origins for one block)
-				if($directSkyLight => 14){
-					$newLightWays = $this->findLightWays($lightWay[0], $lightWay[1], $lightWay[2]);
-					$lightLvlsFromDir[$dir] = $this->getSkyLightViaWays($newLightWays, $lightWay); //lightWay contains originpos
-				}else{
-					$lightLvlsFromDir[$dir] = $directSkyLight; //repl 15 with $directSkyLight?
+				if($directSkyLight =< 14){
+					$lightLvlsFromDir[$dir] = $directSkyLight;
+					continue;
 				}
+				echo(" NOT YET CALCULATEABLE!!!! origin found, too low to assume only origin. "); 
+				return;
+				$origins[Level::blockHash($lightWay[0], $lightWay[1], $lightWay[2])] = $directSkyLight;
 			}
+			echo(" NOT YET CALCULATEABLE!!!! no origin found, must calculate further. ");
+			return;
+			$newLightWays = $this->findLightWays($lightWay[0], $lightWay[1], $lightWay[2]);
+			$lightLvlsFromDir[$dir] = $this->getSkyLightViaWays($newLightWays, $lightWay); //lightWay contains originpos
 		}
 		return max($lightLvlsFromDir) - 1;
 	}

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1223,8 +1223,8 @@ class Level implements ChunkManager, Metadatable{
 		$chunk = $this->getChunk($pos->x >> 4, $pos->z >> 4, false);
 		$level = 0;
 		if($chunk instanceof Chunk){
-			//Do not decrease skylightlvl over day. MCPC and MCPE don't do this either.
-			$level = max($chunk->getBlockLight($pos->x & 0x0f, $pos->y & Level::Y_MASK, $pos->z & 0x0f), $chunk->getBlockSkyLight($pos->x & 0x0f, $pos->y & Level::Y_MASK, $pos->z & 0x0f));
+			//Do not decrease skylightlvl over time. MCPC and MCPE don't do this either.
+			$level = max($chunk->getBlockLight($pos->x & 0x0f, $pos->y, $pos->z & 0x0f), $chunk->getBlockSkyLight($pos->x & 0x0f, $pos->y, $pos->z & 0x0f));
 		}
 
 		return $level;
@@ -1281,7 +1281,7 @@ class Level implements ChunkManager, Metadatable{
 	*/
 	public function updateBlockSkyLight(int $x, int $y, int $z){
 		$this->server->broadcastMessage("-------Calc::'".$x."/".$y."/".$z."/"."'-------"); #DBG
-		if(Block::getVerticalLightFilter($this->getBlockIdAt($x, $y, $z)) >= 14){
+		if(Block::getVerticalSkyLightFilter($this->getBlockIdAt($x, $y, $z)) >= 14){
 			$this->setBlockSkyLightAt($x, $y, $z, 0);
 			$this->server->broadcastMessage("-------EndCalc::'".$x."/".$y."/".$z."/"."'::TOOHIGHBASERES-------"); #DBG
 			return;
@@ -1313,13 +1313,13 @@ class Level implements ChunkManager, Metadatable{
 	private function getDirectSkyLight($x, $y, $z){
 		$chunk = $this->getChunk($x >> 4, $z >> 4, true);
 		if(($highestBlock = $chunk->getHighestBlockAt($x & 0xf, $z & 0xf)) < $y){
+			$this->server->getLogger()->debug("Assuming full light because of: y=$y highestBlock=$highestBlock"); #DBG
 			return 15;
 		}
 		
 		$directSkyLight = 15;
 		for($i = $y; $i <= $highestBlock; $i++){
-			$lightResistance = Block::getVerticalLightFilter($chunk->getBlockId($x & 0x0f, $i & 0x7f, $z & 0x0f));
-			echo("i=$i y=$y lR=$lightResistance highestBlock=$highestBlock \n");
+			$lightResistance = Block::getVerticalSkyLightFilter($chunk->getBlockId($x & 0x0f, $i & 0x7f, $z & 0x0f));
 			if($lightResistance == -1){ //diffusion
 				$lightResistance = $i - $y;
 				$y = $i; //If another diffusion occurs, it will not do double diffusion
@@ -1341,15 +1341,15 @@ class Level implements ChunkManager, Metadatable{
 	 * @param $currWayResistance   The horizontal resistance of the current root way
 	 * @param &$visitedBlocks      Blocks visited in the current base way
 	 *
-	 * Note: Origin is referred to as the real origin for which the updateBlockSkyLight call was made. Origins are all blocks that have directSkyLight.
+	 * Note: Origin is referred to as the real origin for which the updateBlockSkyLight call was made.
 	 *
 	 * @return int 0-15
 	*/
 	private function getSkyLightViaWays(array $calcBase, array $lightWays, int $currLightAtOrigin = 0, int $currWayResistance = -1, array &$visitedBlocks = [], $fncId = 0){
-		$this->server->broadcastMessage("CurrWayResistance (".implode($calcBase, "/").") is '".$currWayResistance."'"); #DBG
+		$this->server->getLogger()->debug("CurrWayResistance (".implode($calcBase, "/").") is '".$currWayResistance."'"); #DBG
 		if($currWayResistance !== -1){ //not base
 			if($currWayResistance >= 15 - $currLightAtOrigin){
-				$this->server->brodcastMessage("ARBORTING at $fncId");
+				$this->server->getLogger()->debug("ARBORTING at $fncId");
 				return 0; //No origins useful after this point (They can't make the origin brighter.)
 			}
 		}
@@ -1357,7 +1357,7 @@ class Level implements ChunkManager, Metadatable{
 		$lightLvlsFromDir = [];
 		$currResistance = Block::getHorizontalLightFilter($this->getBlockIdAt($calcBase[0], $calcBase[1], $calcBase[2]));
 		$calcWayResistance = $currWayResistance;
-		$this->server->broadcastMessage("LightResistance for ".implode($calcBase, "/")." is '".$currResistance."'"); #DBG
+		$this->server->getLogger()->debug("LightResistance for ".implode($calcBase, "/")." is '".$currResistance."'"); #DBG
 		var_dump($lightWays); #DBG
 		
 		foreach($lightWays as $dir => $lightWay){ //max 4
@@ -1372,12 +1372,12 @@ class Level implements ChunkManager, Metadatable{
 			$visitedBlocks[Level::blockHash($lightWay[0], $lightWay[1], $lightWay[2])] = true;
 			
 			$directSkyLight = $this->getDirectSkyLight($lightWay[0], $lightWay[1], $lightWay[2]);
-			$this->server->broadcastMessage("LightWay '".$dir."' (recCallLvl:'".$fncId."') has ".$directSkyLight." directSkyLight"); #DBG
+			$this->server->getLogger()->debug("LightWay '".$dir."' (recCallLvl:'".$fncId."') has ".$directSkyLight." directSkyLight"); #DBG
 			
 			if($directSkyLight > 0){ //Found an origin of light in our current lightWay!
 				if($directSkyLight >= 14){ //No need to continue calculation, we can't get higher skylight for $calcBase!
 					$lightLvlsFromDir[$dir] = $directSkyLight;
-					$this->server->broadcastMessage("End foreach at '".$dir."' because dirSkyLight ".$directSkyLight." >= 14. (".implode($calcBase, "/").")"); #DBG
+					$this->server->getLogger()->debug("End foreach at '".$dir."' because dirSkyLight ".$directSkyLight." >= 14. (".implode($calcBase, "/").")"); #DBG
 					break;
 				}
 			}
@@ -1385,20 +1385,20 @@ class Level implements ChunkManager, Metadatable{
 			$newLightWays = $this->findLightWays($lightWay[0], $lightWay[1], $lightWay[2]);
 			
 			if($newLightWays === false){ //No further ways found
-				$this->server->broadcastMessage("Dir '".$dir."' is ended!"); #DBG
+				$this->server->getLogger()->debug("Dir '".$dir."' has ended!"); #DBG
 				continue;
 			}
 			
-			$this->server->broadcastMessage("Dir '".$dir."' has to be explored further!"); #DBG
+			$this->server->getLogger()->debug("Dir '".$dir."' has to be explored further!"); #DBG
 			$lightLvlsFromDir[$dir] = $this->getSkyLightViaWays($lightWay, $newLightWays, $currLightAtOrigin, $calcWayResistance + $currResistance, $visitedBlocks, $fncId + 1); //$fncId : DEBUG ONLY
 			if($currWayResistance === -1){ //base
 				$currLightAtOrigin = max($lightLvlsFromDir);
 			}
 		}
-		$this->server->broadcastMessage("lightLvlDir for (".implode($calcBase, "/").") is '".max($lightLvlsFromDir)."'"); #DBG
 		if($lightLvlsFromDir === []){ //Revisited an already visited block -_-
 			return 0;
 		}
+		$this->server->getLogger()->debug("lightLvlDir for (".implode($calcBase, "/").") is '".max($lightLvlsFromDir)."'"); #DBG
 		return max($lightLvlsFromDir) - $currResistance;
 	}
 		

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1281,7 +1281,7 @@ class Level implements ChunkManager, Metadatable{
 	*/
 	public function updateBlockSkyLight(int $x, int $y, int $z){
 		$this->server->broadcastMessage("-------Calc::'".$x."/".$y."/".$z."/"."'-------"); #DBG
-		if(Block::getSkyLightResistance($this->getBlockIdAt($x, $y, $z)) >= 14){
+		if(Block::getSkyLightVerticalFilter($this->getBlockIdAt($x, $y, $z)) >= 14){
 			$this->setBlockSkyLightAt($x, $y, $z, 0);
 			$this->server->broadcastMessage("-------EndCalc::'".$x."/".$y."/".$z."/"."'::TOOHIGHBASERES-------"); #DBG
 			return;
@@ -1316,16 +1316,12 @@ class Level implements ChunkManager, Metadatable{
 			return 15;
 		}
 		
-		$diffused = false;
 		$directSkyLight = 15;
 		for($i = $y; $i <= $highestBlock; $i++){
-			$lightResistance = Block::getSkyLightResistance($chunk->getBlockId($x & 0x0f, $i & 0x7f, $z & 0x0f));
+			$lightResistance = Block::getSkyLightVerticalFilter($chunk->getBlockId($x & 0x0f, $i & 0x7f, $z & 0x0f));
 			if($lightResistance == -1){ //diffusion
-				$diffused = true;
-				$lightResistance = 0;
-			}
-			if($diffused){
-				$lightResiatance++;
+				$lightResistance = $i - $y;
+				$y = $i; //If another diffusion occurs, it will not do double diffusion
 			}
 			$directSkyLight -= $lightResistance;
 			if($directSkyLight <= 0){ //Skylight is 0 from above (No need to continue calculating)
@@ -1356,7 +1352,7 @@ class Level implements ChunkManager, Metadatable{
 		}
 		
 		$lightLvlsFromDir = [];
-		$currResistance = Block::getHorizontalSkyLightResistance($this->getBlockIdAt($calcBase[0], $calcBase[1], $calcBase[2]));
+		$currResistance = Block::getHorizontalLightFilter($this->getBlockIdAt($calcBase[0], $calcBase[1], $calcBase[2]));
 		$calcWayResistance = $currWayResistance;
 		$this->server->broadcastMessage("LightResistance for ".implode($calcBase, "/")." is '".$currResistance."'"); #DBG
 		var_dump($lightWays); #DBG
@@ -1409,7 +1405,7 @@ class Level implements ChunkManager, Metadatable{
 		$vec3 = new Vector3($x, $y, $z);
 		for($i = Vector3::SIDE_NORTH; $i <= Vector3::SIDE_EAST; $i++){
 			$newVec3 = $vec3->getSide($i);
-			if($blockResistance = Block::getSkyLightResistance($this->getBlockIdAt($newVec3->x, $newVec3->y, $newVec3->z)) < 15){
+			if($blockResistance = Block::getSkyLightVerticalFilter($this->getBlockIdAt($newVec3->x, $newVec3->y, $newVec3->z)) < 15){
 				$lightWays[$i] = [$newVec3->x, $newVec3->y, $newVec3->z, $blockResistance]; //TODO::Use or scrap blockResistance
 			}
 		}


### PR DESCRIPTION
#### If you want to discuss this on a bigger scale please refer to this [thread](https://forums.pmmp.io/threads/implementing-skylight-into-pmmp.19/).
Hello there! This is my first real contribution to pmmp.
# Unfinished?
This is currently awaiting reviews&testing. **If you want to help out** please **test this** using the instructions in this post, or do a **code review**.
Also chunk generation time population is still missing.

Currently this also has massive debug in it, that will be removed if this is ready to merge.

### Known bugs
- Currently all bugs 🐞 🐜  are fixed.

### Missing logic&features
- [x] ~directSkyLight is missing Light Diffusion support~ DONE in https://github.com/pmmp/PocketMine-MP/pull/160/commits/175a5462d1c49acb4bca67b1d7afe01cd90fd4af
- [x] ~skyLightResistance is probably wrong for some blocks [*HELP* would be appreciated here]~ DONE in https://github.com/pmmp/PocketMine-MP/pull/160/commits/175a5462d1c49acb4bca67b1d7afe01cd90fd4af
- [x] ~Support for light ways that have a step in them~ DONE in https://github.com/pmmp/PocketMine-MP/pull/160/commits/11568389135404d0d2aed2cacbd48d9d88a30158
```
      _______
_____|   ____
________|
```
- [x] ~General abort logic in getSkyLightViaWays (details in TODO list below)~

### Todo
- [ ] fix any bugs if found
- [ ] remove debug messages / ~change some to logger->debug~
- [ ] Make performance better
- [x] implement missing features
- [x] remove some unneded variables in getSkyLightViaWays
- [x] Better abort logic
- [x] direct: getHeightMap -> can help to determine if skylight can reach calcpos at all [Problem with half transparent blocks!] DONE in https://github.com/pmmp/PocketMine-MP/pull/160/commits/175a5462d1c49acb4bca67b1d7afe01cd90fd4af
- [x] clean up code
- ~ways: if cannot reach origin ->more research&thinking needed~

### Problems:
- Performance Currently takes 0.001 to 0.05s. Currently due to missing skylight info on chunk population and massive debug messages.
- ~Abort techniques: When will they decrease the performance too much, when will they increase performance~
- Needing to update a 15 block radius if 1 block changed?

# How can I test this?
You can test this using [this](https://github.com/pmmp/PocketMine-MP/files/858131/SkylightTester.php.zip) plugin. Install it, and run the server using https://github.com/robske110/pmmp-PocketMine-MP/tree/skylight_curr. Then just touch a block and you will get the skylight value of it.
If you found a bug, please enable debug and post the console output with a screenshot of the block you calculated for here.

# Wtf is skylight?
A form of light that comes from the sky and can travel horizontally on the ground. It is used for many gameplay mechanics like grass spreading,  spawning. It also affects the brightness of blocks in a certain way.
it is not useable for things like lightdetectors, skylight (at least in MCPC) does not decrease at night. This is done by the client through Brightness, pretty much at the Render level.

# Technical details
This code checks at first for the skylight from above. This is done by going from the origin block to the build limit/the highest block in the chunk and subtracting the resistance of each block in the air from 15. We immediately abort calculating if the block is above the highest block in the chunk. Air has no (vertical) resistance. If the direct skylight is 14 or 15, we save that value and are done here. (We can't get higher SkyLight horizontal) If it's below that we check if we have horizontal ways for the light to get in. We start into a big recursive function that basically looks at each side of the block, and from each of these blocks it checks if it receives direct-skylight, if it is too low/it doesn't recieve skylight it looks if it has ways on the 4 sides or above, and checks these blocks.  Waylight is the light which comes from the four sides for a block.
<!--- https://github.com/pmmp/PocketMine-MP/files/776963/SkylightTester.php.zip ---> 