### PR TITLE
Fixed duplicate SetTimePacket(), and fixed useless overwrite of $pos.

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -776,16 +776,9 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		$this->inventory->sendContents($this);
 		$this->inventory->sendArmorContents($this);
 
-		$pk = new SetTimePacket();
-		$pk->time = $this->level->getTime();
-		$pk->started = $this->level->stopTime == false;
-		$this->dataPacket($pk);
-
 		$pos = $this->level->getSafeSpawn($this);
 
 		$this->server->getPluginManager()->callEvent($ev = new PlayerRespawnEvent($this, $pos));
-
-		$pos = $ev->getRespawnPosition();
 
 		$pk = new RespawnPacket();
 		$pk->x = $pos->x;


### PR DESCRIPTION
Some code clean up.

Removes the overwrite of $pos and fixes SetTimePacket sending twice (It is already sent when the packet is first received).