### PR TITLE
Fixed type of empty ListTags and removed some undefined behaviour

### DIFF
--- a/src/pocketmine/nbt/tag/ListTag.php
+++ b/src/pocketmine/nbt/tag/ListTag.php
@@ -136,7 +136,7 @@ class ListTag extends NamedTag implements \ArrayAccess, \Countable{
 
 	public function write(NBT $nbt, bool $network = false){
 		if(!isset($this->tagType)){
-			$id = null;
+			$id = NBT::TAG_End; //MC defaults to TAG_End for empty lists
 			foreach($this as $tag){
 				if($tag instanceof Tag){
 					if(!isset($id)){

--- a/src/pocketmine/nbt/tag/ListTag.php
+++ b/src/pocketmine/nbt/tag/ListTag.php
@@ -27,7 +27,7 @@ use pocketmine\nbt\NBT;
 
 class ListTag extends NamedTag implements \ArrayAccess, \Countable{
 
-	private $tagType;
+	private $tagType = NBT::TAG_End;
 
 	public function __construct($name = "", $value = []){
 		$this->__name = $name;
@@ -113,11 +113,11 @@ class ListTag extends NamedTag implements \ArrayAccess, \Countable{
 		return NBT::TAG_List;
 	}
 
-	public function setTagType($type){
+	public function setTagType(int $type){
 		$this->tagType = $type;
 	}
 
-	public function getTagType(){
+	public function getTagType() : int{
 		return $this->tagType;
 	}
 
@@ -135,11 +135,11 @@ class ListTag extends NamedTag implements \ArrayAccess, \Countable{
 	}
 
 	public function write(NBT $nbt, bool $network = false){
-		if(!isset($this->tagType)){
-			$id = NBT::TAG_End; //MC defaults to TAG_End for empty lists
+		if($this->tagType === NBT::TAG_End){ //previously empty list, try detecting type from tag children
+			$id = NBT::TAG_End;
 			foreach($this as $tag){
-				if($tag instanceof Tag){
-					if(!isset($id)){
+				if($tag instanceof Tag and !($tag instanceof EndTag)){
+					if($id === NBT::TAG_End){
 						$id = $tag->getType();
 					}elseif($id !== $tag->getType()){
 						return false;


### PR DESCRIPTION
## Introduction
Empty list tags should (as of Minecraft 1.10 or thereabouts) have a tag type of TAG_End. They should certainly not be `null`. Due to weak types this previously caused a silent cast to `0`, which concealed this issue.

### Relevant issues
fixes #972 

## Changes
### Behavioural changes
fixed some unexpected behaviour

## Tests
```
			$item = Item::get(Item::APPLE, 0, 1);
			$item->setNamedTag(new CompoundTag("", [
				new ListTag("idk", [])
			]));
```
Previously to this PR, this code would cause the issue described in #962. This issue no longer occurs with the changes in this PR.
