### PR TITLE
Add Server::broadcastTitle()

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -78,8 +78,6 @@ use pocketmine\network\mcpe\protocol\BatchPacket;
 use pocketmine\network\mcpe\protocol\DataPacket;
 use pocketmine\network\mcpe\protocol\ProtocolInfo;
 use pocketmine\network\mcpe\protocol\PlayerListPacket;
-use pocketmine\network\mcpe\protocol\SetTitlePacket;
-use pocketmine\network\mcpe\protocol\TextPacket;
 use pocketmine\network\mcpe\RakLibInterface;
 use pocketmine\network\Network;
 use pocketmine\network\query\QueryHandler;
@@ -1685,61 +1683,9 @@ class Server{
 		}
 
 		/** @var Player[] $recipients */
-		$pk = new TextPacket();
-		$pk->type = TextPacket::TYPE_TIP;
-		$pk->message = $tip;
-		$this->broadcastPacket($recipients, $pk);
-
-		return count($recipients);
-	}
-
-
-	/**
-	 * @param string $title
-	 * @param string $subtitle
-	 * @param int    $fadeIn Duration in ticks for fade-in. If -1 is given, client-sided defaults will be used.
-	 * @param int    $stay Duration in ticks to stay on screen for
-	 * @param int    $fadeOut Duration in ticks for fade-out.
-	 *
-	 * @return int
-	 */
-	public function broadcastTitle(string $title, string $subtitle = "", int $fadeIn = -1, int $stay = -1, int $fadeOut = -1, $recipients = null){
-		if(!is_array($recipients)){
-			/** @var Player[] $recipients */
-			$recipients = [];
-
-			foreach($this->pluginManager->getPermissionSubscriptions(self::BROADCAST_CHANNEL_USERS) as $permissible){
-				if($permissible instanceof Player and $permissible->hasPermission(self::BROADCAST_CHANNEL_USERS)){
-					$recipients[spl_object_hash($permissible)] = $permissible; // do not send messages directly, or some might be repeated
-				}
-			}
+		foreach($recipients as $recipient){
+			$recipient->sendTip($tip);
 		}
-
-		/** @var SetTitlePacket[] $packets */
-		$packets = [];
-
-		if($fadeIn >= 0 and $stay >= 0 and $fadeOut >= 0){
-			$pk = new SetTitlePacket();
-			$pk->type = SetTitlePacket::TYPE_SET_ANIMATION_TIMES;
-			$pk->fadeInTime = $fadeIn;
-			$pk->stayTime = $stay;
-			$pk->fadeOutTime = $fadeOut;
-			$packets[] = $pk;
-		}
-
-		if($subtitle !== ""){
-			$pk = new SetTitlePacket();
-			$pk->type = SetTitlePacket::TYPE_SET_SUBTITLE;
-			$pk->text = $subtitle;
-			$packets[] = $pk;
-		}
-
-		$pk = new SetTitlePacket();
-		$pk->type = SetTitlePacket::TYPE_SET_TITLE;
-		$pk->text = $title;
-		$packets[] = $pk;
-
-		$this->batchPackets($recipients, $packets);
 
 		return count($recipients);
 	}
@@ -1763,10 +1709,38 @@ class Server{
 		}
 
 		/** @var Player[] $recipients */
-		$pk = new TextPacket();
-		$pk->type = TextPacket::TYPE_POPUP;
-		$pk->source = $popup;
-		$this->broadcastPacket($recipients, $pk);
+		foreach($recipients as $recipient){
+			$recipient->sendPopup($popup);
+		}
+
+		return count($recipients);
+	}
+
+	/**
+	 * @param string $title
+	 * @param string $subtitle
+	 * @param int    $fadeIn Duration in ticks for fade-in. If -1 is given, client-sided defaults will be used.
+	 * @param int    $stay Duration in ticks to stay on screen for
+	 * @param int    $fadeOut Duration in ticks for fade-out.
+	 *
+	 * @return int
+	 */
+	public function broadcastTitle(string $title, string $subtitle = "", int $fadeIn = -1, int $stay = -1, int $fadeOut = -1, $recipients = null){
+		if(!is_array($recipients)){
+			/** @var Player[] $recipients */
+			$recipients = [];
+
+			foreach($this->pluginManager->getPermissionSubscriptions(self::BROADCAST_CHANNEL_USERS) as $permissible){
+				if($permissible instanceof Player and $permissible->hasPermission(self::BROADCAST_CHANNEL_USERS)){
+					$recipients[spl_object_hash($permissible)] = $permissible; // do not send messages directly, or some might be repeated
+				}
+			}
+		}
+
+		/** @var Player[] $recipients */
+		foreach($recipients as $recipient){
+			$recipient->addTitle($title, $subtitle, $fadeIn, $stay, $fadeOut);
+		}
 
 		return count($recipients);
 	}

--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -1722,6 +1722,7 @@ class Server{
 	 * @param int    $fadeIn Duration in ticks for fade-in. If -1 is given, client-sided defaults will be used.
 	 * @param int    $stay Duration in ticks to stay on screen for
 	 * @param int    $fadeOut Duration in ticks for fade-out.
+	 * @param Player[]|null $recipients
 	 *
 	 * @return int
 	 */


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

Since there is a Server::broadcastMessage(), Server::broadcastTip() and Server::broadcastPopup(); why not a Server::broadcastTitle()?
## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
* Added Server::broadcastTitle() function to broadcast titles to a group of recipients.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
* Added Server::broadcastTitle() function to broadcast titles to a group of recipients.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Compatible.


## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
```php
/** @var Server $server */
$server->broadcastTitle("This is a title", "and THIS, is a subtitle!");//broadcasts title "This is a title", and subtitle "and THIS, is a subtitle!"

//$server::$serverList = [Player("alistair"), Player("billy")];
$players = [
    $server->getPlayer("a"),
    $server->getPlayer("b")
];

//The following broadcasts the given title and subtitle to players: "Aliastair" and "Billy"
$server->broadcastTitle("If you can read this", "then you are an honored player!", -1, -1, -1, $players);
```