### PR TITLE
Chunk of changes involving chunks

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -4043,7 +4043,6 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			return false;
 		}
 
-		$oldPos = $this->getPosition();
 		if(parent::teleport($pos, $yaw, $pitch)){
 
 			foreach($this->windowIndex as $window){

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -333,8 +333,8 @@ class Level implements ChunkManager, Metadatable{
 
 		$this->chunkTickRadius = min($this->server->getViewDistance(), max(1, (int) $this->server->getProperty("chunk-ticking.tick-radius", 4)));
 		$this->chunksPerTick = (int) $this->server->getProperty("chunk-ticking.per-tick", 40);
-		$this->chunkGenerationQueueSize = (int) $this->server->getProperty("chunk-generation.queue-size", 8);
-		$this->chunkPopulationQueueSize = (int) $this->server->getProperty("chunk-generation.population-queue-size", 2);
+		$this->chunkGenerationQueueSize = (int) $this->server->getProperty("chunk-generation.queue-size", 8) === 0 ? 1 : (int) $this->server->getProperty("chunk-generation.queue-size", 8);
+		$this->chunkPopulationQueueSize = (int) $this->server->getProperty("chunk-generation.population-queue-size", 2) === 0 ? 1 : (int) $this->server->getProperty("chunk-generation.population-queue-size", 2);
 		$this->chunkTickList = [];
 		$this->clearChunksOnTick = (bool) $this->server->getProperty("chunk-ticking.clear-tick-list", true);
 		$this->cacheChunks = (bool) $this->server->getProperty("chunk-sending.cache-chunks", false);

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -333,8 +333,8 @@ class Level implements ChunkManager, Metadatable{
 
 		$this->chunkTickRadius = min($this->server->getViewDistance(), max(1, (int) $this->server->getProperty("chunk-ticking.tick-radius", 4)));
 		$this->chunksPerTick = (int) $this->server->getProperty("chunk-ticking.per-tick", 40);
-		$this->chunkGenerationQueueSize = (int) $this->server->getProperty("chunk-generation.queue-size", 8) === 0 ? 1 : (int) $this->server->getProperty("chunk-generation.queue-size", 8);
-		$this->chunkPopulationQueueSize = (int) $this->server->getProperty("chunk-generation.population-queue-size", 2) === 0 ? 1 : (int) $this->server->getProperty("chunk-generation.population-queue-size", 2);
+		$this->chunkGenerationQueueSize = (int) $this->server->getProperty("chunk-generation.queue-size", 8);
+		$this->chunkPopulationQueueSize = (int) $this->server->getProperty("chunk-generation.population-queue-size", 2) <= 0 ? 1 : (int) $this->server->getProperty("chunk-generation.population-queue-size", 2);
 		$this->chunkTickList = [];
 		$this->clearChunksOnTick = (bool) $this->server->getProperty("chunk-ticking.clear-tick-list", true);
 		$this->cacheChunks = (bool) $this->server->getProperty("chunk-sending.cache-chunks", false);


### PR DESCRIPTION
# About
This pull request fixes a good chunk of bugs involving chunks.

### What’s fixed/changed:
- Chunks no longer order twice during login.
- Fixed chunks ordering twice when Player::teleportImmediate() is called.
- Fixed (or hack-fixed) getting stuck during teleports. (That nasty bug where you are stuck in a teleport limbo and all you can see is void)
- This also fixes the respawn bug issue, where again once you click re-spawn all you see is void.
- PocketMine now corrects the value of the chunk population ~and generation~ queue size if its below one. This is because the server won’t work properly if ~these~ this value~s~ ~are~ is below one, and players won’t be able to spawn.
- Removed delayed teleports.

###  Performance improvements:
- Chunks are no longer ordered on a schedule. They will be ordered when a player moves around in relationship to your servers view distance.
- Chunks are no longer ordered twice on logins.

### Why change to a new non-schedule ordering system?
It’s a waste of CPU to order chunks on schedule. If you have a lot of players it could impact performance as well. The old system ordered chunks every 200 ticks if a player is idle, and if the player starts moving it would order chunks every 20 ticks. This caused orderChunks() to unnecessarily waste server CPU. Also idle players don't need there chunks ordered every 200 ticks.

### The new system:
The players view distance is taken (example: 8). It is then multiplied by 20 and that will be the players nextChunkOrderRun reset value. 8*20= 160, meaning each valid player movement will subtract this value by one or two if the player is sprinting, and when it reaches 0 chunks will be ordered. This system makes it so chunks order only as often as needed too, if the view distance is high, chunks won’t have to order as much (vice versa).

### Teleporting fixes:
This is more of a hack fix, so changes may need to be made here before merging. During delayed teleports, the $forceMovement Vector3 object interferes with the players teleport process. The client will start to spazz out as PocketMine is telling the client to go to different directions. This PR removes forceMovement from the teleport process. This may cause some problems, and unintended side-effects.

**Small cosmetic change: If check teleport position evaluates to true, spawnToAll does not need to be called again.**

### Immediate teleport:
Fixed a silly typo that ordered chunks twice.

### API changes:
Backwards compatible changes; plugins that are coded properly will not break. The two API changes are as follows:
- Added $orderChunks bool to teleport() function.
- Added $orderChunks bool to setViewDistance() function.
- Deprecated teleportImmediate().

 This PR may fix #530 joining's issue. Though I can confirm it fixes the respawning bug reported there. It also knocks off a item off #262 (non-scheduled ordering system). Current concerns are the effects of removing $forceMovement from the teleport process. WIP.