### PR TITLE
Remove movement checks

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1349,20 +1349,17 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
 		$revert = false;
 
-		if(($distanceSquared / ($tickDiff ** 2)) > 100){
-			$revert = true;
-		}else{
-			if($this->chunk === null or !$this->chunk->isGenerated()){
-				$chunk = $this->level->getChunk($newPos->x >> 4, $newPos->z >> 4, false);
-				if($chunk === null or !$chunk->isGenerated()){
-					$revert = true;
-					$this->nextChunkOrderRun = 0;
-				}else{
-					if($this->chunk !== null){
-						$this->chunk->removeEntity($this);
-					}
-					$this->chunk = $chunk;
+
+		if($this->chunk === null or !$this->chunk->isGenerated()){
+			$chunk = $this->level->getChunk($newPos->x >> 4, $newPos->z >> 4, false);
+			if($chunk === null or !$chunk->isGenerated()){
+				$revert = true;
+				$this->nextChunkOrderRun = 0;
+			}else{
+				if($this->chunk !== null){
+					$this->chunk->removeEntity($this);
 				}
+				$this->chunk = $chunk;
 			}
 		}
 
@@ -1377,21 +1374,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			$diffY = $this->y - $newPos->y;
 			$diffZ = $this->z - $newPos->z;
 
-			$yS = 0.5 + $this->ySize;
-			if($diffY >= -$yS or $diffY <= $yS){
-				$diffY = 0;
-			}
-
 			$diff = ($diffX ** 2 + $diffY ** 2 + $diffZ ** 2) / ($tickDiff ** 2);
-
-			if($this->isSurvival()){
-				if(!$revert and !$this->isSleeping()){
-					if($diff > 0.0625){
-						$revert = true;
-						$this->server->getLogger()->warning($this->getServer()->getLanguage()->translateString("pocketmine.player.invalidMove", [$this->getName()]));
-					}
-				}
-			}
 
 			if($diff > 0){
 				$this->x = $newPos->x;


### PR DESCRIPTION
Anti-cheat should be done by plugins for those who want it. It is otherwise usually just an irritation.

Removing these checks fixes a bunch of issues, including:

- being TPed up/down ladders (#22)
- flying up/down pull-backs in blocks in spectator mode
- [player] moved wrongly! when moving more than 0.25 blocks in a tick or when server is lagging (#119)

NOTE: This is the REMOVAL of some highly irritating and buggy anti-cheat. 

**If you depend on this anti-cheat, I recommend you wait until there is a plugin substitute available to provide this.**

### Possible improvements
Add CheatEvents which are cancelled by default, and let plugins handle these events.