### PR TITLE
Fixed effect amplifier overflow crash, close #147

### DIFF
--- a/src/pocketmine/command/defaults/EffectCommand.php
+++ b/src/pocketmine/command/defaults/EffectCommand.php
@@ -90,6 +90,13 @@ class EffectCommand extends VanillaCommand{
 
 		if(count($args) >= 4){
 			$amplification = (int) $args[3];
+			if($amplification > 255){
+				$sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.num.tooBig", [(string) $args[3], "255"]));
+				return true;
+			}elseif($amplification < 0){
+				$sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.num.tooSmall", [(string) $args[3], "0"]));
+				return true;
+			}
 		}
 
 		if(count($args) >= 5){

--- a/src/pocketmine/entity/Effect.php
+++ b/src/pocketmine/entity/Effect.php
@@ -169,8 +169,8 @@ class Effect{
 	 *
 	 * @return $this
 	 */
-	public function setAmplifier($amplifier){
-		$this->amplifier = (int) $amplifier;
+	public function setAmplifier(int $amplifier){
+		$this->amplifier = $amplifier & 0xff;
 		return $this;
 	}
 

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -598,12 +598,14 @@ abstract class Entity extends Location implements Metadatable{
 
 		if(isset($this->namedtag->ActiveEffects)){
 			foreach($this->namedtag->ActiveEffects->getValue() as $e){
+				$amplifier = $e["Amplifier"] & 0xff; //0-255 only
+
 				$effect = Effect::getEffect($e["Id"]);
 				if($effect === null){
 					continue;
 				}
 
-				$effect->setAmplifier($e["Amplifier"])->setDuration($e["Duration"])->setVisible($e["ShowParticles"] > 0);
+				$effect->setAmplifier($amplifier)->setDuration($e["Duration"])->setVisible($e["ShowParticles"] > 0);
 
 				$this->addEffect($effect);
 			}


### PR DESCRIPTION
Because amplifiers are stored as ByteTags and read back from storage as signed, anything over 128 would become a negative amplifier and cause a crash next time the player joined.

## Changes
- /effect command is now capped to adding effects in the range 0-255
- Fixed amplifiers being read as negative.

This will require translation updates to ensure that force-language and the console work correctly.