### PR TITLE
Call PlayerInteractEvent (ItemFrameDropItemPacket)

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3241,7 +3241,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
 		$tile = $this->level->getTile($this->temporalVector->setComponents($packet->x, $packet->y, $packet->z));
 		if($tile instanceof ItemFrame){
-			$ev = new PlayerInteractEvent($this, $this->inventory->getItemInHand(), $tile->getBlock(), $tile->getBlock()->getDamage(), PlayerInteractEvent::LEFT_CLICK_BLOCK);
+			$ev = new PlayerInteractEvent($this, $this->inventory->getItemInHand(), $tile->getBlock(), 5 - $tile->getBlock()->getDamage(), PlayerInteractEvent::LEFT_CLICK_BLOCK);
 			$this->server->getPluginManager()->callEvent($ev);
 
 			if($this->isSpectator()){

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3241,7 +3241,14 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
 		$tile = $this->level->getTile($this->temporalVector->setComponents($packet->x, $packet->y, $packet->z));
 		if($tile instanceof ItemFrame){
+			$ev = new PlayerInteractEvent($this, $this->inventory->getItemInHand(), $tile->getBlock(), $tile->getBlock()->getDamage(), PlayerInteractEvent::LEFT_CLICK_BLOCK);
+			$this->server->getPluginManager()->callEvent($ev);
+
 			if($this->isSpectator()){
+				$ev->setCancelled();
+			}
+
+			if($ev->isCancelled()){
 				$tile->spawnTo($this);
 				return true;
 			}


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

Item frames are one of the many essentials that contribute to decoration. In PocketMine-MP, there's no way to stop players from triggering ItemFrameDropItemPacket (other than using DataPacketReceiveEvent, of course; which is like the worst-but-the-only-possible decision).
To make it a possibility to cancel ItemFrameDropItemPacket from being triggered, calling PlayerInteractEvent would be a suitable fix.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
None.
## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
I don't think so, as this can be considered as a "fix".
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
ItemFrameDropItemPacket now triggers PlayerInteractEvent.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Compatible.
## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
None.
## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
The following code will stop ItemFrames from dropping the item.
```
public function onInteract(PlayerInteractEvent $event){
    if(
        $event->getBlock()->getId() === \pocketmine\block\BlockIds::ITEM_FRAME_BLOCK and
        $event->getAction() === PlayerInteractEvent::LEFT_CLICK_BLOCK
    ){//PlayerInteractEvent::RIGHT_CLICK_BLOCK => When player puts an item in the item frame.
        $event->setCancelled();
    }
}
```