### PR TITLE
Added short-hand Event->call() for easier event calling

### DIFF
--- a/src/pocketmine/MemoryManager.php
+++ b/src/pocketmine/MemoryManager.php
@@ -148,8 +148,7 @@ class MemoryManager{
 			}
 		}
 
-		$ev = new LowMemoryEvent($memory, $limit, $global, $triggerCount);
-		$this->server->getPluginManager()->callEvent($ev);
+		($ev = new LowMemoryEvent($memory, $limit, $global, $triggerCount))->call();
 
 		$cycles = 0;
 		if($this->garbageCollectionTrigger){

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -890,7 +890,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
 		$pos = $this->level->getSafeSpawn($this);
 
-		$this->server->getPluginManager()->callEvent($ev = new PlayerRespawnEvent($this, $pos));
+		($ev = new PlayerRespawnEvent($this, $pos))->call();
 
 		$pos = $ev->getRespawnPosition();
 
@@ -909,11 +909,11 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			$this->server->getPluginManager()->subscribeToPermission(Server::BROADCAST_CHANNEL_ADMINISTRATIVE, $this);
 		}
 
-		$this->server->getPluginManager()->callEvent($ev = new PlayerJoinEvent($this,
+		($ev = new PlayerJoinEvent($this,
 			new TranslationContainer(TextFormat::YELLOW . "%multiplayer.player.joined", [
 				$this->getDisplayName()
 			])
-		));
+		))->call();
 		if(strlen(trim($ev->getJoinMessage())) > 0){
 			$this->server->broadcastMessage($ev->getJoinMessage());
 		}
@@ -1054,7 +1054,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
 		$timings = Timings::getSendDataPacketTimings($packet);
 		$timings->startTiming();
