### PR TITLE
Added Plugins section to the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -25,6 +25,12 @@ ALSO NOTE: NO support whatsoever will be provided for forks or spoons of PocketM
 * Server OS:
 * Game version: PE/Win10 (delete as appropriate)
 
+### Plugins
+- Test on a clean server without plugins: is the issue reproducible without any plugins loaded?
+- If it is not, have you asked for help on our forums before creating an issue?
+- Can you provide sample, *minimal* reproducing code for the issue? If so, paste it in the bottom section
+- Paste your list of plugins here (use the 'plugins' command in PocketMine-MP)
+
 ### Crashdump, backtrace or other files
 <!--- please use gist or anything else and add links here -->
 * ...

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -27,7 +27,9 @@ ALSO NOTE: NO support whatsoever will be provided for forks or spoons of PocketM
 
 ### Plugins
 - Test on a clean server without plugins: is the issue reproducible without any plugins loaded?
-- If it is not, have you asked for help on our forums before creating an issue?
+
+If the issue is **not** reproducible without plugins:
+- Have you asked for help on our forums before creating an issue?
 - Can you provide sample, *minimal* reproducing code for the issue? If so, paste it in the bottom section
 - Paste your list of plugins here (use the 'plugins' command in PocketMine-MP)
 


### PR DESCRIPTION
## Introduction
more detail on how to handle plugins when a crash occurs.

It's very tiring when people keep creating issues on the repository about their plugins suddenly crashing due to core changes which haven't been dealt with by the plugin author. I've altered the issue template to ask for the following details:
- Is the issue reproducible without any plugins loaded?
- If not, has the issue creator asked for help on the forums before creating the issue?
- Can the creator provide reproducing code if this is an API issue?

### Relevant issues
more than I can be bothered listing