### PR TITLE
Added missing fields to server name for ping responses

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -440,6 +440,21 @@ class Server{
 		return "UNKNOWN";
 	}
 
+	public static function getGamemodeName(int $mode) : string{
+		switch($mode){
+			case Player::SURVIVAL:
+				return "Survival";
+			case Player::CREATIVE:
+				return "Creative";
+			case Player::ADVENTURE:
+				return "Adventure";
+			case Player::SPECTATOR:
+				return "Spectator";
+			default:
+				throw new \InvalidArgumentException("Invalid gamemode $mode");
+		}
+	}
+
 	/**
 	 * Parses a string and returns a gamemode integer, -1 if not found
 	 *

--- a/src/pocketmine/network/SourceInterface.php
+++ b/src/pocketmine/network/SourceInterface.php
@@ -58,7 +58,7 @@ interface SourceInterface{
 	/**
 	 * @param string $name
 	 */
-	public function setName($name);
+	public function setName(string $name);
 
 	/**
 	 * @return bool

--- a/src/pocketmine/network/mcpe/RakLibInterface.php
+++ b/src/pocketmine/network/mcpe/RakLibInterface.php
@@ -165,15 +165,21 @@ class RakLibInterface implements ServerInstance, AdvancedSourceInterface{
 
 	}
 
-	public function setName($name){
+	public function setName(string $name){
 		$info = $this->server->getQueryInformation();
 
-		$this->interface->sendOption("name",
-			"MCPE;" . rtrim(addcslashes($name, ";"), '\\') . ";" .
-			ProtocolInfo::CURRENT_PROTOCOL . ";" .
-			ProtocolInfo::MINECRAFT_VERSION_NETWORK . ";" .
-			$info->getPlayerCount() . ";" .
-			$info->getMaxPlayerCount()
+		$this->interface->sendOption("name", implode(";",
+			[
+				"MCPE",
+				rtrim(addcslashes($name, ";"), '\\'),
+				ProtocolInfo::CURRENT_PROTOCOL,
+				ProtocolInfo::MINECRAFT_VERSION_NETWORK,
+				$info->getPlayerCount(),
+				$info->getMaxPlayerCount(),
+				"-1",
+				$this->server->getName(),
+				Server::getGamemodeName($this->server->getGamemode())
+			])
 		);
 	}
 


### PR DESCRIPTION
## Introduction
This data is used to send back responses when a client pings the server, to show the server in the server list. However, there were 3 fields missing that vanilla MCPE sends that PocketMine-MP was not:

- world seed - Specified as `-1`, since with multiple worlds, which seed do you pick?
- host name - In vanilla this would be the name of the player hosting the multiplayer game.
- gamemode - Server global gamemode.

This pull request will also provide a quick way to identify a PocketMine-MP server based on its ping response.

There are some unconfirmed bugs with this such as servers appearing in the wrong place in the server list if the list contains servers which do not include these extra fields. Please test and review.

## Changes
### API changes
- Added API method `Server::getGamemodeName(int $gamemode)`

### Behavioural changes
- Server ping response now includes previously missing fields.