### PR TITLE
Added API for transferring players to other servers

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -64,6 +64,7 @@ use pocketmine\event\player\PlayerRespawnEvent;
 use pocketmine\event\player\PlayerToggleFlightEvent;
 use pocketmine\event\player\PlayerToggleSneakEvent;
 use pocketmine\event\player\PlayerToggleSprintEvent;
+use pocketmine\event\player\PlayerTransferEvent;
 use pocketmine\event\server\DataPacketReceiveEvent;
 use pocketmine\event\server\DataPacketSendEvent;
 use pocketmine\event\TextContainer;
@@ -127,6 +128,7 @@ use pocketmine\network\protocol\SetTimePacket;
 use pocketmine\network\protocol\StartGamePacket;
 use pocketmine\network\protocol\TakeItemEntityPacket;
 use pocketmine\network\protocol\TextPacket;
+use pocketmine\network\protocol\TransferPacket;
 use pocketmine\network\protocol\UpdateAttributesPacket;
 use pocketmine\network\protocol\UpdateBlockPacket;
 use pocketmine\network\SourceInterface;
@@ -2973,6 +2975,27 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		}
 
 		$timings->stopTiming();
+	}
+
+	/**
+	 * Transfers a player to another server.
+	 *
+	 * @param string $address The IP address or hostname of the destination server
+	 * @param int    $port    The destination port, defaults to 19132
+	 *
+	 * @return bool if transfer was successful.
+	 */
+	public function transfer(string $address, int $port = 19132) : bool{
+		$this->server->getPluginManager()->callEvent($ev = new PlayerTransferEvent($this, $address, $port));
+		if(!$ev->isCancelled()){
+			$pk = new TransferPacket();
+			$pk->address = $ev->getAddress();
+			$pk->port = $ev->getPort();
+			$this->dataPacket($pk);
+			$this->close($this->getDisplayName() . " transferred to another server", "transferred to another server", false); //TODO: add language strings
+			return true;
+		}
+		return false;
 	}
 
 	/**

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2985,14 +2985,14 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	 *
 	 * @return bool if transfer was successful.
 	 */
