### PR TITLE
Fix falling blocks destroyed by grass, close #897

### DIFF
--- a/src/pocketmine/entity/FallingSand.php
+++ b/src/pocketmine/entity/FallingSand.php
@@ -22,7 +22,6 @@
 namespace pocketmine\entity;
 
 use pocketmine\block\Block;
-use pocketmine\block\Liquid;
 use pocketmine\event\entity\EntityBlockChangeEvent;
 use pocketmine\event\entity\EntityDamageEvent;
 use pocketmine\item\Item as ItemItem;
@@ -116,12 +115,12 @@ class FallingSand extends Entity{
 			$this->motionY *= 1 - $this->drag;
 			$this->motionZ *= $friction;
 
-			$pos = (new Vector3($this->x - 0.5, $this->y, $this->z - 0.5))->floor();
+			$pos = (new Vector3($this->x - ($this->width / 2), $this->y, $this->z - ($this->length / 2)))->floor();
 
 			if($this->onGround){
 				$this->kill();
 				$block = $this->level->getBlock($pos);
-				if($block->getId() > 0 and !$block->isSolid() and !($block instanceof Liquid)){
+				if($block->getId() > 0 and !$block->isSolid() and !$block->canBeReplaced()){
 					$this->getLevel()->dropItem($this, ItemItem::get($this->getBlock(), $this->getDamage(), 1));
 				}else{
 					$this->server->getPluginManager()->callEvent($ev = new EntityBlockChangeEvent($this, $block, Block::get($this->getBlock(), $this->getDamage())));


### PR DESCRIPTION
# WIP
Also fix a slight motion offset mistake (or you fix the width/length ;)

Fixes everything mentioned in #897 
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Falling blocks drop on tallgrass/snow layer
### Relevant issues
<!-- List relevant issues here -->

* Fixes #897 
* Smal fix for motion

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
None

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
Not really

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Compatible

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
* https://youtu.be/9kcRy-YrLy4