### PR TITLE
Added support for Composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ Desktop.ini
 # Sphinx-doc
 /docs/build/
 !/docs/requirements.txt
+
+vendor/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_script:
  - make install
  - cd ..
  - echo "extension=pthreads.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+ - composer install
 
 script:
  - ./tests/travis.sh

--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,13 @@
       "ext-weakref": ">=0.3.3",
       "ext-yaml": ">=2.0.0",
       "ext-zlib": ">=1.2.11"
+   },
+   "autoload": {
+      "exclude-from-classmap": [
+        "src/spl/stubs"
+      ],
+      "psr-0": {
+         "": ["src", "src/spl"]
+      }
    }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,20 @@
+{
+   "name": "pmmp/pocketmine-mp",
+   "description": "A server software for Minecraft: Pocket Edition written in PHP",
+   "type": "project",
+   "homepage": "https://pmmp.io",
+   "license": "LGPL-3.0",
+   "require": {
+      "php": ">=7.0",
+      "ext-curl": "*",
+      "ext-json": "*",
+      "ext-mbstring": "*",
+      "ext-openssl": "*",
+      "ext-phar": "*",
+      "ext-pthreads": ">=3.1.6",
+      "ext-sockets": "*",
+      "ext-weakref": ">=0.3.3",
+      "ext-yaml": ">=2.0.0",
+      "ext-zlib": ">=1.2.11"
+   }
+}

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
    "license": "LGPL-3.0",
    "require": {
       "php": ">=7.2",
+      "ext-bcmath": "*",
       "ext-curl": "*",
       "ext-json": "*",
       "ext-mbstring": "*",

--- a/composer.json
+++ b/composer.json
@@ -8,13 +8,18 @@
       "php": ">=7.2",
       "ext-bcmath": "*",
       "ext-curl": "*",
+      "ext-hash": "*",
       "ext-json": "*",
       "ext-mbstring": "*",
       "ext-openssl": "*",
+      "ext-pcre": "*",
       "ext-phar": "*",
       "ext-pthreads": ">=3.1.7dev",
+      "ext-reflection": "*",
       "ext-sockets": "*",
+      "ext-spl": "*",
       "ext-yaml": ">=2.0.0",
+      "ext-zip": "*",
       "ext-zlib": ">=1.2.11"
    },
    "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -5,15 +5,14 @@
    "homepage": "https://pmmp.io",
    "license": "LGPL-3.0",
    "require": {
-      "php": ">=7.0",
+      "php": ">=7.2",
       "ext-curl": "*",
       "ext-json": "*",
       "ext-mbstring": "*",
       "ext-openssl": "*",
       "ext-phar": "*",
-      "ext-pthreads": ">=3.1.6",
+      "ext-pthreads": ">=3.1.7dev",
       "ext-sockets": "*",
-      "ext-weakref": ">=0.3.3",
       "ext-yaml": ">=2.0.0",
       "ext-zlib": ">=1.2.11"
    },

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,29 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "d6227fdf71778b90d853c72f579dce13",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=7.0",
+        "ext-curl": "*",
+        "ext-json": "*",
+        "ext-mbstring": "*",
+        "ext-openssl": "*",
+        "ext-phar": "*",
+        "ext-pthreads": ">=3.1.6",
+        "ext-sockets": "*",
+        "ext-weakref": ">=0.3.3",
+        "ext-yaml": ">=2.0.0",
+        "ext-zlib": ">=1.2.11"
+    },
+    "platform-dev": []
+}

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "f08cd8c470d7bca68a2d0ed17d16f5e6",
+    "content-hash": "d4fecad9dce5314493052c870c8cf059",
     "packages": [],
     "packages-dev": [],
     "aliases": [],
@@ -18,13 +18,18 @@
         "php": ">=7.2",
         "ext-bcmath": "*",
         "ext-curl": "*",
+        "ext-hash": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",
+        "ext-pcre": "*",
         "ext-phar": "*",
         "ext-pthreads": ">=3.1.7dev",
+        "ext-reflection": "*",
         "ext-sockets": "*",
+        "ext-spl": "*",
         "ext-yaml": ">=2.0.0",
+        "ext-zip": "*",
         "ext-zlib": ">=1.2.11"
     },
     "platform-dev": []

--- a/composer.lock
+++ b/composer.lock
@@ -4,24 +4,25 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "d6227fdf71778b90d853c72f579dce13",
+    "content-hash": "5d5516bb1bc4697a6307988ef6295146",
     "packages": [],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "ext-pthreads": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.0",
+        "php": ">=7.2",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "ext-phar": "*",
-        "ext-pthreads": ">=3.1.6",
+        "ext-pthreads": ">=3.1.7dev",
         "ext-sockets": "*",
-        "ext-weakref": ">=0.3.3",
         "ext-yaml": ">=2.0.0",
         "ext-zlib": ">=1.2.11"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "5d5516bb1bc4697a6307988ef6295146",
+    "content-hash": "f08cd8c470d7bca68a2d0ed17d16f5e6",
     "packages": [],
     "packages-dev": [],
     "aliases": [],
@@ -16,6 +16,7 @@
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.2",
+        "ext-bcmath": "*",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",

