### PR TITLE
Remove shutdown after memory dump.

### DIFF
--- a/src/pocketmine/MemoryManager.php
+++ b/src/pocketmine/MemoryManager.php
@@ -292,8 +292,6 @@ class MemoryManager{
 		echo "[Dump] Finished!\n";
 
 		gc_enable();
-
-		$this->server->forceShutdown();
 	}
 
 	private function continueDump($from, &$data, &$objects, &$refCounts, $recursion, $maxNesting, $maxStringSize){


### PR DESCRIPTION
"[Dump] After the memory dump is done, the server might crash"

With that said, it should not shutdown.