### PR TITLE
Added "extensions" attribute in plugin.yml with version checking

### DIFF
--- a/src/pocketmine/plugin/PluginDescription.php
+++ b/src/pocketmine/plugin/PluginDescription.php
@@ -164,7 +164,7 @@ class PluginDescription{
 	/**
 	 * @return array
 	 */
-	public function getExtensions(){
+	public function getRequiredExtensions(){
 		return $this->extensions;
 	}
 
@@ -173,7 +173,7 @@ class PluginDescription{
 	 *
 	 * @throws PluginException if there are required extensions missing or have incompatible version, or if the version constraint cannot be parsed
 	 */
-	public function checkExtensions(){
+	public function checkRequiredExtensions(){
 		foreach($this->extensions as $name => $versionConstrs){
 			if(!extension_loaded($name)){
 				throw new PluginException("Required extension $name not loaded");

--- a/src/pocketmine/plugin/PluginDescription.php
+++ b/src/pocketmine/plugin/PluginDescription.php
@@ -27,6 +27,7 @@ class PluginDescription{
 	private $name;
 	private $main;
 	private $api;
+	private $extensions = [];
 	private $depend = [];
 	private $softDepend = [];
 	private $loadBefore = [];
@@ -74,6 +75,17 @@ class PluginDescription{
 
 		if(isset($plugin["depend"])){
 			$this->depend = (array) $plugin["depend"];
+		}
+		if(isset($plugin["extensions"])){
+			$extensions = (array) $plugin["extensions"];
+			$isLinear = $extensions === array_values($extensions);
+			foreach($extensions as $k => $v){
+				if($isLinear){
+					$k = $v;
+					$v = "*";
+				}
+				$this->extensions[$k] = is_array($v) ? $v : [$v];
+			}
 		}
 		if(isset($plugin["softdepend"])){
 			$this->softDepend = (array) $plugin["softdepend"];
@@ -147,6 +159,50 @@ class PluginDescription{
 	 */
 	public function getCommands(){
 		return $this->commands;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getExtensions(){
+		return $this->extensions;
+	}
+
+	/**
+	 * Checks if the current PHP runtime has the extensions required by the plugin.
+	 *
+	 * @throws PluginException if there are required extensions missing or have incompatible version, or if the version constraint cannot be parsed
+	 */
+	public function checkExtensions(){
+		foreach($this->extensions as $name => $versionConstrs){
+			if(!extension_loaded($name)){
+				throw new PluginException("Required extension $name not loaded");
+			}
+
+			if(!is_array($versionConstrs)){
+				$versionConstrs = [$versionConstrs];
+			}
+			$gotVersion = phpversion($name);
+			foreach($versionConstrs as $constr){ // versionConstrs_loop
+				if($constr === "*"){
+					continue;
+				}
+				if($constr === ""){
+					throw new PluginException("One of the extension version constraints of $name is empty. Consider quoting the version string in plugin.yml");
+				}
+				foreach(["<=", "le", "<>", "!=", "ne", "<", "lt", "==", "=", "eq", ">=", "ge", ">", "gt"] as $comparator){
+					// warning: the > character should be quoted in YAML
+					if(substr($constr, 0, strlen($comparator)) === $comparator){
+						$version = substr($constr, strlen($comparator));
+						if(!version_compare($gotVersion, $version, $comparator)){
+							throw new PluginException("Required extension $name has an incompatible version ($gotVersion not $constr)");
+						}
+						continue 2; // versionConstrs_loop
+					}
+				}
+				throw new PluginException("Error parsing version constraint: $constr");
+			}
+		}
 	}
 
 	/**

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -147,6 +147,13 @@ class PluginManager{
 			if(preg_match($loader->getPluginFilters(), basename($path)) > 0){
 				$description = $loader->getPluginDescription($path);
 				if($description instanceof PluginDescription){
+					try{
+						$description->checkExtensions();
+					}catch(PluginException $ex){
+						$this->server->getLogger()->error($ex->getMessage());
+						return null;
+					}
+
 					if(($plugin = $loader->loadPlugin($path)) instanceof Plugin){
 						$this->plugins[$plugin->getDescription()->getName()] = $plugin;
 

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -148,7 +148,7 @@ class PluginManager{
 				$description = $loader->getPluginDescription($path);
 				if($description instanceof PluginDescription){
 					try{
-						$description->checkExtensions();
+						$description->checkRequiredExtensions();
 					}catch(PluginException $ex){
 						$this->server->getLogger()->error($ex->getMessage());
 						return null;


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
With the prevalence of third-party modifications of PocketMine-MP, the set of available PHP extensions in a PocketMine runtime is no longer standardized; the original set of available PHP extensions is messed up as well.

This pull request introduces the `extensions` attribute, which will make sure the current PHP runtime has the required extensions with the expected versions.

## Changes
### API changes
The `PluginDescription::getRequiredExtensions()` method is added to return an array whose keys are extension names and values are extension version constraints (a string array).

See the [Tests](#tests) section for possible ways of declaring extensions.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
Plugins will fail to load if the extensions are missing or have an incorrect version, or if the extension versions are declared syntactically wrong.

## Backwards compatibility
<!-- Any possible backwards-incompatible changes? How are they solved, or how can they be solved? -->
Plugins that do not have the `extensions` attribute in their plugin.yml will be considered as requiring no extensions (to be checked), identical to this:

```yaml
extensions: []
```

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
Nil
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
The following fragments of `plugin.yml` have been tested and have the expected behaviour of crashing or passing, tested on a server with pthreads 3.1.6 and without the ncurses extension.

The version constraint is the concatenation of two strings, _comparator_ and *compared_version*. The comparator should be one of `<`, `lt`, `<=`, `le`, `>`, `gt`, `>=`, `ge`, `==`, `=`, `eq`, `!=`, `<>`, `ne`. Then this condition is checked whether to be true:

```
extension_version {comparator} compared_version
```

### No extensions attribute
```yaml
```
Loads correctly.

### As a simple string, extension present
```yaml
extensions: pthreads
```
Loads correctly.

### As a simple string, extension missing
```yaml
extensions: ncurses
```

Fails to load:
```
[19:06:24] [Server thread/ERROR]: Required extension ncurses not loaded
[19:06:24] [Server thread/CRITICAL]: Could not load plugin 'TestExtensions'
```

### As a linear array, one extension present and one extension missing
```yaml
extensions: [pthreads, ncurses]
```

Fails to load:
```
[19:06:58] [Server thread/ERROR]: Required extension ncurses not loaded
[19:06:58] [Server thread/CRITICAL]: Could not load plugin 'TestExtensions'
```

### As a map, using asterisk, extension present
**Note: `*` in YAML does not get parsed as a string. Use `"*"` to escape.
```yaml
extensions:
  pthreads: "*"
```

Loads correctly.

### As a map, using asterisk, extension absent
```yaml
extensions:
  ncurses: "*"
```

Fails to load:
```
[19:10:56] [Server thread/ERROR]: Required extension ncurses not loaded
[19:10:56] [Server thread/CRITICAL]: Could not load plugin 'TestExtensions'
```

### As a map, using a string as a true version constraint
**Note: `>` is a special symbol in YAML. _Always_ Quote the version constraint.**
```yaml
extensions:
  pthreads: ">=3"
```

Loads correctly.

### As a map, using a string as a false version constraint
```yaml
extensions:
  pthreads: "<>3.1.6"
```

Fails to load:
```
[19:21:39] [Server thread/ERROR]: Required extension pthreads has an incompatible version (3.1.6 not <>3.1.6)
[19:21:39] [Server thread/CRITICAL]: Could not load plugin 'TestExtensions'
```

### As a map, using an empty string as version constraint
This test shows what happens if `>` is used and the version gets YAML-parsed incorrectly into an empty string.
```yaml
extensions:
  pthreads: >2
```

Fails to load:
```
[19:14:33] [Server thread/ERROR]: One of the extension version constraints of pthreads is empty. Consider quoting the version string in plugin.yml
[19:14:33] [Server thread/CRITICAL]: Could not load plugin 'TestExtensions'
```

### As a map, using two true version constraints
```yaml
extensions:
  pthreads:
    - ">=3"
    - "<4"
```

Loads correctly.

### As a map, using one true version constraint and one false version constraint
```yaml
extensions:
  pthreads:
    - ">=3"
    - "<>3.1.6"
```

Fails to load:
```
[19:16:20] [Server thread/ERROR]: Required extension pthreads has an incompatible version (3.1.6 not <>3.1.6)
[19:16:20] [Server thread/CRITICAL]: Could not load plugin 'TestExtensions'
```