### PR TITLE
Fixed AsyncTask memory leaks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,6 @@
 [submodule "tests/plugins/PocketMine-DevTools"]
 	path = tests/plugins/PocketMine-DevTools
 	url = https://github.com/pmmp/PocketMine-DevTools.git
+[submodule "tests/plugins/PocketMine-TesterPlugin"]
+	path = tests/plugins/PocketMine-TesterPlugin
+	url = https://github.com/pmmp/PocketMine-TesterPlugin.git

--- a/src/pocketmine/scheduler/AsyncPool.php
+++ b/src/pocketmine/scheduler/AsyncPool.php
@@ -41,9 +41,6 @@ class AsyncPool{
 	/** @var int[] */
 	private $workerUsage = [];
 
-	/** @var AsyncTask[] */
-	private $deadTasks = [];
-
 	public function __construct(Server $server, $size){
 		$this->server = $server;
 		$this->size = (int) $size;
@@ -118,7 +115,7 @@ class AsyncPool{
 		unset($this->tasks[$task->getTaskId()]);
 		unset($this->taskWorkers[$task->getTaskId()]);
 
-		$this->deadTasks[] = $task;
+		$task->cleanObject();
 	}
 
 	public function removeTasks(){
@@ -164,11 +161,6 @@ class AsyncPool{
 		foreach($this->workers as $worker){
 			$worker->collect();
 		}
-
-		foreach($this->deadTasks as $task){
-			$task->cleanObject();
-		}
-		$this->deadTasks = [];
 
 		Timings::$schedulerAsyncTimer->stopTiming();
 	}

--- a/src/pocketmine/scheduler/AsyncTask.php
+++ b/src/pocketmine/scheduler/AsyncTask.php
@@ -261,7 +261,8 @@ abstract class AsyncTask extends Collectable{
 				$this->{$p} = null;
 			}
 		}
-	}
 
+		$this->setGarbage();
+	}
 }
 

--- a/tests/travis.sh
+++ b/tests/travis.sh
@@ -17,7 +17,11 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
-cp -r tests/plugins plugins
+rm server.log 2> /dev/null
+mkdir -p ./plugins
+
+cp -r tests/plugins/PocketMine-DevTools ./plugins
+
 "$PHP_BINARY" ./plugins/PocketMine-DevTools/src/DevTools/ConsoleScript.php --make ./plugins/PocketMine-DevTools --relative ./plugins/PocketMine-DevTools --out ./plugins/DevTools.phar
 rm -rf ./plugins/PocketMine-DevTools
 
@@ -27,4 +31,16 @@ if ls plugins/DevTools/PocketMine*.phar >/dev/null 2>&1; then
 else
     echo No phar created!
     exit 1
+fi
+
+cp -r tests/plugins/PocketMine-TesterPlugin ./plugins
+"$PHP_BINARY" src/pocketmine/PocketMine.php --no-wizard --disable-ansi --disable-readline --debug.level=2
+
+result=$(grep 'TesterPlugin' server.log | grep 'Finished' | grep -v 'PASS')
+if [ "$result" != "" ]; then
+   echo "$result"
+   echo Some tests did not complete successfully, changing build status to failed
+   exit 1
+else
+    echo All tests passed
 fi


### PR DESCRIPTION
## Introduction
AsyncTask objects were not being correctly collected after completion, causing the server to leak memory if async tasks were used frequently. This was a major show-stopper for stuff like asynchronous chunk serialization, and a big problem for plugins such as @SOF3's Hormones.

## Changes
### Behavioural changes
- AsyncTasks don't leak anymore

## Tests
A new submodule, [PocketMine-TesterPlugin](https://github.com/pmmp/PocketMine-TesterPlugin), has been added. Currently this plugin only contains a regression test for this particular bug.
However, the plugin can be easily extended to add more tests (TODO).