### PR TITLE
Deprecate Minecraft game version constants in the `pocketmine` root namespace

### DIFF
--- a/src/pocketmine/PocketMine.php
+++ b/src/pocketmine/PocketMine.php
@@ -65,6 +65,7 @@ namespace {
 }
 
 namespace pocketmine {
+	use pocketmine\network\protocol\Info as ProtocolInfo;
 	use pocketmine\utils\Binary;
 	use pocketmine\utils\MainLogger;
 	use pocketmine\utils\ServerKiller;
@@ -76,8 +77,6 @@ namespace pocketmine {
 	const VERSION = "1.6.1dev";
 	const API_VERSION = "2.1.0";
 	const CODENAME = "Unleashed";
-	const MINECRAFT_VERSION = "v0.16.0.5 alpha";
-	const MINECRAFT_VERSION_NETWORK = "0.16.0.5";
 
 	/*
 	 * Startup code. Do not look at it, it may harm you.
@@ -145,6 +144,16 @@ namespace pocketmine {
 
 	define('pocketmine\DATA', isset($opts["data"]) ? $opts["data"] . DIRECTORY_SEPARATOR : \getcwd() . DIRECTORY_SEPARATOR);
 	define('pocketmine\PLUGIN_PATH', isset($opts["plugins"]) ? $opts["plugins"] . DIRECTORY_SEPARATOR : \getcwd() . DIRECTORY_SEPARATOR . "plugins" . DIRECTORY_SEPARATOR);
+
+	/**
+	 * @deprecated This constant has moved to {@link \pocketmine\network\protocol\Info} and will be removed from here in the future.
+	 */
+	const MINECRAFT_VERSION = ProtocolInfo::MINECRAFT_VERSION;
+	/**
+	 * @deprecated This constant has moved to {@link \pocketmine\network\protocol\Info} and will be removed from here in the future.
+	 */
+	const MINECRAFT_VERSION_NETWORK = ProtocolInfo::MINECRAFT_VERSION_NETWORK;
+
 
 	Terminal::init();
 

--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -87,6 +87,7 @@ use pocketmine\network\Network;
 use pocketmine\network\protocol\BatchPacket;
 use pocketmine\network\protocol\CraftingDataPacket;
 use pocketmine\network\protocol\DataPacket;
+use pocketmine\network\protocol\Info as ProtocolInfo;
 use pocketmine\network\protocol\PlayerListPacket;
 use pocketmine\network\query\QueryHandler;
 use pocketmine\network\RakLibInterface;
@@ -302,7 +303,7 @@ class Server{
 	 * @return string
 	 */
 	public function getVersion(){
-		return \pocketmine\MINECRAFT_VERSION;
+		return ProtocolInfo::MINECRAFT_VERSION;
 	}
 
 	/**

--- a/src/pocketmine/network/RakLibInterface.php
+++ b/src/pocketmine/network/RakLibInterface.php
@@ -172,7 +172,7 @@ class RakLibInterface implements ServerInstance, AdvancedSourceInterface{
 		$this->interface->sendOption("name",
 			"MCPE;" . addcslashes($name, ";") . ";" .
 			Info::CURRENT_PROTOCOL . ";" .
-			\pocketmine\MINECRAFT_VERSION_NETWORK . ";" .
+			Info::MINECRAFT_VERSION_NETWORK . ";" .
 			$info->getPlayerCount() . ";" .
 			$info->getMaxPlayerCount()
 		);

--- a/src/pocketmine/network/protocol/Info.php
+++ b/src/pocketmine/network/protocol/Info.php
@@ -31,6 +31,8 @@ interface Info{
 	 * Actual Minecraft: PE protocol version
 	 */
 	const CURRENT_PROTOCOL = 91;
+	const MINECRAFT_VERSION = "v0.16.0.5 alpha";
+	const MINECRAFT_VERSION_NETWORK = "0.16.0.5";
 
 	const LOGIN_PACKET = 0x01;
 	const PLAY_STATUS_PACKET = 0x02;


### PR DESCRIPTION
Moved to ProtocolInfo in the network module instead.

### Why?
Because I usually auto-generate basic protocol data for updates, and this makes it annoying because I have to manually edit constants in PocketMine.php. Also, if we ever do manage to modularise the network component, the version supported by the server will be decided by the networking component.