### PR TITLE
Skip ticks when server is under heavy load

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -2374,9 +2374,15 @@ class Server{
 
 		Timings::$serverTickTimer->stopTiming();
 
-		$now = microtime(true);
-		$this->currentTPS = min(20, 1 / max(0.001, $now - $tickTime));
-		$this->currentUse = min(1, ($now - $tickTime) / 0.05);
+		$totalTime = round(microtime(true) - $tickTime, 4);
+		$this->currentTPS = min(20, 1 / max(0.001, $totalTime));
+		$this->currentUse = min(1, $totalTime / 0.05);
+
+		if($totalTime > 0.05){ //tick took too long to execute
+			$skipping = floor($totalTime / 0.05);
+			$this->getLogger()->debug("1 tick took $totalTime seconds to execute, skipping $skipping ticks");
+			$this->tickCounter += $skipping;
+		}
 
 		TimingsHandler::tick($this->currentTPS <= $this->profilingTickRate);
 


### PR DESCRIPTION
Bump the tick counter when a tick took longer than 50ms to execute. This resolves issues such as #292 where a single tick lags enough for _several_ ticks to pass client-side, resulting in issues such as the server thinking the client has moved too far in a single tick.

### Possible improvements
- Add a server watchdog as described [here](http://minecraft.gamepedia.com/Server.properties#Minecraft_server_properties) to forcefully kill the server if a tick takes longer than a certain number of milliseconds. (is pthreads consistent enough for this to work reliably?)