### PR TITLE
Remove unneeded foreach loop in Human::getDrops()

### DIFF
--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -425,14 +425,7 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 	}
 
 	public function getDrops(){
-		$drops = [];
-		if($this->inventory !== null){
-			foreach($this->inventory->getContents() as $item){
-				$drops[] = $item;
-			}
-		}
-
-		return $drops;
+		return $this->inventory !== null ? $this->inventory->getContents() : [];
 	}
 
 	public function saveNBT(){

--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -425,7 +425,7 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 	}
 
 	public function getDrops(){
-		return $this->inventory !== null ? $this->inventory->getContents() : [];
+		return $this->inventory !== null ? array_values($this->inventory->getContents()) : [];
 	}
 
 	public function saveNBT(){


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

The foreach loop was useless as it was doing nothing other than copying every value of Human::getInventory()->getContents() into another array.

In other words:
```
//METHOD 1
$drops = [];
foreach(Human::getInventory()->getContents() as $item){
    $drops[] = $item;
}
//METHOD 2
$drops = Human::getInventory()->getContents();
```
METHOD 1 = METHOD 2

The only difference would be the array keys.
In METHOD 2, the array keys are basically the slot numbers. so it may look something like:
```
$drops = [
    0 => Item::class,
    1 => Item::class,
    100 => Armor::class, Air::class,
    101 => Armor::class | Air::class
];
```
while in METHOD 1:
```
$drops = [
    0 => Item::class,
    1 => Item::class,
    2 => Armor::class, Air::class,
    3 => Armor::class | Air::class
];
```

That can be solved using array_values(), but:
* Unneeded
* ~~Makes much more sense treating keys as slot numbers.~~
### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
None
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
A micro-optimization, and a sensible change. Living::getDrops() returns Living::getInventory()->getContents() which is a much better approach ~~as BaseInventory::getContents() returns an array in which the keys are the slots of the values (items).~~

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
