### PR TITLE
Fix deepEquals() crash when tag check is specified and only one item …

### DIFF
--- a/src/pocketmine/item/Item.php
+++ b/src/pocketmine/item/Item.php
@@ -756,7 +756,7 @@ class Item implements ItemIds, \JsonSerializable{
 	public final function deepEquals(Item $item, bool $checkDamage = true, bool $checkCompound = true) : bool{
 		if($this->equals($item, $checkDamage, $checkCompound)){
 			return true;
-		}elseif($item->hasCompoundTag() or $this->hasCompoundTag()){
+		}elseif($item->hasCompoundTag() and $this->hasCompoundTag()){
 			return NBT::matchTree($this->getNamedTag(), $item->getNamedTag());
 		}
 


### PR DESCRIPTION
…has a tag

Not sure if this may break something, please review. 