### PR TITLE
Added CraftingDataPacket cache, reduced lag spikes on player join

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -45,8 +45,6 @@ use pocketmine\event\TranslationContainer;
 use pocketmine\inventory\CraftingManager;
 use pocketmine\inventory\InventoryType;
 use pocketmine\inventory\Recipe;
-use pocketmine\inventory\ShapedRecipe;
-use pocketmine\inventory\ShapelessRecipe;
 use pocketmine\item\enchantment\Enchantment;
 use pocketmine\item\Item;
 use pocketmine\lang\BaseLang;
@@ -78,7 +76,6 @@ use pocketmine\nbt\tag\StringTag;
 use pocketmine\network\CompressBatchedTask;
 use pocketmine\network\Network;
 use pocketmine\network\protocol\BatchPacket;
-use pocketmine\network\protocol\CraftingDataPacket;
 use pocketmine\network\protocol\DataPacket;
 use pocketmine\network\protocol\Info as ProtocolInfo;
 use pocketmine\network\protocol\PlayerListPacket;
@@ -2102,7 +2099,7 @@ class Server{
 		}
 
 		$this->sendFullPlayerListData($player);
-		$this->sendRecipeList($player);
+		$player->dataPacket($this->craftingManager->getCraftingDataPacket());
 	}
 
 	public function addPlayer($identifier, Player $player){
@@ -2149,25 +2146,6 @@ class Server{
 				continue; //fixes duplicates
 			}
 			$pk->entries[] = [$player->getUniqueId(), $player->getId(), $player->getDisplayName(), $player->getSkinId(), $player->getSkinData()];
-		}
-
-		$p->dataPacket($pk);
-	}
-
-	public function sendRecipeList(Player $p){
-		$pk = new CraftingDataPacket();
-		$pk->cleanRecipes = true;
-
-		foreach($this->getCraftingManager()->getRecipes() as $recipe){
-			if($recipe instanceof ShapedRecipe){
-				$pk->addShapedRecipe($recipe);
-			}elseif($recipe instanceof ShapelessRecipe){
-				$pk->addShapelessRecipe($recipe);
-			}
-		}
-
-		foreach($this->getCraftingManager()->getFurnaceRecipes() as $recipe){
-			$pk->addFurnaceRecipe($recipe);
 		}
 
 		$p->dataPacket($pk);

--- a/src/pocketmine/event/Timings.php
+++ b/src/pocketmine/event/Timings.php
@@ -104,6 +104,9 @@ abstract class Timings{
 	/** @var TimingsHandler */
 	public static $playerCommandTimer;
 
+	/** @var TimingsHandler */
+	public static $craftingDataCacheRebuildTimer;
+
 	/** @var TimingsHandler[] */
 	public static $entityTypeTimingMap = [];
 	/** @var TimingsHandler[] */
@@ -158,6 +161,7 @@ abstract class Timings{
 		self::$schedulerAsyncTimer = new TimingsHandler("** Scheduler - Async Tasks");
 
 		self::$playerCommandTimer = new TimingsHandler("** playerCommand");
+		self::$craftingDataCacheRebuildTimer = new TimingsHandler("** craftingDataCacheRebuild");
 
 	}
 

--- a/src/pocketmine/inventory/CraftingManager.php
+++ b/src/pocketmine/inventory/CraftingManager.php
@@ -21,7 +21,9 @@
 
 namespace pocketmine\inventory;
 
+use pocketmine\event\Timings;
 use pocketmine\item\Item;
+use pocketmine\network\protocol\CraftingDataPacket;
 use pocketmine\Server;
 use pocketmine\utils\Config;
 use pocketmine\utils\MainLogger;
@@ -39,6 +41,9 @@ class CraftingManager{
 	public $furnaceRecipes = [];
 
 	private static $RECIPE_COUNT = 0;
+
+	/** @var CraftingDataPacket */
+	private $craftingDataCache;
 
 	public function __construct(){
 		// load recipes from src/pocketmine/resources/recipes.json
@@ -84,6 +89,48 @@ class CraftingManager{
 					break;
 			}
 		}
+
+		$this->buildCraftingDataCache();
+	}
+
+	/**
+	 * Rebuilds the cached CraftingDataPacket.
+	 */
+	public function buildCraftingDataCache(){
+		Timings::$craftingDataCacheRebuildTimer->startTiming();
+		$pk = new CraftingDataPacket();
+		$pk->cleanRecipes = true;
+
+		foreach($this->recipes as $recipe){
+			if($recipe instanceof ShapedRecipe){
+				$pk->addShapedRecipe($recipe);
+			}elseif($recipe instanceof ShapelessRecipe){
+				$pk->addShapelessRecipe($recipe);
+			}
+		}
+
+		foreach($this->furnaceRecipes as $recipe){
+			$pk->addFurnaceRecipe($recipe);
+		}
+
+		$pk->encode();
+		$pk->isEncoded = true;
+
+		$this->craftingDataCache = $pk;
+		Timings::$craftingDataCacheRebuildTimer->stopTiming();
+	}
+
+	/**
+	 * Returns a CraftingDataPacket for sending to players. Rebuilds the cache if it is outdated.
+	 *
+	 * @return CraftingDataPacket
+	 */
+	public function getCraftingDataPacket() : CraftingDataPacket{
+		if($this->craftingDataCache === null){
+			$this->buildCraftingDataCache();
+		}
+
+		return $this->craftingDataCache;
 	}
 
 	public function sort(Item $i1, Item $i2){
@@ -162,6 +209,7 @@ class CraftingManager{
 		}
 
 		$this->recipeLookup[$result->getId() . ":" . $result->getDamage()][$hash] = $recipe;
+		$this->craftingDataCache = null;
 	}
 
 	/**
@@ -177,6 +225,7 @@ class CraftingManager{
 			$hash .= $item->getId() . ":" . ($item->hasAnyDamageValue() ? "?" : $item->getDamage()) . "x" . $item->getCount() . ",";
 		}
 		$this->recipeLookup[$result->getId() . ":" . $result->getDamage()][$hash] = $recipe;
+		$this->craftingDataCache = null;
 	}
 
 	/**
@@ -185,6 +234,7 @@ class CraftingManager{
 	public function registerFurnaceRecipe(FurnaceRecipe $recipe){
 		$input = $recipe->getInput();
 		$this->furnaceRecipes[$input->getId() . ":" . ($input->hasAnyDamageValue() ? "?" : $input->getDamage())] = $recipe;
+		$this->craftingDataCache = null;
 	}
 
 	/**


### PR DESCRIPTION
Closes #248 

This will cause the server to build a CraftingDataPacket on startup, which will then be used for all players, instead of creating a new packet for every player joining. This reduces timings of CraftingDataPacket by more than 90% on my machine with one player. With more players the difference will be more significant.

I have not tested the plugin API side of things, but whenever the CraftingManager has a new recipe added, the crafting cache will be destroyed, and rebuilt next time a player joins. This should work fine for plugins, but as I have said I haven't tested.

### Tests
Tested with one player, but no API tests have been performed. If anyone would like to trial-run their plugin which modifies crafting stuff against this, then please do.

### NOTE
For maximum performance, the packet is also immediately _encoded_ when the cache is created. This is because actually _encoding_ the packet takes up nearly half of the time in the timings reports. (13/29ms on my machine). This may affect plugins' capability to modify the packet contents before sending.

### Possible improvements
- Add an option to disable the cache
- Add an option for whether to encode the packet straightaway when creating the cache (better for performance, possibly not so good for plugins)