### PR TITLE
Fixed wrong commit parsing on non-default branches

### DIFF
--- a/src/pocketmine/PocketMine.php
+++ b/src/pocketmine/PocketMine.php
@@ -470,7 +470,15 @@ namespace pocketmine {
 		exit(1); //Exit with error
 	}
 
-	if(file_exists(\pocketmine\PATH . ".git/refs/heads/master")){ //Found Git information!
+	$git_heads = scandir(\pocketmine\PATH . ".git/refs/heads"); //Get contents of Git heads folder
+	if(count($git_heads) > 3){ //If the user is using the master branch, $git_heads should only have 3 items: ".", ".." and "master"
+		foreach($git_heads as $branch){
+			if($branch !== "master" && $branch !== "." && $branch !== ".."){ //Find Git information of the branch other than master
+				define('pocketmine\GIT_COMMIT', strtolower(trim(file_get_contents(\pocketmine\PATH . ".git/refs/heads/" . $branch))));
+				break;
+			}
+		}
+	}elseif(file_exists(\pocketmine\PATH . ".git/refs/heads/master")){ //Found Git information!
 		define('pocketmine\GIT_COMMIT', strtolower(trim(file_get_contents(\pocketmine\PATH . ".git/refs/heads/master"))));
 	}else{ //Unknown :(
 		define('pocketmine\GIT_COMMIT', str_repeat("00", 20));


### PR DESCRIPTION
This pull request closes #295.  

After this change, PocketMine-MP will first scan `.git/refs/heads` folder and store all contents of the folder to `$git_heads` array using `scandir` function.  
If the user is using `master` branch, there should be only 3 items in that array:
- `.`
- `..`
- `master`

However, if the user is not using the default branch, an extra file with the other branch's name will appear. So if the length of the array is more than 3, we can say that the user is not using `master` branch. Then, PocketMine-MP reads that extra file and get correct Git commit hash tag.

#### Testing
To trigger a crash and see Git commit hash, I deleted `Player.php` during development.  
Here is part of the crash dump when `mcpe-1.0` file exists in `.git/refs/heads` folder:
```
PocketMine-MP Crash Dump Fri Jan 27 03:37:25 UTC 2017

Error: Class pocketmine\Player not found
File: /src/spl/BaseClassLoader
Line: 144
Type: notice

THIS CRASH WAS CAUSED BY A PLUGIN

Code:
[135] 
[136] 			if(method_exists($name, "onClassLoaded") and (new ReflectionClass($name))->getMethod("onClassLoaded")->isStatic()){
[137] 				$name::onClassLoaded();
[138] 			}
[139] 			
[140] 			$this->classes[] = $name;
[141] 
[142] 			return true;
[143] 		}elseif($this->getParent() === null){
[144] 			throw new ClassNotFoundException("Class $name not found");
[145] 		}
[146] 
[147] 		return false;
[148] 	}
[149] 
[150] 	/**
[151] 	 * Returns the path for the class, if any
[152] 	 *
[153] 	 * @param string $name
[154] 	 *

Backtrace:
#0 /src/pocketmine/Server(405): spl_autoload_call(string pocketmine\Player)
#1 /src/pocketmine/Server(1962): pocketmine\Server::getGamemodeString(integer 0)
#2 /src/pocketmine/Server(1587): pocketmine\Server->start(boolean)
#3 /src/pocketmine/PocketMine(500): pocketmine\Server->__construct(pocketmine\CompatibleClassLoader object, pocketmine\utils\MainLogger object, string F:\pmmp\PocketMine-MP\, string F:\pmmp\PocketMine-MP\, string F:\pmmp\PocketMine-MP\plugins\)

PocketMine-MP version: 1.6.2dev #0 [Protocol 100; API 3.0.0-ALPHA3]
Git commit: 740a8ad436272327fded022d6558713ad0566a75
uname -a: Windows NT LEO-PC 10.0 build 14393 (Windows 10) AMD64
PHP Version: 7.0.13
Zend version: 3.0.0
OS : WINNT, win
```
Here is another dump when `mcpe-1.0` file does not exist:
```
PocketMine-MP Crash Dump Fri Jan 27 03:42:04 UTC 2017

Error: Class pocketmine\Player not found
File: /src/spl/BaseClassLoader
Line: 144
Type: notice

THIS CRASH WAS CAUSED BY A PLUGIN

Code:
[135] 
[136] 			if(method_exists($name, "onClassLoaded") and (new ReflectionClass($name))->getMethod("onClassLoaded")->isStatic()){
[137] 				$name::onClassLoaded();
[138] 			}
[139] 			
[140] 			$this->classes[] = $name;
[141] 
[142] 			return true;
[143] 		}elseif($this->getParent() === null){
[144] 			throw new ClassNotFoundException("Class $name not found");
[145] 		}
[146] 
[147] 		return false;
[148] 	}
[149] 
[150] 	/**
[151] 	 * Returns the path for the class, if any
[152] 	 *
[153] 	 * @param string $name
[154] 	 *

Backtrace:
#0 /src/pocketmine/Server(405): spl_autoload_call(string pocketmine\Player)
#1 /src/pocketmine/Server(1962): pocketmine\Server::getGamemodeString(integer 0)
#2 /src/pocketmine/Server(1587): pocketmine\Server->start(boolean)
#3 /src/pocketmine/PocketMine(500): pocketmine\Server->__construct(pocketmine\CompatibleClassLoader object, pocketmine\utils\MainLogger object, string F:\pmmp\PocketMine-MP\, string F:\pmmp\PocketMine-MP\, string F:\pmmp\PocketMine-MP\plugins\)

PocketMine-MP version: 1.6.2dev #0 [Protocol 100; API 3.0.0-ALPHA3]
Git commit: 09a6776674ddfb1e7f25facc89301607972e3c2b
uname -a: Windows NT LEO-PC 10.0 build 14393 (Windows 10) AMD64
PHP Version: 7.0.13
Zend version: 3.0.0
OS : WINNT, win
```
Git commit hash displayed correctly in both cases.