### PR TITLE
Increase ladder bounding box to 3/16, fix kicked for flying when sneaking on ladders

### DIFF
--- a/src/pocketmine/block/Ladder.php
+++ b/src/pocketmine/block/Ladder.php
@@ -59,7 +59,7 @@ class Ladder extends Transparent{
 
 	protected function recalculateBoundingBox(){
 
-		$f = 0.125;
+		$f = 0.1875;
 
 		if($this->meta === 2){
 			return new AxisAlignedBB(


### PR DESCRIPTION
Possible fix for #22 - I cannot reproduce the issue since making this change, although since I don't know what exactly caused the issue to begin with I can't say for sure.

This is in accordance with the (Ladder wiki page)[http://minecraft.gamepedia.com/Ladder#History], which states that (for PC at least) the ladder bounding box is 3/16 of a block wide. It appears to be the same in PE also.