### PR TITLE
Added an easier function to quickly get an OfflinePlayer object from a Player object

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -321,6 +321,16 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	/** @var PermissibleBase */
 	private $perm = null;
 
+
+	/**
+	 * Returns a new OfflinePlayer object with the name of the current player.
+	 *
+	 * @return OfflinePlayer
+	 */
+	public function getOfflinePlayer() : OfflinePlayer{
+		return new OfflinePlayer($this->getServer(), $this->getName());
+	}
+
 	public function getLeaveMessage(){
 		return new TranslationContainer(TextFormat::YELLOW . "%multiplayer.player.left", [
 			$this->getDisplayName()


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This pull request adds a very simple function: $player->getOfflinePlayer(). I felt like it would be easier to do this instead of having to construct a new OfflinePlayer object without API. 

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
No issues for this kind of addition.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
A new API function in the Player class:
`$player->getOfflinePlayer()`

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
This does change the way anything behaves, nor performance.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? --> No backwards incompatible changes are made.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
-
## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
-