### PR TITLE
Added safety checks for region file validity

### DIFF
--- a/src/pocketmine/level/format/io/region/CorruptedRegionException.php
+++ b/src/pocketmine/level/format/io/region/CorruptedRegionException.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+
+namespace pocketmine\level\format\io\region;
+
+
+class CorruptedRegionException extends RegionException{
+
+}

--- a/src/pocketmine/level/format/io/region/RegionException.php
+++ b/src/pocketmine/level/format/io/region/RegionException.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+
+namespace pocketmine\level\format\io\region;
+
+
+class RegionException extends \RuntimeException{
+
+}

--- a/src/pocketmine/level/format/io/region/RegionLoader.php
+++ b/src/pocketmine/level/format/io/region/RegionLoader.php
@@ -25,6 +25,7 @@ namespace pocketmine\level\format\io\region;
 
 use pocketmine\level\format\Chunk;
 use pocketmine\level\format\io\ChunkException;
+use pocketmine\level\LevelException;
 use pocketmine\utils\Binary;
 use pocketmine\utils\MainLogger;
 
@@ -32,7 +33,11 @@ class RegionLoader{
 	const VERSION = 1;
 	const COMPRESSION_GZIP = 1;
 	const COMPRESSION_ZLIB = 2;
+
 	const MAX_SECTOR_LENGTH = 256 << 12; //256 sectors, (1 MiB)
+	const REGION_HEADER_LENGTH = 8192; //4096 location table + 4096 timestamps
+	const MAX_REGION_FILE_SIZE = 32 * 32 * self::MAX_SECTOR_LENGTH + self::REGION_HEADER_LENGTH; //32 * 32 1MiB chunks + header size
+
 	public static $COMPRESSION_LEVEL = 7;
 
 	protected $x;
@@ -51,10 +56,21 @@ class RegionLoader{
 		$this->z = $regionZ;
 		$this->levelProvider = $level;
 		$this->filePath = $this->levelProvider->getPath() . "region/r.$regionX.$regionZ.$fileExtension";
+	}
+
+	public function open(){
 		$exists = file_exists($this->filePath);
 		if(!$exists){
 			touch($this->filePath);
+		}else{
+			$fileSize = filesize($this->filePath);
+			if($fileSize > self::MAX_REGION_FILE_SIZE){
+				throw new CorruptedRegionException("Corrupted oversized region file found, should be a maximum of " . self::MAX_REGION_FILE_SIZE . " bytes, got " . $fileSize . " bytes");
+			}elseif($fileSize % 4096 !== 0){
+				throw new CorruptedRegionException("Region file should be padded to a multiple of 4KiB");
+			}
 		}
+
 		$this->filePointer = fopen($this->filePath, "r+b");
 		stream_set_read_buffer($this->filePointer, 1024 * 16); //16KB
 		stream_set_write_buffer($this->filePointer, 1024 * 16); //16KB
@@ -170,9 +186,20 @@ class RegionLoader{
 		return $x + ($z << 5);
 	}
 
-	public function close(){
-		$this->writeLocationTable();
-		fclose($this->filePointer);
+	/**
+	 * Writes the region header and closes the file
+	 *
+	 * @param bool $writeHeader
+	 */
+	public function close(bool $writeHeader = true){
+		if(is_resource($this->filePointer)){
+			if($writeHeader){
+				$this->writeLocationTable();
+			}
+
+			fclose($this->filePointer);
+		}
+
 		$this->levelProvider = null;
 	}
 
@@ -255,14 +282,34 @@ class RegionLoader{
 		fseek($this->filePointer, 0);
 		$this->lastSector = 1;
 
-		$data = unpack("N*", fread($this->filePointer, 4 * 1024 * 2)); //1024 records * 4 bytes * 2 times
+		$headerRaw = fread($this->filePointer, self::REGION_HEADER_LENGTH);
+		if(($len = strlen($headerRaw)) !== self::REGION_HEADER_LENGTH){
+			throw new CorruptedRegionException("Invalid region file header, expected " . self::REGION_HEADER_LENGTH . " bytes, got " . $len . " bytes");
+		}
+
+		$data = unpack("N*", $headerRaw);
+		$usedOffsets = [];
 		for($i = 0; $i < 1024; ++$i){
 			$index = $data[$i + 1];
+			$offset = $index >> 8;
+			if($offset !== 0){
+				fseek($this->filePointer, ($offset << 12));
+				if(fgetc($this->filePointer) === false){ //Try and read from the location
+					throw new CorruptedRegionException("Region file location offset points to invalid location");
+				}elseif(isset($usedOffsets[$offset])){
+					throw new CorruptedRegionException("Found two chunk offsets pointing to the same location");
+				}else{
+					$usedOffsets[$offset] = true;
+				}
+			}
+
 			$this->locationTable[$i] = [$index >> 8, $index & 0xff, $data[1024 + $i + 1]];
 			if(($this->locationTable[$i][0] + $this->locationTable[$i][1] - 1) > $this->lastSector){
 				$this->lastSector = $this->locationTable[$i][0] + $this->locationTable[$i][1] - 1;
 			}
 		}
+
+		fseek($this->filePointer, 0);
 	}
 
 	private function writeLocationTable(){
@@ -300,4 +347,7 @@ class RegionLoader{
 		return $this->z;
 	}
 
+	public function getFilePath() : string{
+		return $this->filePath;
+	}
 }


### PR DESCRIPTION
Recently it was brought to my attention, by someone having freeze issues on their server, that corrupted or invalid region files can _really_ mess up your server.

In the process of testing their issue I discovered that the RegionLoader does not impose any checks whatsoever on region file validity. You can feed any random crap into there and PocketMine will attempt to use it.
My test:
- create new anvil world
- cd worlds/world/region
- echo "lelelelelelelelel" > r.0.0.mca
- start the server
- join, teleport to 0 128 0
- server freezes and writes out 60GB worth of crap to disk, machine freezes for about 15 minutes.

The reason for said freeze was due to an invalid location table. Region files begin with an 8192-byte header, the first 4096 bytes of which are chunk locations. The first 3 bytes of each entry is the file offset in 4KiB sectors, and the last byte is the length in sectors. Trying to read a garbage file like the one above produces some extremely large offsets for chunks that don't actually exist, so when the server _writes_ to that offset, it also writes billions of zeros in between.

**This is a very critical issue since the process cannot be killed while it is writing to disk**. In the process of debugging this issue I had to force-kill my laptop half a dozen times.

This pull request adds tight restrictions on region file validity as per the specification [here](http://minecraft.gamepedia.com/Region_file_format) to prevent the issue described above occurring.
- A maximum file size of 1GiB + 8192 bytes has been imposed for region files. The server will treat anything bigger than this as corrupted. A single region should never get this big, regardless.
- Region files must now be padded to the 4KiB boundary, or they will not be accepted. PocketMine-MP already performs this padding, so you don't need to worry about that.
- A check for header length has been added. Since fread() stops reading at eof, it's possible to get a bad region that's smaller than the header size, which will throw out lots of undefined offset errors. The server will now reject region files smaller than 8192 bytes.
- Every offset in the location table is now checked to make sure that
  - it points to a valid location
  - it's not duplicated (this would cause chunks to be overwritten, bad)

If any of the detailed checks fail, the region file will be considered corrupted, will be renamed with a backup name, and a new one will be generated. You may then attempt to use MCEdit or other tools to attempt to repair the defective region.