### PR TITLE
Fix "Creating default object from empty value"

### DIFF
--- a/src/pocketmine/item/Item.php
+++ b/src/pocketmine/item/Item.php
@@ -685,7 +685,7 @@ class Item implements ItemIds, \JsonSerializable{
 	}
 
 	public function setLore(array $lines){
-		$tag = $this->getNamedTag();
+		$tag = $this->getNamedTag() ?? new CompoundTag("", []);
 		if(!isset($tag->display)){
 			$tag->display = new CompoundTag("display", []);
 		}


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

If the item does not have a namedtag set, the console warns of this action.
Necessity: so that lores can be set on items having no namedtag.
isset(), as you know, does not return errors while passing variables. It can only return a boolean value.
### Relevant issues
<!-- List relevant issues here -->
* Fixes #857

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
No
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
No
## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Supports backwards compatibility as this is just something that was left out probably.
## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--
None
Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
```
$item = Item::get(Item::DIAMOND_SWORD, 0, 1);
$item->setLore(['This lore is', 'sexy :D']);
```
Before: Warning: Creating default object from empty value in /root/pmmp/src/pocketmine/item/Item.php...

Now: [item gets lore set]