### PR TITLE
Added PlayerDataSaveEvent, resolved #487

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3608,7 +3608,6 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			$this->server->getPluginManager()->unsubscribeFromPermission(Server::BROADCAST_CHANNEL_ADMINISTRATIVE, $this);
 
 			if($this->joined){
-				//TODO: add events for player data saving
 				$this->save();
 
 				$this->server->getPluginManager()->callEvent($ev = new PlayerQuitEvent($this, $message));
@@ -3709,7 +3708,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		}
 
 		$this->namedtag["playerGameType"] = $this->gamemode;
-		$this->namedtag["lastPlayed"] = new LongTag("lastPlayed", floor(microtime(true) * 1000));
+		$this->namedtag["lastPlayed"] = floor(microtime(true) * 1000);
 
 		if($this->username != "" and $this->namedtag instanceof CompoundTag){
 			$this->server->saveOfflinePlayerData($this->username, $this->namedtag, $async);

--- a/src/pocketmine/event/player/PlayerDataSaveEvent.php
+++ b/src/pocketmine/event/player/PlayerDataSaveEvent.php
@@ -25,7 +25,9 @@ namespace pocketmine\event\player;
 
 use pocketmine\event\Cancellable;
 use pocketmine\event\Event;
+use pocketmine\IPlayer;
 use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\Server;
 
 /**
  * Called when a player's data is about to be saved to disk.
@@ -64,5 +66,13 @@ class PlayerDataSaveEvent extends Event implements Cancellable{
 	 */
 	public function getPlayerName() : string{
 		return $this->playerName;
+	}
+
+	/**
+	 * Returns the player whose data is being saved. This may be a Player or an OfflinePlayer.
+	 * @return IPlayer (Player or OfflinePlayer)
+	 */
+	public function getPlayer() : IPlayer{
+		return Server::getInstance()->getOfflinePlayer($this->playerName);
 	}
 }

--- a/src/pocketmine/event/player/PlayerDataSaveEvent.php
+++ b/src/pocketmine/event/player/PlayerDataSaveEvent.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\event\player;
+
+use pocketmine\event\Cancellable;
+use pocketmine\event\Event;
+use pocketmine\nbt\tag\CompoundTag;
+
+/**
+ * Called when a player's data is about to be saved to disk.
+ */
+class PlayerDataSaveEvent extends Event implements Cancellable{
+	public static $handlerList = null;
+
+	/** @var CompoundTag */
+	protected $data;
+	/** @var string */
+	protected $playerName;
+
+	public function __construct(CompoundTag $nbt, string $playerName){
+		$this->data = $nbt;
+		$this->playerName = $playerName;
+	}
+
+	/**
+	 * Returns the data to be written to disk as a CompoundTag
+	 * @return CompoundTag
+	 */
+	public function getSaveData() : CompoundTag{
+		return $this->data;
+	}
+
+	/**
+	 * @param CompoundTag $data
+	 */
+	public function setSaveData(CompoundTag $data){
+		$this->data = $data;
+	}
+
+	/**
+	 * Returns the username of the player whose data is being saved. This is not necessarily an online player.
+	 * @return string
+	 */
+	public function getPlayerName() : string{
+		return $this->playerName;
+	}
+}

--- a/src/pocketmine/event/player/PlayerQuitEvent.php
+++ b/src/pocketmine/event/player/PlayerQuitEvent.php
@@ -21,6 +21,7 @@
 
 namespace pocketmine\event\player;
 
+use pocketmine\event\TranslationContainer;
 use pocketmine\Player;
 
 /**
@@ -29,19 +30,29 @@ use pocketmine\Player;
 class PlayerQuitEvent extends PlayerEvent{
 	public static $handlerList = null;
 
-	/** @var string */
+	/** @var TranslationContainer|string */
 	protected $quitMessage;
 
-	public function __construct(Player $player, string $quitMessage){
+	/**
+	 * @param Player                      $player
+	 * @param TranslationContainer|string $quitMessage
+	 */
+	public function __construct(Player $player, $quitMessage){
 		$this->player = $player;
 		$this->quitMessage = $quitMessage;
 	}
 
-	public function setQuitMessage(string $quitMessage){
+	/**
+	 * @param TranslationContainer|string $quitMessage
+	 */
+	public function setQuitMessage($quitMessage){
 		$this->quitMessage = $quitMessage;
 	}
 
-	public function getQuitMessage() : string{
+	/**
+	 * @return TranslationContainer|string
+	 */
+	public function getQuitMessage(){
 		return $this->quitMessage;
 	}
 }

--- a/src/pocketmine/event/player/PlayerQuitEvent.php
+++ b/src/pocketmine/event/player/PlayerQuitEvent.php
@@ -31,28 +31,17 @@ class PlayerQuitEvent extends PlayerEvent{
 
 	/** @var string */
 	protected $quitMessage;
-	protected $autoSave = true;
 
-	public function __construct(Player $player, $quitMessage, $autoSave = true){
+	public function __construct(Player $player, string $quitMessage){
 		$this->player = $player;
 		$this->quitMessage = $quitMessage;
-		$this->autoSave = $autoSave;
 	}
 
-	public function setQuitMessage($quitMessage){
+	public function setQuitMessage(string $quitMessage){
 		$this->quitMessage = $quitMessage;
 	}
 
-	public function getQuitMessage(){
+	public function getQuitMessage() : string{
 		return $this->quitMessage;
 	}
-
-	public function getAutoSave(){
-		return $this->autoSave;
-	}
-
-	public function setAutoSave($value = true){
-		$this->autoSave = (bool) $value;
-	}
-
 }


### PR DESCRIPTION
## Introduction
#487 describes why having auto-save controlled by PlayerQuitEvent is a bad idea. This pull request adds a PlayerDataSaveEvent, which resolves this problem and gives plugins more control over saving of player data.

### Relevant issues
#487

## Changes
### API changes
- Added PlayerDataSaveEvent. This event will be called when the server is about to save offline player data. Note that there is no `getPlayer()` for this event, only `getPlayerName()`. You cannot assume a player is online when their data is being saved.
- Removed the following from PlayerQuitEvent:
  - `getAutoSave()`
  - `setAutoSave(bool)`
  - auto-save parameter from PlayerQuitEvent constructor
- Server option to disable saving player data saving can now be overridden by plugins (this is reflected by the cancelled state of the event)

### Behavioural changes
- Server->getOfflinePlayerData() will no longer save data to disk if it doesn't already exist. This is because new Players already save their own data on creation, causing the data to be saved twice when a new Player is created.

## Backwards compatibility
Minor BC break for plugins using PlayerQuitEvent to control auto-saving. This will be covered in the next ALPHA API bump.

## Tests
Loosely tested. The core has no trouble with this, and I've tested cancelling and un-cancelling this new event, works fine. I haven't tested using a plugin to alter the saved data (this may cause some issues due to NBT library bad design).
<!-- Attach scripts or actions to test this pull request, as well as the result -->
