### PR TITLE
Add fireball item and partial functionality

### DIFF
--- a/src/pocketmine/item/Fireball.php
+++ b/src/pocketmine/item/Fireball.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+namespace pocketmine\item;
+
+use pocketmine\block\Block;
+use pocketmine\block\Fire;
+use pocketmine\block\Solid;
+use pocketmine\level\Level;
+use pocketmine\Player;
+
+class Fireball extends Item{
+    public function __construct($meta = 0, $count = 1){
+        parent::__construct(self::FIREBALL, $meta, $count, "Fire Charge");
+    }
+    
+    public function canBeActivated(){
+        return true;
+    }
+    
+    public function onActivate(Level $level, Player $player, Block $block, Block $target, $face, $fx, $fy, $fz){
+        if($block->getId() === self::AIR and ($target instanceof Solid)){
+            $level->setBlock($block, new Fire(), true);
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/pocketmine/item/Item.php
+++ b/src/pocketmine/item/Item.php
@@ -85,6 +85,7 @@ class Item implements ItemIds, \JsonSerializable{
 			self::$list[self::IRON_PICKAXE] = IronPickaxe::class;
 			self::$list[self::IRON_AXE] = IronAxe::class;
 			self::$list[self::FLINT_STEEL] = FlintSteel::class;
+			self::$list[self::FIREBALL] = Fireball::class;
 			self::$list[self::APPLE] = Apple::class;
 			self::$list[self::BOW] = Bow::class;
 			self::$list[self::ARROW] = Arrow::class;

--- a/src/pocketmine/item/ItemIds.php
+++ b/src/pocketmine/item/ItemIds.php
@@ -154,7 +154,7 @@ interface ItemIds extends BlockIds{
 	const GLISTERING_MELON = 382;
 	const SPAWN_EGG = 383;
 	const BOTTLE_O_ENCHANTING = 384, ENCHANTING_BOTTLE = 384;
-	const FIRE_CHARGE = 385;
+	const FIRE_CHARGE = 385, FIREBALL = 385;
 
 	const EMERALD = 388;
 	const ITEM_FRAME = 389;


### PR DESCRIPTION
This pull request adds the fireball *(fire charge)* item to PocketMine. When you tap on the ground using this item it will place fire, like flint and steel. This is exactly what should happen in vanilla.

I named the item "fireball" as per http://minecraft.gamepedia.com/Fire_Charge, so you can now `/give (player) fireball`, however i have kept the original implementation of `/give (player) fire_charge` to avoid breaking any plugins.