### PR TITLE
MemoryManager: Fix sprint too less arguments if $from contains %x

### DIFF
--- a/src/pocketmine/MemoryManager.php
+++ b/src/pocketmine/MemoryManager.php
@@ -323,7 +323,7 @@ class MemoryManager{
 				$this->continueDump($value, $data[$key], $objects, $refCounts, $recursion + 1, $maxNesting, $maxStringSize);
 			}
 		}elseif(is_string($from)){
-			$data = sprintf("(string) len(%d) " . substr(Utils::printable($from), 0, $maxStringSize), strlen($from));
+			$data = "(string) len(". strlen($from) .") " . substr(Utils::printable($from), 0, $maxStringSize);
 		}elseif(is_resource($from)){
 			$data = "(resource) " . print_r($from, true);
 		}else{


### PR DESCRIPTION
This fixes the spam of
```
Warning: sprintf(): Too few arguments in /Users/Tim/Desktop/Pocket_Server/src/pocketmine/MemoryManager.php on line 326

Warning: sprintf(): Too few arguments in /Users/Tim/Desktop/Pocket_Server/src/pocketmine/MemoryManager.php on line 326

Warning: sprintf(): Too few arguments in /Users/Tim/Desktop/Pocket_Server/src/pocketmine/MemoryManager.php on line 326

Warning: sprintf(): Too few arguments in /Users/Tim/Desktop/Pocket_Server/src/pocketmine/MemoryManager.php on line 326

Warning: sprintf(): Too few arguments in /Users/Tim/Desktop/Pocket_Server/src/pocketmine/MemoryManager.php on line 326

Warning: sprintf(): Too few arguments in /Users/Tim/Desktop/Pocket_Server/src/pocketmine/MemoryManager.php on line 326

Warning: sprintf(): Too few arguments in /Users/Tim/Desktop/Pocket_Server/src/pocketmine/MemoryManager.php on line 326

Warning: sprintf(): Too few arguments in /Users/Tim/Desktop/Pocket_Server/src/pocketmine/MemoryManager.php on line 326

Warning: sprintf(): Too few arguments in /Users/Tim/Desktop/Pocket_Server/src/pocketmine/MemoryManager.php on line 326

Warning: sprintf(): Too few arguments in /Users/Tim/Desktop/Pocket_Server/src/pocketmine/MemoryManager.php on line 326

Warning: sprintf(): Too few arguments in /Users/Tim/Desktop/Pocket_Server/src/pocketmine/MemoryManager.php on line 326

Warning: sprintf(): Too few arguments in /Users/Tim/Desktop/Pocket_Server/src/pocketmine/MemoryManager.php on line 326

Warning: sprintf(): Too few arguments in /Users/Tim/Desktop/Pocket_Server/src/pocketmine/MemoryManager.php on line 326

Warning: sprintf(): Too few arguments in /Users/Tim/Desktop/Pocket_Server/src/pocketmine/MemoryManager.php on line 326

Warning: sprintf(): Too few arguments in /Users/Tim/Desktop/Pocket_Server/src/pocketmine/MemoryManager.php on line 326

Warning: sprintf(): Too few arguments in /Users/Tim/Desktop/Pocket_Server/src/pocketmine/MemoryManager.php on line 326

Warning: sprintf(): Too few arguments in /Users/Tim/Desktop/Pocket_Server/src/pocketmine/MemoryManager.php on line 326

Warning: sprintf(): Too few arguments in /Users/Tim/Desktop/Pocket_Server/src/pocketmine/MemoryManager.php on line 326
```
on a memory dump, probably if the string $from contains some %(s;d, u, c, o, x, X, b;g, G, e, E, f, F) stuff.