### PR TITLE
Anti-cheat fixes, settings and API

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1465,7 +1465,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 				$this->checkNearEntities($tickDiff);
 			}
 
-			$this->speed = $from->subtract($to);
+			$this->speed = ($to->subtract($from))->divide($tickDiff);
 		}elseif($distanceSquared == 0){
 			$this->speed = new Vector3(0, 0, 0);
 		}

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1958,7 +1958,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 				break;
 			case ProtocolInfo::ADVENTURE_SETTINGS_PACKET:
 				//TODO: player abilities, check for other changes
-				if($packet->isFlying and !$this->allowFlight){
+				if($packet->isFlying and !$this->allowFlight and !$this->server->getAllowFlight()){
 					$this->kick("Flying is not enabled on this server");
 					break;
 				}else{

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -236,6 +236,9 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	protected $allowFlight = false;
 	protected $flying = false;
 
+	protected $allowMovementCheats = false;
+	protected $allowInstaBreak = false;
+
 	private $needACK = [];
 
 	private $batchedPackets = [];
@@ -331,6 +334,22 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
 	public function hasAutoJump(){
 		return $this->autoJump;
+	}
+
+	public function allowMovementCheats() : bool{
+		return $this->allowMovementCheats;
+	}
+
+	public function setAllowMovementCheats(bool $value = false){
+		$this->allowMovementCheats = $value;
+	}
+
+	public function allowInstaBreak() : bool{
+		return $this->allowInstaBreak;
+	}
+
+	public function setAllowInstaBreak(bool $value = false){
+		$this->allowInstaBreak = $value;
 	}
 
 	/**
@@ -552,6 +571,9 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		$this->rawUUID = null;
 
 		$this->creationTime = microtime(true);
+
+		$this->allowMovementCheats = (bool) $this->server->getProperty("player.anti-cheat.allow-movement-cheats", false);
+		$this->allowInstaBreak = (bool) $this->server->getProperty("player.anti-cheat.allow-instabreak", false);
 	}
 
 	/**
@@ -1358,7 +1380,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
 		$revert = false;
 
-		if(($distanceSquared / ($tickDiff ** 2)) > 100){
+		if(($distanceSquared / ($tickDiff ** 2)) > 100 and !$this->allowMovementCheats){
 			$this->server->getLogger()->warning($this->getName() . " moved too fast, reverting movement");
 			$revert = true;
 		}else{
@@ -1389,7 +1411,8 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
 			$diff = ($diffX ** 2 + $diffY ** 2 + $diffZ ** 2) / ($tickDiff ** 2);
 
-			if($this->isSurvival()){
+			//TODO: add events for anti-cheat triggered
+			if($this->isSurvival() and !$this->allowMovementCheats){
 				if(!$revert and !$this->isSleeping()){
 					if($diff > 0.0625){
 						$revert = true;

--- a/src/pocketmine/PocketMine.php
+++ b/src/pocketmine/PocketMine.php
@@ -75,7 +75,7 @@ namespace pocketmine {
 	use raklib\RakLib;
 
 	const VERSION = "1.6.2dev";
-	const API_VERSION = "3.0.0-ALPHA2";
+	const API_VERSION = "3.0.0-ALPHA3";
 	const CODENAME = "Unleashed";
 
 	/*

--- a/src/pocketmine/event/player/cheat/PlayerCheatEvent.php
+++ b/src/pocketmine/event/player/cheat/PlayerCheatEvent.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link   http://www.pocketmine.net/
+ *
+ *
+ */
+
+/**
+ * Events called when a player attempts to cheat
+ */
+namespace pocketmine\event\player\cheat;
+
+use pocketmine\event\player\PlayerEvent;
+
+abstract class PlayerCheatEvent extends PlayerEvent{
+
+}

--- a/src/pocketmine/event/player/cheat/PlayerIllegalMoveEvent.php
+++ b/src/pocketmine/event/player/cheat/PlayerIllegalMoveEvent.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link   http://www.pocketmine.net/
+ *
+ *
+ */
+
+/**
+ * Events called when a player attempts to perform movement cheats such as clipping through blocks.
+ */
+namespace pocketmine\event\player\cheat;
+
+use pocketmine\event\Cancellable;
+use pocketmine\Player;
+use pocketmine\math\Vector3;
+
+class PlayerIllegalMoveEvent extends PlayerCheatEvent implements Cancellable{
+	public static $handlerList = null;
+
+	private $attemptedPosition;
+
+	public function __construct(Player $player, Vector3 $attemptedPosition){
+		$this->attemptedPosition = $attemptedPosition;
+		$this->player = $player;
+	}
+
+	public function getAttemptedPosition() : Vector3{
+		return $this->attemptedPosition;
+	}
+
+}

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1497,7 +1497,7 @@ class Level implements ChunkManager, Metadatable{
 		}
 
 		if($player !== null){
-			$ev = new BlockBreakEvent($player, $target, $item, $player->isCreative() ? true : false);
+			$ev = new BlockBreakEvent($player, $target, $item, ($player->isCreative() or $player->allowInstaBreak()));
 
 			if($player->isSurvival() and $item instanceof Item and !$target->isBreakable($item)){
 				$ev->setCancelled();

--- a/src/pocketmine/resources/pocketmine.yml
+++ b/src/pocketmine/resources/pocketmine.yml
@@ -99,6 +99,11 @@ debug:
 player:
  #Choose whether to enable player data saving.
  save-player-data: true
+ anti-cheat:
+  #If false, will try to prevent speed and noclip cheats. May cause movement issues with some blocks which are not yet properly implemented.
+  allow-movement-cheats: false
+  #If false, times block breaks to ensure players are not cheating. May cause issues with some blocks which are not yet properly implemented.
+  allow-instabreak: false
 
 level-settings:
  #The default format that levels will use when created


### PR DESCRIPTION
- Added switches to allow disabling anti-noclip and anti-instabreak.
- Added API methods to allow plugin control of anti-instabreak and anti-noclip.
- Added PlayerIllegalMoveEvent, which is fired when a player attempts to clip through a block.
- Fixed anti-flight false-positives when falling (especially when server is heavily lagging)

There are still some minor issues with Toolbox flight-hacks not being detected under certain circumstances. However, many anti-flight-related issues have been fixed.