### PR TITLE
Throw an exception when something attempts to serialize Server

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -2434,4 +2434,13 @@ class Server{
 
 		return true;
 	}
+
+	/**
+	 * Called when something attempts to serialize the server instance.
+	 *
+	 * @throws \BadMethodCallException because Server instances cannot be serialized
+	 */
+	public function __sleep(){
+		throw new \BadMethodCallException("Cannot serialize Server instance");
+	}
 }


### PR DESCRIPTION
As per @Sandertv 's issue, this will provide clarification as to what is actually happening when something unintentionally serializes a referenced Server object instead of a confuzzling `Serialization of Closure is not allowed` exception.