### PR TITLE
Fixed wrong temperature and temperature -> rainfall

### DIFF
--- a/src/pocketmine/level/generator/normal/biome/ForestBiome.php
+++ b/src/pocketmine/level/generator/normal/biome/ForestBiome.php
@@ -49,11 +49,11 @@ class ForestBiome extends GrassyBiome{
 		$this->setElevation(63, 81);
 
 		if($type === self::TYPE_BIRCH){
-			$this->temperature = 0.5;
+			$this->temperature = 0.6;
 			$this->rainfall = 0.5;
 		}else{
 			$this->temperature = 0.7;
-			$this->temperature = 0.8;
+			$this->rainfall = 0.8;
 		}
 	}
 

--- a/src/pocketmine/level/generator/normal/biome/MountainsBiome.php
+++ b/src/pocketmine/level/generator/normal/biome/MountainsBiome.php
@@ -42,7 +42,7 @@ class MountainsBiome extends GrassyBiome{
 
 		$this->setElevation(63, 127);
 
-		$this->temperature = 0.4;
+		$this->temperature = 0.5;
 		$this->rainfall = 0.5;
 	}
 

--- a/src/pocketmine/level/generator/normal/biome/MountainsBiome.php
+++ b/src/pocketmine/level/generator/normal/biome/MountainsBiome.php
@@ -42,7 +42,7 @@ class MountainsBiome extends GrassyBiome{
 
 		$this->setElevation(63, 127);
 
-		$this->temperature = 0.5;
+		$this->temperature = 0.4;
 		$this->rainfall = 0.5;
 	}
 


### PR DESCRIPTION
This Pull Request fixes two very minor things. One of which being the temperature of the birch biome. The correct value can be found here: http://minecraftpc.wikia.com/wiki/Birch_Forest. Furthermore, this pull request fixes temperature being set twice, while one of these should be rainfall, not temperature.