### PR TITLE
Throw exception when attempting to save a non-generated chunk

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -992,7 +992,7 @@ class Level implements ChunkManager, Metadatable{
 
 	public function saveChunks(){
 		foreach($this->chunks as $chunk){
-			if($chunk->hasChanged()){
+			if($chunk->hasChanged() and $chunk->isGenerated()){
 				$this->provider->setChunk($chunk->getX(), $chunk->getZ(), $chunk);
 				$this->provider->saveChunk($chunk->getX(), $chunk->getZ());
 				$chunk->setChanged(false);
@@ -2506,7 +2506,7 @@ class Level implements ChunkManager, Metadatable{
 
 		try{
 			if($chunk !== null){
-				if($trySave and $this->getAutoSave()){
+				if($trySave and $this->getAutoSave() and $chunk->isGenerated()){
 					$entities = 0;
 					foreach($chunk->getEntities() as $e){
 						if($e instanceof Player){

--- a/src/pocketmine/level/format/io/leveldb/LevelDB.php
+++ b/src/pocketmine/level/format/io/leveldb/LevelDB.php
@@ -478,9 +478,13 @@ class LevelDB extends BaseLevelProvider{
 		return false;
 	}
 
-	public function saveChunk(int $x, int $z) : bool{
-		if($this->isChunkLoaded($x, $z)){
-			$this->writeChunk($this->getChunk($x, $z));
+	public function saveChunk(int $chunkX, int $chunkZ) : bool{
+		if($this->isChunkLoaded($chunkX, $chunkZ)){
+			$chunk = $this->getChunk($chunkX, $chunkZ);
+			if(!$chunk->isGenerated()){
+				throw new \InvalidStateException("Cannot save un-generated chunk");
+			}
+			$this->writeChunk($chunk);
 
 			return true;
 		}

--- a/src/pocketmine/level/format/io/region/McRegion.php
+++ b/src/pocketmine/level/format/io/region/McRegion.php
@@ -317,7 +317,7 @@ class McRegion extends BaseLevelProvider{
 			if(!$chunk->isGenerated()){
 				throw new \InvalidStateException("Cannot save un-generated chunk");
 			}
-			$this->getRegion($chunkX >> 5, $chunkZ >> 5)->writeChunk($this->getChunk($chunkX, $chunkZ));
+			$this->getRegion($chunkX >> 5, $chunkZ >> 5)->writeChunk($chunk);
 
 			return true;
 		}

--- a/src/pocketmine/level/format/io/region/McRegion.php
+++ b/src/pocketmine/level/format/io/region/McRegion.php
@@ -313,6 +313,10 @@ class McRegion extends BaseLevelProvider{
 
 	public function saveChunk(int $chunkX, int $chunkZ) : bool{
 		if($this->isChunkLoaded($chunkX, $chunkZ)){
+			$chunk = $this->getChunk($chunkX, $chunkZ);
+			if(!$chunk->isGenerated()){
+				throw new \InvalidStateException("Cannot save un-generated chunk");
+			}
 			$this->getRegion($chunkX >> 5, $chunkZ >> 5)->writeChunk($this->getChunk($chunkX, $chunkZ));
 
 			return true;


### PR DESCRIPTION
Should (hopefully) highlight what's going on with the big dirty holes in some generated maps.