### PR TITLE
Re-implemented CommandReader, fixed CommandReader hanging on shutdown, close #25

### DIFF
--- a/src/pocketmine/PocketMine.php
+++ b/src/pocketmine/PocketMine.php
@@ -2,11 +2,11 @@
 
 /*
  *
- *  ____            _        _   __  __ _                  __  __ ____  
- * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \ 
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
  * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
- * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/ 
- * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_| 
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -15,7 +15,7 @@
  *
  * @author PocketMine Team
  * @link http://www.pocketmine.net/
- * 
+ *
  *
 */
 
@@ -487,16 +487,31 @@ namespace pocketmine {
 	$killer = new ServerKiller(8);
 	$killer->start();
 
+	$erroredThreads = 0;
+
 	foreach(ThreadManager::getInstance()->getAll() as $id => $thread){
 		$logger->debug("Stopping " . $thread->getThreadName() . " thread");
-		$thread->quit();
+		try{
+			$thread->quit();
+			$logger->debug($thread->getThreadName() . " thread stopped successfully.");
+		}catch(\ThreadException $e){
+			++$erroredThreads;
+			$logger->debug("Could not stop " . $thread->getThreadName() . " thread: " . $e->getMessage());
+		}
 	}
 
 	$logger->shutdown();
 	$logger->join();
 
-	echo Terminal::$FORMAT_RESET . "\n";
+	echo Terminal::$FORMAT_RESET . PHP_EOL;
 
-	exit(0);
+	if($erroredThreads > 0){
+		if(\pocketmine\DEBUG > 1){
+			echo "Some threads could not be stopped, performing a force-kill" . PHP_EOL . PHP_EOL;
+		}
+		kill(getmypid());
+	}else{
+		exit(0);
+	}
 
 }

--- a/src/pocketmine/command/CommandReader.php
+++ b/src/pocketmine/command/CommandReader.php
@@ -19,21 +19,32 @@
  *
 */
 
