### PR TITLE
Stop skipping stack frames

### DIFF
--- a/src/pocketmine/CrashDump.php
+++ b/src/pocketmine/CrashDump.php
@@ -143,7 +143,7 @@ class CrashDump{
 			$error = $lastExceptionError;
 		}else{
 			$error = (array) error_get_last();
-			$error["trace"] = @getTrace(3);
+			$error["trace"] = getTrace(4); //Skipping CrashDump->baseCrash, CrashDump->construct, Server->crashDump
 			$errorConversion = [
 				E_ERROR => "E_ERROR",
 				E_WARNING => "E_WARNING",

--- a/src/pocketmine/PocketMine.php
+++ b/src/pocketmine/PocketMine.php
@@ -357,7 +357,7 @@ namespace pocketmine {
 		return -1;
 	}
 
-	function getTrace($start = 1, $trace = null){
+	function getTrace($start = 0, $trace = null){
 		if($trace === null){
 			if(function_exists("xdebug_get_function_stack")){
 				$trace = array_reverse(xdebug_get_function_stack());

--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -2027,9 +2027,8 @@ class Server{
 		$errline = $e->getLine();
 
 		$type = ($errno === E_ERROR or $errno === E_USER_ERROR) ? \LogLevel::ERROR : (($errno === E_USER_WARNING or $errno === E_WARNING) ? \LogLevel::WARNING : \LogLevel::NOTICE);
-		if(($pos = strpos($errstr, "\n")) !== false){
-			$errstr = substr($errstr, 0, $pos);
-		}
+
+		$errstr = preg_replace('/\s+/', ' ', trim($errstr));
 
 		$errfile = cleanPath($errfile);
 
@@ -2041,7 +2040,7 @@ class Server{
 			"fullFile" => $e->getFile(),
 			"file" => $errfile,
 			"line" => $errline,
-			"trace" => @getTrace(1, $trace)
+			"trace" => getTrace(0, $trace)
 		];
 
 		global $lastExceptionError, $lastError;

--- a/src/pocketmine/utils/MainLogger.php
+++ b/src/pocketmine/utils/MainLogger.php
@@ -134,12 +134,10 @@ class MainLogger extends \AttachableThreadedLogger{
 			$type = ($errno === E_ERROR or $errno === E_USER_ERROR) ? LogLevel::ERROR : (($errno === E_USER_WARNING or $errno === E_WARNING) ? LogLevel::WARNING : LogLevel::NOTICE);
 		}
 		$errno = $errorConversion[$errno] ?? $errno;
-		if(($pos = strpos($errstr, "\n")) !== false){
-			$errstr = substr($errstr, 0, $pos);
-		}
+		$errstr = preg_replace('/\s+/', ' ', trim($errstr));
 		$errfile = \pocketmine\cleanPath($errfile);
 		$this->log($type, get_class($e) . ": \"$errstr\" ($errno) in \"$errfile\" at line $errline");
-		foreach(@\pocketmine\getTrace(1, $trace) as $i => $line){
+		foreach(\pocketmine\getTrace(0, $trace) as $i => $line){
 			$this->debug($line);
 		}
 	}


### PR DESCRIPTION
- Fixes highest stack frame missing in exception logs
- fixed issues with line breaks and \r in error messages
- Crash dumps with an error will no longer include the `Server->crashDump()` stack frame. (This also means that currently, crashes with errors without xdebug will have no stack trace at all. See #317)
