### PR TITLE
Throw an exception before calling base entity constructor if skin is not set or invalid, close #835 

### DIFF
--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -27,6 +27,7 @@ use pocketmine\event\player\PlayerExhaustEvent;
 use pocketmine\inventory\InventoryHolder;
 use pocketmine\inventory\PlayerInventory;
 use pocketmine\item\Item as ItemItem;
+use pocketmine\level\Level;
 use pocketmine\nbt\NBT;
 use pocketmine\nbt\tag\ByteTag;
 use pocketmine\nbt\tag\CompoundTag;
@@ -61,12 +62,20 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 	public $eyeHeight = 1.62;
 
 	protected $skinId;
-	protected $skin;
+	protected $skin = null;
 
 	protected $foodTickTimer = 0;
 
 	protected $totalXp = 0;
 	protected $xpSeed;
+
+	public function __construct(Level $level, CompoundTag $nbt){
+		if($this->skin === null and (!isset($nbt->Skin) or !isset($nbt->Skin->Data) or !Player::isValidSkin($nbt->Skin->Data->getValue()))){
+			throw new \InvalidStateException((new \ReflectionClass($this))->getShortName() . " must have a valid skin set");
+		}
+
+		parent::__construct($level, $nbt);
+	}
 
 	public function getSkinData(){
 		return $this->skin;
@@ -95,6 +104,10 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 	 * @param string $skinId
 	 */
 	public function setSkin($str, $skinId){
+		if(!Player::isValidSkin($str)){
+			throw new \InvalidStateException("Specified skin is not valid, must be 8KiB or 16KiB");
+		}
+
 		$this->skin = $str;
 		$this->skinId = $skinId;
 	}
@@ -470,7 +483,7 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 		if($player !== $this and !isset($this->hasSpawned[$player->getLoaderId()])){
 			$this->hasSpawned[$player->getLoaderId()] = $player;
 
-			if(strlen($this->skin) < 64 * 32 * 4){
+			if(!Player::isValidSkin($this->skin)){
 				throw new \InvalidStateException((new \ReflectionClass($this))->getShortName() . " must have a valid skin set");
 			}
 

--- a/src/pocketmine/level/format/Chunk.php
+++ b/src/pocketmine/level/format/Chunk.php
@@ -697,9 +697,16 @@ class Chunk{
 							continue; //Fixes entities allocated in wrong chunks.
 						}
 
-						if(($entity = Entity::createEntity($nbt["id"], $level, $nbt)) instanceof Entity){
-							$entity->spawnToAll();
-						}else{
+						try{
+							$entity = Entity::createEntity($nbt["id"], $level, $nbt);
+							if($entity instanceof Entity){
+								$entity->spawnToAll();
+							}else{
+								$changed = true;
+								continue;
+							}
+						}catch(\Throwable $t){
+							$level->getServer()->getLogger()->logException($t);
 							$changed = true;
 							continue;
 						}


### PR DESCRIPTION
Humans are currently saved to disk even if they have an invalid skin. This causes the server to subsequently always crash when loading the chunk the invalid Human is in.

This PR adds an exception throw before the Entity base constructor is called to prevent humans with invalid skins being saved to disk and handling to prevent such errors with existing saved humans causing server crashes.

## Relevant issues
- fixes #835 

## Changes
An exception will now be thrown when attempting to construct a Human without a valid skin and when trying to set an invalid skin on an entity. Exception handling has been added to chunk initialization to ensure that existing invalid humans will not crash the server and will not be saved to disk again next time the chunk is saved.

## Backwards compatibility 
No issues

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
```
<?php

/**
 * @name TestPlugin
 * @api 3.0.0-ALPHA5
 * @version 1.0.0
 * @description Tests things
 * @main dktapps\TestPlugin\Main
 */

namespace dktapps\TestPlugin{
	use pocketmine\nbt\tag\CompoundTag;
	use pocketmine\nbt\tag\ListTag;
	use pocketmine\nbt\tag\DoubleTag;
	use pocketmine\nbt\tag\FloatTag;
	use pocketmine\nbt\tag\StringTag;

	class Main extends \pocketmine\plugin\PluginBase implements \pocketmine\event\Listener{
		public function onEnable(){
			$this->getServer()->getPluginManager()->registerEvents($this, $this);
		}

		public function onInteract(\pocketmine\event\player\PlayerInteractEvent $e){
			$nbt = new CompoundTag("", [
				"Pos" => new ListTag("Pos", [
					new DoubleTag("", $e->getPlayer()->getX()),
					new DoubleTag("", $e->getPlayer()->getY()),
					new DoubleTag("", $e->getPlayer()->getZ())
				]),

				"Motion" => new ListTag("Motion", [
					new DoubleTag("", 0),
					new DoubleTag("", 0),
					new DoubleTag("", 0)
				]),
				"Rotation" => new ListTag("Rotation", [
					new FloatTag("", 0),
					new FloatTag("", 0)
				])
			]);
			$entity = \pocketmine\entity\Entity::createEntity("Human", $e->getPlayer()->getLevel(), $nbt);
			$entity->spawnToAll();
		}
	}

}
```
Run the server, tap the ground, stop server, start server, join.