### PR TITLE
Sea Lantern Lighting Bug

### DIFF
--- a/src/pocketmine/block/SeaLantern.php
+++ b/src/pocketmine/block/SeaLantern.php
@@ -23,7 +23,7 @@ namespace pocketmine\block;
 
 use pocketmine\item\Item;
 
-class SeaLantern extends Solid{
+class SeaLantern extends Transparent{
 
 	protected $id = self::SEA_LANTERN;
 


### PR DESCRIPTION
Changed Sea Lantern from extending Solid to extending Transparent, like
GlowingObsidian and Glowstone, so that lighting works properly.