+declare(strict_types = 1);
+
 namespace pocketmine\command;
 
 use pocketmine\Thread;
 
 class CommandReader extends Thread{
-	private $readline;
+
+	const TYPE_READLINE = 0;
+	const TYPE_STREAM = 1;
+	const TYPE_PIPED = 2;
+
 	/** @var \Threaded */
 	protected $buffer;
 	private $shutdown = false;
-	private $streamBlocking = false;
+	private $type = self::TYPE_STREAM;
+	private $lastLine = -1;
 
 	public function __construct(){
 		$this->buffer = new \Threaded;
 		$opts = getopt("", ["disable-readline"]);
-		$this->readline = (extension_loaded("readline") and !isset($opts["disable-readline"]));
+
+		if((extension_loaded("readline") and !isset($opts["disable-readline"]) and !$this->isPipe(STDIN))){
+			$this->type = self::TYPE_READLINE;
+		}
+
 		$this->start();
 	}
 
@@ -41,36 +52,105 @@ class CommandReader extends Thread{
 		$this->shutdown = true;
 	}
 
-	private function initStdin(){
-		global $stdin;
-		$stdin = fopen("php://stdin", "r");
-		$this->streamBlocking = (stream_set_blocking($stdin, 0) === false);
+	public function quit(){
+		$wait = microtime(true) + 0.5;
+		while(microtime(true) < $wait){
+			if($this->isRunning()){
+				usleep(100000);
+			}else{
+				parent::quit();
+				return;
+			}
+		}
+
+		$message = "Thread blocked for unknown reason";
+		if($this->type === self::TYPE_PIPED){
+			$message = "STDIN is being piped from another location and the pipe is blocked, cannot stop safely";
+		}
+
+		throw new \ThreadException($message);
 	}
 
-	private function readLine(){
-		if(!$this->readline){
+	private function initStdin(){
+		global $stdin;
+
+		if(is_resource($stdin)){
+			fclose($stdin);
+		}
+
+		$stdin = fopen("php://stdin", "r");
+		if($this->isPipe($stdin)){
+			$this->type = self::TYPE_PIPED;
+		}else{
+			$this->type = self::TYPE_STREAM;
+		}
+	}
+
+	/**
+	 * Checks if the specified stream is a FIFO pipe.
+	 *
+	 * @return bool
+	 */
+	private function isPipe($stream) : bool{
+		return is_resource($stream) and ((function_exists("posix_isatty") and !posix_isatty($stream)) or ((fstat($stream)["mode"] & 0170000) === 0010000));
+	}
+
+	/**
+	 * Reads a line from the console and adds it to the buffer. This method may block the thread.
+	 *
+	 * @return bool if the main execution should continue reading lines
+	 */
+	private function readLine() : bool{
+		$line = "";
+		if($this->type === self::TYPE_READLINE){
+			$line = trim(readline("> "));
+			if($line !== ""){
+				readline_add_history($line);
+			}else{
+				return true;
+			}
+		}else{
 			global $stdin;
 
 			if(!is_resource($stdin)){
 				$this->initStdin();
 			}
 
-			$line = fgets($stdin);
-			
-			if($line === false and $this->streamBlocking === true){ //windows sucks
-				$this->initStdin();
-				$line = fgets($stdin);
-			}
-			
-			return trim($line);
-		}else{
-			$line = trim(readline("> "));
-			if($line != ""){
-				readline_add_history($line);
-			}
+			switch($this->type){
+				case self::TYPE_STREAM:
+					$r = [$stdin];
+					if(($count = stream_select($r, $w, $e, 0, 200000)) === 0){ //nothing changed in 200000 microseconds
+						return true;
+					}elseif($count === false){ //stream error
+						$this->initStdin();
+					}
 
-			return $line;
+					if(($raw = fgets($stdin)) !== false){
+						$line = trim($raw);
+					}else{
+						return false; //user pressed ctrl+c?
+					}
+
+					break;
+				case self::TYPE_PIPED:
+					if(($raw = fgets($stdin)) === false){ //broken pipe or EOF
+						$this->initStdin();
+						$this->synchronized(function(){
+							$this->wait(200000);
+						}); //prevent CPU waste if it's end of pipe
+						return true; //loop back round
+					}else{
+						$line = trim($raw);
+					}
+					break;
+			}
 		}
+
+		if($line !== ""){
+			$this->buffer[] = preg_replace("#\\x1b\\x5b([^\\x1b]*\\x7e|[\\x40-\\x50])#", "", $line);
+		}
+
+		return true;
 	}
 
 	/**
@@ -87,27 +167,17 @@ class CommandReader extends Thread{
 	}
 
 	public function run(){
-		if(!$this->readline){
+		if($this->type !== self::TYPE_READLINE){
 			$this->initStdin();
 		}
 
-		$lastLine = microtime(true);
-		while(!$this->shutdown){
-			if(($line = $this->readLine()) !== ""){
-				$this->buffer[] = preg_replace("#\\x1b\\x5b([^\\x1b]*\\x7e|[\\x40-\\x50])#", "", $line);
-			}elseif(!$this->shutdown and (microtime(true) - $lastLine) <= 0.1){ //Non blocking! Sleep to save CPU
-				$this->synchronized(function(){
-					$this->wait(10000);
-				});
-			}
+		while(!$this->shutdown and $this->readLine());
 
-			$lastLine = microtime(true);
-		}
-
-		if(!$this->readline){
+		if($this->type !== self::TYPE_READLINE){
 			global $stdin;
 			fclose($stdin);
 		}
+
 	}
 
 	public function getThreadName(){


### PR DESCRIPTION
Re-implemented the Command Reader to fix the issue described in #25.

This pull changes the behaviour of the Command Reader stdin stream to be blocking by default, which is better for performance than the original method of querying the stream every 0.01 seconds. It now uses `stream_select` to poll the status of the stream to check if there have been any changes before entering a blocking stream read. This works flawlessly on most regular systems, including in Powershell and CMD on Windows.

This PR also adds auto-detection for fifo piped input. This was necessary because most people use MinTTY as a console for Windows servers, which is essentially a fifo pipe, not an actual console. `stream_select` always returns 1 for fifo pipes, which causes Windows servers under MinTTY to end up in a blocked state anyway, necessitating a force-kill on shutdown _only_ under the circumstances that the fifo pipe is blocking and does not terminate.

Under MinTTY, the thread will throw an exception to indicate that it is blocked. This will cause the server to skip trying to stop that thread and stop other threads safely, before performing process suicide to take the CR thread with it. Without debug, this will merely show an `Exit 1` in the MinTTY console; if debug is enabled the user will see a debug message to say that the CR thread was blocked, and that the server had to be force-killed to get rid of it. The Exit 1 can also be removed to have the console close automatically by removing the `-h error` option from the MinTTY command line in start.cmd.