### PR TITLE
Add Entity::isPlayer() and CommandSender::isPlayer() function

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1139,7 +1139,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		}
 
 		foreach($this->level->getNearbyEntities($this->boundingBox->grow(2, 1, 2), $this) as $p){
-			if($p instanceof Player){
+			if($p->isPlayer()){
 				if($p->sleeping !== null and $pos->distance($p->sleeping) <= 0.1){
 					return false;
 				}
@@ -2357,7 +2357,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
 					if(!$this->canInteract($target, 8)){
 						$cancelled = true;
-					}elseif($target instanceof Player){
+					}elseif($target->isPlayer()){
 						if(($target->getGamemode() & 0x01) > 0){
 							break;
 						}elseif($this->server->getConfigBoolean("pvp") !== true or $this->server->getDifficulty() === 0){
@@ -3796,7 +3796,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			case EntityDamageEvent::CAUSE_ENTITY_ATTACK:
 				if($cause instanceof EntityDamageByEntityEvent){
 					$e = $cause->getDamager();
-					if($e instanceof Player){
+					if($e->isPlayer()){
 						$message = "death.attack.player";
 						$params[] = $e->getDisplayName();
 						break;
@@ -3812,7 +3812,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			case EntityDamageEvent::CAUSE_PROJECTILE:
 				if($cause instanceof EntityDamageByEntityEvent){
 					$e = $cause->getDamager();
-					if($e instanceof Player){
+					if($e->isPlayer()){
 						$message = "death.attack.arrow";
 						$params[] = $e->getDisplayName();
 					}elseif($e instanceof Living){
@@ -3872,7 +3872,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			case EntityDamageEvent::CAUSE_ENTITY_EXPLOSION:
 				if($cause instanceof EntityDamageByEntityEvent){
 					$e = $cause->getDamager();
-					if($e instanceof Player){
+					if($e->isPlayer()){
 						$message = "death.attack.explosion.player";
 						$params[] = $e->getDisplayName();
 					}elseif($e instanceof Living){

--- a/src/pocketmine/command/CommandSender.php
+++ b/src/pocketmine/command/CommandSender.php
@@ -40,5 +40,9 @@ interface CommandSender extends Permissible{
 	 */
 	public function getName();
 
+	/**
+	 * @return bool
+	 */
+	public function isPlayer();
 
 }

--- a/src/pocketmine/command/defaults/GamemodeCommand.php
+++ b/src/pocketmine/command/defaults/GamemodeCommand.php
@@ -24,7 +24,6 @@ namespace pocketmine\command\defaults;
 use pocketmine\command\Command;
 use pocketmine\command\CommandSender;
 use pocketmine\event\TranslationContainer;
-use pocketmine\Player;
 use pocketmine\Server;
 use pocketmine\utils\TextFormat;
 
@@ -66,7 +65,7 @@ class GamemodeCommand extends VanillaCommand{
 
 				return true;
 			}
-		}elseif(!($sender instanceof Player)){
+		}elseif(!$sender->isPlayer()){
 			$sender->sendMessage(new TranslationContainer("commands.generic.usage", [$this->usageMessage]));
 
 			return true;

--- a/src/pocketmine/command/defaults/ListCommand.php
+++ b/src/pocketmine/command/defaults/ListCommand.php
@@ -23,7 +23,6 @@ namespace pocketmine\command\defaults;
 
 use pocketmine\command\CommandSender;
 use pocketmine\event\TranslationContainer;
-use pocketmine\Player;
 
 class ListCommand extends VanillaCommand{
 
@@ -45,7 +44,7 @@ class ListCommand extends VanillaCommand{
 		$onlineCount = 0;
 
 		foreach($sender->getServer()->getOnlinePlayers() as $player){
-			if($player->isOnline() and (!($sender instanceof Player) or $sender->canSee($player))){
+			if($player->isOnline() and (!$sender->isPlayer() or $sender->canSee($player))){
 				$online .= $player->getDisplayName() . ", ";
 				++$onlineCount;
 			}

--- a/src/pocketmine/command/defaults/MeCommand.php
+++ b/src/pocketmine/command/defaults/MeCommand.php
@@ -23,7 +23,6 @@ namespace pocketmine\command\defaults;
 
 use pocketmine\command\CommandSender;
 use pocketmine\event\TranslationContainer;
-use pocketmine\Player;
 use pocketmine\utils\TextFormat;
 
 class MeCommand extends VanillaCommand{
@@ -48,7 +47,7 @@ class MeCommand extends VanillaCommand{
 			return false;
 		}
 
-		$sender->getServer()->broadcastMessage(new TranslationContainer("chat.type.emote", [$sender instanceof Player ? $sender->getDisplayName() : $sender->getName(), TextFormat::WHITE . implode(" ", $args)]));
+		$sender->getServer()->broadcastMessage(new TranslationContainer("chat.type.emote", [$sender->isPlayer() ? $sender->getDisplayName() : $sender->getName(), TextFormat::WHITE . implode(" ", $args)]));
 
 		return true;
 	}

--- a/src/pocketmine/command/defaults/ParticleCommand.php
+++ b/src/pocketmine/command/defaults/ParticleCommand.php
@@ -54,7 +54,6 @@ use pocketmine\level\particle\TerrainParticle;
 use pocketmine\level\particle\WaterDripParticle;
 use pocketmine\level\particle\WaterParticle;
 use pocketmine\math\Vector3;
-use pocketmine\Player;
 use pocketmine\utils\Random;
 use pocketmine\utils\TextFormat;
 
@@ -80,7 +79,7 @@ class ParticleCommand extends VanillaCommand{
 			return true;
 		}
 
-		if($sender instanceof Player){
+		if($sender->isPlayer()){
 			$level = $sender->getLevel();
 		}else{
 			$level = $sender->getServer()->getDefaultLevel();

--- a/src/pocketmine/command/defaults/SayCommand.php
+++ b/src/pocketmine/command/defaults/SayCommand.php
@@ -24,7 +24,6 @@ namespace pocketmine\command\defaults;
 use pocketmine\command\CommandSender;
 use pocketmine\command\ConsoleCommandSender;
 use pocketmine\event\TranslationContainer;
-use pocketmine\Player;
 use pocketmine\utils\TextFormat;
 
 class SayCommand extends VanillaCommand{
@@ -49,7 +48,7 @@ class SayCommand extends VanillaCommand{
 			return false;
 		}
 
-		$sender->getServer()->broadcastMessage(new TranslationContainer(TextFormat::LIGHT_PURPLE . "%chat.type.announcement", [$sender instanceof Player ? $sender->getDisplayName() : ($sender instanceof ConsoleCommandSender ? "Server" : $sender->getName()), TextFormat::LIGHT_PURPLE . implode(" ", $args)]));
+		$sender->getServer()->broadcastMessage(new TranslationContainer(TextFormat::LIGHT_PURPLE . "%chat.type.announcement", [$sender->isPlayer() ? $sender->getDisplayName() : ($sender instanceof ConsoleCommandSender ? "Server" : $sender->getName()), TextFormat::LIGHT_PURPLE . implode(" ", $args)]));
 		return true;
 	}
 }

--- a/src/pocketmine/command/defaults/SeedCommand.php
+++ b/src/pocketmine/command/defaults/SeedCommand.php
@@ -23,7 +23,6 @@ namespace pocketmine\command\defaults;
 
 use pocketmine\command\CommandSender;
 use pocketmine\event\TranslationContainer;
-use pocketmine\Player;
 
 class SeedCommand extends VanillaCommand{
 
@@ -41,7 +40,7 @@ class SeedCommand extends VanillaCommand{
 			return true;
 		}
 
-		if($sender instanceof Player){
+		if($sender->isPlayer()){
 			$seed = $sender->getLevel()->getSeed();
 		}else{
 			$seed = $sender->getServer()->getDefaultLevel()->getSeed();

--- a/src/pocketmine/command/defaults/SetWorldSpawnCommand.php
+++ b/src/pocketmine/command/defaults/SetWorldSpawnCommand.php
@@ -25,7 +25,6 @@ use pocketmine\command\Command;
 use pocketmine\command\CommandSender;
 use pocketmine\event\TranslationContainer;
 use pocketmine\math\Vector3;
-use pocketmine\Player;
 use pocketmine\utils\TextFormat;
 
 class SetWorldSpawnCommand extends VanillaCommand{
@@ -45,7 +44,7 @@ class SetWorldSpawnCommand extends VanillaCommand{
 		}
 
 		if(count($args) === 0){
-			if($sender instanceof Player){
+			if($sender->isPlayer()){
 				$level = $sender->getLevel();
 				$pos = (new Vector3($sender->x, $sender->y, $sender->z))->round();
 			}else{

--- a/src/pocketmine/command/defaults/SpawnpointCommand.php
+++ b/src/pocketmine/command/defaults/SpawnpointCommand.php
@@ -25,7 +25,6 @@ use pocketmine\command\Command;
 use pocketmine\command\CommandSender;
 use pocketmine\event\TranslationContainer;
 use pocketmine\level\Position;
-use pocketmine\Player;
 use pocketmine\utils\TextFormat;
 
 class SpawnpointCommand extends VanillaCommand{
@@ -47,7 +46,7 @@ class SpawnpointCommand extends VanillaCommand{
 		$target = null;
 
 		if(count($args) === 0){
-			if($sender instanceof Player){
+			if($sender->isPlayer()){
 				$target = $sender;
 			}else{
 				$sender->sendMessage(TextFormat::RED . "Please provide a player!");
@@ -67,7 +66,7 @@ class SpawnpointCommand extends VanillaCommand{
 
 		if(count($args) === 4){
 			if($level !== null){
-				$pos = $sender instanceof Player ? $sender->getPosition() : $level->getSpawnLocation();
+				$pos = $sender->isPlayer() ? $sender->getPosition() : $level->getSpawnLocation();
 				$x = (int) $this->getRelativeDouble($pos->x, $sender, $args[1]);
 				$y = $this->getRelativeDouble($pos->y, $sender, $args[2], 0, 128);
 				$z = $this->getRelativeDouble($pos->z, $sender, $args[3]);
@@ -78,7 +77,7 @@ class SpawnpointCommand extends VanillaCommand{
 				return true;
 			}
 		}elseif(count($args) <= 1){
-			if($sender instanceof Player){
+			if($sender->isPlayer()){
 				$pos = new Position((int) $sender->x, (int) $sender->y, (int) $sender->z, $sender->getLevel());
 				$target->setSpawn($pos);
 

--- a/src/pocketmine/command/defaults/TeleportCommand.php
+++ b/src/pocketmine/command/defaults/TeleportCommand.php
@@ -25,7 +25,6 @@ use pocketmine\command\Command;
 use pocketmine\command\CommandSender;
 use pocketmine\event\TranslationContainer;
 use pocketmine\math\Vector3;
-use pocketmine\Player;
 use pocketmine\utils\TextFormat;
 
 class TeleportCommand extends VanillaCommand{
@@ -57,7 +56,7 @@ class TeleportCommand extends VanillaCommand{
 		$origin = $sender;
 
 		if(count($args) === 1 or count($args) === 3){
-			if($sender instanceof Player){
+			if($sender->isPlayer()){
 				$target = $sender;
 			}else{
 				$sender->sendMessage(TextFormat::RED . "Please provide a player!");

--- a/src/pocketmine/command/defaults/TellCommand.php
+++ b/src/pocketmine/command/defaults/TellCommand.php
@@ -60,7 +60,7 @@ class TellCommand extends VanillaCommand{
 
 		if($player instanceof Player){
 			$sender->sendMessage("[{$sender->getName()} -> {$player->getDisplayName()}] " . implode(" ", $args));
-			$name = $sender instanceof Player ? $sender->getDisplayName() : $sender->getName();
+			$name = $sender->isPlayer() ? $sender->getDisplayName() : $sender->getName();
 			$player->sendMessage("[$name -> {$player->getName()}] " . implode(" ", $args));
 		}else{
 			$sender->sendMessage(new TranslationContainer("commands.generic.player.notFound"));

--- a/src/pocketmine/command/defaults/TimeCommand.php
+++ b/src/pocketmine/command/defaults/TimeCommand.php
@@ -25,7 +25,6 @@ use pocketmine\command\Command;
 use pocketmine\command\CommandSender;
 use pocketmine\event\TranslationContainer;
 use pocketmine\level\Level;
-use pocketmine\Player;
 use pocketmine\utils\TextFormat;
 
 class TimeCommand extends VanillaCommand{
@@ -78,7 +77,7 @@ class TimeCommand extends VanillaCommand{
 
 				return true;
 			}
-			if($sender instanceof Player){
+			if($sender->isPlayer()){
 				$level = $sender->getLevel();
 			}else{
 				$level = $sender->getServer()->getDefaultLevel();

--- a/src/pocketmine/command/defaults/TimingsCommand.php
+++ b/src/pocketmine/command/defaults/TimingsCommand.php
@@ -24,7 +24,6 @@ namespace pocketmine\command\defaults;
 use pocketmine\command\CommandSender;
 use pocketmine\event\TimingsHandler;
 use pocketmine\event\TranslationContainer;
-use pocketmine\Player;
 use pocketmine\scheduler\BulkCurlTask;
 use pocketmine\Server;
 
@@ -115,7 +114,7 @@ class TimingsCommand extends VanillaCommand{
 				], $sender) extends BulkCurlTask{
 					public function onCompletion(Server $server){
 						$sender = $this->fetchLocal($server);
-						if($sender instanceof Player and !$sender->isOnline()){ // TODO replace with a more generic API method for checking availability of CommandSender
+						if($sender->isPlayer() and !$sender->isOnline()){ // TODO replace with a more generic API method for checking availability of CommandSender
 							return;
 						}
 						$result = $this->getResult()[0];

--- a/src/pocketmine/command/defaults/TransferServerCommand.php
+++ b/src/pocketmine/command/defaults/TransferServerCommand.php
@@ -25,7 +25,6 @@ namespace pocketmine\command\defaults;
 
 use pocketmine\command\CommandSender;
 use pocketmine\event\TranslationContainer;
-use pocketmine\Player;
 
 class TransferServerCommand extends VanillaCommand{
 
@@ -43,7 +42,7 @@ class TransferServerCommand extends VanillaCommand{
 			$sender->sendMessage(new TranslationContainer("commands.generic.usage", [$this->usageMessage]));
 
 			return false;
-		}elseif(!($sender instanceof Player)){
+		}elseif(!$sender->isPlayer()){
 			$sender->sendMessage("This command must be executed as a player");
 
 			return false;

--- a/src/pocketmine/entity/Effect.php
+++ b/src/pocketmine/entity/Effect.php
@@ -27,7 +27,6 @@ use pocketmine\event\entity\EntityEffectRemoveEvent;
 use pocketmine\event\entity\EntityRegainHealthEvent;
 use pocketmine\event\player\PlayerExhaustEvent;
 use pocketmine\network\mcpe\protocol\MobEffectPacket;
-use pocketmine\Player;
 use pocketmine\utils\Config;
 
 class Effect{
@@ -394,7 +393,7 @@ class Effect{
 		if($ev->isCancelled()){
 			return;
 		}
-		if($entity instanceof Player){
+		if($entity->isPlayer()){
 			$pk = new MobEffectPacket();
 			$pk->entityRuntimeId = $entity->getId();
 			$pk->effectId = $this->getId();
@@ -466,7 +465,7 @@ class Effect{
 		if($ev->isCancelled()){
 			return;
 		}
-		if($entity instanceof Player){
+		if($entity->isPlayer()){
 			$pk = new MobEffectPacket();
 			$pk->entityRuntimeId = $entity->getId();
 			$pk->eventId = MobEffectPacket::EVENT_REMOVE;

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -533,6 +533,15 @@ abstract class Entity extends Location implements Metadatable{
 	}
 
 	/**
+	 * Returns whether this entity is a player.
+	 *
+	 * @return bool
+	 */
+	public function isPlayer() :  bool{
+		return $this->isPlayer;
+	}
+
+	/**
 	 * Returns the entity ID of the owning entity, or null if the entity doesn't have an owner.
 	 * @return int|string|null
 	 */
@@ -732,7 +741,7 @@ abstract class Entity extends Location implements Metadatable{
 	}
 
 	public function saveNBT(){
-		if(!($this instanceof Player)){
+		if(!$this->isPlayer()){
 			$this->namedtag->id = new StringTag("id", $this->getSaveId());
 			if($this->getNameTag() !== ""){
 				$this->namedtag->CustomName = new StringTag("CustomName", $this->getNameTag());
@@ -865,7 +874,7 @@ abstract class Entity extends Location implements Metadatable{
 			$p->dataPacket(clone $pk);
 		}
 
-		if($this instanceof Player){
+		if($this->isPlayer()){
 			$this->dataPacket($pk);
 		}
 	}
@@ -1264,7 +1273,7 @@ abstract class Entity extends Location implements Metadatable{
 
 		//if($this->isStatic())
 		return $hasUpdate;
-		//return !($this instanceof Player);
+		//return !$this->isPlayer();
 	}
 
 	final public function scheduleUpdate(){
@@ -1489,7 +1498,7 @@ abstract class Entity extends Location implements Metadatable{
 
 			$axisalignedbb = clone $this->boundingBox;
 
-			/*$sneakFlag = $this->onGround and $this instanceof Player;
+			/*$sneakFlag = $this->onGround and $this->isPlayer();
 
 			if($sneakFlag){
 				for($mov = 0.05; $dx != 0.0 and count($this->level->getCollisionCubes($this, $this->boundingBox->getOffsetBoundingBox($dx, -1, 0))) === 0; $movX = $dx){

--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -280,7 +280,7 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 		$this->setDataProperty(self::DATA_PLAYER_BED_POSITION, self::DATA_TYPE_POS, [0, 0, 0], false);
 
 		$this->inventory = new PlayerInventory($this);
-		if($this instanceof Player){
+		if($this->isPlayer()){
 			$this->addWindow($this->inventory, 0);
 		}else{
 			if(isset($this->namedtag->NameTag)){
@@ -497,7 +497,7 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 				throw new \InvalidStateException((new \ReflectionClass($this))->getShortName() . " must have a valid skin set");
 			}
 
-			if(!($this instanceof Player)){
+			if(!$this->isPlayer()){
 				$this->server->updatePlayerListData($this->getUniqueId(), $this->getId(), $this->getName(), $this->skinId, $this->skin, [$player]);
 			}
 
@@ -519,7 +519,7 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 
 			$this->inventory->sendArmorContents($player);
 
-			if(!($this instanceof Player)){
+			if(!$this->isPlayer()){
 				$this->server->removePlayerListData($this->getUniqueId(), [$player]);
 			}
 		}

--- a/src/pocketmine/entity/Zombie.php
+++ b/src/pocketmine/entity/Zombie.php
@@ -59,7 +59,7 @@ class Zombie extends Monster{
 		$drops = [
 			ItemItem::get(ItemItem::FEATHER, 0, 1)
 		];
-		if($this->lastDamageCause instanceof EntityDamageByEntityEvent and $this->lastDamageCause->getEntity() instanceof Player){
+		if($this->lastDamageCause instanceof EntityDamageByEntityEvent and $this->lastDamageCause->getEntity()->isPlayer()){
 			if(mt_rand(0, 199) < 5){
 				switch(mt_rand(0, 2)){
 					case 0:

--- a/src/pocketmine/event/Timings.php
+++ b/src/pocketmine/event/Timings.php
@@ -23,7 +23,6 @@ namespace pocketmine\event;
 
 use pocketmine\entity\Entity;
 use pocketmine\network\mcpe\protocol\DataPacket;
-use pocketmine\Player;
 use pocketmine\plugin\PluginManager;
 use pocketmine\scheduler\PluginTask;
 use pocketmine\scheduler\TaskHandler;
@@ -206,7 +205,7 @@ abstract class Timings{
 	public static function getEntityTimings(Entity $entity){
 		$entityType = (new \ReflectionClass($entity))->getShortName();
 		if(!isset(self::$entityTypeTimingMap[$entityType])){
-			if($entity instanceof Player){
+			if($entity->isPlayer()){
 				self::$entityTypeTimingMap[$entityType] = new TimingsHandler("** tickEntity - EntityPlayer", self::$tickEntityTimer);
 			}else{
 				self::$entityTypeTimingMap[$entityType] = new TimingsHandler("** tickEntity - " . $entityType, self::$tickEntityTimer);

--- a/src/pocketmine/item/Food.php
+++ b/src/pocketmine/item/Food.php
@@ -25,7 +25,6 @@ use pocketmine\entity\Entity;
 use pocketmine\entity\Human;
 use pocketmine\event\entity\EntityEatItemEvent;
 use pocketmine\network\mcpe\protocol\EntityEventPacket;
-use pocketmine\Player;
 
 abstract class Food extends Item implements FoodSource{
 	public function canBeConsumed() : bool{
@@ -54,7 +53,7 @@ abstract class Food extends Item implements FoodSource{
 		$pk = new EntityEventPacket();
 		$pk->entityRuntimeId = $human->getId();
 		$pk->event = EntityEventPacket::USE_ITEM;
-		if($human instanceof Player){
+		if($human->isPlayer()){
 			$human->dataPacket($pk);
 		}
 		$human->getLevel()->getServer()->broadcastPacket($human->getViewers(), $pk);

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -2446,7 +2446,7 @@ class Level implements ChunkManager, Metadatable{
 			throw new LevelException("Invalid Entity level");
 		}
 
-		if($entity instanceof Player){
+		if($entity->isPlayer()){
 			unset($this->players[$entity->getId()]);
 			$this->checkSleep();
 		}else{
@@ -2466,7 +2466,7 @@ class Level implements ChunkManager, Metadatable{
 		if($entity->getLevel() !== $this){
 			throw new LevelException("Invalid Entity level");
 		}
-		if($entity instanceof Player){
+		if($entity->isPlayer()){
 			$this->players[$entity->getId()] = $entity;
 		}
 		$this->entities[$entity->getId()] = $entity;
@@ -2605,7 +2605,7 @@ class Level implements ChunkManager, Metadatable{
 				if($trySave and $this->getAutoSave() and $chunk->isGenerated()){
 					$entities = 0;
 					foreach($chunk->getEntities() as $e){
-						if($e instanceof Player){
+						if($e->isPlayer()){
 							continue;
 						}
 						++$entities;

--- a/src/pocketmine/level/format/Chunk.php
+++ b/src/pocketmine/level/format/Chunk.php
@@ -32,7 +32,6 @@ use pocketmine\level\format\io\ChunkException;
 use pocketmine\level\Level;
 use pocketmine\nbt\NBT;
 use pocketmine\nbt\tag\CompoundTag;
-use pocketmine\Player;
 use pocketmine\tile\Spawnable;
 use pocketmine\tile\Tile;
 use pocketmine\utils\BinaryStream;
@@ -584,7 +583,7 @@ class Chunk{
 			throw new \InvalidArgumentException("Attempted to add a garbage closed Entity to a chunk");
 		}
 		$this->entities[$entity->getId()] = $entity;
-		if(!($entity instanceof Player) and $this->isInit){
+		if(!$entity->isPlayer() and $this->isInit){
 			$this->hasChanged = true;
 		}
 	}
@@ -594,7 +593,7 @@ class Chunk{
 	 */
 	public function removeEntity(Entity $entity){
 		unset($this->entities[$entity->getId()]);
-		if(!($entity instanceof Player) and $this->isInit){
+		if(!$entity->isPlayer() and $this->isInit){
 			$this->hasChanged = true;
 		}
 	}
@@ -667,14 +666,14 @@ class Chunk{
 	public function unload(bool $safe = true) : bool{
 		if($safe){
 			foreach($this->getEntities() as $entity){
-				if($entity instanceof Player){
+				if($entity->isPlayer()){
 					return false;
 				}
 			}
 		}
 
 		foreach($this->getEntities() as $entity){
-			if($entity instanceof Player){
+			if($entity->isPlayer()){
 				continue;
 			}
 			$entity->close();

--- a/src/pocketmine/level/format/io/region/Anvil.php
+++ b/src/pocketmine/level/format/io/region/Anvil.php
@@ -31,7 +31,6 @@ use pocketmine\nbt\NBT;
 use pocketmine\nbt\tag\{
 	ByteArrayTag, ByteTag, CompoundTag, IntArrayTag, IntTag, ListTag, LongTag
 };
-use pocketmine\Player;
 use pocketmine\utils\MainLogger;
 
 class Anvil extends McRegion{
@@ -71,7 +70,7 @@ class Anvil extends McRegion{
 		$entities = [];
 
 		foreach($chunk->getEntities() as $entity){
-			if(!($entity instanceof Player) and !$entity->closed){
+			if(!$entity->isPlayer() and !$entity->closed){
 				$entity->saveNBT();
 				$entities[] = $entity->namedtag;
 			}

--- a/src/pocketmine/level/format/io/region/McRegion.php
+++ b/src/pocketmine/level/format/io/region/McRegion.php
@@ -34,7 +34,6 @@ use pocketmine\nbt\NBT;
 use pocketmine\nbt\tag\{
 	ByteArrayTag, ByteTag, CompoundTag, IntArrayTag, IntTag, ListTag, LongTag, StringTag
 };
-use pocketmine\Player;
 use pocketmine\utils\MainLogger;
 
 class McRegion extends BaseLevelProvider{
@@ -89,7 +88,7 @@ class McRegion extends BaseLevelProvider{
 		$entities = [];
 
 		foreach($chunk->getEntities() as $entity){
-			if(!($entity instanceof Player) and !$entity->closed){
+			if(!$entity->isPlayer() and !$entity->closed){
 				$entity->saveNBT();
 				$entities[] = $entity->namedtag;
 			}

--- a/src/pocketmine/level/format/io/region/PMAnvil.php
+++ b/src/pocketmine/level/format/io/region/PMAnvil.php
@@ -30,7 +30,6 @@ use pocketmine\nbt\NBT;
 use pocketmine\nbt\tag\{
 	ByteArrayTag, ByteTag, CompoundTag, IntArrayTag, IntTag, ListTag, LongTag
 };
-use pocketmine\Player;
 use pocketmine\utils\MainLogger;
 
 /**
@@ -74,7 +73,7 @@ class PMAnvil extends Anvil{
 		$entities = [];
 
 		foreach($chunk->getEntities() as $entity){
-			if(!($entity instanceof Player) and !$entity->closed){
+			if(!$entity->isPlayer() and !$entity->closed){
 				$entity->saveNBT();
 				$entities[] = $entity->namedtag;
 			}


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

I believe this was an incomplete piece of PocketMine. Entity::$isPlayer existed and so did ConsoleCommandSender::isPlayer(). I assume these were added for the very reason to remove instanceof checks.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Added `Entity::isPlayer()` function which returns true if the entity is an instance of Player.
Any class extending CommandSender will now be required to have an `isPlayer()` function which should return a boolean value.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
None

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
This commit(s) is/are backwards compatible and don't break anything.

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
```php
/** @var \pocketmine\entity\Item $itemEntity */
var_dump($itemEntity->isPlayer()); //returns false

/** @var Human $human */
var_dump($human->isPlayer()); //returns false

/** @var Player $player */
var_dump($player->isPlayer()); //returns true
```



