### PR TITLE
Added title command and API for resetting title duration

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3416,9 +3416,18 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	public function addTitle(string $title, string $subtitle = "", int $fadeIn = -1, int $stay = -1, int $fadeOut = -1){
 		$this->setTitleDuration($fadeIn, $stay, $fadeOut);
 		if($subtitle !== ""){
-			$this->sendTitleText($subtitle, SetTitlePacket::TYPE_SET_SUBTITLE);
+			$this->setSubTitle($subtitle);
 		}
 		$this->sendTitleText($title, SetTitlePacket::TYPE_SET_TITLE);
+	}
+	
+	/**
+	 * Sets the subtitle message, without a title.
+	 *
+	 * @param strint $subtitle
+	 */
+	public function setSubTitle(string $subtitle){
+	    $this->sendTitleText($subtitle, SetTitlePacket::TYPE_SET_SUBTITLE);
 	}
 
 	/**

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3422,9 +3422,9 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	}
 	
 	/**
-	 * Sets the subtitle message, without a title.
+	 * Sets the subtitle message, without sending a title.
 	 *
-	 * @param strint $subtitle
+	 * @param string $subtitle
 	 */
 	public function addSubTitle(string $subtitle){
 	    $this->sendTitleText($subtitle, SetTitlePacket::TYPE_SET_SUBTITLE);

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3438,6 +3438,15 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		$pk->type = SetTitlePacket::TYPE_CLEAR_TITLE;
 		$this->dataPacket($pk);
 	}
+	
+	/**
+	 * Resets the title duration settings.
+	 */
+	public function resetTitles(){
+	    $pk = new SetTitlePacket();
+	    $pk->type = SetTitlePacket::TYPE_RESET_TITLE;
+	    $this->dataPacket($pk);
+	}
 
 	/**
 	 * Sets the title duration.

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3416,7 +3416,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	public function addTitle(string $title, string $subtitle = "", int $fadeIn = -1, int $stay = -1, int $fadeOut = -1){
 		$this->setTitleDuration($fadeIn, $stay, $fadeOut);
 		if($subtitle !== ""){
-			$this->setSubTitle($subtitle);
+			$this->addSubTitle($subtitle);
 		}
 		$this->sendTitleText($title, SetTitlePacket::TYPE_SET_TITLE);
 	}
@@ -3426,7 +3426,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	 *
 	 * @param strint $subtitle
 	 */
