### PR TITLE
Improved cURL functions

### DIFF
--- a/src/pocketmine/utils/Utils.php
+++ b/src/pocketmine/utils/Utils.php
@@ -362,7 +362,7 @@ class Utils{
 	 */
 	public static function getURL($page, $timeout = 10, array $extraHeaders = [], &$err = null, &$headers = null, &$httpCode = null){
 		try{
-			list($httpCode, $headers, $ret) = self::simpleCurl($page, $timeout, $extraHeaders);
+			list($ret, $headers, $httpCode) = self::simpleCurl($page, $timeout, $extraHeaders);
 			return $ret;
 		}catch(\RuntimeException $ex){
 			$err = $ex->getMessage();
@@ -386,7 +386,7 @@ class Utils{
 	 */
 	public static function postURL($page, $args, $timeout = 10, array $extraHeaders = [], &$err = null, &$headers = null, &$httpCode = null){
 		try{
-			list($httpCode, $headers, $ret) = self::simpleCurl($page, $timeout, $extraHeaders, [
+			list($ret, $headers, $httpCode) = self::simpleCurl($page, $timeout, $extraHeaders, [
 				CURLOPT_POST => 1,
 				CURLOPT_POSTFIELDS => $args
 			]);
@@ -408,7 +408,7 @@ class Utils{
 	 * @param array    $extraOpts extra CURLOPT_* to set as an [opt => value] map
 	 * @param callable|null $onSuccess function to be called if there is no error. Accepts a resource argument as the cURL handle.
 	 *
-	 * @return array a plain array of three [HTTP response code : int, headers : array[], result body : string]. Headers are grouped by requests with header name as keys and header value as values
+	 * @return array a plain array of three [result body : string, headers : array[], HTTP response code : int]. Headers are grouped by requests with header name as keys and header value as values
 	 *
 	 * @throws \RuntimeException if a cURL error occurs
 	 */
@@ -453,7 +453,7 @@ class Utils{
 			if($onSuccess !== null){
 				$onSuccess($ch);
 			}
-			return [$httpCode, $headers, $body];
+			return [$body, $headers, $httpCode];
 		}finally{
 			curl_close($ch);
 		}

--- a/src/pocketmine/utils/Utils.php
+++ b/src/pocketmine/utils/Utils.php
@@ -22,6 +22,7 @@
 /**
  * Various Utilities used around the code
  */
+
 namespace pocketmine\utils;
 
 use pocketmine\ThreadManager;
@@ -350,71 +351,112 @@ class Utils{
 	 * GETs an URL using cURL
 	 * NOTE: This is a blocking operation and can take a significant amount of time. It is inadvisable to use this method on the main thread.
 	 *
-	 * @param        $page
-	 * @param int    $timeout default 10
-	 * @param array  $extraHeaders
-	 * @param string &$err Will be set to the output of curl_error(). Use this to retrieve errors that occured during the operation.
+	 * @param         $page
+	 * @param int     $timeout default 10
+	 * @param array   $extraHeaders
+	 * @param string  &$err    Will be set to the output of curl_error(). Use this to retrieve errors that occured during the operation.
+	 * @param array[] &$headers
+	 * @param int     &$httpCode
 	 *
 	 * @return bool|mixed false if an error occurred, mixed data if successful.
 	 */
-	public static function getURL($page, $timeout = 10, array $extraHeaders = [], &$err = null){
-		if(Utils::$online === false){
+	public static function getURL($page, $timeout = 10, array $extraHeaders = [], &$err = null, &$headers = null, &$httpCode = null){
+		try{
+			list($httpCode, $headers, $ret) = self::simpleCurl($page, $timeout, $extraHeaders);
+			return $ret;
+		}catch(\RuntimeException $ex){
+			$err = $ex->getMessage();
 			return false;
 		}
-
-		$ch = curl_init($page);
-		curl_setopt($ch, CURLOPT_HTTPHEADER, array_merge(["User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64; rv:12.0) Gecko/20100101 Firefox/12.0 PocketMine-MP"], $extraHeaders));
-		curl_setopt($ch, CURLOPT_AUTOREFERER, true);
-		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
-		curl_setopt($ch, CURLOPT_FORBID_REUSE, 1);
-		curl_setopt($ch, CURLOPT_FRESH_CONNECT, 1);
-		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, (int) $timeout);
-		curl_setopt($ch, CURLOPT_TIMEOUT, (int) $timeout);
-		$ret = curl_exec($ch);
-		$err = curl_error($ch);
-		curl_close($ch);
-
-		return $ret;
 	}
 
 	/**
 	 * POSTs data to an URL
 	 * NOTE: This is a blocking operation and can take a significant amount of time. It is inadvisable to use this method on the main thread.
 	 *
-	 * @param              $page
+	 * @param string       $page
 	 * @param array|string $args
 	 * @param int          $timeout
 	 * @param array        $extraHeaders
 	 * @param string       &$err Will be set to the output of curl_error(). Use this to retrieve errors that occured during the operation.
+	 * @param array[]      &$headers
+	 * @param int          &$httpCode
 	 *
 	 * @return bool|mixed false if an error occurred, mixed data if successful.
 	 */
-	public static function postURL($page, $args, $timeout = 10, array $extraHeaders = [], &$err = null){
-		if(Utils::$online === false){
+	public static function postURL($page, $args, $timeout = 10, array $extraHeaders = [], &$err = null, &$headers = null, &$httpCode = null){
+		try{
+			list($httpCode, $headers, $ret) = self::simpleCurl($page, $timeout, $extraHeaders, [
+				CURLOPT_POST => 1,
+				CURLOPT_POSTFIELDS => $args
+			]);
+			return $ret;
+		}catch(\RuntimeException $ex){
+			$err = $ex->getMessage();
 			return false;
 		}
 
-		$ch = curl_init($page);
-		curl_setopt($ch, CURLOPT_POST, 1);
-		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
-		curl_setopt($ch, CURLOPT_FORBID_REUSE, 1);
-		curl_setopt($ch, CURLOPT_FRESH_CONNECT, 1);
-		curl_setopt($ch, CURLOPT_POSTFIELDS, $args);
-		curl_setopt($ch, CURLOPT_AUTOREFERER, true);
-		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-		curl_setopt($ch, CURLOPT_HTTPHEADER, array_merge(["User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64; rv:12.0) Gecko/20100101 Firefox/12.0 PocketMine-MP"], $extraHeaders));
-		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, (int) $timeout);
-		curl_setopt($ch, CURLOPT_TIMEOUT, (int) $timeout);
-		$ret = curl_exec($ch);
-		$err = curl_error($ch);
-		curl_close($ch);
+	}
 
-		return $ret;
+	/**
+	 * General cURL shorthand function.
+	 * NOTE: This is a blocking operation and can take a significant amount of time. It is inadvisable to use this method on the main thread.
+	 *
+	 * @param string    $page
+	 * @param float|int $timeout The maximum connect timeout and timeout in seconds, correct to ms.
+	 * @param string[] $extraHeaders extra headers to send as a plain string array
+	 * @param array    $extraOpts extra CURLOPT_* to set as an [opt => value] map
+	 * @param callable|null $onSuccess function to be called if there is no error. Accepts a resource argument as the cURL handle.
+	 *
+	 * @return array a plain array of three [HTTP response code : int, headers : array[], result body : string]. Headers are grouped by requests with header name as keys and header value as values
+	 *
+	 * @throws \RuntimeException if a cURL error occurs
+	 */
+	public static function simpleCurl(string $page, $timeout, array $extraHeaders = [], array $extraOpts = [], callable $onSuccess = null){
+		if(Utils::$online === false){
+			throw new \RuntimeException("Server is offline");
+		}
+
+		$ch = curl_init($page);
+		curl_setopt_array($ch, array_merge([
+			CURLOPT_SSL_VERIFYPEER => false,
+			CURLOPT_SSL_VERIFYHOST => 2,
+			CURLOPT_FORBID_REUSE => 1,
+			CURLOPT_FRESH_CONNECT => 1,
+			CURLOPT_AUTOREFERER => true,
+			CURLOPT_FOLLOWLOCATION => true,
+			CURLOPT_RETURNTRANSFER => true,
+			CURLOPT_CONNECTTIMEOUT_MS => (int) ($timeout * 1000),
+			CURLOPT_TIMEOUT_MS => (int) ($timeout * 1000),
+			CURLOPT_HTTPHEADER => array_merge(["User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64; rv:12.0) Gecko/20100101 Firefox/12.0 PocketMine-MP"], $extraHeaders),
+			CURLOPT_HEADER => true
+		], $extraOpts));
+		try{
+			$raw = curl_exec($ch);
+			$error = curl_error($ch);
+			if($error !== ""){
+				throw new \RuntimeException($error);
+			}
+			$httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+			$headerSize = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
+			$rawHeaders = substr($raw, 0, $headerSize);
+			$body = substr($raw, $headerSize);
+			$headers = [];
+			foreach(explode("\r\n\r\n", $rawHeaders) as $rawHeaderGroup){
+				$headerGroup = [];
+				foreach(explode("\r\n", $rawHeaderGroup) as $line){
+					list($name, $value) = explode(":", $line);
+					$headerGroup[strtolower($name)] = $value;
+				}
+				$headers[] = $headerGroup;
+			}
+			if($onSuccess !== null){
+				$onSuccess($ch);
+			}
+			return [$httpCode, $headers, $body];
+		}finally{
+			curl_close($ch);
+		}
 	}
 
 	public static function javaStringHash($string){


### PR DESCRIPTION
Adds the `&$headers` and `&$httpCode` parameters to getURL() and postURL() and merged their code into `Utils::simpleCurl()`. `Utils::simpleCurl()` is also exposed as a public API method.

Regarding the order of parameters/return values, `httpCode, headers, body` is the order sent in HTTP, while `body, headers, httpCode` is the reverse of it (mnemonic reason), and in descending order of general usage frequency.
I would agree if the return value of `simpleCurl` should be reversed.

This change shall have 100% backwards compatibility as getURL() and postURL() are modified into backward-compatible wrappers for simpleCurl().