### PR TITLE
Stop the server sending blank messages to players

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3025,14 +3025,16 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			$message = $message->getText();
 		}
 
-		//TODO: Remove this workaround (broken client MCPE 1.0.0)
-		$this->messageQueue[] = $this->server->getLanguage()->translateString($message);
-		/*
-		$pk = new TextPacket();
-		$pk->type = TextPacket::TYPE_RAW;
-		$pk->message = $this->server->getLanguage()->translateString($message);
-		$this->dataPacket($pk);
-		*/
+		if(($translated = $this->server->getLanguage()->translateString($message)) !== ""){
+			//TODO: Remove this workaround (broken client MCPE 1.0.0)
+			$this->messageQueue[] = $translated;
+			/*
+			$pk = new TextPacket();
+			$pk->type = TextPacket::TYPE_RAW;
+			$pk->message = $this->server->getLanguage()->translateString($message);
+			$this->dataPacket($pk);
+			*/
+		}
 	}
 
 	public function sendTranslation($message, array $parameters = []){


### PR DESCRIPTION
### Description
Stops the server queuing blank messages to send to players.

### Reason to modify
Some plugins allow users to edit messages and they can be set to a blank message. Currently a blank message will result in a blank message line being rendered on the client, this didn't happen before the hack to fix duplicated messages was added.

### Tests & Reviews
I've tested this myself with this script plugin:
```
<?php

/**
 * @name MessageSendTest
 * @main jacknoordhuis\MessageSendTest
 * @api 3.0.0-ALPHA3
 * @description Sends a blank message to players every 4 seconds
 * @author JackNoordhuis
 * @version 1.0.0
 */

namespace jacknoordhuis{
	class MessageSendTest extends \pocketmine\plugin\PluginBase{
		public function onEnable(){
			$this->getServer()->getScheduler()->scheduleRepeatingTask(new class($this) extends \pocketmine\scheduler\PluginTask{
				public function onRun($tick){
					foreach($this->getOwner()->getServer()->getOnlinePlayers() as $p) $p->sendMessage("");
				}
			}, 80);
		}
	}
}
```