-	public function setSubTitle(string $subtitle){
+	public function addSubTitle(string $subtitle){
 	    $this->sendTitleText($subtitle, SetTitlePacket::TYPE_SET_SUBTITLE);
 	}
 

--- a/src/pocketmine/command/SimpleCommandMap.php
+++ b/src/pocketmine/command/SimpleCommandMap.php
@@ -57,6 +57,7 @@ use pocketmine\command\defaults\TeleportCommand;
 use pocketmine\command\defaults\TellCommand;
 use pocketmine\command\defaults\TimeCommand;
 use pocketmine\command\defaults\TimingsCommand;
+use pocketmine\command\defaults\TitleCommand;
 use pocketmine\command\defaults\TransferServerCommand;
 use pocketmine\command\defaults\VanillaCommand;
 use pocketmine\command\defaults\VersionCommand;
@@ -115,6 +116,7 @@ class SimpleCommandMap implements CommandMap{
 		$this->register("pocketmine", new TeleportCommand("tp"));
 		$this->register("pocketmine", new TimeCommand("time"));
 		$this->register("pocketmine", new TimingsCommand("timings"));
+		$this->register("pocketmine", new TitleCommand("title"));
 		$this->register("pocketmine", new ReloadCommand("reload"));
 		$this->register("pocketmine", new TransferServerCommand("transferserver"));
 

--- a/src/pocketmine/command/defaults/TitleCommand.php
+++ b/src/pocketmine/command/defaults/TitleCommand.php
@@ -43,59 +43,54 @@ class TitleCommand extends VanillaCommand{
 		}
 
 		if(count($args) < 2){
-		    $sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.usage", [$this->usageMessage]));
+		    $sender->sendMessage(new TranslationContainer("commands.generic.usage", [$this->usageMessage]));
 		    return true;
 		}
 		
 		$player = $sender->getServer()->getPlayer($args[0]);
 		
 		if($player === null){
-		    $sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.player.notFound"));
+		    $sender->sendMessage(new TranslationContainer(TextFormat::RED . "commands.generic.player.notFound"));
 		    return true;
 		}
 		
-		switch($args[1]){
-		    case "clear":
-		        $player->removeTitles();
-		        break;
-		    case "reset":
-		        $player->resetTitles();
-		        break;
+        switch($args[0]){
+            case "clear":
+                $player->removeTitles();
+                break;
+            case "reset":
+                $player->resetTitles();
+                break;
 		    case "title":
 		        if(count($args) < 3){
-		            $sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.usage", [$this->usageMessage]));
-		            
+		            $sender->sendMessage(new TranslationContainer(TextFormat::RED . "commands.generic.usage", [$this->usageMessage]));
 		            return false;
 		        }
 		        $player->addTitle(implode(" ", array_slice($args, 2)));
 		        break;
 		    case "subtitle":
 		        if(count($args) < 3){
-		            $sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.usage", [$this->usageMessage]));
-		            
+		            $sender->sendMessage(new TranslationContainer(TextFormat::RED . "commands.generic.usage", [$this->usageMessage]));
 		            return false;
 		        }
 		        $player->addSubTitle(implode(" ", array_slice($args, 2)));
 		        break;
 		    case "actionbar":
 		        if(count($args) < 3){
-		            $sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.usage", [$this->usageMessage]));
-		        
+		            $sender->sendMessage(new TranslationContainer(TextFormat::RED . "commands.generic.usage", [$this->usageMessage]));
 		            return false;
 		        }
-		        $player->addActionBarMessage(implode(" ", array_slice($args, 2)));
+		        $player->addActionBarMessage(array_slice($args, 2));
 		        break;
 		    case "times":
 		        if(count($args) < 4){
-		            $sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.usage", [$this->usageMessage]));
-		        
+		            $sender->sendMessage(new TranslationContainer(TextFormat::RED . "commands.generic.usage", [$this->usageMessage]));
 		            return false;
 		        }
 		        $player->setTitleDuration($this->getInteger($sender, $args[2]), $this->getInteger($sender, $args[3]), $this->getInteger($sender, $args[4]));
 		        break;
 		    default:
-		        $sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.usage", [$this->usageMessage]));
-		        
+		        $sender->sendMessage(new TranslationContainer(TextFormat::RED . "commands.generic.usage", [$this->usageMessage]));
 		        return false;
 		}
 		$sender->sendMessage(new TranslationContainer("commands.title.success"));

--- a/src/pocketmine/command/defaults/TitleCommand.php
+++ b/src/pocketmine/command/defaults/TitleCommand.php
@@ -50,11 +50,11 @@ class TitleCommand extends VanillaCommand{
 		$player = $sender->getServer()->getPlayer($args[0]);
 		
 		if($player === null){
-		    $sender->sendMessage(new TranslationContainer(TextFormat::RED . "commands.generic.player.notFound"));
+		    $sender->sendMessage(new TranslationContainer("commands.generic.player.notFound"));
 		    return true;
 		}
 		
-        switch($args[0]){
+        switch($args[1]){
             case "clear":
                 $player->removeTitles();
                 break;
@@ -63,34 +63,34 @@ class TitleCommand extends VanillaCommand{
                 break;
 		    case "title":
 		        if(count($args) < 3){
-		            $sender->sendMessage(new TranslationContainer(TextFormat::RED . "commands.generic.usage", [$this->usageMessage]));
+		            $sender->sendMessage(new TranslationContainer("commands.generic.usage", [$this->usageMessage]));
 		            return false;
 		        }
 		        $player->addTitle(implode(" ", array_slice($args, 2)));
 		        break;
 		    case "subtitle":
 		        if(count($args) < 3){
-		            $sender->sendMessage(new TranslationContainer(TextFormat::RED . "commands.generic.usage", [$this->usageMessage]));
+		            $sender->sendMessage(new TranslationContainer("commands.generic.usage", [$this->usageMessage]));
 		            return false;
 		        }
 		        $player->addSubTitle(implode(" ", array_slice($args, 2)));
 		        break;
 		    case "actionbar":
 		        if(count($args) < 3){
-		            $sender->sendMessage(new TranslationContainer(TextFormat::RED . "commands.generic.usage", [$this->usageMessage]));
+		            $sender->sendMessage(new TranslationContainer("commands.generic.usage", [$this->usageMessage]));
 		            return false;
 		        }
-		        $player->addActionBarMessage(array_slice($args, 2));
+		        $player->addActionBarMessage(implode(" ", array_slice($args, 2)));
 		        break;
 		    case "times":
 		        if(count($args) < 4){
-		            $sender->sendMessage(new TranslationContainer(TextFormat::RED . "commands.generic.usage", [$this->usageMessage]));
+		            $sender->sendMessage(new TranslationContainer("commands.generic.usage", [$this->usageMessage]));
 		            return false;
 		        }
 		        $player->setTitleDuration($this->getInteger($sender, $args[2]), $this->getInteger($sender, $args[3]), $this->getInteger($sender, $args[4]));
 		        break;
 		    default:
-		        $sender->sendMessage(new TranslationContainer(TextFormat::RED . "commands.generic.usage", [$this->usageMessage]));
+		        $sender->sendMessage(new TranslationContainer("commands.generic.usage", [$this->usageMessage]));
 		        return false;
 		}
 		$sender->sendMessage(new TranslationContainer("commands.title.success"));

--- a/src/pocketmine/command/defaults/TitleCommand.php
+++ b/src/pocketmine/command/defaults/TitleCommand.php
@@ -74,7 +74,7 @@ class TitleCommand extends VanillaCommand{
 		        
 		        return false;
 		    }
-		    $player->setSubTitle(implode(" ", array_slice($args, 2)));
+		    $player->addSubTitle(implode(" ", array_slice($args, 2)));
 		}elseif($args[1] === "actionbar"){
 		    if(count($args) < 3){
 		        $sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.usage", [$this->usageMessage]));

--- a/src/pocketmine/command/defaults/TitleCommand.php
+++ b/src/pocketmine/command/defaults/TitleCommand.php
@@ -41,7 +41,7 @@ class TitleCommand extends VanillaCommand{
 		if(!$this->testPermission($sender)){
 			return true;
 		}
-		
+
 		if(count($args) < 2){
 		    $sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.usage", [$this->usageMessage]));
 		    return true;
@@ -74,7 +74,7 @@ class TitleCommand extends VanillaCommand{
 		        
 		        return false;
 		    }
-		    $player->addTitle("", implode(" ", array_slice($args, 3)));
+		    $player->setSubTitle(implode(" ", array_slice($args, 2)));
 		}elseif($args[1] === "actionbar"){
 		    if(count($args) < 3){
 		        $sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.usage", [$this->usageMessage]));

--- a/src/pocketmine/command/defaults/TitleCommand.php
+++ b/src/pocketmine/command/defaults/TitleCommand.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+namespace pocketmine\command\defaults;
+
+use pocketmine\command\CommandSender;
+use pocketmine\event\TranslationContainer;
+use pocketmine\plugin\Plugin;
+use pocketmine\utils\TextFormat;
+
+class TitleCommand extends VanillaCommand{
+
+	public function __construct($name){
+		parent::__construct(
+			$name,
+			"%pocketmine.command.title.description",
+			"%commands.title.usage"
+		);
+		$this->setPermission("pocketmine.command.title");
+	}
+
+	public function execute(CommandSender $sender, $currentAlias, array $args){
+		if(!$this->testPermission($sender)){
+			return true;
+		}
+		
+		if(count($args) < 2){
+		    $sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.usage", [$this->usageMessage]));
+		    return true;
+		}
+		
+		$player = $sender->getServer()->getPlayer($args[0]);
+		
+		if($player === null){
+		    $sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.player.notFound"));
+		    return true;
+		}
+		
+		if($args[1] === "clear"){
+		    $player->removeTitles();
+		    
+		}elseif($args[1] === "reset"){
+		    $player->resetTitles(); 
+		    
+		}elseif($args[1] === "title"){
+		    if(count($args) < 3){
+		        $sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.usage", [$this->usageMessage]));
+		        
+		        return false;
+		    }  
+		    $player->addTitle(implode(" ", array_slice($args, 2)));
+		  
+		}elseif($args[1] === "subtitle"){
+		    if(count($args) < 3){
+		        $sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.usage", [$this->usageMessage]));
+		        
+		        return false;
+		    }
+		    $player->addTitle("", implode(" ", array_slice($args, 3)));
+		}elseif($args[1] === "actionbar"){
+		    if(count($args) < 3){
+		        $sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.usage", [$this->usageMessage]));
+		        
+		        return false;
+		    }
+		    $player->addActionBarMessage(implode(" ", array_slice($args, 2)));    
+		}elseif($args[1] === "times"){
+		    if(count($args) !== 5){
+		        $sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.usage", [$this->usageMessage]));
+		    
+		        return false;
+		    }
+		    $player->setTitleDuration($this->getInteger($sender, $args[3]), $this->getInteger($sender, $args[4]), $this->getInteger($sender, $args[5]));
+		}
+		$sender->sendMessage(new TranslationContainer("%commands.title.success"));
+
+		return true;
+	}
+}

--- a/src/pocketmine/command/defaults/TitleCommand.php
+++ b/src/pocketmine/command/defaults/TitleCommand.php
@@ -54,44 +54,50 @@ class TitleCommand extends VanillaCommand{
 		    return true;
 		}
 		
-		if($args[1] === "clear"){
-		    $player->removeTitles();
-		    
-		}elseif($args[1] === "reset"){
-		    $player->resetTitles(); 
-		    
-		}elseif($args[1] === "title"){
-		    if(count($args) < 3){
+		switch($args[1]){
+		    case "clear":
+		        $player->removeTitles();
+		        break;
+		    case "reset":
+		        $player->resetTitles();
+		        break;
+		    case "title":
+		        if(count($args) < 3){
+		            $sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.usage", [$this->usageMessage]));
+		            
+		            return false;
+		        }
+		        $player->addTitle(implode(" ", array_slice($args, 2)));
+		        break;
+		    case "subtitle":
+		        if(count($args) < 3){
+		            $sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.usage", [$this->usageMessage]));
+		            
+		            return false;
+		        }
+		        $player->addSubTitle(implode(" ", array_slice($args, 2)));
+		        break;
+		    case "actionbar":
+		        if(count($args) < 3){
+		            $sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.usage", [$this->usageMessage]));
+		        
+		            return false;
+		        }
+		        $player->addActionBarMessage(implode(" ", array_slice($args, 2)));
+		        break;
+		    case "times":
+		        if(count($args) < 4){
+		            $sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.usage", [$this->usageMessage]));
+		        
+		            return false;
+		        }
+		        $player->setTitleDuration($this->getInteger($sender, $args[2]), $this->getInteger($sender, $args[3]), $this->getInteger($sender, $args[4]));
+		        break;
+		    default:
 		        $sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.usage", [$this->usageMessage]));
 		        
 		        return false;
-		    }  
-		    $player->addTitle(implode(" ", array_slice($args, 2)));
-		  
-		}elseif($args[1] === "subtitle"){
-		    if(count($args) < 3){
-		        $sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.usage", [$this->usageMessage]));
-		        
-		        return false;
-		    }
-		    $player->addSubTitle(implode(" ", array_slice($args, 2)));
-		}elseif($args[1] === "actionbar"){
-		    if(count($args) < 3){
-		        $sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.usage", [$this->usageMessage]));
-		        
-		        return false;
-		    }
-		    $player->addActionBarMessage(implode(" ", array_slice($args, 2)));    
-		}elseif($args[1] === "times"){
-		    if(count($args) !== 5){
-		        $sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.usage", [$this->usageMessage]));
-		    
-		        return false;
-		    }
-		    $player->setTitleDuration($this->getInteger($sender, $args[3]), $this->getInteger($sender, $args[4]), $this->getInteger($sender, $args[5]));
 		}
-		$sender->sendMessage(new TranslationContainer("%commands.title.success"));
-
-		return true;
+		$sender->sendMessage(new TranslationContainer("commands.title.success"));
 	}
 }

--- a/src/pocketmine/permission/DefaultPermissions.php
+++ b/src/pocketmine/permission/DefaultPermissions.php
@@ -124,6 +124,7 @@ abstract class DefaultPermissions{
 		self::registerPermission(new Permission(self::ROOT . ".command.spawnpoint", "Allows the user to change player's spawnpoint", Permission::DEFAULT_OP), $commands);
 		self::registerPermission(new Permission(self::ROOT . ".command.setworldspawn", "Allows the user to change the world spawn", Permission::DEFAULT_OP), $commands);
 		self::registerPermission(new Permission(self::ROOT . ".command.transferserver", "Allows the user to transfer self to another server", Permission::DEFAULT_OP), $commands);
+		self::registerPermission(new Permission(self::ROOT . ".command.title", "Allows the user to send a title to the specified player", Permission::DEFAULT_OP), $commands);
 
 		$commands->recalculatePermissibles();
 


### PR DESCRIPTION
## What this adds
* Title Command
* Player->resetTitles()
* Player->addSubTitle(string)

If you need me to change anything please just ask.

Apparently any translations with the same key as in MCPE displays as `%ommands.(cmd).usage`. Probably a client bug, or because im using 1.0.5 and theres already been an update.

~~There's currently an issue where settings the subtitle using the command *doesnt* set it. Maybe we need a seperate method in the Player class to set the subtitle?~~

~~EDIT: We definitely need a seperate method to set subtitle, i'll add it now~~