### PR TITLE
ScriptPluginLoader: Fix only use first doc comment.

### DIFF
--- a/src/pocketmine/plugin/ScriptPluginLoader.php
+++ b/src/pocketmine/plugin/ScriptPluginLoader.php
@@ -105,7 +105,7 @@ class ScriptPluginLoader implements PluginLoader{
 				$data[$key] = $content;
 			}
 
-			if($insideHeader and strpos($line, "**/") !== false){
+			if($insideHeader and strpos($line, "*/") !== false){
 				break;
 			}
 		}


### PR DESCRIPTION
Title says it all.
Somehow the code expected **/ instead of */, which confused me for a long time, because it was always reading the version of the doc comments for the libraries in my script plugin, while PM’s documentation stated only the first phpdoc is used for reading the versions, name, etc. This won't break old plugins, because **/ is including */.

Proof that it was a mistake: https://gist.github.com/shoghicp/516105d470cf7d140757#file-myplugin-php-L19