### PR TITLE
Added asVector3(), asPosition() and asLocation()

### DIFF
--- a/src/pocketmine/block/Block.php
+++ b/src/pocketmine/block/Block.php
@@ -539,16 +539,7 @@ class Block extends Position implements BlockIds, Metadatable{
 		$this->level = $v->level;
 		$this->boundingBox = null;
 	}
-	
-	/**
-	 * Return the position of the block
-	 *
-	 * @return Position
-	 */
-	public function getPosition() : Position{
-		return self::fromObject($this, $this->level);
-	}
-	
+
 	/**
 	 * Returns an array of Item objects to be dropped
 	 *

--- a/src/pocketmine/block/Block.php
+++ b/src/pocketmine/block/Block.php
@@ -546,7 +546,7 @@ class Block extends Position implements BlockIds, Metadatable{
 	 * @return Position
 	 */
 	public function getPosition() : Position{
-		return new Position($this->x, $this->y, $this->z, $this->level);
+		return self::fromObject($this, $this->level);
 	}
 	
 	/**

--- a/src/pocketmine/block/Block.php
+++ b/src/pocketmine/block/Block.php
@@ -539,7 +539,16 @@ class Block extends Position implements BlockIds, Metadatable{
 		$this->level = $v->level;
 		$this->boundingBox = null;
 	}
-
+	
+	/**
+	 * Return the position of the block
+	 *
+	 * @return Position
+	 */
+	public function getPosition() : Position{
+		return new Position($this->x, $this->y, $this->z, $this->level);
+	}
+	
 	/**
 	 * Returns an array of Item objects to be dropped
 	 *

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -1383,10 +1383,20 @@ abstract class Entity extends Location implements Metadatable{
 		return true;
 	}
 
+	/**
+	 * @deprecated Use asPosition() instead getPosition()
+	 * 
+	 * @return Position
+	 */
 	public function getPosition(){
 		return new Position($this->x, $this->y, $this->z, $this->level);
 	}
 
+	/**
+	 * @deprecated Use asLocation() instead getLocation()
+	 * 
+	 * @return Location
+	 */
 	public function getLocation(){
 		return new Location($this->x, $this->y, $this->z, $this->yaw, $this->pitch, $this->level);
 	}

--- a/src/pocketmine/level/Location.php
+++ b/src/pocketmine/level/Location.php
@@ -62,7 +62,7 @@ class Location extends Position{
 	 * 
 	 * @return Location
 	 */
-	public function asLocation() : Location {
+	public function asLocation() : Location{
 		return new Location($this->x, $this->y, $this->z, $this->yaw, $this->pitch, $this->level);
 	}
 

--- a/src/pocketmine/level/Location.php
+++ b/src/pocketmine/level/Location.php
@@ -57,6 +57,15 @@ class Location extends Position{
 		return new Location($pos->x, $pos->y, $pos->z, $yaw, $pitch, $level ?? (($pos instanceof Position) ? $pos->level : null));
 	}
 
+	/**
+	 * Return a Location instance
+	 * 
+	 * @return Location
+	 */
+	public function asLocation() : Location {
+		return new Location($this->x, $this->y, $this->z, $this->yaw, $this->pitch, $this->level);
+	}
+
 	public function getYaw(){
 		return $this->yaw;
 	}

--- a/src/pocketmine/level/Position.php
+++ b/src/pocketmine/level/Position.php
@@ -47,6 +47,15 @@ class Position extends Vector3{
 	}
 
 	/**
+	 * Return a Position instance
+	 * 
+	 * @return Position
+	 */
+	public function asPosition() : Position {
+		return new Position($this->x, $this->y, $this->z, $this->level);
+	}
+	
+	/**
 	 * Returns the target Level, or null if the target is not valid.
 	 * If a reference exists to a Level which is closed, the reference will be destroyed and null will be returned.
 	 *

--- a/src/pocketmine/level/Position.php
+++ b/src/pocketmine/level/Position.php
@@ -51,7 +51,7 @@ class Position extends Vector3{
 	 * 
 	 * @return Position
 	 */
-	public function asPosition() : Position {
+	public function asPosition() : Position{
 		return new Position($this->x, $this->y, $this->z, $this->level);
 	}
 	

--- a/src/pocketmine/math/Vector3.php
+++ b/src/pocketmine/math/Vector3.php
@@ -158,6 +158,15 @@ class Vector3{
 	}
 
 	/**
+	 * Return a Vector3 instance
+	 * 
+	 * @return Vector3
+	 */
+	public function asVector3() : Vector3 {
+		return new Vector3($this->x, $this->y, $this->z);
+	}
+
+	/**
 	 * Returns the Vector3 side number opposite the specified one
 	 *
 	 * @param int $side 0-5 one of the Vector3::SIDE_* constants

--- a/src/pocketmine/math/Vector3.php
+++ b/src/pocketmine/math/Vector3.php
@@ -162,7 +162,7 @@ class Vector3{
 	 * 
 	 * @return Vector3
 	 */
-	public function asVector3() : Vector3 {
+	public function asVector3() : Vector3{
 		return new Vector3($this->x, $this->y, $this->z);
 	}
 


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This pull request allow developers to get faster access to the block position without work around the level or its coordinates.
## Changes
### API changes
Added `Position::asPosition()` function.
Added `Location::asLocation()` function.
Added `Vector3::asVector3()` function.
Deprecated `Entity::getLocation()` function. _(Note by @SOF3: Undone while squash-merging)_
Deprecated `Entity::getPosition()` function. _(Note by @SOF3: Undone while squash-merging)_