### PR TITLE
Fixes sendHeldItem to stop crashes when executing.

### DIFF
--- a/src/pocketmine/inventory/PlayerInventory.php
+++ b/src/pocketmine/inventory/PlayerInventory.php
@@ -137,7 +137,7 @@ class PlayerInventory extends BaseInventory{
 				$this->sendSlot($this->getHeldItemSlot(), $target);
 			}
 		}else{
-			$this->holder->getServer()->broadcastPacket($target, $pk);
+			$this->getHolder()->getLevel()->getServer()->broadcastPacket($target, $pk);
 			foreach($target as $player){
 				if($player === $this->getHolder()){
 					$this->sendSlot($this->getHeldItemSlot(), $player);

--- a/src/pocketmine/item/Food.php
+++ b/src/pocketmine/item/Food.php
@@ -57,7 +57,7 @@ abstract class Food extends Item implements FoodSource{
 		if($human instanceof Player){
 			$human->dataPacket($pk);
 		}
-		$human->getServer()->broadcastPacket($human->getViewers(), $pk);
+		$human->getLevel()->getServer()->broadcastPacket($human->getViewers(), $pk);
 
 		$ev = new EntityEatItemEvent($human, $this);
 


### PR DESCRIPTION
This pull request fixes issues with plugins such as Slapper. Human entities would crash when getting near entities, due to $entity->getServer() not being a defined method. Instead I've replaced it with getHolder and getLevel in order to be able to get the server. 