### PR TITLE
Use entity IDs in EntityDamageByEntityEvents, fixed memory leaks related to PvP/PvE/PvM

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -1088,6 +1088,31 @@ class Server{
 	}
 
 	/**
+	 * Searches all levels for the entity with the specified ID.
+	 * Useful for tracking entities across multiple worlds without needing strong references.
+	 *
+	 * @param int        $entityId
+	 * @param Level|null $expectedLevel Level to look in first for the target
+	 *
+	 * @return Entity|null
+	 */
+	public function findEntity(int $entityId, Level $expectedLevel = null){
+		$levels = $this->levels;
+		if($expectedLevel !== null){
+			array_unshift($levels, $expectedLevel);
+		}
+
+		foreach($levels as $level){
+			assert(!$level->isClosed());
+			if(($entity = $level->getEntity($entityId)) instanceof Entity){
+				return $entity;
+			}
+		}
+
+		return null;
+	}
+
+	/**
 	 * @param string $variable
 	 * @param string $defaultValue
 	 *

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -1652,6 +1652,7 @@ abstract class Entity extends Location implements Metadatable{
 			}
 
 			$this->namedtag = null;
+			$this->lastDamageCause = null;
 		}
 	}
 

--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -123,13 +123,15 @@ abstract class Living extends Entity implements Damageable{
 				$e = $source->getChild();
 			}
 
-			if($e->isOnFire() > 0){
-				$this->setOnFire(2 * $this->server->getDifficulty());
-			}
+			if($e !== null){
+				if($e->isOnFire() > 0){
+					$this->setOnFire(2 * $this->server->getDifficulty());
+				}
 
-			$deltaX = $this->x - $e->x;
-			$deltaZ = $this->z - $e->z;
-			$this->knockBack($e, $damage, $deltaX, $deltaZ, $source->getKnockBack());
+				$deltaX = $this->x - $e->x;
+				$deltaZ = $this->z - $e->z;
+				$this->knockBack($e, $damage, $deltaX, $deltaZ, $source->getKnockBack());
+			}
 		}
 
 		$pk = new EntityEventPacket();

--- a/src/pocketmine/entity/Squid.php
+++ b/src/pocketmine/entity/Squid.php
@@ -60,7 +60,9 @@ class Squid extends WaterAnimal implements Ageable{
 		if($source instanceof EntityDamageByEntityEvent){
 			$this->swimSpeed = mt_rand(150, 350) / 2000;
 			$e = $source->getDamager();
-			$this->swimDirection = (new Vector3($this->x - $e->x, $this->y - $e->y, $this->z - $e->z))->normalize();
+			if($e !== null){
+				$this->swimDirection = (new Vector3($this->x - $e->x, $this->y - $e->y, $this->z - $e->z))->normalize();
+			}
 
 			$pk = new EntityEventPacket();
 			$pk->eid = $this->getId();

--- a/src/pocketmine/event/entity/EntityDamageByBlockEvent.php
+++ b/src/pocketmine/event/entity/EntityDamageByBlockEvent.php
@@ -24,6 +24,9 @@ namespace pocketmine\event\entity;
 use pocketmine\block\Block;
 use pocketmine\entity\Entity;
 
+/**
+ * Called when an entity takes damage from a block.
+ */
 class EntityDamageByBlockEvent extends EntityDamageEvent{
 
 	/** @var Block */

--- a/src/pocketmine/event/entity/EntityDamageByChildEntityEvent.php
+++ b/src/pocketmine/event/entity/EntityDamageByChildEntityEvent.php
@@ -23,10 +23,13 @@ namespace pocketmine\event\entity;
 
 use pocketmine\entity\Entity;
 
+/**
+ * Called when an entity takes damage from an entity sourced from another entity, for example being hit by a snowball thrown by a Player.
+ */
 class EntityDamageByChildEntityEvent extends EntityDamageByEntityEvent{
 
-	/** @var Entity */
-	private $childEntity;
+	/** @var int */
+	private $childEntityEid;
 
 
 	/**
@@ -37,15 +40,17 @@ class EntityDamageByChildEntityEvent extends EntityDamageByEntityEvent{
 	 * @param int|int[] $damage
 	 */
 	public function __construct(Entity $damager, Entity $childEntity, Entity $entity, $cause, $damage){
-		$this->childEntity = $childEntity;
+		$this->childEntityEid = $childEntity->getId();
 		parent::__construct($damager, $entity, $cause, $damage);
 	}
 
 	/**
-	 * @return Entity
+	 * Returns the entity which caused the damage, or null if the entity has been killed or closed.
+	 *
+	 * @return Entity|null
 	 */
 	public function getChild(){
-		return $this->childEntity;
+		return $this->getEntity()->getLevel()->getServer()->findEntity($this->childEntityEid, $this->getEntity()->getLevel());
 	}
 
 

--- a/src/pocketmine/event/entity/EntityDamageByEntityEvent.php
+++ b/src/pocketmine/event/entity/EntityDamageByEntityEvent.php
@@ -24,10 +24,13 @@ namespace pocketmine\event\entity;
 use pocketmine\entity\Effect;
 use pocketmine\entity\Entity;
 
+/**
+ * Called when an entity takes damage from another entity.
+ */
 class EntityDamageByEntityEvent extends EntityDamageEvent{
 
-	/** @var Entity */
-	private $damager;
+	/** @var int */
+	private $damagerEid;
 	/** @var float */
 	private $knockBack;
 
@@ -39,7 +42,7 @@ class EntityDamageByEntityEvent extends EntityDamageEvent{
 	 * @param float     $knockBack
 	 */
 	public function __construct(Entity $damager, Entity $entity, $cause, $damage, $knockBack = 0.4){
-		$this->damager = $damager;
+		$this->damagerEid = $damager->getId();
 		$this->knockBack = $knockBack;
 		parent::__construct($entity, $cause, $damage);
 		$this->addAttackerModifiers($damager);
@@ -56,10 +59,12 @@ class EntityDamageByEntityEvent extends EntityDamageEvent{
 	}
 
 	/**
-	 * @return Entity
+	 * Returns the attacking entity, or null if the attacker has been killed or closed.
+	 *
+	 * @return Entity|null
 	 */
 	public function getDamager(){
-		return $this->damager;
+		return $this->getEntity()->getLevel()->getServer()->findEntity($this->damagerEid, $this->getEntity()->getLevel());
 	}
 
 	/**

--- a/src/pocketmine/event/entity/EntityDamageEvent.php
+++ b/src/pocketmine/event/entity/EntityDamageEvent.php
@@ -25,6 +25,9 @@ use pocketmine\entity\Effect;
 use pocketmine\entity\Entity;
 use pocketmine\event\Cancellable;
 
+/**
+ * Called when an entity takes damage.
+ */
 class EntityDamageEvent extends EntityEvent implements Cancellable{
 	public static $handlerList = null;
 


### PR DESCRIPTION
This issue is critical on big PvP servers.

### Explanation
Entities hold a reference to an EntityDamageEvent which details their last damage cause. This is problematic for damage by entities, because entities may be killed, or in the case of players they may quit. This causes those referenced objects to leak. This is commonly seen on large PvP servers with lots of players.
The memory consumed by referenced players would have been a rather large amount before 4f27bce5b34a9e2cbbca0b862761b629270e7fe7. While that commit alleviates general Player leaks by destroying large NBT object trees, it merely reduces the impact of the issue, and does not fix it.

This is not a magical WOWy-style leak fix, it will not magically fix all your issues. You'll probably still see issues after this PR has been merged, as this is not the only leak I have discovered in the process of debugging these issues.