### PR TITLE
Added basic fire spread implementation

### DIFF
--- a/src/pocketmine/block/Anvil.php
+++ b/src/pocketmine/block/Anvil.php
@@ -35,12 +35,12 @@ class Anvil extends Fallable{
 
 	protected $id = self::ANVIL;
 
-	public function isSolid(){
-		return false;
-	}
-
 	public function __construct($meta = 0){
 		$this->meta = $meta;
+	}
+
+	public function isSolid(){
+		return false;
 	}
 
 	public function getHardness(){

--- a/src/pocketmine/block/Bed.php
+++ b/src/pocketmine/block/Bed.php
@@ -44,17 +44,6 @@ class Bed extends Transparent{
 		return "Bed Block";
 	}
 
-	protected function recalculateBoundingBox(){
-		return new AxisAlignedBB(
-			$this->x,
-			$this->y,
-			$this->z,
-			$this->x + 1,
-			$this->y + 0.5625,
-			$this->z + 1
-		);
-	}
-
 	public function onActivate(Item $item, Player $player = null){
 
 		$time = $this->getLevel()->getTime() % Level::TIME_FULL;
@@ -157,6 +146,17 @@ class Bed extends Transparent{
 		return [
 			[Item::BED, 0, 1],
 		];
+	}
+
+	protected function recalculateBoundingBox(){
+		return new AxisAlignedBB(
+			$this->x,
+			$this->y,
+			$this->z,
+			$this->x + 1,
+			$this->y + 0.5625,
+			$this->z + 1
+		);
 	}
 
 }

--- a/src/pocketmine/block/Block.php
+++ b/src/pocketmine/block/Block.php
@@ -312,6 +312,11 @@ class Block extends Position implements BlockIds, Metadatable{
 	/** @var AxisAlignedBB */
 	public $boundingBox = null;
 
+	protected $flammable = false;
+	protected $canCatchFireFromLava = false;
+	protected $flammability = 0;
+	protected $flameEncouragement = 0;
+
 
 	/**
 	 * @param int $id
@@ -349,6 +354,42 @@ class Block extends Position implements BlockIds, Metadatable{
 	 */
 	public function isBreakable(Item $item){
 		return true;
+	}
+
+	/**
+	 * Returns if the item is flammable
+	 *
+	 * @return bool
+	 */
+	public function isFlammable() : bool{
+		return $this->flammable;
+	}
+
+	/**
+	 * Returns if the item can catch fire if near lava
+	 *
+	 * @return bool
+	 */
+	public function canCatchFireFromLava() : bool{
+		return $this->canCatchFireFromLava;
+	}
+
+	/**
+	 * Returns the flammability of a block (the higher, the more quickly a block will burn away)
+	 *
+	 * @return int
+	 */
+	public function getFlammability(): int {
+		return $this->flammability;
+	}
+
+	/**
+	 * Returns the flame encouragement of a block (the higher, the more chance the block will catch fire)
+	 *
+	 * @return int
+	 */
+	public function getFlameEncouragement(): int {
+		return $this->flameEncouragement;
 	}
 
 	/**

--- a/src/pocketmine/block/Bookshelf.php
+++ b/src/pocketmine/block/Bookshelf.php
@@ -26,6 +26,10 @@ use pocketmine\item\Tool;
 class Bookshelf extends Solid{
 
 	protected $id = self::BOOKSHELF;
+	protected $canCatchFireFromLava = true;
+	protected $flammable = true;
+	protected $flammability = 20;
+	protected $flameEncouragement = 30;
 
 	public function __construct(){
 

--- a/src/pocketmine/block/Cactus.php
+++ b/src/pocketmine/block/Cactus.php
@@ -52,18 +52,6 @@ class Cactus extends Transparent{
 		return "Cactus";
 	}
 
-	protected function recalculateBoundingBox(){
-
-		return new AxisAlignedBB(
-			$this->x + 0.0625,
-			$this->y + 0.0625,
-			$this->z + 0.0625,
-			$this->x + 0.9375,
-			$this->y + 0.9375,
-			$this->z + 0.9375
-		);
-	}
-
 	public function onEntityCollide(Entity $entity){
 		$ev = new EntityDamageByBlockEvent($this, $entity, EntityDamageEvent::CAUSE_CONTACT, 1);
 		$entity->attack($ev->getFinalDamage(), $ev);
@@ -127,5 +115,17 @@ class Cactus extends Transparent{
 		return [
 			[$this->id, 0, 1],
 		];
+	}
+
+	protected function recalculateBoundingBox(){
+
+		return new AxisAlignedBB(
+			$this->x + 0.0625,
+			$this->y + 0.0625,
+			$this->z + 0.0625,
+			$this->x + 0.9375,
+			$this->y + 0.9375,
+			$this->z + 0.9375
+		);
 	}
 }

--- a/src/pocketmine/block/Cake.php
+++ b/src/pocketmine/block/Cake.php
@@ -46,20 +46,6 @@ class Cake extends Transparent implements FoodSource{
 		return "Cake Block";
 	}
 
-	protected function recalculateBoundingBox(){
-
-		$f = (($this->getDamage() * 2) / 16);
-
-		return new AxisAlignedBB(
-			$this->x + 0.0625 + $f,
-			$this->y,
-			$this->z + 0.0625,
-			$this->x + 1 - 0.0625,
-			$this->y + 0.5,
-			$this->z + 1 - 0.0625
-		);
-	}
-
 	public function place(Item $item, Block $block, Block $target, $face, $fx, $fy, $fz, Player $player = null){
 		$down = $this->getSide(0);
 		if($down->getId() !== self::AIR){
@@ -133,5 +119,19 @@ class Cake extends Transparent implements FoodSource{
 
 	public function onConsume(Entity $consumer){
 
+	}
+
+	protected function recalculateBoundingBox(){
+
+		$f = (($this->getDamage() * 2) / 16);
+
+		return new AxisAlignedBB(
+			$this->x + 0.0625 + $f,
+			$this->y,
+			$this->z + 0.0625,
+			$this->x + 1 - 0.0625,
+			$this->y + 0.5,
+			$this->z + 1 - 0.0625
+		);
 	}
 }

--- a/src/pocketmine/block/Carpet.php
+++ b/src/pocketmine/block/Carpet.php
@@ -29,6 +29,10 @@ use pocketmine\Player;
 class Carpet extends Flowable{
 
 	protected $id = self::CARPET;
+	protected $flammable = true;
+	protected $canCatchFireFromLava = true;
+	protected $flameEncouragement = 30;
+	protected $flammability = 60;
 
 	public function __construct($meta = 0){
 		$this->meta = $meta;

--- a/src/pocketmine/block/Carpet.php
+++ b/src/pocketmine/block/Carpet.php
@@ -68,18 +68,6 @@ class Carpet extends Flowable{
 		return $names[$this->meta & 0x0f];
 	}
 
-	protected function recalculateBoundingBox(){
-
-		return new AxisAlignedBB(
-			$this->x,
-			$this->y,
-			$this->z,
-			$this->x + 1,
-			$this->y + 0.0625,
-			$this->z + 1
-		);
-	}
-
 	public function place(Item $item, Block $block, Block $target, $face, $fx, $fy, $fz, Player $player = null){
 		$down = $this->getSide(0);
 		if($down->getId() !== self::AIR){
@@ -101,6 +89,18 @@ class Carpet extends Flowable{
 		}
 
 		return false;
+	}
+
+	protected function recalculateBoundingBox(){
+
+		return new AxisAlignedBB(
+			$this->x,
+			$this->y,
+			$this->z,
+			$this->x + 1,
+			$this->y + 0.0625,
+			$this->z + 1
+		);
 	}
 
 }

--- a/src/pocketmine/block/Chest.php
+++ b/src/pocketmine/block/Chest.php
@@ -36,6 +36,10 @@ use pocketmine\tile\Tile;
 class Chest extends Transparent{
 
 	protected $id = self::CHEST;
+	protected $flammable = true;
+	protected $flammability = 0;
+	protected $canCatchFireFromLava = true;
+	protected $flameEncouragement = 25;
 
 	public function __construct($meta = 0){
 		$this->meta = $meta;

--- a/src/pocketmine/block/Chest.php
+++ b/src/pocketmine/block/Chest.php
@@ -57,17 +57,6 @@ class Chest extends Transparent{
 		return Tool::TYPE_AXE;
 	}
 
-	protected function recalculateBoundingBox(){
-		return new AxisAlignedBB(
-			$this->x + 0.0625,
-			$this->y,
-			$this->z + 0.0625,
-			$this->x + 0.9375,
-			$this->y + 0.9475,
-			$this->z + 0.9375
-		);
-	}
-
 	public function place(Item $item, Block $block, Block $target, $face, $fx, $fy, $fz, Player $player = null){
 		$faces = [
 			0 => 4,
@@ -174,5 +163,16 @@ class Chest extends Transparent{
 		return [
 			[$this->id, 0, 1],
 		];
+	}
+
+	protected function recalculateBoundingBox(){
+		return new AxisAlignedBB(
+			$this->x + 0.0625,
+			$this->y,
+			$this->z + 0.0625,
+			$this->x + 0.9375,
+			$this->y + 0.9475,
+			$this->z + 0.9375
+		);
 	}
 }

--- a/src/pocketmine/block/Coal.php
+++ b/src/pocketmine/block/Coal.php
@@ -28,6 +28,9 @@ use pocketmine\item\Tool;
 class Coal extends Solid{
 
 	protected $id = self::COAL_BLOCK;
+	protected $flammable = true;
+	protected $flammability = 5;
+	protected $flameEncouragement = 5;
 
 	public function __construct(){
 

--- a/src/pocketmine/block/CobblestoneWall.php
+++ b/src/pocketmine/block/CobblestoneWall.php
@@ -26,6 +26,7 @@ use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Vector3;
 
 class CobblestoneWall extends Transparent{
+
 	const NONE_MOSSY_WALL = 0;
 	const MOSSY_WALL = 1;
 

--- a/src/pocketmine/block/CraftingTable.php
+++ b/src/pocketmine/block/CraftingTable.php
@@ -28,6 +28,9 @@ use pocketmine\Player;
 class CraftingTable extends Solid{
 
 	protected $id = self::CRAFTING_TABLE;
+	protected $flammable = true;
+	protected $flammability = 0;
+	protected $flameEncouragement = 25;
 
 	public function __construct($meta = 0){
 		$this->meta = $meta;

--- a/src/pocketmine/block/Dandelion.php
+++ b/src/pocketmine/block/Dandelion.php
@@ -29,6 +29,9 @@ use pocketmine\Player;
 class Dandelion extends Flowable{
 
 	protected $id = self::DANDELION;
+	protected $flammable = true;
+	protected $flammability = 100;
+	protected $flameEncouragement = 30;
 
 	public function __construct(){
 

--- a/src/pocketmine/block/DaylightSensor.php
+++ b/src/pocketmine/block/DaylightSensor.php
@@ -24,6 +24,9 @@ namespace pocketmine\block;
 class DaylightSensor extends Transparent{
 
 	protected $id = self::DAYLIGHT_SENSOR;
+	protected $flammable = true;
+	protected $flammability = 0;
+	protected $flameEncouragement = 25;
 
 	public function __construct($meta = 0){
 		$this->meta = $meta;

--- a/src/pocketmine/block/Door.php
+++ b/src/pocketmine/block/Door.php
@@ -35,21 +35,86 @@ abstract class Door extends Transparent{
 		return false;
 	}
 
-	private function getFullDamage(){
-		$damage = $this->getDamage();
-		$isUp = ($damage & 0x08) > 0;
+	public function onUpdate($type){
+		if($type === Level::BLOCK_UPDATE_NORMAL){
+			if($this->getSide(0)->getId() === self::AIR){ //Replace with common break method
+				$this->getLevel()->setBlock($this, new Air(), false);
+				if($this->getSide(1) instanceof Door){
+					$this->getLevel()->setBlock($this->getSide(1), new Air(), false);
+				}
 
-		if($isUp){
-			$down = $this->getSide(Vector3::SIDE_DOWN)->getDamage();
-			$up = $damage;
-		}else{
-			$down = $damage;
-			$up = $this->getSide(Vector3::SIDE_UP)->getDamage();
+				return Level::BLOCK_UPDATE_NORMAL;
+			}
 		}
 
-		$isRight = ($up & 0x01) > 0;
+		return false;
+	}
 
-		return $down & 0x07 | ($isUp ? 8 : 0) | ($isRight ? 0x10 : 0);
+	public function place(Item $item, Block $block, Block $target, $face, $fx, $fy, $fz, Player $player = null){
+		if($face === 1){
+			$blockUp = $this->getSide(1);
+			$blockDown = $this->getSide(0);
+			if($blockUp->canBeReplaced() === false or $blockDown->isTransparent() === true){
+				return false;
+			}
+			$direction = $player instanceof Player ? $player->getDirection() : 0;
+			$face = [
+				0 => 3,
+				1 => 4,
+				2 => 2,
+				3 => 5,
+			];
+			$next = $this->getSide($face[(($direction + 2) % 4)]);
+			$next2 = $this->getSide($face[$direction]);
+			$metaUp = 0x08;
+			if($next->getId() === $this->getId() or ($next2->isTransparent() === false and $next->isTransparent() === true)){ //Door hinge
+				$metaUp |= 0x01;
+			}
+
+			$this->setDamage($player->getDirection() & 0x03);
+			$this->getLevel()->setBlock($block, $this, true, true); //Bottom
+			$this->getLevel()->setBlock($blockUp, $b = Block::get($this->getId(), $metaUp), true); //Top
+			return true;
+		}
+
+		return false;
+	}
+
+	public function onBreak(Item $item){
+		if(($this->getDamage() & 0x08) === 0x08){
+			$down = $this->getSide(0);
+			if($down->getId() === $this->getId()){
+				$this->getLevel()->setBlock($down, new Air(), true);
+			}
+		}else{
+			$up = $this->getSide(1);
+			if($up->getId() === $this->getId()){
+				$this->getLevel()->setBlock($up, new Air(), true);
+			}
+		}
+		$this->getLevel()->setBlock($this, new Air(), true);
+
+		return true;
+	}
+
+	public function onActivate(Item $item, Player $player = null){
+		if(($this->getDamage() & 0x08) === 0x08){ //Top
+			$down = $this->getSide(0);
+			if($down->getId() === $this->getId()){
+				$meta = $down->getDamage() ^ 0x04;
+				$this->level->setBlock($down, Block::get($this->getId(), $meta), true);
+				$this->level->addSound(new DoorSound($this));
+				return true;
+			}
+
+			return false;
+		}else{
+			$this->meta ^= 0x04;
+			$this->level->setBlock($this, $this, true);
+			$this->level->addSound(new DoorSound($this));
+		}
+
+		return true;
 	}
 
 	protected function recalculateBoundingBox(){
@@ -199,85 +264,20 @@ abstract class Door extends Transparent{
 		return $bb;
 	}
 
-	public function onUpdate($type){
-		if($type === Level::BLOCK_UPDATE_NORMAL){
-			if($this->getSide(0)->getId() === self::AIR){ //Replace with common break method
-				$this->getLevel()->setBlock($this, new Air(), false);
-				if($this->getSide(1) instanceof Door){
-					$this->getLevel()->setBlock($this->getSide(1), new Air(), false);
-				}
+	private function getFullDamage(){
+		$damage = $this->getDamage();
+		$isUp = ($damage & 0x08) > 0;
 
-				return Level::BLOCK_UPDATE_NORMAL;
-			}
-		}
-
-		return false;
-	}
-
-	public function place(Item $item, Block $block, Block $target, $face, $fx, $fy, $fz, Player $player = null){
-		if($face === 1){
-			$blockUp = $this->getSide(1);
-			$blockDown = $this->getSide(0);
-			if($blockUp->canBeReplaced() === false or $blockDown->isTransparent() === true){
-				return false;
-			}
-			$direction = $player instanceof Player ? $player->getDirection() : 0;
-			$face = [
-				0 => 3,
-				1 => 4,
-				2 => 2,
-				3 => 5,
-			];
-			$next = $this->getSide($face[(($direction + 2) % 4)]);
-			$next2 = $this->getSide($face[$direction]);
-			$metaUp = 0x08;
-			if($next->getId() === $this->getId() or ($next2->isTransparent() === false and $next->isTransparent() === true)){ //Door hinge
-				$metaUp |= 0x01;
-			}
-
-			$this->setDamage($player->getDirection() & 0x03);
-			$this->getLevel()->setBlock($block, $this, true, true); //Bottom
-			$this->getLevel()->setBlock($blockUp, $b = Block::get($this->getId(), $metaUp), true); //Top
-			return true;
-		}
-
-		return false;
-	}
-
-	public function onBreak(Item $item){
-		if(($this->getDamage() & 0x08) === 0x08){
-			$down = $this->getSide(0);
-			if($down->getId() === $this->getId()){
-				$this->getLevel()->setBlock($down, new Air(), true);
-			}
+		if($isUp){
+			$down = $this->getSide(Vector3::SIDE_DOWN)->getDamage();
+			$up = $damage;
 		}else{
-			$up = $this->getSide(1);
-			if($up->getId() === $this->getId()){
-				$this->getLevel()->setBlock($up, new Air(), true);
-			}
-		}
-		$this->getLevel()->setBlock($this, new Air(), true);
-
-		return true;
-	}
-
-	public function onActivate(Item $item, Player $player = null){
-		if(($this->getDamage() & 0x08) === 0x08){ //Top
-			$down = $this->getSide(0);
-			if($down->getId() === $this->getId()){
-				$meta = $down->getDamage() ^ 0x04;
-				$this->level->setBlock($down, Block::get($this->getId(), $meta), true);
-				$this->level->addSound(new DoorSound($this));
-				return true;
-			}
-
-			return false;
-		}else{
-			$this->meta ^= 0x04;
-			$this->level->setBlock($this, $this, true);
-			$this->level->addSound(new DoorSound($this));
+			$down = $damage;
+			$up = $this->getSide(Vector3::SIDE_UP)->getDamage();
 		}
 
-		return true;
+		$isRight = ($up & 0x01) > 0;
+
+		return $down & 0x07 | ($isUp ? 8 : 0) | ($isRight ? 0x10 : 0);
 	}
 }

--- a/src/pocketmine/block/DoublePlant.php
+++ b/src/pocketmine/block/DoublePlant.php
@@ -27,6 +27,10 @@ use pocketmine\level\Level;
 class DoublePlant extends Flowable{
 
 	protected $id = self::DOUBLE_PLANT;
+	protected $flammable = true;
+	protected $flammability = 100;
+	protected $canCatchFireFromLava = true;
+	protected $flameEncouragement = 60;
 
 	public function __construct($meta = 0){
 		$this->meta = $meta;

--- a/src/pocketmine/block/DoubleWoodSlab.php
+++ b/src/pocketmine/block/DoubleWoodSlab.php
@@ -27,6 +27,10 @@ use pocketmine\item\Tool;
 class DoubleWoodSlab extends Solid{
 
 	protected $id = self::DOUBLE_WOODEN_SLAB;
+	protected $flammable = true;
+	protected $flammability = 20;
+	protected $canCatchFireFromLava = true;
+	protected $flameEncouragement = 5;
 
 	public function __construct($meta = 0){
 		$this->meta = $meta;

--- a/src/pocketmine/block/Farmland.php
+++ b/src/pocketmine/block/Farmland.php
@@ -45,6 +45,12 @@ class Farmland extends Transparent{
 		return Tool::TYPE_SHOVEL;
 	}
 
+	public function getDrops(Item $item){
+		return [
+			[Item::DIRT, 0, 1],
+		];
+	}
+
 	protected function recalculateBoundingBox(){
 		return new AxisAlignedBB(
 			$this->x,
@@ -54,11 +60,5 @@ class Farmland extends Transparent{
 			$this->y + 0.9375,
 			$this->z + 1
 		);
-	}
-
-	public function getDrops(Item $item){
-		return [
-			[Item::DIRT, 0, 1],
-		];
 	}
 }

--- a/src/pocketmine/block/Fence.php
+++ b/src/pocketmine/block/Fence.php
@@ -34,6 +34,10 @@ class Fence extends Transparent{
 	const FENCE_DARKOAK = 5;
 
 	protected $id = self::FENCE;
+	protected $flammable = true;
+	protected $flammability = 20;
+	protected $canCatchFireFromLava = true;
+	protected $flameEncouragement = 5;
 
 	public function __construct($meta = 0){
 		$this->meta = $meta;

--- a/src/pocketmine/block/Fence.php
+++ b/src/pocketmine/block/Fence.php
@@ -26,6 +26,7 @@ use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Vector3;
 
 class Fence extends Transparent{
+
 	const FENCE_OAK = 0;
 	const FENCE_SPRUCE = 1;
 	const FENCE_BIRCH = 2;

--- a/src/pocketmine/block/FenceGate.php
+++ b/src/pocketmine/block/FenceGate.php
@@ -30,6 +30,10 @@ use pocketmine\Player;
 class FenceGate extends Transparent{
 
 	protected $id = self::FENCE_GATE;
+	protected $flammable = true;
+	protected $flammability = 20;
+	protected $canCatchFireFromLava = true;
+	protected $flameEncouragement = 5;
 
 	public function __construct($meta = 0){
 		$this->meta = $meta;

--- a/src/pocketmine/block/FenceGate.php
+++ b/src/pocketmine/block/FenceGate.php
@@ -47,6 +47,30 @@ class FenceGate extends Transparent{
 		return Tool::TYPE_AXE;
 	}
 
+	public function place(Item $item, Block $block, Block $target, $face, $fx, $fy, $fz, Player $player = null){
+		$this->meta = ($player instanceof Player ? ($player->getDirection() - 1) & 0x03 : 0);
+		$this->getLevel()->setBlock($block, $this, true, true);
+
+		return true;
+	}
+
+	public function getDrops(Item $item){
+		return [
+			[$this->id, 0, 1],
+		];
+	}
+
+	public function onActivate(Item $item, Player $player = null){
+		$this->meta = (($this->meta ^ 0x04) & ~0x02);
+
+		if($player !== null){
+			$this->meta |= (($player->getDirection() - 1) & 0x02);
+		}
+
+		$this->getLevel()->setBlock($this, $this, true);
+		$this->level->addSound(new DoorSound($this));
+		return true;
+	}
 
 	protected function recalculateBoundingBox(){
 
@@ -74,30 +98,5 @@ class FenceGate extends Transparent{
 				$this->z + 1
 			);
 		}
-	}
-
-	public function place(Item $item, Block $block, Block $target, $face, $fx, $fy, $fz, Player $player = null){
-		$this->meta = ($player instanceof Player ? ($player->getDirection() - 1) & 0x03 : 0);
-		$this->getLevel()->setBlock($block, $this, true, true);
-
-		return true;
-	}
-
-	public function getDrops(Item $item){
-		return [
-			[$this->id, 0, 1],
-		];
-	}
-
-	public function onActivate(Item $item, Player $player = null){
-		$this->meta = (($this->meta ^ 0x04) & ~0x02);
-
-		if($player !== null){
-			$this->meta |= (($player->getDirection() - 1) & 0x02);
-		}
-
-		$this->getLevel()->setBlock($this, $this, true);
-		$this->level->addSound(new DoorSound($this));
-		return true;
 	}
 }

--- a/src/pocketmine/block/Fire.php
+++ b/src/pocketmine/block/Fire.php
@@ -93,38 +93,42 @@ class Fire extends Flowable{
 		}elseif($type === Level::BLOCK_UPDATE_RANDOM){
 			$fireSpread = false;
 			$flammableBlocks = [];
-			for($flameSide = 0; $flameSide <= 5; $flameSide++) {
+			for($flameSide = 0; $flameSide <= 5; $flameSide++){
 				$flameBlock = $this->getSide($flameSide);
 				for($s = 0; $s <= 5; $s++){
 					$flame = $flameBlock->getSide($s);
-					if($s === $flameSide && $flameBlock->getId() !== Block::AIR) {
+					if($s === $flameSide && $flameBlock->getId() !== Block::AIR){
 						continue;
 					}
-					if($flame->getId() !== Block::AIR && $flame->getId() !== Block::FIRE) {
-						$flammableBlocks[$flame->getId()] = $flameBlock;
+					if($flame->getId() !== Block::AIR && $flame->getId() !== Block::FIRE){
+						if($flameBlock->getId() === Block::AIR){
+							$flammableBlocks[$flame->getId()] = $flameBlock;
+						}
 						continue;
+					}elseif($flame->getId() === Block::AIR){
+						$flammableBlocks[$flameBlock->getId()] = $flame;
 					}
-					$flammableBlocks[$flameBlock->getId()] = $flame;
 				}
 			}
-			if(empty($flammableBlocks)) {
+			if(empty($flammableBlocks)){
 				return false;
 			}
 			$randomFlame = $flammableBlocks[array_rand($flammableBlocks)];
-			if(mt_rand(0, 200) <= Block::get(key($randomFlame))->getFlameEncouragement()) {
+			if(mt_rand(0, 200) <= Block::get(key($randomFlame))->getFlameEncouragement()){
 				$this->level->setBlock($randomFlame, new Fire());
 				$fireSpread = true;
 			}
 
-			if($this->getSide(0)->isFlammable()) {
-				if(mt_rand(0, 200) <= $this->getSide(0)->getFlammability()) {
-					$this->level->setBlock($this->getSide(0), $this);
+			if($this->getSide(0)->isFlammable()){
+				if(mt_rand(0, 200) <= $this->getSide(0)->getFlammability()){
+					$this->level->setBlock($this->getSide(0), new Fire());
 					$this->level->setBlock($this, new Air());
 					$fireSpread = true;
 				}
-			} elseif($fireSpread === false) {
-				if(mt_rand(0, 2) === 0) {
-					if($this->meta === 0x0F) {
+			}
+			if($fireSpread === false){
+				if(mt_rand(0, 2) === 0){
+					if($this->meta === 0x0F){
 						$this->level->setBlock($this, new Air());
 						return Level::BLOCK_UPDATE_NORMAL;
 					}else{

--- a/src/pocketmine/block/Flower.php
+++ b/src/pocketmine/block/Flower.php
@@ -38,6 +38,10 @@ class Flower extends Flowable{
 	const TYPE_OXEYE_DAISY = 8;
 
 	protected $id = self::RED_FLOWER;
+	protected $flammable = true;
+	protected $flammability = 100;
+	protected $canCatchFireFromLava = true;
+	protected $flameEncouragement = 30;
 
 	public function __construct($meta = 0){
 		$this->meta = $meta;

--- a/src/pocketmine/block/Flower.php
+++ b/src/pocketmine/block/Flower.php
@@ -27,6 +27,7 @@ use pocketmine\math\Vector3;
 use pocketmine\Player;
 
 class Flower extends Flowable{
+
 	const TYPE_POPPY = 0;
 	const TYPE_BLUE_ORCHID = 1;
 	const TYPE_ALLIUM = 2;

--- a/src/pocketmine/block/FlowerPot.php
+++ b/src/pocketmine/block/FlowerPot.php
@@ -48,17 +48,6 @@ class FlowerPot extends Flowable{
 		return "Flower Pot Block";
 	}
 
-	protected function recalculateBoundingBox(){
-		return new AxisAlignedBB(
-			$this->x + 0.3125,
-			$this->y,
-			$this->z + 0.3125,
-			$this->x + 0.6875,
-			$this->y + 0.375,
-			$this->z + 0.6875
-		);
-	}
-
 	public function place(Item $item, Block $block, Block $target, $face, $fx, $fy, $fz, Player $player = null){
 		if($this->getSide(Vector3::SIDE_DOWN)->isTransparent()){
 			return false;
@@ -128,6 +117,17 @@ class FlowerPot extends Flowable{
 			}
 		}
 		return $items;
+	}
+
+	protected function recalculateBoundingBox(){
+		return new AxisAlignedBB(
+			$this->x + 0.3125,
+			$this->y,
+			$this->z + 0.3125,
+			$this->x + 0.6875,
+			$this->y + 0.375,
+			$this->z + 0.6875
+		);
 	}
 
 }

--- a/src/pocketmine/block/FlowingLava.php
+++ b/src/pocketmine/block/FlowingLava.php
@@ -73,29 +73,29 @@ class FlowingLava extends Liquid{
 	public function onUpdate($type){
 		if($type === Level::BLOCK_UPDATE_RANDOM){
 			$flammableBlocks = [];
-			for($flameSide = 0; $flameSide <= 5; $flameSide++) {
+			for($flameSide = 0; $flameSide <= 5; $flameSide++){
 				$flameBlock = $this->getSide($flameSide);
 				for($s = 0; $s <= 5; $s++){
 					$flame = $flameBlock->getSide($s);
-					if($s === $flameSide && $flameBlock->getId() !== Block::AIR) {
+					if($s === $flameSide && $flameBlock->getId() !== Block::AIR){
 						continue;
 					}
-					if($flame->getId() !== Block::AIR && $flame->getId() !== Block::FLOWING_LAVA && $flame->getId() !== Block::STILL_LAVA) {
-						if($flame->canCatchFireFromLava()) {
+					if($flame->getId() !== Block::AIR && $flame->getId() !== Block::FLOWING_LAVA && $flame->getId() !== Block::STILL_LAVA){
+						if($flame->canCatchFireFromLava() && $flameBlock->getId() === Block::AIR){
 							$flammableBlocks[$flame->getId()] = $flameBlock;
 						}
 						continue;
 					}
-					if($flameBlock->canCatchFireFromLava()) {
+					if($flameBlock->canCatchFireFromLava() && $flame->getId() === Block::AIR){
 						$flammableBlocks[$flameBlock->getId()] = $flame;
 					}
 				}
 			}
-			if(empty($flammableBlocks)) {
+			if(empty($flammableBlocks)){
 				return false;
 			}
 			$randomFlame = $flammableBlocks[array_rand($flammableBlocks)];
-			if(mt_rand(0, 200) <= Block::get(key($randomFlame))->getFlameEncouragement()) {
+			if(mt_rand(0, 200) <= Block::get(key($randomFlame))->getFlameEncouragement()){
 				$this->level->setBlock($randomFlame, new Fire());
 			}
 			return Level::BLOCK_UPDATE_NORMAL;

--- a/src/pocketmine/block/GrassPath.php
+++ b/src/pocketmine/block/GrassPath.php
@@ -41,17 +41,6 @@ class GrassPath extends Transparent{
 		return Tool::TYPE_SHOVEL;
 	}
 
-	protected function recalculateBoundingBox(){
-		return new AxisAlignedBB(
-			$this->x,
-			$this->y,
-			$this->z,
-			$this->x + 1,
-			$this->y + 0.9375,
-			$this->z + 1
-		);
-	}
-
 	public function getHardness(){
 		return 0.6;
 	}
@@ -64,5 +53,16 @@ class GrassPath extends Transparent{
 
 	public function canBeTilled() : bool{
 		return true;
+	}
+
+	protected function recalculateBoundingBox(){
+		return new AxisAlignedBB(
+			$this->x,
+			$this->y,
+			$this->z,
+			$this->x + 1,
+			$this->y + 0.9375,
+			$this->z + 1
+		);
 	}
 }

--- a/src/pocketmine/block/HayBale.php
+++ b/src/pocketmine/block/HayBale.php
@@ -27,6 +27,9 @@ use pocketmine\Player;
 class HayBale extends Solid{
 
 	protected $id = self::HAY_BALE;
+	protected $flammable = true;
+	protected $flammability = 20;
+	protected $flameEncouragement = 60;
 
 	public function __construct($meta = 0){
 		$this->meta = $meta;

--- a/src/pocketmine/block/ItemFrame.php
+++ b/src/pocketmine/block/ItemFrame.php
@@ -31,6 +31,7 @@ use pocketmine\tile\ItemFrame as TileItemFrame;
 use pocketmine\tile\Tile;
 
 class ItemFrame extends Flowable{
+
 	protected $id = self::ITEM_FRAME_BLOCK;
 
 	public function __construct($meta = 0){

--- a/src/pocketmine/block/Ladder.php
+++ b/src/pocketmine/block/Ladder.php
@@ -61,52 +61,6 @@ class Ladder extends Transparent{
 		$entity->onGround = true;
 	}
 
-	protected function recalculateBoundingBox(){
-
-		$f = 0.1875;
-
-		if($this->meta === 2){
-			return new AxisAlignedBB(
-				$this->x,
-				$this->y,
-				$this->z + 1 - $f,
-				$this->x + 1,
-				$this->y + 1,
-				$this->z + 1
-			);
-		}elseif($this->meta === 3){
-			return new AxisAlignedBB(
-				$this->x,
-				$this->y,
-				$this->z,
-				$this->x + 1,
-				$this->y + 1,
-				$this->z + $f
-			);
-		}elseif($this->meta === 4){
-			return new AxisAlignedBB(
-				$this->x + 1 - $f,
-				$this->y,
-				$this->z,
-				$this->x + 1,
-				$this->y + 1,
-				$this->z + 1
-			);
-		}elseif($this->meta === 5){
-			return new AxisAlignedBB(
-				$this->x,
-				$this->y,
-				$this->z,
-				$this->x + $f,
-				$this->y + 1,
-				$this->z + 1
-			);
-		}
-
-		return null;
-	}
-
-
 	public function place(Item $item, Block $block, Block $target, $face, $fx, $fy, $fz, Player $player = null){
 		if($target->isTransparent() === false){
 			$faces = [
@@ -151,5 +105,50 @@ class Ladder extends Transparent{
 		return [
 			[$this->id, 0, 1],
 		];
+	}
+
+	protected function recalculateBoundingBox(){
+
+		$f = 0.1875;
+
+		if($this->meta === 2){
+			return new AxisAlignedBB(
+				$this->x,
+				$this->y,
+				$this->z + 1 - $f,
+				$this->x + 1,
+				$this->y + 1,
+				$this->z + 1
+			);
+		}elseif($this->meta === 3){
+			return new AxisAlignedBB(
+				$this->x,
+				$this->y,
+				$this->z,
+				$this->x + 1,
+				$this->y + 1,
+				$this->z + $f
+			);
+		}elseif($this->meta === 4){
+			return new AxisAlignedBB(
+				$this->x + 1 - $f,
+				$this->y,
+				$this->z,
+				$this->x + 1,
+				$this->y + 1,
+				$this->z + 1
+			);
+		}elseif($this->meta === 5){
+			return new AxisAlignedBB(
+				$this->x,
+				$this->y,
+				$this->z,
+				$this->x + $f,
+				$this->y + 1,
+				$this->z + 1
+			);
+		}
+
+		return null;
 	}
 }

--- a/src/pocketmine/block/Leaves.php
+++ b/src/pocketmine/block/Leaves.php
@@ -38,6 +38,10 @@ class Leaves extends Transparent{
 
 	protected $id = self::LEAVES;
 	protected $woodType = self::LOG;
+	protected $flammable = true;
+	protected $flammability = 60;
+	protected $canCatchFireFromLava = true;
+	protected $flameEncouragement = 30;
 
 	public function __construct($meta = 0){
 		$this->meta = $meta;

--- a/src/pocketmine/block/Leaves.php
+++ b/src/pocketmine/block/Leaves.php
@@ -29,6 +29,7 @@ use pocketmine\math\Vector3;
 use pocketmine\Player;
 
 class Leaves extends Transparent{
+
 	const OAK = 0;
 	const SPRUCE = 1;
 	const BIRCH = 2;
@@ -67,6 +68,33 @@ class Leaves extends Transparent{
 
 	public function diffusesSkyLight() : bool{
 		return true;
+	}
+
+	public function onUpdate($type){
+		if($type === Level::BLOCK_UPDATE_NORMAL){
+			if(($this->meta & 0b00001100) === 0){
+				$this->meta |= 0x08;
+				$this->getLevel()->setBlock($this, $this, true, false);
+			}
+		}elseif($type === Level::BLOCK_UPDATE_RANDOM){
+			if(($this->meta & 0b00001100) === 0x08){
+				$this->meta &= 0x03;
+				$visited = [];
+				$check = 0;
+
+				$this->getLevel()->getServer()->getPluginManager()->callEvent($ev = new LeavesDecayEvent($this));
+
+				if($ev->isCancelled() or $this->findLog($this, $visited, 0, $check) === true){
+					$this->getLevel()->setBlock($this, $this, false, false);
+				}else{
+					$this->getLevel()->useBreakOn($this);
+
+					return Level::BLOCK_UPDATE_NORMAL;
+				}
+			}
+		}
+
+		return false;
 	}
 
 	protected function findLog(Block $pos, array $visited, $distance, &$check, $fromSide = null){
@@ -127,33 +155,6 @@ class Leaves extends Transparent{
 							return true;
 						}
 						break;
-				}
-			}
-		}
-
-		return false;
-	}
-
-	public function onUpdate($type){
-		if($type === Level::BLOCK_UPDATE_NORMAL){
-			if(($this->meta & 0b00001100) === 0){
-				$this->meta |= 0x08;
-				$this->getLevel()->setBlock($this, $this, true, false);
-			}
-		}elseif($type === Level::BLOCK_UPDATE_RANDOM){
-			if(($this->meta & 0b00001100) === 0x08){
-				$this->meta &= 0x03;
-				$visited = [];
-				$check = 0;
-
-				$this->getLevel()->getServer()->getPluginManager()->callEvent($ev = new LeavesDecayEvent($this));
-
-				if($ev->isCancelled() or $this->findLog($this, $visited, 0, $check) === true){
-					$this->getLevel()->setBlock($this, $this, false, false);
-				}else{
-					$this->getLevel()->useBreakOn($this);
-
-					return Level::BLOCK_UPDATE_NORMAL;
 				}
 			}
 		}

--- a/src/pocketmine/block/Leaves2.php
+++ b/src/pocketmine/block/Leaves2.php
@@ -27,6 +27,10 @@ class Leaves2 extends Leaves{
 
 	protected $id = self::LEAVES2;
 	protected $woodType = self::LOG2;
+	protected $flammable = true;
+	protected $flammability = 30;
+	protected $canCatchFireFromLava = true;
+	protected $flameEncouragement = 60;
 
 	public function getName(){
 		static $names = [

--- a/src/pocketmine/block/MelonStem.php
+++ b/src/pocketmine/block/MelonStem.php
@@ -30,12 +30,12 @@ class MelonStem extends Crops{
 
 	protected $id = self::MELON_STEM;
 
-	public function getName(){
-		return "Melon Stem";
-	}
-
 	public function __construct($meta = 0){
 		$this->meta = $meta;
+	}
+
+	public function getName(){
+		return "Melon Stem";
 	}
 
 	public function onUpdate($type){

--- a/src/pocketmine/block/NetherBrickStairs.php
+++ b/src/pocketmine/block/NetherBrickStairs.php
@@ -27,6 +27,10 @@ class NetherBrickStairs extends Stair{
 
 	protected $id = self::NETHER_BRICK_STAIRS;
 
+	public function __construct($meta = 0){
+		$this->meta = $meta;
+	}
+
 	public function getName(){
 		return "Nether Brick Stairs";
 	}
@@ -37,10 +41,6 @@ class NetherBrickStairs extends Stair{
 
 	public function getToolType(){
 		return Tool::TYPE_PICKAXE;
-	}
-
-	public function __construct($meta = 0){
-		$this->meta = $meta;
 	}
 
 }

--- a/src/pocketmine/block/NetherWartPlant.php
+++ b/src/pocketmine/block/NetherWartPlant.php
@@ -30,6 +30,7 @@ use pocketmine\math\Vector3;
 use pocketmine\Player;
 
 class NetherWartPlant extends Flowable{
+
 	protected $id = Block::NETHER_WART_PLANT;
 
 	public function __construct($meta = 0){

--- a/src/pocketmine/block/Netherrack.php
+++ b/src/pocketmine/block/Netherrack.php
@@ -28,6 +28,10 @@ use pocketmine\item\Tool;
 class Netherrack extends Solid{
 
 	protected $id = self::NETHERRACK;
+	protected $flammable = true;
+	protected $flammability = 0;
+	protected $canCatchFireFromLava = true;
+	protected $flameEncouragement = 40;
 
 	public function __construct(){
 

--- a/src/pocketmine/block/NoteBlock.php
+++ b/src/pocketmine/block/NoteBlock.php
@@ -24,6 +24,9 @@ namespace pocketmine\block;
 class NoteBlock extends Solid{
 
 	protected $id = self::NOTE_BLOCK;
+	protected $flammable = true;
+	protected $flammability = 0;
+	protected $flameEncouragement = 25;
 
 	public function __construct($meta = 0){
 		$this->meta = $meta;

--- a/src/pocketmine/block/Planks.php
+++ b/src/pocketmine/block/Planks.php
@@ -32,6 +32,10 @@ class Planks extends Solid{
 	const DARK_OAK = 5;
 
 	protected $id = self::WOODEN_PLANKS;
+	protected $flammable = true;
+	protected $flammability = 20;
+	protected $canCatchFireFromLava = true;
+	protected $flameEncouragement = 5;
 
 	public function __construct($meta = 0){
 		$this->meta = $meta;

--- a/src/pocketmine/block/Planks.php
+++ b/src/pocketmine/block/Planks.php
@@ -24,6 +24,7 @@ namespace pocketmine\block;
 use pocketmine\item\Tool;
 
 class Planks extends Solid{
+
 	const OAK = 0;
 	const SPRUCE = 1;
 	const BIRCH = 2;

--- a/src/pocketmine/block/PoweredRail.php
+++ b/src/pocketmine/block/PoweredRail.php
@@ -22,6 +22,7 @@
 namespace pocketmine\block;
 
 class PoweredRail extends Rail{
+
 	protected $id = self::POWERED_RAIL;
 
 	public function __construct($meta = 0){

--- a/src/pocketmine/block/Pumpkin.php
+++ b/src/pocketmine/block/Pumpkin.php
@@ -47,7 +47,7 @@ class Pumpkin extends Solid{
 
 	public function place(Item $item, Block $block, Block $target, $face, $fx, $fy, $fz, Player $player = null){
 		if($player instanceof Player){
-			$this->meta = ((int) $player->getDirection() + 1) % 4;
+			$this->meta = ((int)$player->getDirection() + 1) % 4;
 		}
 		$this->getLevel()->setBlock($block, $this, true, true);
 

--- a/src/pocketmine/block/Sapling.php
+++ b/src/pocketmine/block/Sapling.php
@@ -28,6 +28,7 @@ use pocketmine\Player;
 use pocketmine\utils\Random;
 
 class Sapling extends Flowable{
+
 	const OAK = 0;
 	const SPRUCE = 1;
 	const BIRCH = 2;

--- a/src/pocketmine/block/Skull.php
+++ b/src/pocketmine/block/Skull.php
@@ -48,18 +48,6 @@ class Skull extends Flowable{
 		return "Skull";
 	}
 
-	protected function recalculateBoundingBox(){
-		//TODO: different bounds depending on attached face (meta)
-		return new AxisAlignedBB(
-			$this->x + 0.25,
-			$this->y,
-			$this->z + 0.25,
-			$this->x + 0.75,
-			$this->y + 0.5,
-			$this->z + 0.75
-		);
-	}
-
 	public function place(Item $item, Block $block, Block $target, $face, $fx, $fy, $fz, Player $player = null){
 		if($face !== 0){
 			$this->meta = $face;
@@ -73,9 +61,9 @@ class Skull extends Flowable{
 				new StringTag("id", Tile::SKULL),
 				new ByteTag("SkullType", $item->getDamage()),
 				new ByteTag("Rot", $rot),
-				new IntTag("x", (int) $this->x),
-				new IntTag("y", (int) $this->y),
-				new IntTag("z", (int) $this->z)
+				new IntTag("x", (int)$this->x),
+				new IntTag("y", (int)$this->y),
+				new IntTag("z", (int)$this->z)
 			]);
 			if($item->hasCustomName()){
 				$nbt->CustomName = new StringTag("CustomName", $item->getCustomName());
@@ -96,5 +84,17 @@ class Skull extends Flowable{
 		}
 
 		return [];
+	}
+
+	protected function recalculateBoundingBox(){
+		//TODO: different bounds depending on attached face (meta)
+		return new AxisAlignedBB(
+			$this->x + 0.25,
+			$this->y,
+			$this->z + 0.25,
+			$this->x + 0.75,
+			$this->y + 0.5,
+			$this->z + 0.75
+		);
 	}
 }

--- a/src/pocketmine/block/Stair.php
+++ b/src/pocketmine/block/Stair.php
@@ -104,29 +104,6 @@ abstract class Stair extends Transparent{
 	}
 	*/
 
-	protected function recalculateBoundingBox(){
-
-		if(($this->getDamage() & 0x04) > 0){
-			return new AxisAlignedBB(
-				$this->x,
-				$this->y + 0.5,
-				$this->z,
-				$this->x + 1,
-				$this->y + 1,
-				$this->z + 1
-			);
-		}else{
-			return new AxisAlignedBB(
-				$this->x,
-				$this->y,
-				$this->z,
-				$this->x + 1,
-				$this->y + 0.5,
-				$this->z + 1
-			);
-		}
-	}
-
 	public function place(Item $item, Block $block, Block $target, $face, $fx, $fy, $fz, Player $player = null){
 		$faces = [
 			0 => 0,
@@ -150,6 +127,29 @@ abstract class Stair extends Transparent{
 			];
 		}else{
 			return [];
+		}
+	}
+
+	protected function recalculateBoundingBox(){
+
+		if(($this->getDamage() & 0x04) > 0){
+			return new AxisAlignedBB(
+				$this->x,
+				$this->y + 0.5,
+				$this->z,
+				$this->x + 1,
+				$this->y + 1,
+				$this->z + 1
+			);
+		}else{
+			return new AxisAlignedBB(
+				$this->x,
+				$this->y,
+				$this->z,
+				$this->x + 1,
+				$this->y + 0.5,
+				$this->z + 1
+			);
 		}
 	}
 }

--- a/src/pocketmine/block/StandingSign.php
+++ b/src/pocketmine/block/StandingSign.php
@@ -34,6 +34,10 @@ use pocketmine\tile\Tile;
 class StandingSign extends Transparent{
 
 	protected $id = self::STANDING_SIGN;
+	protected $flammable = true;
+	protected $flammability = 20;
+	protected $canCatchFireFromLava = true;
+	protected $flameEncouragement = 5;
 
 	public function __construct($meta = 0){
 		$this->meta = $meta;

--- a/src/pocketmine/block/StillLava.php
+++ b/src/pocketmine/block/StillLava.php
@@ -21,8 +21,6 @@
 
 namespace pocketmine\block;
 
-use pocketmine\level\Level;
-
 class StillLava extends FlowingLava{
 
 	protected $id = self::STILL_LAVA;

--- a/src/pocketmine/block/StillWater.php
+++ b/src/pocketmine/block/StillWater.php
@@ -21,8 +21,6 @@
 
 namespace pocketmine\block;
 
-use pocketmine\level\Level;
-
 class StillWater extends FlowingWater{
 
 	protected $id = self::STILL_WATER;

--- a/src/pocketmine/block/Stone.php
+++ b/src/pocketmine/block/Stone.php
@@ -26,6 +26,7 @@ use pocketmine\item\TieredTool;
 use pocketmine\item\Tool;
 
 class Stone extends Solid{
+
 	const NORMAL = 0;
 	const GRANITE = 1;
 	const POLISHED_GRANITE = 2;

--- a/src/pocketmine/block/StoneBricks.php
+++ b/src/pocketmine/block/StoneBricks.php
@@ -26,6 +26,7 @@ use pocketmine\item\TieredTool;
 use pocketmine\item\Tool;
 
 class StoneBricks extends Solid{
+
 	const NORMAL = 0;
 	const MOSSY = 1;
 	const CRACKED = 2;

--- a/src/pocketmine/block/StoneSlab.php
+++ b/src/pocketmine/block/StoneSlab.php
@@ -26,6 +26,7 @@ use pocketmine\item\TieredTool;
 use pocketmine\item\Tool;
 
 class StoneSlab extends WoodenSlab{
+
 	const STONE = 0;
 	const SANDSTONE = 1;
 	const WOODEN = 2;

--- a/src/pocketmine/block/TallGrass.php
+++ b/src/pocketmine/block/TallGrass.php
@@ -28,6 +28,10 @@ use pocketmine\Player;
 class TallGrass extends Flowable{
 
 	protected $id = self::TALL_GRASS;
+	protected $flammable = true;
+	protected $flammability = 100;
+	protected $canCatchFireFromLava = true;
+	protected $flameEncouragement = 60;
 
 	public function __construct($meta = 1){
 		$this->meta = $meta;

--- a/src/pocketmine/block/Trapdoor.php
+++ b/src/pocketmine/block/Trapdoor.php
@@ -37,6 +37,9 @@ class Trapdoor extends Transparent{
 	const MASK_SIDE_WEST = 1;
 
 	protected $id = self::TRAPDOOR;
+	protected $flammable = true;
+	protected $flammability = 0;
+	protected $flameEncouragement = 25;
 
 	public function __construct($meta = 0){
 		$this->meta = $meta;

--- a/src/pocketmine/block/Trapdoor.php
+++ b/src/pocketmine/block/Trapdoor.php
@@ -28,6 +28,7 @@ use pocketmine\math\AxisAlignedBB;
 use pocketmine\Player;
 
 class Trapdoor extends Transparent{
+
 	const MASK_UPPER = 0x04;
 	const MASK_OPENED = 0x08;
 	const MASK_SIDE = 0x03;
@@ -51,6 +52,40 @@ class Trapdoor extends Transparent{
 
 	public function getHardness(){
 		return 3;
+	}
+
+	public function place(Item $item, Block $block, Block $target, $face, $fx, $fy, $fz, Player $player = null){
+		$directions = [
+			0 => 1,
+			1 => 3,
+			2 => 0,
+			3 => 2
+		];
+		if($player !== null){
+			$this->meta = $directions[$player->getDirection() & 0x03];
+		}
+		if(($fy > 0.5 and $face !== self::SIDE_UP) or $face === self::SIDE_DOWN){
+			$this->meta |= self::MASK_UPPER; //top half of block
+		}
+		$this->getLevel()->setBlock($block, $this, true, true);
+		return true;
+	}
+
+	public function getDrops(Item $item){
+		return [
+			[$this->id, 0, 1],
+		];
+	}
+
+	public function onActivate(Item $item, Player $player = null){
+		$this->meta ^= self::MASK_OPENED;
+		$this->getLevel()->setBlock($this, $this, true);
+		$this->level->addSound(new DoorSound($this));
+		return true;
+	}
+
+	public function getToolType(){
+		return Tool::TYPE_AXE;
 	}
 
 	protected function recalculateBoundingBox(){
@@ -122,39 +157,5 @@ class Trapdoor extends Transparent{
 		}
 
 		return $bb;
-	}
-
-	public function place(Item $item, Block $block, Block $target, $face, $fx, $fy, $fz, Player $player = null){
-		$directions = [
-			0 => 1,
-			1 => 3,
-			2 => 0,
-			3 => 2
-		];
-		if($player !== null){
-			$this->meta = $directions[$player->getDirection() & 0x03];
-		}
-		if(($fy > 0.5 and $face !== self::SIDE_UP) or $face === self::SIDE_DOWN){
-			$this->meta |= self::MASK_UPPER; //top half of block
-		}
-		$this->getLevel()->setBlock($block, $this, true, true);
-		return true;
-	}
-
-	public function getDrops(Item $item){
-		return [
-			[$this->id, 0, 1],
-		];
-	}
-
-	public function onActivate(Item $item, Player $player = null){
-		$this->meta ^= self::MASK_OPENED;
-		$this->getLevel()->setBlock($this, $this, true);
-		$this->level->addSound(new DoorSound($this));
-		return true;
-	}
-
-	public function getToolType(){
-		return Tool::TYPE_AXE;
 	}
 }

--- a/src/pocketmine/block/Vine.php
+++ b/src/pocketmine/block/Vine.php
@@ -64,6 +64,56 @@ class Vine extends Transparent{
 		$entity->resetFallDistance();
 	}
 
+	public function place(Item $item, Block $block, Block $target, $face, $fx, $fy, $fz, Player $player = null){
+		if($target->isSolid()){
+			$faces = [
+				2 => 1,
+				3 => 4,
+				4 => 8,
+				5 => 2,
+			];
+			if(isset($faces[$face])){
+				$this->meta = $faces[$face];
+				$this->getLevel()->setBlock($block, $this, true, true);
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	public function onUpdate($type){
+		if($type === Level::BLOCK_UPDATE_NORMAL){
+			$sides = [
+				2 => 4,
+				3 => 1,
+				4 => 2,
+				5 => 8
+			];
+			if(!$this->getSide($sides[$this->meta])->isSolid()){ //Replace with common break method
+				$this->level->useBreakOn($this);
+				return Level::BLOCK_UPDATE_NORMAL;
+			}
+		}
+
+		return false;
+	}
+
+	public function getDrops(Item $item){
+		if($item->isShears()){
+			return [
+				[$this->id, 0, 1],
+			];
+		}else{
+			return [];
+		}
+	}
+
+	public function getToolType(){
+		return Tool::TYPE_AXE;
+	}
+
 	protected function recalculateBoundingBox(){
 
 		$f1 = 1;
@@ -122,56 +172,5 @@ class Vine extends Transparent{
 			$this->y + $f5,
 			$this->z + $f6
 		);
-	}
-
-
-	public function place(Item $item, Block $block, Block $target, $face, $fx, $fy, $fz, Player $player = null){
-		if($target->isSolid()){
-			$faces = [
-				2 => 1,
-				3 => 4,
-				4 => 8,
-				5 => 2,
-			];
-			if(isset($faces[$face])){
-				$this->meta = $faces[$face];
-				$this->getLevel()->setBlock($block, $this, true, true);
-
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	public function onUpdate($type){
-		if($type === Level::BLOCK_UPDATE_NORMAL){
-			$sides = [
-				2 => 4,
-				3 => 1,
-				4 => 2,
-				5 => 8
-			];
-			if(!$this->getSide($sides[$this->meta])->isSolid()){ //Replace with common break method
-				$this->level->useBreakOn($this);
-				return Level::BLOCK_UPDATE_NORMAL;
-			}
-		}
-
-		return false;
-	}
-
-	public function getDrops(Item $item){
-		if($item->isShears()){
-			return [
-				[$this->id, 0, 1],
-			];
-		}else{
-			return [];
-		}
-	}
-
-	public function getToolType(){
-		return Tool::TYPE_AXE;
 	}
 }

--- a/src/pocketmine/block/WaterLily.php
+++ b/src/pocketmine/block/WaterLily.php
@@ -43,18 +43,6 @@ class WaterLily extends Flowable{
 		return 0.6;
 	}
 
-	protected function recalculateBoundingBox(){
-		return new AxisAlignedBB(
-			$this->x + 0.0625,
-			$this->y,
-			$this->z + 0.0625,
-			$this->x + 0.9375,
-			$this->y + 0.015625,
-			$this->z + 0.9375
-		);
-	}
-
-
 	public function place(Item $item, Block $block, Block $target, $face, $fx, $fy, $fz, Player $player = null){
 		if($target instanceof FlowingWater){
 			$up = $target->getSide(Vector3::SIDE_UP);
@@ -82,5 +70,16 @@ class WaterLily extends Flowable{
 		return [
 			[$this->id, 0, 1]
 		];
+	}
+
+	protected function recalculateBoundingBox(){
+		return new AxisAlignedBB(
+			$this->x + 0.0625,
+			$this->y,
+			$this->z + 0.0625,
+			$this->x + 0.9375,
+			$this->y + 0.015625,
+			$this->z + 0.9375
+		);
 	}
 }

--- a/src/pocketmine/block/Wood.php
+++ b/src/pocketmine/block/Wood.php
@@ -34,6 +34,10 @@ class Wood extends Solid{
 	//const DARK_OAK = 5;
 
 	protected $id = self::WOOD;
+	protected $flammable = true;
+	protected $flammability = 5;
+	protected $canCatchFireFromLava = true;
+	protected $flameEncouragement = 5;
 
 	public function __construct($meta = 0){
 		$this->meta = $meta;

--- a/src/pocketmine/block/Wood.php
+++ b/src/pocketmine/block/Wood.php
@@ -26,6 +26,7 @@ use pocketmine\item\Tool;
 use pocketmine\Player;
 
 class Wood extends Solid{
+
 	const OAK = 0;
 	const SPRUCE = 1;
 	const BIRCH = 2;

--- a/src/pocketmine/block/Wood2.php
+++ b/src/pocketmine/block/Wood2.php
@@ -28,6 +28,10 @@ class Wood2 extends Wood{
 	const DARK_OAK = 1;
 
 	protected $id = self::WOOD2;
+	protected $flammable = true;
+	protected $flammability = 5;
+	protected $canCatchFireFromLava = true;
+	protected $flameEncouragement = 5;
 
 	public function getName(){
 		static $names = [

--- a/src/pocketmine/block/WoodenDoor.php
+++ b/src/pocketmine/block/WoodenDoor.php
@@ -27,6 +27,9 @@ use pocketmine\item\Tool;
 class WoodenDoor extends Door{
 
 	protected $id = self::WOODEN_DOOR_BLOCK;
+	protected $flammable = true;
+	protected $flammability = 0;
+	protected $flameEncouragement = 25;
 
 	public function __construct($meta = 0){
 		$this->meta = $meta;

--- a/src/pocketmine/block/WoodenPressurePlate.php
+++ b/src/pocketmine/block/WoodenPressurePlate.php
@@ -24,6 +24,9 @@ namespace pocketmine\block;
 class WoodenPressurePlate extends StonePressurePlate{
 
 	protected $id = self::WOODEN_PRESSURE_PLATE;
+	protected $flammable = true;
+	protected $flammability = 0;
+	protected $flameEncouragement = 25;
 
 	public function __construct($meta = 0){
 		$this->meta = $meta;

--- a/src/pocketmine/block/WoodenSlab.php
+++ b/src/pocketmine/block/WoodenSlab.php
@@ -58,29 +58,6 @@ class WoodenSlab extends Transparent{
 		return (($this->meta & 0x08) === 0x08 ? "Upper " : "") . $names[$this->meta & 0x07] . " Wooden Slab";
 	}
 
-	protected function recalculateBoundingBox(){
-
-		if(($this->meta & 0x08) > 0){
-			return new AxisAlignedBB(
-				$this->x,
-				$this->y + 0.5,
-				$this->z,
-				$this->x + 1,
-				$this->y + 1,
-				$this->z + 1
-			);
-		}else{
-			return new AxisAlignedBB(
-				$this->x,
-				$this->y,
-				$this->z,
-				$this->x + 1,
-				$this->y + 0.5,
-				$this->z + 1
-			);
-		}
-	}
-
 	public function place(Item $item, Block $block, Block $target, $face, $fx, $fy, $fz, Player $player = null){
 		$this->meta &= 0x07;
 		if($face === 0){
@@ -137,5 +114,28 @@ class WoodenSlab extends Transparent{
 		return [
 			[$this->id, $this->meta & 0x07, 1],
 		];
+	}
+
+	protected function recalculateBoundingBox(){
+
+		if(($this->meta & 0x08) > 0){
+			return new AxisAlignedBB(
+				$this->x,
+				$this->y + 0.5,
+				$this->z,
+				$this->x + 1,
+				$this->y + 1,
+				$this->z + 1
+			);
+		}else{
+			return new AxisAlignedBB(
+				$this->x,
+				$this->y,
+				$this->z,
+				$this->x + 1,
+				$this->y + 0.5,
+				$this->z + 1
+			);
+		}
 	}
 }

--- a/src/pocketmine/block/WoodenSlab.php
+++ b/src/pocketmine/block/WoodenSlab.php
@@ -29,6 +29,10 @@ use pocketmine\Player;
 class WoodenSlab extends Transparent{
 
 	protected $id = self::WOODEN_SLAB;
+	protected $flammable = true;
+	protected $flammability = 20;
+	protected $canCatchFireFromLava = true;
+	protected $flameEncouragement = 5;
 
 	protected $doubleId = self::DOUBLE_WOODEN_SLAB;
 

--- a/src/pocketmine/block/WoodenStairs.php
+++ b/src/pocketmine/block/WoodenStairs.php
@@ -27,6 +27,10 @@ use pocketmine\item\Tool;
 class WoodenStairs extends Stair{
 
 	protected $id = self::OAK_STAIRS;
+	protected $flammable = true;
+	protected $flammability = 20;
+	protected $canCatchFireFromLava = true;
+	protected $flameEncouragement = 5;
 
 	public function __construct($meta = 0){
 		$this->meta = $meta;

--- a/src/pocketmine/block/Wool.php
+++ b/src/pocketmine/block/Wool.php
@@ -26,6 +26,10 @@ use pocketmine\item\Tool;
 class Wool extends Solid{
 
 	protected $id = self::WOOL;
+	protected $flammable = true;
+	protected $flammability = 60;
+	protected $canCatchFireFromLava = true;
+	protected $flameEncouragement = 30;
 
 	public function __construct($meta = 0){
 		$this->meta = $meta;


### PR DESCRIPTION
…f login timeout.

## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This pull request adds basic fire spread implementation, both by lava and fire. This is NOT finished yet. I only made this pull request to get some feedback. 

### Relevant issues
No relevent issues, unimplemented feature.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
```
       /**
	 * Returns if the item is flammable
	 *
	 * @return bool
	 */
	public function isFlammable() : bool{
		return $this->flammable;
	}

	/**
	 * Returns if the item can catch fire if near lava
	 *
	 * @return bool
	 */
	public function canCatchFireFromLava() : bool{
		return $this->canCatchFireFromLava;
	}

	/**
	 * Returns the flammability of a block (the higher, the more quickly a block will burn away)
	 *
	 * @return int
	 */
	public function getFlammability(): int {
		return $this->flammability;
	}

	/**
	 * Returns the flame encouragement of a block (the higher, the more chance the block will catch fire)
	 *
	 * @return int
	 */
	public function getFlameEncouragement(): int {
		return $this->flameEncouragement;
	}
```

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
Performance has not been tested. I have not been able to test this yet due to being timed out whenever trying to join the server using this branch.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? --> No backwards incompatible changes as far as I can tell. Mostly additions.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
Should be tested properly, and enhanced wherever possible. (Which is likely everywhere)

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
None so far.