### PR TITLE
Added Windows PowerShell start script with loop capability

### DIFF
--- a/start.ps1
+++ b/start.ps1
@@ -1,0 +1,40 @@
+﻿param (
+	[switch]$Loop = $false
+)
+
+if(Test-Path "bin\php\php.exe"){
+	$env:PHPRC = ""
+	$binary = "bin\php\php.exe"
+}else{
+	$binary = "php"
+}
+
+if(Test-Path "PocketMine-MP.phar"){
+	$file = "PocketMine-MP.phar"
+}elseif(Test-Path "src\pocketmine\PocketMine.php"){
+	$file = "src\pocketmine\PocketMine.php"
+}else{
+	echo "Couldn't find a valid PocketMine-MP installation"
+	pause
+	exit 1
+}
+
+function StartServer{
+	$command = $binary + " " + $file + " --enable-ansi"
+	iex $command
+}
+
+$loops = 0
+
+StartServer
+
+while($Loop){
+	if($loops -ne 0){
+		echo ("Restarted " + $loops + " times")
+	}
+	$loops++
+	echo "To escape the loop, press CTRL+C now. Otherwise, wait 5 seconds for the server to restart."
+	echo ""
+	Start-Sleep 5
+	StartServer
+}


### PR DESCRIPTION
Mainly useful for Win10 users since the Threshold 2 update, since PowerShell now supports ANSI colour, and no CommandReader issues will occur under PowerShell due to it being a native system shell.

### How do I use it?
a) Right-click on the file and click "Run with PowerShell", or
b) open PowerShell, cd into the server dir and exec `.\start.ps1`

I use this all of the time now, since PowerShell is nicer to use than MinTTY and doesn't have the same issues that MinTTY does with the CommandReader, meaning that my server will actually shut down cleanly.

This script also adds looped server restarting, like the Linux script. Passing the parameter `-loop` or `-l` (non-case-sensitive) or changing [this](https://github.com/pmmp/PocketMine-MP/pull/240/files#diff-fa8293e353ab2dab865fcd4f17564ff2R2) to `$true` will automatically restart your server if it crashes for whatever reason. Do not enable this unless you know what you are doing. It will give you a 5-second breathing period in between shutdowns and starts to allow safely exiting the window.