### PR TITLE
Added a hack for multiworld chunk bug

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -662,10 +662,19 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		$level = $level === null ? $this->level : $level;
 		$index = Level::chunkHash($x, $z);
 		if(isset($this->usedChunks[$index])){
-			foreach($level->getChunkEntities($x, $z) as $entity){
+			$chunk = $level->getChunk($x, $z);
+			foreach($chunk->getEntities() as $entity){
 				if($entity !== $this){
 					$entity->despawnFrom($this);
 				}
+			}
+
+			if($level !== $this->level){
+				$pk = new FullChunkDataPacket();
+				$pk->chunkX = $x;
+				$pk->chunkZ = $z;
+				$pk->data = chr($chunk->getSubChunkSendCount());
+				$this->dataPacket($pk);
 			}
 
 			unset($this->usedChunks[$index]);


### PR DESCRIPTION
Sends an empty chunk column when unloading old-world chunks to clear the column client-side. Note this isn't always foolproof, since PocketMine's tracking of chunks loaded by players is bad and inaccurate. This will be improved in the future (#262). It does however work in most cases.