### PR TITLE
Fixed double gc_enable call

### DIFF
--- a/src/pocketmine/PocketMine.php
+++ b/src/pocketmine/PocketMine.php
@@ -128,7 +128,6 @@ namespace pocketmine {
 
 	set_time_limit(0); //Who set it to 30 seconds?!?!
 
-	gc_enable();
 	error_reporting(-1);
 	ini_set("allow_url_fopen", 1);
 	ini_set("display_errors", 1);


### PR DESCRIPTION
It's already called in Memory Manager.. also it makes more sense to call it in memory manager to keep the code clean.