### PR TITLE
Moved crash dumps to a separate folder

### DIFF
--- a/src/pocketmine/CrashDump.php
+++ b/src/pocketmine/CrashDump.php
@@ -41,7 +41,10 @@ class CrashDump{
 	public function __construct(Server $server){
 		$this->time = time();
 		$this->server = $server;
-		$this->path = $this->server->getDataPath() . "CrashDump_" . date("D_M_j-H.i.s-T_Y", $this->time) . ".log";
+		if(!is_dir($this->server->getDataPath()) . "crashdumps"){
+			mkdir($this->server->getDataPath() . "crashdumps");
+		}
+		$this->path = $this->server->getDataPath() . "crashdumps/" . date("D_M_j-H.i.s-T_Y", $this->time) . ".log";
 		$this->fp = @fopen($this->path, "wb");
 		if(!is_resource($this->fp)){
 			throw new \RuntimeException("Could not create Crash Dump");


### PR DESCRIPTION
Does as title says, I'm sure many people will find this useful.

Once I had a bug that would crash the server every couple seconds, it ended making tons of crash dumps making it hard to even begin to transfer files without freezing my sftp client. This will prevent such a situation and is more organized.