### PR TITLE
Fix instabreak anti-cheat false positive on obsidian broken

### DIFF
--- a/src/pocketmine/block/Obsidian.php
+++ b/src/pocketmine/block/Obsidian.php
@@ -41,7 +41,7 @@ class Obsidian extends Solid{
 	}
 
 	public function getHardness(){
-		return 50;
+		return 35;
 	}
 
 	public function getDrops(Item $item){


### PR DESCRIPTION
Fixes having to break obsidian twice to mine it.

Adjust hardness value to match Pocket Edition, which for some reason has a lower hardness than PC.