### PR TITLE
Update core for PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,20 @@
 language: php
 
 php:
- - 7.0
+ - 7.1
 
 before_script:
- - pecl install channel://pecl.php.net/pthreads-3.1.6
+# - pecl install channel://pecl.php.net/pthreads-3.1.6
  - pecl install channel://pecl.php.net/weakref-0.3.3
  - echo | pecl install channel://pecl.php.net/yaml-2.0.0
+ - git clone https://github.com/SirSnyder/pthreads.git -b php/71 --depth=1
+ - cd pthreads
+ - phpize
+ - ./configure
+ - make
+ - make install
+ - cd ..
+ - echo "extension=pthreads.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
 script:
  - ./tests/travis.sh

--- a/src/pocketmine/PocketMine.php
+++ b/src/pocketmine/PocketMine.php
@@ -89,8 +89,8 @@ namespace pocketmine {
 	 * Enjoy it as much as I did writing it. I don't want to do it again.
 	 */
 
-	if(version_compare("7.0", PHP_VERSION) > 0){
-		echo "[CRITICAL] You must use PHP >= 7.0" . PHP_EOL;
+	if(version_compare("7.1", PHP_VERSION) > 0){
+		echo "[CRITICAL] You must use PHP >= 7.1" . PHP_EOL;
 		echo "[CRITICAL] Please use the installer provided on the homepage." . PHP_EOL;
 		exit(1);
 	}
@@ -427,8 +427,8 @@ namespace pocketmine {
 		if(substr_count($pthreads_version, ".") < 2){
 			$pthreads_version = "0.$pthreads_version";
 		}
-		if(version_compare($pthreads_version, "3.1.5") < 0){
-			$logger->critical("pthreads >= 3.1.5 is required, while you have $pthreads_version.");
+		if(version_compare($pthreads_version, "3.1.7-dev") < 0){
+			$logger->critical("pthreads >= 3.1.7-dev is required, while you have $pthreads_version.");
 			++$errors;
 		}
 

--- a/src/pocketmine/Thread.php
+++ b/src/pocketmine/Thread.php
@@ -53,7 +53,7 @@ abstract class Thread extends \Thread{
 		}
 	}
 
-	public function start(int $options = PTHREADS_INHERIT_ALL){
+	public function start(?int $options = \PTHREADS_INHERIT_ALL){
 		ThreadManager::getInstance()->add($this);
 
 		if(!$this->isRunning() and !$this->isJoined() and !$this->isTerminated()){

--- a/src/pocketmine/Worker.php
+++ b/src/pocketmine/Worker.php
@@ -54,7 +54,7 @@ abstract class Worker extends \Worker{
 		}
 	}
 
-	public function start(int $options = PTHREADS_INHERIT_ALL){
+	public function start(?int $options = \PTHREADS_INHERIT_ALL){
 		ThreadManager::getInstance()->add($this);
 
 		if(!$this->isRunning() and !$this->isJoined() and !$this->isTerminated()){


### PR DESCRIPTION
## Introduction
read the title

## Changes
### API changes
Alterations to `pocketmine\Thread->start()` and `pocketmine\Worker->start()` in accordance with pthreads 3.1.7-dev

### Behavioural changes
less performance because PHP 7.1 is somewhat slower than 7.0.

## Backwards compatibility
This is _not_ backwards-compatible with PHP 7.0, however most plugins won't be suffering breaking changes yet, at least until we start upgrading the core to use new features.

## Follow-up
- typehint all the things
- nullable typehints and void return types
