### PR TITLE
TAG_Byte should always be signed

### DIFF
--- a/src/pocketmine/nbt/NBT.php
+++ b/src/pocketmine/nbt/NBT.php
@@ -267,8 +267,8 @@ class NBT{
 		$tag->write($this, $network);
 	}
 
-	public function getByte(){
-		return Binary::readByte($this->get(1));
+	public function getByte(bool $signed = false){
+		return Binary::readByte($this->get(1), $signed);
 	}
 
 	public function putByte($v){

--- a/src/pocketmine/nbt/tag/ByteTag.php
+++ b/src/pocketmine/nbt/tag/ByteTag.php
@@ -32,7 +32,7 @@ class ByteTag extends NamedTag{
 	}
 
 	public function read(NBT $nbt, bool $network = false){
-		$this->value = $nbt->getByte();
+		$this->value = $nbt->getByte(true);
 	}
 
 	public function write(NBT $nbt, bool $network = false){


### PR DESCRIPTION
This is correct, but this change is practically guaranteed to break something.

This fixes an issue with inventory where null slot link (-1) is saved as a TAG_Byte but then read back as unsigned (255).