### PR TITLE
Added exception throws when an error occurs during Utils::getURL() or…

### DIFF
--- a/src/pocketmine/updater/AutoUpdater.php
+++ b/src/pocketmine/updater/AutoUpdater.php
@@ -57,7 +57,13 @@ class AutoUpdater{
 	}
 
 	protected function check(){
-		$response = Utils::getURL($this->endpoint . "?channel=" . $this->getChannel(), 4);
+		$error = "";
+		$response = Utils::getURL($this->endpoint . "?channel=" . $this->getChannel(), 4, [], $error);
+		if($error !== ""){
+			$this->server->getLogger()->debug("[AutoUpdater] Update check failed due to \"$error\"");
+			return;
+		}
+
 		$response = json_decode($response, true);
 		if(!is_array($response)){
 			return;

--- a/src/pocketmine/utils/Utils.php
+++ b/src/pocketmine/utils/Utils.php
@@ -354,6 +354,8 @@ class Utils{
 	 * @param array $extraHeaders
 	 *
 	 * @return bool|mixed
+	 *
+	 * @throws \Throwable if an error occurred
 	 */
 	public static function getURL($page, $timeout = 10, array $extraHeaders = []){
 		if(Utils::$online === false){
@@ -372,7 +374,18 @@ class Utils{
 		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, (int) $timeout);
 		curl_setopt($ch, CURLOPT_TIMEOUT, (int) $timeout);
 		$ret = curl_exec($ch);
+
+		$err = "";
+		if($ret === false){
+			//Need to get error before closing
+			$err = curl_error($ch);
+		}
+
 		curl_close($ch);
+
+		if($err !== ""){
+			throw new \Exception($err);
+		}
 
 		return $ret;
 	}
@@ -386,6 +399,8 @@ class Utils{
 	 * @param array        $extraHeaders
 	 *
 	 * @return bool|mixed
+	 *
+	 * @throws \Throwable if an error occurred
 	 */
 	public static function postURL($page, $args, $timeout = 10, array $extraHeaders = []){
 		if(Utils::$online === false){
@@ -406,7 +421,18 @@ class Utils{
 		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, (int) $timeout);
 		curl_setopt($ch, CURLOPT_TIMEOUT, (int) $timeout);
 		$ret = curl_exec($ch);
+
+		$err = "";
+		if($ret === false){
+			//Need to get error before closing
+			$err = curl_error($ch);
+		}
+
 		curl_close($ch);
+
+		if($err !== ""){
+			throw new \Exception($err);
+		}
 
 		return $ret;
 	}

--- a/src/pocketmine/utils/Utils.php
+++ b/src/pocketmine/utils/Utils.php
@@ -348,16 +348,16 @@ class Utils{
 
 	/**
 	 * GETs an URL using cURL
+	 * NOTE: This is a blocking operation and can take a significant amount of time. It is inadvisable to use this method on the main thread.
 	 *
-	 * @param       $page
-	 * @param int   $timeout default 10
-	 * @param array $extraHeaders
+	 * @param        $page
+	 * @param int    $timeout default 10
+	 * @param array  $extraHeaders
+	 * @param string &$err Will be set to the output of curl_error(). Use this to retrieve errors that occured during the operation.
 	 *
-	 * @return bool|mixed
-	 *
-	 * @throws \Throwable if an error occurred
+	 * @return bool|mixed false if an error occurred, mixed data if successful.
 	 */
-	public static function getURL($page, $timeout = 10, array $extraHeaders = []){
+	public static function getURL($page, $timeout = 10, array $extraHeaders = [], &$err = null){
 		if(Utils::$online === false){
 			return false;
 		}
@@ -374,35 +374,25 @@ class Utils{
 		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, (int) $timeout);
 		curl_setopt($ch, CURLOPT_TIMEOUT, (int) $timeout);
 		$ret = curl_exec($ch);
-
-		$err = "";
-		if($ret === false){
-			//Need to get error before closing
-			$err = curl_error($ch);
-		}
-
+		$err = curl_error($ch);
 		curl_close($ch);
-
-		if($err !== ""){
-			throw new \Exception($err);
-		}
 
 		return $ret;
 	}
 
 	/**
 	 * POSTs data to an URL
+	 * NOTE: This is a blocking operation and can take a significant amount of time. It is inadvisable to use this method on the main thread.
 	 *
 	 * @param              $page
 	 * @param array|string $args
 	 * @param int          $timeout
 	 * @param array        $extraHeaders
+	 * @param string       &$err Will be set to the output of curl_error(). Use this to retrieve errors that occured during the operation.
 	 *
-	 * @return bool|mixed
-	 *
-	 * @throws \Throwable if an error occurred
+	 * @return bool|mixed false if an error occurred, mixed data if successful.
 	 */
-	public static function postURL($page, $args, $timeout = 10, array $extraHeaders = []){
+	public static function postURL($page, $args, $timeout = 10, array $extraHeaders = [], &$err = null){
 		if(Utils::$online === false){
 			return false;
 		}
@@ -421,18 +411,8 @@ class Utils{
 		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, (int) $timeout);
 		curl_setopt($ch, CURLOPT_TIMEOUT, (int) $timeout);
 		$ret = curl_exec($ch);
-
-		$err = "";
-		if($ret === false){
-			//Need to get error before closing
-			$err = curl_error($ch);
-		}
-
+		$err = curl_error($ch);
 		curl_close($ch);
-
-		if($err !== ""){
-			throw new \Exception($err);
-		}
 
 		return $ret;
 	}


### PR DESCRIPTION
… Utils::postURL(), close #332 

Some ugly boilerplate code needed due to not being able to get curl errors after closing.

This PR adds detection for errors to Utils::getURL() and Utils::postURL(), and throws exceptions containing the messages outputted by `curl_error()` if an error happened.

I haven't tested this yet, if anyone would like to, please feel free to make comments below.