### PR TITLE
Improve checks for Position::equals() and Location::equals()

### DIFF
--- a/src/pocketmine/level/Location.php
+++ b/src/pocketmine/level/Location.php
@@ -68,4 +68,11 @@ class Location extends Position{
 	public function __toString(){
 		return "Location (level=" . ($this->isValid() ? $this->getLevel()->getName() : "null") . ", x=$this->x, y=$this->y, z=$this->z, yaw=$this->yaw, pitch=$this->pitch)";
 	}
+
+	public function equals(Vector3 $v){
+		if($v instanceof Location){
+			return parent::equals($v) and $v->yaw == $this->yaw and $v->pitch == $this->pitch;
+		}
+		return parent::equals($v);
+	}
 }

--- a/src/pocketmine/level/Position.php
+++ b/src/pocketmine/level/Position.php
@@ -124,7 +124,7 @@ class Position extends Vector3{
 
 	public function equals(Vector3 $v){
 		if($v instanceof Position){
-			return parent::equals($v) and $v->getLevel()->getId() === $this->level->getId();
+			return parent::equals($v) and $v->getLevel() === $this->level;
 		}
 		return parent::equals($v);
 	}

--- a/src/pocketmine/level/Position.php
+++ b/src/pocketmine/level/Position.php
@@ -124,7 +124,7 @@ class Position extends Vector3{
 
 	public function equals(Vector3 $v){
 		if($v instanceof Position){
-			return parent::equals($v) and $v->getLevel() === $this->level;
+			return parent::equals($v) and $v->getLevel() === $this->getLevel();
 		}
 		return parent::equals($v);
 	}

--- a/src/pocketmine/level/Position.php
+++ b/src/pocketmine/level/Position.php
@@ -122,4 +122,10 @@ class Position extends Vector3{
 		return $this;
 	}
 
+	public function equals(Vector3 $v){
+		if($v instanceof Position){
+			return parent::equals($v) and $v->getLevel()->getId() === $this->level->getId();
+		}
+		return parent::equals($v);
+	}
 }


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Since Location extends Position extends Vector3, and since equals() is not being overwritten in Location and Position, Location::equals(Location) would be equal to Position::equals(Position) which would be equal to Vector3::equals(Vector3) if Location's $x, $y and $z are equal to Position's $x, $y, and $z are equal to Vector3's $x, $y, and $z.

_This was an issue reported in the development section of [forums.pmmp.io](https://forums.pmmp.io)._
### Relevant issues
* https://forums.pmmp.io/threads/rotating-head-seems-to-change-position.2349/

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
* _Position::equals(PositionToCheck)_ now checks whether
  * _Position::$level === PositionToCheck::$level_

* _Location::equals(LocationToCheck)_ now checks whether
  * _Location::$level === LocationToCheck::$level_
  * _Location::$yaw == LocationToCheck::$yaw_
  * _Location::$pitch == LocationToCheck::$pitch_

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
None.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Checking whether Position::equals(Position2) now checks whether Position's level is the same as Position2's level. If in your plugins, Position::equals(Position2) returns true though the levels are different, you'll need to convert Position2 to Vector3.

Same for Location. Location::equals(Location2) returns true only if Location::$level is the same as Location2::$level and Location::$yaw is equal to (==, not === because of floats and ints) Location2::$yaw and Location::$pitch is equal to Location2::$pitch.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
None, since PocketMine has never used Vector3::equals() (nor Position::equals() or Location::equals()).

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
Returns true:
```php
/** @var Location $loc */
$loc2 = clone $loc;
return $loc->equals($loc2);

/** @var Position $pos */
$pos2 = clone $pos;
return $pos->equals($pos2);

$p1 = new Position(100, 220, 130, $level = Level::class);
$p2 = new Position(100, 220, 130, $level);
return $p1->equals($p2);
return $p1->equals(new Vector3($p2->x, $p2->y, $p2->z));

$l1 = new Location(100, 200, 300, 100.24, 100.34, $level = Level::class);
$l2 = new Location($l1->x, $l1->y, $l1->z, 100, 100, $level);
return !$l1->equals($l2);//100.24 != 100 and 100.34 != 100
return $l1->equals(new Vector3($l2->x, $l2->y, $l2->z));
```