-	public function transfer(string $address, int $port = 19132) : bool{
+	public function transfer(string $address, int $port = 19132, string $message = "transfer") : bool{
 		$this->server->getPluginManager()->callEvent($ev = new PlayerTransferEvent($this, $address, $port));
 		if(!$ev->isCancelled()){
 			$pk = new TransferPacket();
 			$pk->address = $ev->getAddress();
 			$pk->port = $ev->getPort();
 			$this->dataPacket($pk);
-			$this->close($this->getDisplayName() . " transferred to another server", "transferred to another server", false); //TODO: add language strings
+			$this->close("", $message, false);
 			return true;
 		}
 		return false;

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2982,19 +2982,23 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	 *
 	 * @param string $address The IP address or hostname of the destination server
 	 * @param int    $port    The destination port, defaults to 19132
+	 * @param string $message Message to show in the console when closing the player
 	 *
 	 * @return bool if transfer was successful.
 	 */
 	public function transfer(string $address, int $port = 19132, string $message = "transfer") : bool{
-		$this->server->getPluginManager()->callEvent($ev = new PlayerTransferEvent($this, $address, $port));
+		$this->server->getPluginManager()->callEvent($ev = new PlayerTransferEvent($this, $address, $port, $message));
+
 		if(!$ev->isCancelled()){
 			$pk = new TransferPacket();
 			$pk->address = $ev->getAddress();
 			$pk->port = $ev->getPort();
 			$this->dataPacket($pk);
-			$this->close("", $message, false);
+			$this->close("", $ev->getMessage(), false);
+
 			return true;
 		}
+
 		return false;
 	}
 

--- a/src/pocketmine/command/SimpleCommandMap.php
+++ b/src/pocketmine/command/SimpleCommandMap.php
@@ -57,6 +57,7 @@ use pocketmine\command\defaults\TeleportCommand;
 use pocketmine\command\defaults\TellCommand;
 use pocketmine\command\defaults\TimeCommand;
 use pocketmine\command\defaults\TimingsCommand;
+use pocketmine\command\defaults\TransferServerCommand;
 use pocketmine\command\defaults\VanillaCommand;
 use pocketmine\command\defaults\VersionCommand;
 use pocketmine\command\defaults\WhitelistCommand;
@@ -115,6 +116,7 @@ class SimpleCommandMap implements CommandMap{
 		$this->register("pocketmine", new TimeCommand("time"));
 		$this->register("pocketmine", new TimingsCommand("timings"));
 		$this->register("pocketmine", new ReloadCommand("reload"));
+		$this->register("pocketmine", new TransferServerCommand("transferserver"));
 
 		if($this->server->getProperty("debug.commands", false)){
 			$this->register("pocketmine", new StatusCommand("status"));

--- a/src/pocketmine/command/defaults/TransferServerCommand.php
+++ b/src/pocketmine/command/defaults/TransferServerCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+
+namespace pocketmine\command\defaults;
+
+
+use pocketmine\command\CommandSender;
+use pocketmine\event\TranslationContainer;
+use pocketmine\Player;
+
+class TransferServerCommand extends VanillaCommand{
+
+	public function __construct($name){
+		parent::__construct(
+			$name,
+			"%pocketmine.command.transferserver.description",
+			"%pocketmine.command.transferserver.usage"
+		);
+		$this->setPermission("pocketmine.command.transferserver");
+	}
+
+	public function execute(CommandSender $sender, $commandLabel, array $args){
+		if(count($args) < 1){
+			$sender->sendMessage(new TranslationContainer("commands.generic.usage", [$this->usageMessage]));
+
+			return false;
+		}elseif(!($sender instanceof Player)){
+			$sender->sendMessage("This command must be executed as a player");
+
+			return false;
+		}
+
+		$sender->transfer($args[0], (int) ($args[1] ?? 19132));
+
+		return true;
+	}
+}

--- a/src/pocketmine/event/player/PlayerTransferEvent.php
+++ b/src/pocketmine/event/player/PlayerTransferEvent.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\event\player;
+
+use pocketmine\event\Cancellable;
+use pocketmine\Player;
+
+class PlayerTransferEvent extends PlayerEvent implements Cancellable{
+	public static $handlerList = null;
+
+	protected $address;
+	protected $port = 19132;
+
+	public function __construct(Player $player, string $address, int $port){
+		$this->player = $player;
+		$this->address = $address;
+		$this->port = $port;
+	}
+
+	public function getAddress() : string{
+		return $this->address;
+	}
+
+	public function setAddress(string $address){
+		$this->address = $address;
+	}
+
+	public function getPort() : int{
+		return $this->port;
+	}
+
+	public function setPort(int $port){
+		$this->port = $port;
+	}
+}

--- a/src/pocketmine/event/player/PlayerTransferEvent.php
+++ b/src/pocketmine/event/player/PlayerTransferEvent.php
@@ -31,11 +31,13 @@ class PlayerTransferEvent extends PlayerEvent implements Cancellable{
 
 	protected $address;
 	protected $port = 19132;
+	protected $message;
 
-	public function __construct(Player $player, string $address, int $port){
+	public function __construct(Player $player, string $address, int $port, string $message){
 		$this->player = $player;
 		$this->address = $address;
 		$this->port = $port;
+		$this->message = $message;
 	}
 
 	public function getAddress() : string{
@@ -52,5 +54,13 @@ class PlayerTransferEvent extends PlayerEvent implements Cancellable{
 
 	public function setPort(int $port){
 		$this->port = $port;
+	}
+
+	public function getMessage() : string{
+		return $this->message;
+	}
+
+	public function setMessage(string $message){
+		$this->message = $message;
 	}
 }


### PR DESCRIPTION
Added `Player->transfer()` and `PlayerTransferEvent`. See diff for details.

#### Why?
Because components of the network module, such as packet classes, are not covered by the PocketMine-MP API and are subject to change at any time. It is much easier and cleaner to create a core transfer API that can later be deprecated if some client features happen to be removed or broken.