### PR TITLE
Remove damage variable in Entity->knockBack

### DIFF
--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -161,7 +161,7 @@ abstract class Living extends Entity implements Damageable{
 
 				$deltaX = $this->x - $e->x;
 				$deltaZ = $this->z - $e->z;
-				$this->knockBack($e, $damage, $deltaX, $deltaZ, $source->getKnockBack());
+				$this->knockBack($e, $deltaX, $deltaZ, $source->getKnockBack());
 			}
 		}
 
@@ -173,7 +173,7 @@ abstract class Living extends Entity implements Damageable{
 		$this->attackTime = 10; //0.5 seconds cooldown
 	}
 
-	public function knockBack(Entity $attacker, $damage, $x, $z, $base = 0.4){
+	public function knockBack(Entity $attacker, $x, $z, $base = 0.4){
 		$f = sqrt($x * $x + $z * $z);
 		if($f <= 0){
 			return;


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
the damage number isn't used whatsoever in the knockback function.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
knockBack second variable $damage removed

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
Nope.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Remove the damage variable in plugins.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
no tests done, but kinda common sense