--- a/src/pocketmine/PocketMine.php
+++ b/src/pocketmine/PocketMine.php
@@ -70,6 +70,7 @@ namespace {
 }
 
 namespace pocketmine {
+
 	use pocketmine\utils\Binary;
 	use pocketmine\utils\MainLogger;
 	use pocketmine\utils\ServerKiller;
@@ -148,10 +149,13 @@ namespace pocketmine {
 		require_once(\pocketmine\PATH . "src/spl/BaseClassLoader.php");
 	}
 
+	/*
+	 * We now use the Composer autoloader, but this autoloader is still used by RakLib and for loading plugins.
+	 */
 	$autoloader = new \BaseClassLoader();
 	$autoloader->addPath(\pocketmine\PATH . "src");
 	$autoloader->addPath(\pocketmine\PATH . "src" . DIRECTORY_SEPARATOR . "spl");
-	$autoloader->register(true);
+	$autoloader->register(false);
 
 	if(!class_exists(RakLib::class)){
 		echo "[CRITICAL] Unable to find the RakLib library." . PHP_EOL;

--- a/src/pocketmine/PocketMine.php
+++ b/src/pocketmine/PocketMine.php
@@ -130,6 +130,14 @@ namespace pocketmine {
 		exit(1);
 	}
 
+	if(is_file(\pocketmine\PATH . "vendor/autoload.php")){
+		require_once(\pocketmine\PATH . "vendor/autoload.php");
+	}else{
+		echo "[CRITICAL] Composer autoloader not found" . PHP_EOL;
+		echo "[CRITICAL] Please initialize composer dependencies before running." . PHP_EOL;
+		exit(1);
+	}
+
 	if(!class_exists("ClassLoader", false)){
 		if(!is_file(\pocketmine\PATH . "src/spl/ClassLoader.php")){
 			echo "[CRITICAL] Unable to find the PocketMine-SPL library." . PHP_EOL;

--- a/src/pocketmine/Thread.php
+++ b/src/pocketmine/Thread.php
@@ -57,7 +57,7 @@ abstract class Thread extends \Thread{
 			require(\pocketmine\PATH . "src/spl/BaseClassLoader.php");
 		}
 		if($this->classLoader !== null){
-			$this->classLoader->register(true);
+			$this->classLoader->register(false);
 		}
 	}
 

--- a/src/pocketmine/Thread.php
+++ b/src/pocketmine/Thread.php
@@ -51,6 +51,7 @@ abstract class Thread extends \Thread{
 	 * (unless you are using a custom autoloader).
 	 */
 	public function registerClassLoader(){
+		require(\pocketmine\PATH . "vendor/autoload.php");
 		if(!interface_exists("ClassLoader", false)){
 			require(\pocketmine\PATH . "src/spl/ClassLoader.php");
 			require(\pocketmine\PATH . "src/spl/BaseClassLoader.php");

--- a/src/pocketmine/Worker.php
+++ b/src/pocketmine/Worker.php
@@ -52,6 +52,7 @@ abstract class Worker extends \Worker{
 	 * (unless you are using a custom autoloader).
 	 */
 	public function registerClassLoader(){
+		require(\pocketmine\PATH . "vendor/autoload.php");
 		if(!interface_exists("ClassLoader", false)){
 			require(\pocketmine\PATH . "src/spl/ClassLoader.php");
 			require(\pocketmine\PATH . "src/spl/BaseClassLoader.php");

--- a/src/pocketmine/Worker.php
+++ b/src/pocketmine/Worker.php
@@ -58,7 +58,7 @@ abstract class Worker extends \Worker{
 			require(\pocketmine\PATH . "src/spl/BaseClassLoader.php");
 		}
 		if($this->classLoader !== null){
-			$this->classLoader->register(true);
+			$this->classLoader->register(false);
 		}
 	}
 

--- a/tests/travis.sh
+++ b/tests/travis.sh
@@ -24,7 +24,7 @@ cd tests/plugins/PocketMine-DevTools
 "$PHP_BINARY" -dphar.readonly=0 ./src/DevTools/ConsoleScript.php --make ./ --relative ./ --out ../../../DevTools.phar
 cd ../../..
 
-"$PHP_BINARY" -dphar.readonly=0 DevTools.phar --make src --relative ./ --entry src/pocketmine/PocketMine.php --out PocketMine-MP.phar
+"$PHP_BINARY" -dphar.readonly=0 DevTools.phar --make src,vendor --relative ./ --entry src/pocketmine/PocketMine.php --out PocketMine-MP.phar
 if [ -f PocketMine-MP.phar ]; then
 	echo Server phar created successfully.
 else


### PR DESCRIPTION
This pull request adds Composer support to PocketMine-MP.

### What is Composer?
Composer is a dependency manager for PHP projects. Please see the [Composer documentation](https://getcomposer.org/doc/) for a more detailed overview of what Composer is and does.

### Why?
Adding Composer to the project brings much more ease to managing extension and library dependencies. This will allow PocketMine-MP to make use of pre-written libraries for various things instead of writing in-house implementations or copy-pasting code into the project.

### Changes to CI
I have altered the test process of Travis-CI to:
- Install dependencies via Composer
- Build a server phar including the `vendor` directory.

### Changes to the installation process
- If you wish to run PocketMine-MP from source-code or compile a phar from source-code, Composer is now REQUIRED to install necessary dependencies before compiling. Currently, there are no external dependencies - Composer is currently only in use for extension management, but this will change in the near future.

#### Steps to setup PocketMine-MP in source form with Composer
- Install Composer from [here](https://getcomposer.org/download/)
- cd into the directory where you cloned PocketMine-MP
- Run `composer install`
- Composer will tell you if any of the required dependencies are missing, including extensions.

*NOTE: You need the OpenSSL for PHP extension to use Composer.*

#### Compiling a phar
After installing dependencies, you may compile a phar using DevTools. You will need to use a new version of DevTools, as you will need to include multiple paths in the phar.
```
php DevTools.phar --make src,vendor --relative ./ --entry src/pocketmine/PocketMine.php --out PocketMine-MP.phar
```