### PR TITLE
Fix duplicated chat messages

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2996,6 +2996,14 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			$message = $message->getText();
 		}
 
+		$message = $this->server->getLanguage()->translateString($message);
+
+		$pk = new TextPacket();
+		$pk->type = TextPacket::TYPE_RAW;
+		$pk->message = $message;
+		$this->dataPacket($pk);
+		
+		/*
 		$mes = explode("\n", $this->server->getLanguage()->translateString($message));
 		foreach($mes as $m){
 			if($m !== ""){
@@ -3005,6 +3013,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 				$this->dataPacket($pk);
 			}
 		}
+		*/
 	}
 
 	public function sendTranslation($message, array $parameters = []){


### PR DESCRIPTION
This fixes duplicated chat messages if a line break (\n) was included.

Although I do not get the reason to send lines separated in the first
place, it somehow messes up the client, and it duplicates them in a
strange pattern. Funny enough, after 2hrs of desperately trying to find the place where the server duplicates the packets, i discovered that locking/suspending my device/minecraft, and unlocking/resuming it will magically make the duplicated messages disappear.