### PR TITLE
Removed misleading outdated documentation

### DIFF
--- a/src/pocketmine/event/Event.php
+++ b/src/pocketmine/event/Event.php
@@ -30,8 +30,6 @@ abstract class Event{
 	 * Any callable event must declare the static variable
 	 *
 	 * public static $handlerList = null;
-	 * public static $eventPool = [];
-	 * public static $nextEvent = 0;
 	 *
 	 * Not doing so will deny the proper event initialization
 	 */


### PR DESCRIPTION
This fixes outdated documentation, which doesn't apply on the latest PocketMine versions anymore.