### PR TITLE
Update Config.php for supporting Chinese character encode??

### DIFF
--- a/src/pocketmine/utils/Config.php
+++ b/src/pocketmine/utils/Config.php
@@ -187,7 +187,7 @@ class Config{
 						$content = $this->writeProperties();
 						break;
 					case Config::JSON:
-						$content = json_encode($this->config, JSON_PRETTY_PRINT | JSON_BIGINT_AS_STRING);
+						$content = json_encode($this->config, JSON_PRETTY_PRINT | JSON_BIGINT_AS_STRING | JSON_UNESCAPED_UNICODE);
 						break;
 					case Config::YAML:
 						$content = yaml_emit($this->config, YAML_UTF8_ENCODING);


### PR DESCRIPTION
Old Config.php can't save Chinese character well. It was saved as unicode. Adding this option "JSON_UNESCAPED_UNICODE" can fix this bug.