### PR TITLE
Removed masks for Y coordinates, throw exception for block hash Y out of bounds, fixed #914

### DIFF
--- a/src/pocketmine/level/ChunkManager.php
+++ b/src/pocketmine/level/ChunkManager.php
@@ -131,4 +131,22 @@ interface ChunkManager{
 	 * @return int
 	 */
 	public function getSeed();
+
+	/**
+	 * Returns the height of the world
+	 * @return int
+	 */
+	public function getWorldHeight() : int;
+
+	/**
+	 * Returns whether the specified coordinates are within the valid world boundaries, taking world format limitations
+	 * into account.
+	 *
+	 * @param float $x
+	 * @param float $y
+	 * @param float $z
+	 *
+	 * @return bool
+	 */
+	public function isInWorld(float $x, float $y, float $z) : bool;
 }

--- a/src/pocketmine/level/Explosion.php
+++ b/src/pocketmine/level/Explosion.php
@@ -89,7 +89,7 @@ class Explosion{
 							$vBlock->x = $pointerX >= $x ? $x : $x - 1;
 							$vBlock->y = $pointerY >= $y ? $y : $y - 1;
 							$vBlock->z = $pointerZ >= $z ? $z : $z - 1;
-							if($vBlock->y < 0 or $vBlock->y >= Level::Y_MAX){
+							if(!$this->level->isInWorld($vBlock)){
 								break;
 							}
 							$block = $this->level->getBlock($vBlock);

--- a/src/pocketmine/level/Explosion.php
+++ b/src/pocketmine/level/Explosion.php
@@ -89,7 +89,7 @@ class Explosion{
 							$vBlock->x = $pointerX >= $x ? $x : $x - 1;
 							$vBlock->y = $pointerY >= $y ? $y : $y - 1;
 							$vBlock->z = $pointerZ >= $z ? $z : $z - 1;
-							if(!$this->level->isInWorld($vBlock)){
+							if(!$this->level->isInWorld($vBlock->x, $vBlock->y, $vBlock->z)){
 								break;
 							}
 							$block = $this->level->getBlock($vBlock);

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -269,7 +269,7 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	public static function blockHash(int $x, int $y, int $z){
-		if(($y & ~Level::Y_MASK) !== 0){
+		if($y < 0 or $y >= Level::Y_MAX){
 			throw new \InvalidArgumentException("Y coordinate $y is out of range!");
 		}
 		return (($x & 0xFFFFFFF) << 36) | (($y & Level::Y_MASK) << 28) | ($z & 0xFFFFFFF);
@@ -1098,8 +1098,8 @@ class Level implements ChunkManager, Metadatable{
 		$pos = $pos->floor();
 
 		for($i = 0; $i <= 5; ++$i){
-			if($this->isInWorld($s = $pos->getSide($i))){
-				$this->neighbourBlockUpdateQueue->enqueue(Level::blockHash($pos->x, $pos->y, $pos->z));
+			if($this->isInWorld($side = $pos->getSide($i))){
+				$this->neighbourBlockUpdateQueue->enqueue(Level::blockHash($side->x, $side->y, $side->z));
 			}
 		}
 	}
@@ -1328,6 +1328,7 @@ class Level implements ChunkManager, Metadatable{
 		$pos = $pos->floor();
 
 		$fullState = 0;
+		$index = null;
 
 		if($this->isInWorld($pos)){
 			$index = Level::blockHash($pos->x, $pos->y, $pos->z);
@@ -1336,8 +1337,6 @@ class Level implements ChunkManager, Metadatable{
 			}elseif(isset($this->chunks[$chunkIndex = Level::chunkHash($pos->x >> 4, $pos->z >> 4)])){
 				$fullState = $this->chunks[$chunkIndex]->getFullBlock($pos->x & 0x0f, $pos->y, $pos->z & 0x0f);
 			}
-		}else{
-			$addToCache = false;
 		}
 
 		$block = clone $this->blockStates[$fullState & 0xfff];
@@ -1347,7 +1346,7 @@ class Level implements ChunkManager, Metadatable{
 		$block->z = $pos->z;
 		$block->level = $this;
 
-		if($addToCache){
+		if($addToCache and $index !== null){
 			$this->blockCache[$index] = $block;
 		}
 

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1304,12 +1304,6 @@ class Level implements ChunkManager, Metadatable{
 		return $this->getChunk($x >> 4, $z >> 4, false)->getFullBlock($x & 0x0f, $y, $z & 0x0f);
 	}
 
-	/**
-	 * Returns whether the specified Vector3 position is within a valid area of the world.
-	 * @param Vector3 $pos
-	 *
-	 * @return bool
-	 */
 	public function isInWorld(float $x, float $y, float $z) : bool{
 		return (
 			$x <= INT32_MAX and $x >= INT32_MIN and

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1306,21 +1306,23 @@ class Level implements ChunkManager, Metadatable{
 	 *
 	 * @return bool
 	 */
-	public function isInWorld(Vector3 $pos){
+	public function isInWorld(Vector3 $pos) : bool{
 		return (
-			$pos->x < 0x7fffffff and $pos->x > -0x7fffffff and
+			$pos->x <= INT32_MAX and $pos->x >= INT32_MIN and
 			$pos->y < $this->provider->getWorldHeight() and $pos->y >= 0 and
-			$pos->z < 0x7fffffff and $pos->z > -0x7fffffff
+			$pos->z <= INT32_MAX and $pos->z >= INT32_MIN
 		);
 	}
 
 	/**
 	 * Gets the Block object at the Vector3 location
 	 *
+	 * Note for plugin developers: If you are using this method a lot (thousands of times for many positions for
+	 * example), you may want to set addToCache to false to avoid using excessive amounts of memory.
+	 *
 	 * @param Vector3 $pos
 	 * @param bool    $cached Whether to use the block cache for getting the block (faster, but may be inaccurate)
 	 * @param bool    $addToCache Whether to cache the block object created by this method call.
-	 *                             Note for plugin developers: If you are using this method a lot (thousands of times for many positions), you may want to set this to false to avoid using excessive amounts of memory.
 	 *
 	 * @return Block
 	 */

--- a/src/pocketmine/level/SimpleChunkManager.php
+++ b/src/pocketmine/level/SimpleChunkManager.php
@@ -31,9 +31,11 @@ class SimpleChunkManager implements ChunkManager{
 	protected $chunks = [];
 
 	protected $seed;
+	protected $worldHeight;
 
-	public function __construct($seed){
+	public function __construct($seed, int $worldHeight = Level::Y_MAX){
 		$this->seed = $seed;
+		$this->worldHeight = $worldHeight;
 	}
 
 	/**
@@ -158,5 +160,17 @@ class SimpleChunkManager implements ChunkManager{
 	 */
 	public function getSeed(){
 		return $this->seed;
+	}
+
+	public function getWorldHeight() : int{
+		return $this->worldHeight;
+	}
+
+	public function isInWorld(float $x, float $y, float $z) : bool{
+		return (
+			$x <= INT32_MAX and $x >= INT32_MIN and
+			$y < $this->worldHeight and $y >= 0 and
+			$z <= INT32_MAX and $z >= INT32_MIN
+		);
 	}
 }

--- a/src/pocketmine/level/generator/GeneratorRegisterTask.php
+++ b/src/pocketmine/level/generator/GeneratorRegisterTask.php
@@ -36,18 +36,20 @@ class GeneratorRegisterTask extends AsyncTask{
 	public $settings;
 	public $seed;
 	public $levelId;
+	public $worldHeight = Level::Y_MAX;
 
 	public function __construct(Level $level, Generator $generator){
 		$this->generator = get_class($generator);
 		$this->settings = serialize($generator->getSettings());
 		$this->seed = $level->getSeed();
 		$this->levelId = $level->getId();
+		$this->worldHeight = $level->getWorldHeight();
 	}
 
 	public function onRun(){
 		Block::init();
 		Biome::init();
-		$manager = new SimpleChunkManager($this->seed);
+		$manager = new SimpleChunkManager($this->seed, $this->worldHeight);
 		$this->saveToThreadStore("generation.level{$this->levelId}.manager", $manager);
 		/** @var Generator $generator */
 		$generator = $this->generator;

--- a/src/pocketmine/level/light/LightUpdate.php
+++ b/src/pocketmine/level/light/LightUpdate.php
@@ -62,9 +62,14 @@ abstract class LightUpdate{
 	abstract protected function setLight(int $x, int $y, int $z, int $level);
 
 	public function setAndUpdateLight(int $x, int $y, int $z, int $newLevel){
+		if(!$this->level->isInWorld($x, $y, $z)){
+			throw new \InvalidArgumentException("Coordinates x=$x, y=$y, z=$z are out of range");
+		}
+
 		if(isset($this->spreadVisited[$index = Level::blockHash($x, $y, $z)]) or isset($this->removalVisited[$index])){
 			throw new \InvalidArgumentException("Already have a visit ready for this block");
 		}
+
 		$oldLevel = $this->getLight($x, $y, $z);
 
 		if($oldLevel !== $newLevel){
@@ -93,7 +98,7 @@ abstract class LightUpdate{
 			];
 
 			foreach($points as list($cx, $cy, $cz)){
-				if($cy < 0){
+				if(!$this->level->isInWorld($cx, $cy, $cz)){
 					continue;
 				}
 				$this->computeRemoveLight($cx, $cy, $cz, $oldAdjacentLight);
@@ -118,7 +123,7 @@ abstract class LightUpdate{
 			];
 
 			foreach($points as list($cx, $cy, $cz)){
-				if($cy < 0){
+				if(!$this->level->isInWorld($cx, $cy, $cz)){
 					continue;
 				}
 				$this->computeSpreadLight($cx, $cy, $cz, $newAdjacentLight);


### PR DESCRIPTION
## Introduction
These masks produced many unexpected behaviours relating to Y coordinates out of bounds, like #914.

This PR carries changes required to fix this issue, along with several others. Adding an exception throw for out-of-bounds Y coordinates for block hashes uncovered several wraparound problems, such as:

- Flying below y=0 would cause block collision checks for blocks up at y=~250
- Breaking blocks at y=0 would trigger block updates at the top of the map.

This may also cause other crashy issues which I haven't identified yet, so this needs careful testing before merging.

### Relevant issues
- fixes #914

## Changes

### API changes
- Added `addToCache` parameter to `Level->getBlock()` to allow plugin developers to choose to not cache the returned block object if they are making frequent requests to the method. This may mitigate issues with block-cache issues like #152 .

### Behavioural changes
- An exception will now be thrown when attempting to create a block coordinate hash with an invalid Y coordinate.
- bugs fixed above