-		$this->server->getPluginManager()->callEvent($ev = new DataPacketSendEvent($this, $packet));
+		($ev = new DataPacketSendEvent($this, $packet))->call();
 		if($ev->isCancelled()){
 			$timings->stopTiming();
 			return false;
@@ -1086,7 +1086,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		$timings = Timings::getSendDataPacketTimings($packet);
 		$timings->startTiming();
 
-		$this->server->getPluginManager()->callEvent($ev = new DataPacketSendEvent($this, $packet));
+		($ev = new DataPacketSendEvent($this, $packet))->call();
 		if($ev->isCancelled()){
 			$timings->stopTiming();
 			return false;
@@ -1123,7 +1123,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
 		$timings = Timings::getSendDataPacketTimings($packet);
 		$timings->startTiming();
-		$this->server->getPluginManager()->callEvent($ev = new DataPacketSendEvent($this, $packet));
+		($ev = new DataPacketSendEvent($this, $packet))->call();
 		if($ev->isCancelled()){
 			$timings->stopTiming();
 			return false;
@@ -1160,7 +1160,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			}
 		}
 
-		$this->server->getPluginManager()->callEvent($ev = new PlayerBedEnterEvent($this, $this->level->getBlock($pos)));
+		($ev = new PlayerBedEnterEvent($this, $this->level->getBlock($pos)))->call();
 		if($ev->isCancelled()){
 			return false;
 		}
@@ -1199,7 +1199,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
 	public function stopSleep(){
 		if($this->sleeping instanceof Vector3){
-			$this->server->getPluginManager()->callEvent($ev = new PlayerBedLeaveEvent($this, $this->level->getBlock($this->sleeping)));
+			($ev = new PlayerBedLeaveEvent($this, $this->level->getBlock($this->sleeping)))->call();
 
 			$this->sleeping = null;
 			$this->setDataProperty(self::DATA_PLAYER_BED_POSITION, self::DATA_TYPE_POS, [0, 0, 0]);
@@ -1226,7 +1226,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 					return false;
 				}
 			}
-			$this->server->getPluginManager()->callEvent($ev = new PlayerAchievementAwardedEvent($this, $achievementId));
+			($ev = new PlayerAchievementAwardedEvent($this, $achievementId))->call();
 			if(!$ev->isCancelled()){
 				$this->achievements[$achievementId] = true;
 				Achievement::broadcast($this, $achievementId);
@@ -1260,7 +1260,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			return false;
 		}
 
-		$this->server->getPluginManager()->callEvent($ev = new PlayerGameModeChangeEvent($this, (int) $gm));
+		($ev = new PlayerGameModeChangeEvent($this, (int) $gm))->call();
 		if($ev->isCancelled()){
 			if($client){ //gamemode change by client in the GUI
 				$pk = new SetPlayerGameTypePacket();
@@ -1428,7 +1428,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 					continue;
 				}
 
-				$this->server->getPluginManager()->callEvent($ev = new InventoryPickupArrowEvent($this->inventory, $entity));
+				($ev = new InventoryPickupArrowEvent($this->inventory, $entity))->call();
 				if($ev->isCancelled()){
 					continue;
 				}
@@ -1449,7 +1449,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 							continue;
 						}
 
-						$this->server->getPluginManager()->callEvent($ev = new InventoryPickupItemEvent($this->inventory, $entity));
+						($ev = new InventoryPickupItemEvent($this->inventory, $entity))->call();
 						if($ev->isCancelled()){
 							continue;
 						}
@@ -1521,7 +1521,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 				$ev = new PlayerIllegalMoveEvent($this, $newPos);
 				$ev->setCancelled($this->allowMovementCheats);
 
-				$this->server->getPluginManager()->callEvent($ev);
+				$ev->call();
 
 				if(!$ev->isCancelled()){
 					$revert = true;
@@ -1829,7 +1829,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
 	protected function completeLoginSequence(){
 		parent::__construct($this->level, $this->namedtag);
-		$this->server->getPluginManager()->callEvent($ev = new PlayerLoginEvent($this, "Plugin reason"));
+		($ev = new PlayerLoginEvent($this, "Plugin reason"))->call();
 		if($ev->isCancelled()){
 			$this->close($this->getLeaveMessage(), $ev->getKickMessage());
 
@@ -1946,7 +1946,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
 		$this->setSkin($packet->skin, $packet->skinId);
 
-		$this->server->getPluginManager()->callEvent($ev = new PlayerPreLoginEvent($this, "Plugin reason"));
+		($ev = new PlayerPreLoginEvent($this, "Plugin reason"))->call();
 		if($ev->isCancelled()){
 			$this->close("", $ev->getKickMessage());
 
@@ -2057,7 +2057,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 					if(mb_strlen($ev->getMessage(), "UTF-8") > 320){
 						$ev->setCancelled();
 					}
-					$this->server->getPluginManager()->callEvent($ev);
+					$ev->call();
 
 					if($ev->isCancelled()){
 						break;
@@ -2229,7 +2229,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 					if(!$slot->canBeConsumedBy($this)){
 						$ev->setCancelled();
 					}
-					$this->server->getPluginManager()->callEvent($ev);
+					$ev->call();
 					if(!$ev->isCancelled()){
 						$slot->onConsume($this);
 					}else{
@@ -2490,9 +2490,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 				$item = $this->inventory->getItemInHand();
 			}
 
-			$ev = new PlayerInteractEvent($this, $item, $aimPos, $packet->face, PlayerInteractEvent::RIGHT_CLICK_AIR);
-
-			$this->server->getPluginManager()->callEvent($ev);
+			($ev = new PlayerInteractEvent($this, $item, $aimPos, $packet->face, PlayerInteractEvent::RIGHT_CLICK_AIR))->call();
 
 			if($ev->isCancelled()){
 				$this->inventory->sendHeldItem($this);
@@ -2525,7 +2523,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 					$this->inventory->setItemInHand($item->getCount() > 0 ? $item : Item::get(Item::AIR));
 				}
 				if($snowball instanceof Projectile){
-					$this->server->getPluginManager()->callEvent($projectileEv = new ProjectileLaunchEvent($snowball));
+					($projectileEv = new ProjectileLaunchEvent($snowball))->call();
 					if($projectileEv->isCancelled()){
 						$snowball->kill();
 					}else{
@@ -2559,7 +2557,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 				}
 				$target = $this->level->getBlock($pos);
 				$ev = new PlayerInteractEvent($this, $this->inventory->getItemInHand(), $target, $packet->face, $target->getId() === 0 ? PlayerInteractEvent::LEFT_CLICK_AIR : PlayerInteractEvent::LEFT_CLICK_BLOCK);
-				$this->getServer()->getPluginManager()->callEvent($ev);
+				$ev->call();
 				if($ev->isCancelled()){
 					$this->inventory->sendHeldItem($this);
 					break;
@@ -2612,7 +2610,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 							$ev->setCancelled();
 						}
 
-						$this->server->getPluginManager()->callEvent($ev);
+						$ev->call()
 
 						if($ev->isCancelled()){
 							$ev->getProjectile()->kill();
@@ -2629,7 +2627,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 								}
 							}
 							if($ev->getProjectile() instanceof Projectile){
-								$this->server->getPluginManager()->callEvent($projectileEv = new ProjectileLaunchEvent($ev->getProjectile()));
+								($projectileEv = new ProjectileLaunchEvent($ev->getProjectile()))->call();
 								if($projectileEv->isCancelled()){
 									$ev->getProjectile()->kill();
 								}else{
@@ -2642,7 +2640,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 						}
 					}
 				}elseif($this->inventory->getItemInHand()->getId() === Item::BUCKET and $this->inventory->getItemInHand()->getDamage() === 1){ //Milk!
-					$this->server->getPluginManager()->callEvent($ev = new PlayerItemConsumeEvent($this, $this->inventory->getItemInHand()));
+					($ev = new PlayerItemConsumeEvent($this, $this->inventory->getItemInHand()))->call();
 					if($ev->isCancelled()){
 						$this->inventory->sendContents($this);
 						break;
@@ -2681,7 +2679,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
 				$this->craftingType = 0;
 
-				$this->server->getPluginManager()->callEvent($ev = new PlayerRespawnEvent($this, $this->getSpawn()));
+				($ev = new PlayerRespawnEvent($this, $this->getSpawn()))->call();
 
 				$this->teleport($ev->getRespawnPosition());
 
@@ -2713,8 +2711,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 				$this->jump();
 				return true;
 			case PlayerActionPacket::ACTION_START_SPRINT:
-				$ev = new PlayerToggleSprintEvent($this, true);
-				$this->server->getPluginManager()->callEvent($ev);
+				($ev = new PlayerToggleSprintEvent($this, true))->call();
 				if($ev->isCancelled()){
 					$this->sendData($this);
 				}else{
@@ -2722,8 +2719,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 				}
 				return true;
 			case PlayerActionPacket::ACTION_STOP_SPRINT:
-				$ev = new PlayerToggleSprintEvent($this, false);
-				$this->server->getPluginManager()->callEvent($ev);
+				($ev = new PlayerToggleSprintEvent($this, false))->call();
 				if($ev->isCancelled()){
 					$this->sendData($this);
 				}else{
@@ -2731,8 +2727,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 				}
 				return true;
 			case PlayerActionPacket::ACTION_START_SNEAK:
-				$ev = new PlayerToggleSneakEvent($this, true);
-				$this->server->getPluginManager()->callEvent($ev);
+				($ev = new PlayerToggleSneakEvent($this, true))->call();
 				if($ev->isCancelled()){
 					$this->sendData($this);
 				}else{
@@ -2740,8 +2735,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 				}
 				return true;
 			case PlayerActionPacket::ACTION_STOP_SNEAK:
-				$ev = new PlayerToggleSneakEvent($this, false);
-				$this->server->getPluginManager()->callEvent($ev);
+				($ev = new PlayerToggleSneakEvent($this, false))->call();
 				if($ev->isCancelled()){
 					$this->sendData($this);
 				}else{
@@ -2795,7 +2789,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			return true;
 		}
 
-		$this->server->getPluginManager()->callEvent($ev = new PlayerAnimationEvent($this, $packet->action));
+		($ev = new PlayerAnimationEvent($this, $packet->action))->call();
 		if($ev->isCancelled()){
 			return true;
 		}
@@ -2823,8 +2817,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		}
 
 		$item = $this->inventory->getItemInHand();
-		$ev = new PlayerDropItemEvent($this, $item);
-		$this->server->getPluginManager()->callEvent($ev);
+		($ev = new PlayerDropItemEvent($this, $item))->call();
 		if($ev->isCancelled()){
 			$this->inventory->sendContents($this);
 			return true;
@@ -2856,7 +2849,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		$this->craftingType = 0;
 		$this->currentTransaction = null;
 		if(isset($this->windowIndex[$packet->windowid])){
-			$this->server->getPluginManager()->callEvent(new InventoryCloseEvent($this->windowIndex[$packet->windowid], $this));
+			(new InventoryCloseEvent($this->windowIndex[$packet->windowid], $this))->call();
 			$this->removeWindow($this->windowIndex[$packet->windowid]);
 		}else{
 			unset($this->windowIndex[$packet->windowid]);
@@ -3058,7 +3051,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			return true;
 		}
 
-		$this->server->getPluginManager()->callEvent($ev = new CraftItemEvent($this, $ingredients, $recipe));
+		($ev = new CraftItemEvent($this, $ingredients, $recipe))->call();
 
 		if($ev->isCancelled()){
 			$this->inventory->sendContents($this);
@@ -3133,7 +3126,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			$this->kick($this->server->getLanguage()->translateString("kick.reason.cheat", ["%ability.flight"]));
 			return true;
 		}elseif($packet->isFlying !== $this->isFlying()){
-			$this->server->getPluginManager()->callEvent($ev = new PlayerToggleFlightEvent($this, $packet->isFlying));
+			($ev = new PlayerToggleFlightEvent($this, $packet->isFlying))->call();
 			if($ev->isCancelled()){
 				$this->sendSettings();
 			}else{
@@ -3240,11 +3233,12 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		$tile = $this->level->getTile($this->temporalVector->setComponents($packet->x, $packet->y, $packet->z));
 		if($tile instanceof ItemFrame){
 			$ev = new PlayerInteractEvent($this, $this->inventory->getItemInHand(), $tile->getBlock(), 5 - $tile->getBlock()->getDamage(), PlayerInteractEvent::LEFT_CLICK_BLOCK);
-			$this->server->getPluginManager()->callEvent($ev);
 
 			if($this->isSpectator()){
 				$ev->setCancelled();
 			}
+
+			$ev->call();
 
 			if($ev->isCancelled()){
 				$tile->spawnTo($this);
@@ -3288,7 +3282,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 				$commandText .= " " . $arg;
 			}
 		}
-		$this->server->getPluginManager()->callEvent($ev = new PlayerCommandPreprocessEvent($this, "/" . $commandText));
+		($ev = new PlayerCommandPreprocessEvent($this, "/" . $commandText))->call();
 		if($ev->isCancelled()){
 			return true;
 		}
@@ -3385,7 +3379,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	 * @return bool if transfer was successful.
 	 */
 	public function transfer(string $address, int $port = 19132, string $message = "transfer") : bool{
-		$this->server->getPluginManager()->callEvent($ev = new PlayerTransferEvent($this, $address, $port, $message));
+		($ev = new PlayerTransferEvent($this, $address, $port, $message))->call();
 
 		if(!$ev->isCancelled()){
 			$pk = new TransferPacket();
@@ -3409,7 +3403,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	 * @return bool
 	 */
 	public function kick($reason = "", $isAdmin = true){
-		$this->server->getPluginManager()->callEvent($ev = new PlayerKickEvent($this, $reason, $this->getLeaveMessage()));
+		($ev = new PlayerKickEvent($this, $reason, $this->getLeaveMessage()))->call();
 		if(!$ev->isCancelled()){
 			if($isAdmin){
 				if(!$this->isBanned()){
@@ -3604,7 +3598,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 				//TODO: add events for player data saving
 				$this->save();
 
-				$this->server->getPluginManager()->callEvent($ev = new PlayerQuitEvent($this, $message));
+				($ev = new PlayerQuitEvent($this, $message))->call();
 				if($ev->getQuitMessage() != ""){
 					$this->server->broadcastMessage($ev->getQuitMessage());
 				}
@@ -3853,7 +3847,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 				break;
 		}
 
-		$this->server->getPluginManager()->callEvent($ev = new PlayerDeathEvent($this, $this->getDrops(), new TranslationContainer($message, $params)));
+		($ev = new PlayerDeathEvent($this, $this->getDrops(), new TranslationContainer($message, $params)))->call();
 
 		if(!$ev->getKeepInventory()){
 			foreach($ev->getDrops() as $item){

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2610,7 +2610,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 							$ev->setCancelled();
 						}
 
-						$ev->call()
+						$ev->call();
 
 						if($ev->isCancelled()){
 							$ev->getProjectile()->kill();

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1556,9 +1556,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			$this->lastPitch = $to->pitch;
 
 			if(!$isFirst){
-				$ev = new PlayerMoveEvent($this, $from, $to);
-
-				$this->server->getPluginManager()->callEvent($ev);
+				($ev = new PlayerMoveEvent($this, $from, $to))->call();
 
 				if(!($revert = $ev->isCancelled())){ //Yes, this is intended
 					if($to->distanceSquared($ev->getTo()) > 0.01){ //If plugins modify the destination
@@ -2068,7 +2066,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 						$this->server->dispatchCommand($ev->getPlayer(), substr($ev->getMessage(), 1));
 						Timings::$playerCommandTimer->stopTiming();
 					}else{
-						$this->server->getPluginManager()->callEvent($ev = new PlayerChatEvent($this, $ev->getMessage()));
+						($ev = new PlayerChatEvent($this, $ev->getMessage()))->call();
 						if(!$ev->isCancelled()){
 							$this->server->broadcastMessage($this->getServer()->getLanguage()->translateString($ev->getFormat(), [$ev->getPlayer()->getDisplayName(), $ev->getMessage()]), $ev->getRecipients());
 						}
@@ -3361,7 +3359,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		$packet->decode();
 		assert($packet->feof(), "Still " . strlen(substr($packet->buffer, $packet->offset)) . " bytes unread in " . get_class($packet));
 
-		$this->server->getPluginManager()->callEvent($ev = new DataPacketReceiveEvent($this, $packet));
+		($ev = new DataPacketReceiveEvent($this, $packet))->call();
 		if(!$ev->isCancelled() and !$packet->handle($this)){
 			$this->server->getLogger()->debug("Unhandled " . $packet->getName() . " received from " . $this->getName() . ": 0x" . bin2hex($packet->buffer));
 		}

--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -997,7 +997,7 @@ class Server{
 
 		$level->initLevel();
 
-		$this->getPluginManager()->callEvent(new LevelLoadEvent($level));
+		(new LevelLoadEvent($level))->call();
 
 		$level->setTickRate($this->baseTickRate);
 
@@ -1050,9 +1050,9 @@ class Server{
 			return false;
 		}
 
-		$this->getPluginManager()->callEvent(new LevelInitEvent($level));
+		(new LevelInitEvent($level))->call();
 
-		$this->getPluginManager()->callEvent(new LevelLoadEvent($level));
+		(new LevelLoadEvent($level))->call();
 
 		$this->getLogger()->notice($this->getLanguage()->translateString("pocketmine.level.backgroundGeneration", [$name]));
 
@@ -1845,7 +1845,7 @@ class Server{
 	public function checkConsole(){
 		Timings::$serverCommandTimer->startTiming();
 		if(($line = $this->console->getLine()) !== null){
-			$this->pluginManager->callEvent($ev = new ServerCommandEvent($this->consoleSender, $line));
+			($ev = new ServerCommandEvent($this->consoleSender, $line))->call();
 			if(!$ev->isCancelled()){
 				$this->dispatchCommand($ev->getSender(), $ev->getCommand());
 			}
@@ -2388,7 +2388,7 @@ class Server{
 
 			if(($this->tickCounter & 0b111111111) === 0){
 				try{
-					$this->getPluginManager()->callEvent($this->queryRegenerateTask = new QueryRegenerateEvent($this, 5));
+					($this->queryRegenerateTask = new QueryRegenerateEvent($this, 5))->call();
 					if($this->queryHandler !== null){
 						$this->queryHandler->regenerateInfo();
 					}

--- a/src/pocketmine/block/Crops.php
+++ b/src/pocketmine/block/Crops.php
@@ -25,7 +25,6 @@ use pocketmine\event\block\BlockGrowEvent;
 use pocketmine\item\Item;
 use pocketmine\level\Level;
 use pocketmine\Player;
-use pocketmine\Server;
 
 abstract class Crops extends Flowable{
 
@@ -53,7 +52,7 @@ abstract class Crops extends Flowable{
 				$block->meta = 7;
 			}
 
-			Server::getInstance()->getPluginManager()->callEvent($ev = new BlockGrowEvent($this, $block));
+			($ev = new BlockGrowEvent($this, $block))->call();
 
 			if(!$ev->isCancelled()){
 				$this->getLevel()->setBlock($this, $ev->getNewState(), true, true);
@@ -78,7 +77,7 @@ abstract class Crops extends Flowable{
 				if($this->meta < 0x07){
 					$block = clone $this;
 					++$block->meta;
-					Server::getInstance()->getPluginManager()->callEvent($ev = new BlockGrowEvent($this, $block));
+					($ev = new BlockGrowEvent($this, $block))->call();
 
 					if(!$ev->isCancelled()){
 						$this->getLevel()->setBlock($this, $ev->getNewState(), true, true);

--- a/src/pocketmine/event/Event.php
+++ b/src/pocketmine/event/Event.php
@@ -24,6 +24,8 @@
  */
 namespace pocketmine\event;
 
+use pocketmine\Server;
+
 abstract class Event{
 
 	/**
@@ -81,6 +83,10 @@ abstract class Event{
 		}
 
 		return static::$handlerList;
+	}
+
+	public function call(){
+		Server::getInstance()->getPluginManager()->callEvent($this);
 	}
 
 }

--- a/src/pocketmine/inventory/BaseInventory.php
+++ b/src/pocketmine/inventory/BaseInventory.php
@@ -141,7 +141,7 @@ abstract class BaseInventory implements Inventory{
 
 		$holder = $this->getHolder();
 		if($holder instanceof Entity){
-			Server::getInstance()->getPluginManager()->callEvent($ev = new EntityInventoryChangeEvent($holder, $this->getItem($index), $item, $index));
+			($ev = new EntityInventoryChangeEvent($holder, $this->getItem($index), $item, $index))->call();
 			if($ev->isCancelled()){
 				$this->sendSlot($index, $this->getViewers());
 				return false;
@@ -347,7 +347,7 @@ abstract class BaseInventory implements Inventory{
 			$old = $this->slots[$index];
 			$holder = $this->getHolder();
 			if($holder instanceof Entity){
-				Server::getInstance()->getPluginManager()->callEvent($ev = new EntityInventoryChangeEvent($holder, $old, $item, $index));
+				($ev = new EntityInventoryChangeEvent($holder, $old, $item, $index))->call();
 				if($ev->isCancelled()){
 					$this->sendSlot($index, $this->getViewers());
 					return false;
@@ -388,7 +388,7 @@ abstract class BaseInventory implements Inventory{
 	}
 
 	public function open(Player $who){
-		$who->getServer()->getPluginManager()->callEvent($ev = new InventoryOpenEvent($this, $who));
+		($ev = new InventoryOpenEvent($this, $who))->call();
 		if($ev->isCancelled()){
 			return false;
 		}

--- a/src/pocketmine/inventory/PlayerInventory.php
+++ b/src/pocketmine/inventory/PlayerInventory.php
@@ -71,7 +71,7 @@ class PlayerInventory extends BaseInventory{
 			return false;
 		}
 
-		$this->getHolder()->getLevel()->getServer()->getPluginManager()->callEvent($ev = new PlayerItemHeldEvent($this->getHolder(), $this->getItem($inventorySlot), $inventorySlot, $hotbarSlot));
+		($ev = new PlayerItemHeldEvent($this->getHolder(), $this->getItem($inventorySlot), $inventorySlot, $hotbarSlot))->call();
 		if($ev->isCancelled()){
 			$this->sendContents($this->getHolder());
 			return false;
@@ -298,14 +298,14 @@ class PlayerInventory extends BaseInventory{
 		}
 
 		if($index >= $this->getSize()){ //Armor change
-			Server::getInstance()->getPluginManager()->callEvent($ev = new EntityArmorChangeEvent($this->getHolder(), $this->getItem($index), $item, $index));
+			($ev = new EntityArmorChangeEvent($this->getHolder(), $this->getItem($index), $item, $index))->call();
 			if($ev->isCancelled() and $this->getHolder() instanceof Human){
 				$this->sendArmorSlot($index, $this->getViewers());
 				return false;
 			}
 			$item = $ev->getNewItem();
 		}else{
-			Server::getInstance()->getPluginManager()->callEvent($ev = new EntityInventoryChangeEvent($this->getHolder(), $this->getItem($index), $item, $index));
+			($ev = new EntityInventoryChangeEvent($this->getHolder(), $this->getItem($index), $item, $index))->call();
 			if($ev->isCancelled()){
 				$this->sendSlot($index, $this->getViewers());
 				return false;
@@ -326,7 +326,7 @@ class PlayerInventory extends BaseInventory{
 			$item = Item::get(Item::AIR, 0, 0);
 			$old = $this->slots[$index];
 			if($index >= $this->getSize() and $index < $this->size){ //Armor change
-				Server::getInstance()->getPluginManager()->callEvent($ev = new EntityArmorChangeEvent($this->getHolder(), $old, $item, $index));
+				($ev = new EntityArmorChangeEvent($this->getHolder(), $old, $item, $index))->call();
 				if($ev->isCancelled()){
 					if($index >= $this->size){
 						$this->sendArmorSlot($index, $this->getViewers());
@@ -337,7 +337,7 @@ class PlayerInventory extends BaseInventory{
 				}
 				$item = $ev->getNewItem();
 			}else{
-				Server::getInstance()->getPluginManager()->callEvent($ev = new EntityInventoryChangeEvent($this->getHolder(), $old, $item, $index));
+				($ev = new EntityInventoryChangeEvent($this->getHolder(), $old, $item, $index))->call();
 				if($ev->isCancelled()){
 					if($index >= $this->size){
 						$this->sendArmorSlot($index, $this->getViewers());

--- a/src/pocketmine/inventory/PlayerInventory.php
+++ b/src/pocketmine/inventory/PlayerInventory.php
@@ -31,7 +31,6 @@ use pocketmine\network\mcpe\protocol\ContainerSetSlotPacket;
 use pocketmine\network\mcpe\protocol\MobArmorEquipmentPacket;
 use pocketmine\network\mcpe\protocol\MobEquipmentPacket;
 use pocketmine\Player;
-use pocketmine\Server;
 
 class PlayerInventory extends BaseInventory{
 

--- a/src/pocketmine/level/Explosion.php
+++ b/src/pocketmine/level/Explosion.php
@@ -124,7 +124,7 @@ class Explosion{
 		$yield = (1 / $this->size) * 100;
 
 		if($this->what instanceof Entity){
-			$this->level->getServer()->getPluginManager()->callEvent($ev = new EntityExplodeEvent($this->what, $this->source, $this->affectedBlocks, $yield));
+			($ev = new EntityExplodeEvent($this->what, $this->source, $this->affectedBlocks, $yield))->call();
 			if($ev->isCancelled()){
 				return false;
 			}else{
@@ -204,7 +204,7 @@ class Explosion{
 			for($side = 0; $side <= 5; $side++){
 				$sideBlock = $pos->getSide($side);
 				if(!isset($this->affectedBlocks[$index = Level::blockHash($sideBlock->x, $sideBlock->y, $sideBlock->z)]) and !isset($updateBlocks[$index])){
-					$this->level->getServer()->getPluginManager()->callEvent($ev = new BlockUpdateEvent($this->level->getBlock($sideBlock)));
+					($ev = new BlockUpdateEvent($this->level->getBlock($sideBlock)))->call();
 					if(!$ev->isCancelled()){
 						$ev->getBlock()->onUpdate(Level::BLOCK_UPDATE_NORMAL);
 					}

--- a/src/pocketmine/plugin/PharPluginLoader.php
+++ b/src/pocketmine/plugin/PharPluginLoader.php
@@ -121,7 +121,7 @@ class PharPluginLoader implements PluginLoader{
 
 			$plugin->setEnabled(true);
 
-			$this->server->getPluginManager()->callEvent(new PluginEnableEvent($plugin));
+			(new PluginEnableEvent($plugin))->call();
 		}
 	}
 
@@ -132,7 +132,7 @@ class PharPluginLoader implements PluginLoader{
 		if($plugin instanceof PluginBase and $plugin->isEnabled()){
 			$this->server->getLogger()->info($this->server->getLanguage()->translateString("pocketmine.plugin.disable", [$plugin->getDescription()->getFullName()]));
 
-			$this->server->getPluginManager()->callEvent(new PluginDisableEvent($plugin));
+			(new PluginDisableEvent($plugin))->call();
 
 			$plugin->setEnabled(false);
 		}

--- a/src/pocketmine/plugin/ScriptPluginLoader.php
+++ b/src/pocketmine/plugin/ScriptPluginLoader.php
@@ -144,7 +144,7 @@ class ScriptPluginLoader implements PluginLoader{
 
 			$plugin->setEnabled(true);
 
-			$this->server->getPluginManager()->callEvent(new PluginEnableEvent($plugin));
+			(new PluginEnableEvent($plugin))->call();
 		}
 	}
 
@@ -155,7 +155,7 @@ class ScriptPluginLoader implements PluginLoader{
 		if($plugin instanceof PluginBase and $plugin->isEnabled()){
 			$this->server->getLogger()->info($this->server->getLanguage()->translateString("pocketmine.plugin.disable", [$plugin->getDescription()->getFullName()]));
 
-			$this->server->getPluginManager()->callEvent(new PluginDisableEvent($plugin));
+			(new PluginDisableEvent($plugin))->call();
 
 			$plugin->setEnabled(false);
 		}


### PR DESCRIPTION
## Introduction
`$this->server->getPluginManager()->callEvent($ev)` is long and annoying. `$ev->call()` is a much nicer and quicker short-form that can now be used as an alternative.

This PR is still a work in progress since there are a very large number of these event calls scattered throughout the code. A sample has been supplied as an example. If everyone is happy with it I will convert the remaining usages.

## Changes
### API changes
- Added `Event->call()` which can be substituted for long `blah->getBlah()->getBlah()->getServer()->getPluginManager()->...` calls.

## Backwards compatibility
No BC breaks, only API additions.