### PR TITLE
Remove redundant null check in PluginCommand

### DIFF
--- a/src/pocketmine/command/PluginCommand.php
+++ b/src/pocketmine/command/PluginCommand.php
@@ -70,7 +70,7 @@ class PluginCommand extends Command implements PluginIdentifiableCommand{
 	 * @param CommandExecutor $executor
 	 */
 	public function setExecutor(CommandExecutor $executor){
-		$this->executor = ($executor != null) ? $executor : $this->owningPlugin;
+		$this->executor = $executor;
 	}
 
 	/**


### PR DESCRIPTION
# Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This pr removes the null check in PluginCommand::setExecutor() because $executor won't be null in any case.

## Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
No relevant issues (atleast I think so)

# Changes
## API changes
<!-- Any additions to the API that should be documented in release notes? -->
No API changes -> same result as before.
## Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
I doubt there will be any performance improvements, no.
# Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Yes, it is fully compatible.

# Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--
Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
No actions suggested from my side.

# Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
You will need a plugin which manually registers a PluginCommand and sets a CommandExecutor for it. Sorry for not including this here.

The result should be, that $this->executor returns the CommandExecutor mentioned before.