### PR TITLE
Fix client-side death bug

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3340,15 +3340,6 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		$this->dataPacket($pk);
 	}
 
-	public function setHealth($amount){
-		parent::setHealth($amount);
-		if($this->spawned === true){
-			$pk = new SetHealthPacket();
-			$pk->health = $this->getHealth();
-			$this->dataPacket($pk);
-		}
-	}
-
 	public function attack($damage, EntityDamageEvent $source){
 		if(!$this->isAlive()){
 			return;


### PR DESCRIPTION
So here was the bug:

Whenever the player was damaged down to below 3 - 4 hearts and then if they healed quickly in some way(whether it would be plugin-based, effect-based, etc.) it would drop their health below 0 and kill them client-side, while they would be unaffected server-side.

After extensive testing both with and without this commit using the same techniques and repeating them many times, I've determined this was the bug causing it. As far as I'm aware SetHealthPacket is no longer used, because it's handled by attributes. So this will fix annoying issues with random client-side deaths when at a low enough health, making it for all around better gameplay.