### PR TITLE
Removed redundant ZLIB_ENCODING_DEFLATE argument for compressed NBT decoding

### DIFF
--- a/src/pocketmine/level/format/io/region/Anvil.php
+++ b/src/pocketmine/level/format/io/region/Anvil.php
@@ -101,7 +101,7 @@ class Anvil extends McRegion{
 	public function nbtDeserialize(string $data){
 		$nbt = new NBT(NBT::BIG_ENDIAN);
 		try{
-			$nbt->readCompressed($data, ZLIB_ENCODING_DEFLATE);
+			$nbt->readCompressed($data);
 
 			$chunk = $nbt->getData();
 

--- a/src/pocketmine/level/format/io/region/McRegion.php
+++ b/src/pocketmine/level/format/io/region/McRegion.php
@@ -126,7 +126,7 @@ class McRegion extends BaseLevelProvider{
 	public function nbtDeserialize(string $data){
 		$nbt = new NBT(NBT::BIG_ENDIAN);
 		try{
-			$nbt->readCompressed($data, ZLIB_ENCODING_DEFLATE);
+			$nbt->readCompressed($data);
 
 			$chunk = $nbt->getData();
 

--- a/src/pocketmine/level/format/io/region/PMAnvil.php
+++ b/src/pocketmine/level/format/io/region/PMAnvil.php
@@ -104,7 +104,7 @@ class PMAnvil extends Anvil{
 	public function nbtDeserialize(string $data){
 		$nbt = new NBT(NBT::BIG_ENDIAN);
 		try{
-			$nbt->readCompressed($data, ZLIB_ENCODING_DEFLATE);
+			$nbt->readCompressed($data);
 
 			$chunk = $nbt->getData();
 

--- a/src/pocketmine/nbt/NBT.php
+++ b/src/pocketmine/nbt/NBT.php
@@ -423,11 +423,11 @@ class NBT{
 		$this->buffer = "";
 	}
 
-	public function readCompressed($buffer, $compression = ZLIB_ENCODING_GZIP){
+	public function readCompressed($buffer){
 		$this->read(zlib_decode($buffer));
 	}
 
-	public function readNetworkCompressed($buffer, $compression = ZLIB_ENCODING_GZIP){
+	public function readNetworkCompressed($buffer){
 		$this->read(zlib_decode($buffer), false, true);
 	}
 


### PR DESCRIPTION
### Description
Removes redundant compression argument from NBT::readCompressed() and
NBT:: readNetworkCompressed()

### Reason to modify
Addresses #816 

### Tests & Reviews
I haven't tested this but I don't see how it could break anything lol
