### PR TITLE
Fixed half-trees on chunk boundaries, possibly fixed #265

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3602,19 +3602,23 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	}
 
 	public function onChunkChanged(Chunk $chunk){
-		$this->loadQueue[Level::chunkHash($chunk->getX(), $chunk->getZ())] = abs(($this->x >> 4) - $chunk->getX()) + abs(($this->z >> 4) - $chunk->getZ());
+		unset($this->usedChunks[Level::chunkHash($chunk->getX(), $chunk->getZ())]);
 	}
 
 	public function onChunkLoaded(Chunk $chunk){
+
 	}
 
 	public function onChunkPopulated(Chunk $chunk){
+
 	}
 
 	public function onChunkUnloaded(Chunk $chunk){
+
 	}
 
 	public function onBlockChanged(Vector3 $block){
+
 	}
 
 	public function getLoaderId(){


### PR DESCRIPTION
When `Level->setChunk()` is called by anything, `ChunkLoader->onChunkChanged()` should be called for any attached loaders. This is _supposed_ to trigger a chunk resend for players, but currently PocketMine-MP sticks the load request into a load queue that for the most part is overwritten every second.

This pull request fixes the issue by removing the specified chunk from the player's index of usedChunks, which will cause the server to automatically resend that chunk next time a chunk order is made.