### PR TITLE
Address #302

### DIFF
--- a/src/pocketmine/MemoryManager.php
+++ b/src/pocketmine/MemoryManager.php
@@ -129,7 +129,7 @@ class MemoryManager{
 	public function trigger($memory, $limit, $global = false, $triggerCount = 0){
 		$this->server->getLogger()->debug(sprintf("[Memory Manager] %sLow memory triggered, limit %gMB, using %gMB",
 			$global ? "Global " : "", round(($limit / 1024) / 1024, 2), round(($memory / 1024) / 1024, 2)));
-		
+
 		foreach($this->server->getLevels() as $level){
 			if($this->cacheTrigger){
 				$level->clearCache(true);

--- a/src/pocketmine/MemoryManager.php
+++ b/src/pocketmine/MemoryManager.php
@@ -182,6 +182,11 @@ class MemoryManager{
 		if($this->garbageCollectionPeriod > 0 and ++$this->garbageCollectionTicker >= $this->garbageCollectionPeriod){
 			$this->garbageCollectionTicker = 0;
 			$this->triggerGarbageCollector();
+			foreach($this->server->getLevels() as $level){
+				if($this->chunkCollect){
+					$level->doChunkGarbageCollection();
+				}
+			}
 		}
 
 		Timings::$memoryManagerTimer->stopTiming();
@@ -198,12 +203,6 @@ class MemoryManager{
 		}
 
 		$cycles = gc_collect_cycles();
-		
-		foreach($this->server->getLevels() as $level){
-			if($this->chunkCollect){
-				$level->doChunkGarbageCollection();
-			}
-		}
 
 		Timings::$garbageCollectorTimer->stopTiming();
 

--- a/src/pocketmine/MemoryManager.php
+++ b/src/pocketmine/MemoryManager.php
@@ -129,14 +129,12 @@ class MemoryManager{
 	public function trigger($memory, $limit, $global = false, $triggerCount = 0){
 		$this->server->getLogger()->debug(sprintf("[Memory Manager] %sLow memory triggered, limit %gMB, using %gMB",
 			$global ? "Global " : "", round(($limit / 1024) / 1024, 2), round(($memory / 1024) / 1024, 2)));
-		if($this->cacheTrigger){
-			foreach($this->server->getLevels() as $level){
+		
+		foreach($this->server->getLevels() as $level){
+			if($this->cacheTrigger){
 				$level->clearCache(true);
 			}
-		}
-
-		if($this->chunkTrigger and $this->chunkCollect){
-			foreach($this->server->getLevels() as $level){
+			if($this->chunkTrigger and $this->chunkCollect){
 				$level->doChunkGarbageCollection();
 			}
 		}
@@ -200,6 +198,15 @@ class MemoryManager{
 		}
 
 		$cycles = gc_collect_cycles();
+		
+		foreach($this->server->getLevels() as $level){
+			if($this->cacheTrigger){
+				$level->clearCache(true);
+			}
+			if($this->chunkTrigger and $this->chunkCollect){
+				$level->doChunkGarbageCollection();
+			}
+		}
 
 		Timings::$garbageCollectorTimer->stopTiming();
 

--- a/src/pocketmine/MemoryManager.php
+++ b/src/pocketmine/MemoryManager.php
@@ -200,10 +200,7 @@ class MemoryManager{
 		$cycles = gc_collect_cycles();
 		
 		foreach($this->server->getLevels() as $level){
-			if($this->cacheTrigger){
-				$level->clearCache(true);
-			}
-			if($this->chunkTrigger and $this->chunkCollect){
+			if($this->chunkCollect){
 				$level->doChunkGarbageCollection();
 			}
 		}


### PR DESCRIPTION
I think this is the right way to do it. I don’t even know why we don’t collect that in the first place. I'm still digging in the history, trying to find the old way this has been done. Weird thing: The /gc command does this, and I always thought doing the /gc command was the same as the scheduled garbage collector.

I also optimised performance of low memory trigger, probably unnecessary.

EDIT:
It was actually done in 1.4 and it looked like this:
```php
if($this->getProperty("chunk-gc.period-in-ticks", 600) > 0){
	$this->scheduler->scheduleDelayedRepeatingTask(new CallbackTask([$this, "doLevelGC"]), $this->getProperty("chunk-gc.period-in-ticks", 600), $this->getProperty("chunk-gc.period-in-ticks", 600));
}
```
(https://github.com/pmmp/PocketMine-MP/blob/3de14d8ba6d275c870d922cc46888cd9282a5bb3/src/pocketmine/Server.php#L1671)
doLevelGC in Server.php was simply iterating through the levels and calling the doChunkGarbageCollection.