### PR TITLE
Reduced deltas for player movement, significantly smoother player movement and rotation

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1545,7 +1545,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		$delta = pow($this->lastX - $to->x, 2) + pow($this->lastY - $to->y, 2) + pow($this->lastZ - $to->z, 2);
 		$deltaAngle = abs($this->lastYaw - $to->yaw) + abs($this->lastPitch - $to->pitch);
 
-		if(!$revert and ($delta > (1 / 16) or $deltaAngle > 10)){
+		if(!$revert and ($delta >= 0.01 or $deltaAngle >= 1.0)){
 
 			$isFirst = ($this->lastX === null or $this->lastY === null or $this->lastZ === null);
 
@@ -1568,7 +1568,6 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 						$this->level->addEntityMovement($this->x >> 4, $this->z >> 4, $this->getId(), $this->x, $this->y + $this->getEyeHeight(), $this->z, $this->yaw, $this->pitch, $this->yaw);
 
 						$distance = $from->distance($to);
-
 						//TODO: check swimming (adds 0.015 exhaustion in MCPE)
 						if($this->isSprinting()){
 							$this->exhaust(0.1 * $distance, PlayerExhaustEvent::CAUSE_SPRINTING);

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1545,7 +1545,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		$delta = pow($this->lastX - $to->x, 2) + pow($this->lastY - $to->y, 2) + pow($this->lastZ - $to->z, 2);
 		$deltaAngle = abs($this->lastYaw - $to->yaw) + abs($this->lastPitch - $to->pitch);
 
-		if(!$revert and ($delta >= 0.01 or $deltaAngle >= 1.0)){
+		if(!$revert and ($delta > 0.0001 or $deltaAngle > 1.0)){
 
 			$isFirst = ($this->lastX === null or $this->lastY === null or $this->lastZ === null);
 


### PR DESCRIPTION
Player movement in PocketMine-MP is currently disgustingly laggy. This deteriorates the gameplay experience of stuff like PvP, due to things like players not actually being where players think they are, and head rotation being also ludicrously laggy.

1/16th of a block movement or 10 degrees is very clearly visible to observers, and made player movement appear very stuttery and laggy to observers. This also produced some movement issues with players sometimes not actually being where clients expected them to be, for example PvP knockback could knock someone up on top of a block and hang on to the block by less than 1/16th of a block, while other players would see them on the ground.

This pull request reduces the delta checks for player movement processing to eliminate this issue. This produces significantly smoother player movement. 

### Behavioural changes
- PlayerMoveEvent will now be fired whenever the player moves more than 0.01 meters or rotates their head by more than 1 degree. This should produce minimal change in overall behaviour, however may have a very minor performance impact.
