### PR TITLE
Fixed block update recursion issues

### DIFF
--- a/src/pocketmine/block/Lava.php
+++ b/src/pocketmine/block/Lava.php
@@ -64,7 +64,7 @@ class Lava extends Liquid{
 
 	public function place(Item $item, Block $block, Block $target, $face, $fx, $fy, $fz, Player $player = null){
 		$ret = $this->getLevel()->setBlock($this, $this, true, false);
-		$this->getLevel()->scheduleUpdate($this, $this->tickRate());
+		$this->getLevel()->scheduleDelayedBlockUpdate($this, $this->tickRate());
 
 		return $ret;
 	}

--- a/src/pocketmine/block/Liquid.php
+++ b/src/pocketmine/block/Liquid.php
@@ -189,7 +189,7 @@ abstract class Liquid extends Transparent{
 	public function onUpdate($type){
 		if($type === Level::BLOCK_UPDATE_NORMAL){
 			$this->checkForHarden();
-			$this->getLevel()->scheduleUpdate($this, $this->tickRate());
+			$this->getLevel()->scheduleDelayedBlockUpdate($this, $this->tickRate());
 		}elseif($type === Level::BLOCK_UPDATE_SCHEDULED){
 			if($this->temporalVector === null){
 				$this->temporalVector = new Vector3(0, 0, 0);
@@ -242,7 +242,7 @@ abstract class Liquid extends Transparent{
 						$this->getLevel()->setBlock($this, new Air(), true);
 					}else{
 						$this->getLevel()->setBlock($this, Block::get($this->id, $decay), true);
-						$this->getLevel()->scheduleUpdate($this, $this->tickRate());
+						$this->getLevel()->scheduleDelayedBlockUpdate($this, $this->tickRate());
 					}
 				}elseif($flag){
 					//$this->getLevel()->scheduleUpdate($this, $this->tickRate());
@@ -262,10 +262,10 @@ abstract class Liquid extends Transparent{
 
 				if($decay >= 8){
 					$this->getLevel()->setBlock($bottomBlock, Block::get($this->id, $decay), true);
-					$this->getLevel()->scheduleUpdate($bottomBlock, $this->tickRate());
+					$this->getLevel()->scheduleDelayedBlockUpdate($bottomBlock, $this->tickRate());
 				}else{
 					$this->getLevel()->setBlock($bottomBlock, Block::get($this->id, $decay + 8), true);
-					$this->getLevel()->scheduleUpdate($bottomBlock, $this->tickRate());
+					$this->getLevel()->scheduleDelayedBlockUpdate($bottomBlock, $this->tickRate());
 				}
 			}elseif($decay >= 0 and ($decay === 0 or !$bottomBlock->canBeFlowedInto())){
 				$flags = $this->getOptimalFlowDirections();
@@ -310,7 +310,7 @@ abstract class Liquid extends Transparent{
 			}
 
 			$this->getLevel()->setBlock($block, Block::get($this->getId(), $newFlowDecay), true);
-			$this->getLevel()->scheduleUpdate($block, $this->tickRate());
+			$this->getLevel()->scheduleDelayedBlockUpdate($block, $this->tickRate());
 		}
 	}
 

--- a/src/pocketmine/block/Water.php
+++ b/src/pocketmine/block/Water.php
@@ -48,7 +48,7 @@ class Water extends Liquid{
 
 	public function place(Item $item, Block $block, Block $target, $face, $fx, $fy, $fz, Player $player = null){
 		$ret = $this->getLevel()->setBlock($this, $this, true, false);
-		$this->getLevel()->scheduleUpdate($this, $this->tickRate());
+		$this->getLevel()->scheduleDelayedBlockUpdate($this, $this->tickRate());
 
 		return $ret;
 	}

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -193,11 +193,11 @@ class Level implements ChunkManager, Metadatable{
 	private $changedBlocks = [];
 
 	/** @var ReversePriorityQueue */
-	private $updateQueue;
-	private $updateQueueIndex = [];
+	private $scheduledBlockUpdateQueue;
+	private $scheduledBlockUpdateQueueIndex = [];
 
 	/** @var \SplQueue */
-	private $neighbourBlockUpdates = [];
+	private $neighbourBlockUpdateQueue = [];
 
 	/** @var Player[][] */
 	private $chunkSendQueue = [];
@@ -339,10 +339,10 @@ class Level implements ChunkManager, Metadatable{
 		$this->generator = Generator::getGenerator($this->provider->getGenerator());
 
 		$this->folderName = $name;
-		$this->updateQueue = new ReversePriorityQueue();
-		$this->updateQueue->setExtractFlags(\SplPriorityQueue::EXTR_BOTH);
+		$this->scheduledBlockUpdateQueue = new ReversePriorityQueue();
+		$this->scheduledBlockUpdateQueue->setExtractFlags(\SplPriorityQueue::EXTR_BOTH);
 
-		$this->neighbourBlockUpdates = new \SplQueue();
+		$this->neighbourBlockUpdateQueue = new \SplQueue();
 
 		$this->time = (int) $this->provider->getTime();
 
@@ -666,21 +666,25 @@ class Level implements ChunkManager, Metadatable{
 
 		//Do block updates
 		$this->timings->doTickPending->startTiming();
-		while($this->updateQueue->count() > 0 and $this->updateQueue->current()["priority"] <= $currentTick){
-			$block = $this->getBlock($this->updateQueue->extract()["data"]);
-			unset($this->updateQueueIndex[Level::blockHash($block->x, $block->y, $block->z)]);
+
+		//Delayed updates
+		while($this->scheduledBlockUpdateQueue->count() > 0 and $this->scheduledBlockUpdateQueue->current()["priority"] <= $currentTick){
+			$block = $this->getBlock($this->scheduledBlockUpdateQueue->extract()["data"]);
+			unset($this->scheduledBlockUpdateQueueIndex[Level::blockHash($block->x, $block->y, $block->z)]);
 			$block->onUpdate(self::BLOCK_UPDATE_SCHEDULED);
 		}
-		$this->timings->doTickPending->stopTiming();
 
-		while($this->neighbourBlockUpdates->count() > 0){
-			$index = $this->neighbourBlockUpdates->dequeue();
+		//Normal updates
+		while($this->neighbourBlockUpdateQueue->count() > 0){
+			$index = $this->neighbourBlockUpdateQueue->dequeue();
 			Level::getBlockXYZ($index, $x, $y, $z);
 			$this->server->getPluginManager()->callEvent($ev = new BlockUpdateEvent($this->getBlock($this->temporalVector->setComponents($x, $y, $z))));
 			if(!$ev->isCancelled()){
 				$ev->getBlock()->onUpdate(self::BLOCK_UPDATE_NORMAL);
 			}
 		}
+
+		$this->timings->doTickPending->stopTiming();
 
 		$this->timings->entityTick->startTiming();
 		//Update entities that need update
@@ -1076,11 +1080,11 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int     $delay
 	 */
 	public function scheduleDelayedBlockUpdate(Vector3 $pos, int $delay){
-		if(isset($this->updateQueueIndex[$index = Level::blockHash($pos->x, $pos->y, $pos->z)]) and $this->updateQueueIndex[$index] <= $delay){
+		if(isset($this->scheduledBlockUpdateQueueIndex[$index = Level::blockHash($pos->x, $pos->y, $pos->z)]) and $this->scheduledBlockUpdateQueueIndex[$index] <= $delay){
 			return;
 		}
-		$this->updateQueueIndex[$index] = $delay;
-		$this->updateQueue->insert(new Vector3((int) $pos->x, (int) $pos->y, (int) $pos->z), (int) $delay + $this->server->getTick());
+		$this->scheduledBlockUpdateQueueIndex[$index] = $delay;
+		$this->scheduledBlockUpdateQueue->insert(new Vector3((int) $pos->x, (int) $pos->y, (int) $pos->z), (int) $delay + $this->server->getTick());
 	}
 
 	/**
@@ -1092,12 +1096,12 @@ class Level implements ChunkManager, Metadatable{
 	public function scheduleNeighbourBlockUpdates(Vector3 $pos){
 		$pos = $pos->floor();
 
-		$this->neighbourBlockUpdates->enqueue(Level::blockHash($pos->x + 1, $pos->y, $pos->z));
-		$this->neighbourBlockUpdates->enqueue(Level::blockHash($pos->x - 1, $pos->y, $pos->z));
-		$this->neighbourBlockUpdates->enqueue(Level::blockHash($pos->x, $pos->y + 1, $pos->z));
-		$this->neighbourBlockUpdates->enqueue(Level::blockHash($pos->x, $pos->y - 1, $pos->z));
-		$this->neighbourBlockUpdates->enqueue(Level::blockHash($pos->x, $pos->y, $pos->z + 1));
-		$this->neighbourBlockUpdates->enqueue(Level::blockHash($pos->x, $pos->y, $pos->z - 1));
+		$this->neighbourBlockUpdateQueue->enqueue(Level::blockHash($pos->x + 1, $pos->y, $pos->z));
+		$this->neighbourBlockUpdateQueue->enqueue(Level::blockHash($pos->x - 1, $pos->y, $pos->z));
+		$this->neighbourBlockUpdateQueue->enqueue(Level::blockHash($pos->x, $pos->y + 1, $pos->z));
+		$this->neighbourBlockUpdateQueue->enqueue(Level::blockHash($pos->x, $pos->y - 1, $pos->z));
+		$this->neighbourBlockUpdateQueue->enqueue(Level::blockHash($pos->x, $pos->y, $pos->z + 1));
+		$this->neighbourBlockUpdateQueue->enqueue(Level::blockHash($pos->x, $pos->y, $pos->z - 1));
 	}
 
 	/**


### PR DESCRIPTION
Fixes: #251, PocketMine/PocketMine-MP#3752

Obsoletes: PocketMine/PocketMine-MP#4200, PocketMine/PocketMine-MP#4057, PocketMine/PocketMine-MP#3806, PocketMine/PocketMine-MP#3763, PocketMine/PocketMine-MP#3762.

## Changes
This PR adds an extra queue for neighbour block updates. Instead of directly updating blocks when a block is changed, neighbour block updates are now queued to be run at the end of the tick.

@PEMapModder 's original suggested solution [here](https://github.com/PocketMine/PocketMine-MP/issues/3752#issuecomment-164487640) would have worked, except for the issue of plugin events, and also the issue that affected blocks would have needed to handle the scheduled update, which is wrong. This  pull request caters for all possibilities of such recursion without breaking plugin events.