### PR TITLE
Fix most movement-check false-positives and many position bugs

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1387,11 +1387,6 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			$diffY = $this->y - $newPos->y;
 			$diffZ = $this->z - $newPos->z;
 
-			$yS = 0.5 + $this->ySize;
-			if($diffY >= -$yS or $diffY <= $yS){
-				$diffY = 0;
-			}
-
 			$diff = ($diffX ** 2 + $diffY ** 2 + $diffZ ** 2) / ($tickDiff ** 2);
 
 			if($this->isSurvival()){

--- a/src/pocketmine/utils/Binary.php
+++ b/src/pocketmine/utils/Binary.php
@@ -354,18 +354,28 @@ class Binary{
 		return pack("V", $value);
 	}
 
-	public static function readFloat($str){
+	public static function readFloat($str, int $accuracy = -1){
 		self::checkLength($str, 4);
-		return ENDIANNESS === self::BIG_ENDIAN ? unpack("f", $str)[1] : unpack("f", strrev($str))[1];
+		$value = ENDIANNESS === self::BIG_ENDIAN ? unpack("f", $str)[1] : unpack("f", strrev($str))[1];
+		if($accuracy > -1){
+			return round($value, $accuracy);
+		}else{
+			return $value;
+		}
 	}
 
 	public static function writeFloat($value){
 		return ENDIANNESS === self::BIG_ENDIAN ? pack("f", $value) : strrev(pack("f", $value));
 	}
 
-	public static function readLFloat($str){
+	public static function readLFloat($str, int $accuracy = -1){
 		self::checkLength($str, 4);
-		return ENDIANNESS === self::BIG_ENDIAN ? unpack("f", strrev($str))[1] : unpack("f", $str)[1];
+		$value = ENDIANNESS === self::BIG_ENDIAN ? unpack("f", strrev($str))[1] : unpack("f", $str)[1];
+		if($accuracy > -1){
+			return round($value, $accuracy);
+		}else{
+			return $value;
+		}
 	}
 
 	public static function writeLFloat($value){

--- a/src/pocketmine/utils/BinaryStream.php
+++ b/src/pocketmine/utils/BinaryStream.php
@@ -126,8 +126,8 @@ class BinaryStream extends \stdClass{
 		$this->buffer .= Binary::writeShort($v);
 	}
 
-	public function getFloat(){
-		return Binary::readFloat($this->get(4));
+	public function getFloat(int $accuracy = -1){
+		return Binary::readFloat($this->get(4), $accuracy);
 	}
 
 	public function putFloat($v){
@@ -142,8 +142,8 @@ class BinaryStream extends \stdClass{
 		$this->buffer .= Binary::writeLShort($v);
 	}
 
-	public function getLFloat(){
-		return Binary::readLFloat($this->get(4));
+	public function getLFloat(int $accuracy = -1){
+		return Binary::readLFloat($this->get(4), $accuracy);
 	}
 
 	public function putLFloat($v){
@@ -300,9 +300,9 @@ class BinaryStream extends \stdClass{
 	}
 
 	public function getVector3f(&$x, &$y, &$z){
-		$x = $this->getLFloat();
-		$y = $this->getLFloat();
-		$z = $this->getLFloat();
+		$x = $this->getLFloat(4);
+		$y = $this->getLFloat(4);
+		$z = $this->getLFloat(4);
 	}
 
 	public function putVector3f($x, $y, $z){


### PR DESCRIPTION
Fixed myriad movement-checking bugs:

- fixed ladders, close #22 
- fixed auto-jump pull-backs
- fixed pull-backs flying up/down walls
- fixed pull-backs walking _along_ walls
- fixed all known spectator mode pull-back issues (flying up/down pull-backs)
- fixed placing blocks in front of self sometimes vanish
- fixed most known cases of "player moved wrongly!" (does not include stairs, due to stairs bounding boxes actually being wrong (TODO))

A floating-point accuracy has been added to Binary float reading methods. Network Vec3s are now decoded and rounded to an accuracy of 4 decimal places.

Closes #258 , see that for details.

Close #264 