### PR TITLE
Workaround for chat duplication. TODO: Revert this

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2991,15 +2991,10 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			$message = $message->getText();
 		}
 
-		$mes = explode("\n", $this->server->getLanguage()->translateString($message));
-		foreach($mes as $m){
-			if($m !== ""){
-				$pk = new TextPacket();
-				$pk->type = TextPacket::TYPE_RAW;
-				$pk->message = $m;
-				$this->dataPacket($pk);
-			}
-		}
+		$pk = new TextPacket();
+		$pk->type = TextPacket::TYPE_RAW;
+		$pk->message = $this->server->getLanguage()->translateString($message);
+		$this->dataPacket($pk);
 	}
 
 	public function sendTranslation($message, array $parameters = []){

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1569,6 +1569,15 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
 		$this->timings->stopTiming();
 
+		//TODO: remove this workaround (broken client MCPE 1.0.0)
+		if(count($this->messageQueue) > 0){
+			$pk = new TextPacket();
+			$pk->type = TextPacket::TYPE_RAW;
+			$pk->message = implode("\n", $this->messageQueue);
+			$this->dataPacket($pk);
+			$this->messageQueue = [];
+		}
+
 		return true;
 	}
 
@@ -2977,6 +2986,9 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		return false;
 	}
 
+	/** @var string[] */
+	private $messageQueue = [];
+
 	/**
 	 * Sends a direct chat message to a player
 	 *
@@ -2991,10 +3003,14 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			$message = $message->getText();
 		}
 
+		//TODO: Remove this workaround (broken client MCPE 1.0.0)
+		$this->messageQueue[] = $this->server->getLanguage()->translateString($message);
+		/*
 		$pk = new TextPacket();
 		$pk->type = TextPacket::TYPE_RAW;
 		$pk->message = $this->server->getLanguage()->translateString($message);
 		$this->dataPacket($pk);
+		*/
 	}
 
 	public function sendTranslation($message, array $parameters = []){


### PR DESCRIPTION
Obsoletes #206 

This solution is _somewhat_ more effective than the referenced one above. Since multiple TextPackets sent in the space of 1 tick cause dupes of later messages, this _mostly_ alleviates the issue by queuing the messages up and sending them all in one packet on the next available opportunity.

This does not completely resolve the issue though. This only squashes `raw` messages into a single packet, so if, for example, a `translation` and a `raw` are sent in the same tick, like they are in the /help command (header uses translation, entries use raw), then the top messages will still be duplicated.

This does however completely eliminate the /status output issue and mostly eliminates /help issues apart from the one mentioned above.

In the meantime, we wait for Mojang to fix this https://bugs.mojang.com/browse/MCPE-17631. When they do, this change will be reverted.