### PR TITLE
Fixes MCPE syntax checked command parameters being ordered wrongly

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3361,8 +3361,9 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			$mergedOrderedParameters = array_merge($optionalParameters, $nonOptionalParameters);
 
 			$inputJson = $packet->inputJson;
+			$i = 0;
 			foreach($packet->inputJson as $key => $arg){
-				$inputJson[$mergedOrderedParameters[$key]["key"]] = $arg;
+				$inputJson[$mergedOrderedParameters[$i++][$key]["key"]] = $arg;
 			}
 			foreach($inputJson as $key => $arg){
 				$commandText .= " " . $arg;

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3345,7 +3345,18 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 				$nonOptionalParameters[$key] = $overload;
 			}
 		}
-		$mergedOrderedParameters = array_merge(sort($optionalParameters), sort($nonOptionalParameters));
+		$optionalSortingArray = [];
+		foreach($optionalParameters as $key => $parameter){
+			$optionalSortingArray[$key] = $parameter["name"];
+		}
+		$nonOptionalSortingArray = [];
+		foreach($nonOptionalParameters as $key => $parameter){
+			$nonOptionalSortingArray[$key] = $parameter["name"];
+		}
+		array_multisort($optionalSortingArray, $optionalParameters);
+		array_multisort($nonOptionalSortingArray, $nonOptionalParameters);
+
+		$mergedOrderedParameters = array_merge($optionalParameters, $nonOptionalParameters);
 
 		$inputJson = $packet->inputJson;
 		foreach($packet->inputJson as $key => $arg){

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3329,44 +3329,46 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		if($this->spawned === false or !$this->isAlive()){
 			return true;
 		}
-		$this->craftingType = 0;
 		$commandText = $packet->command;
-		$command = $this->getServer()->getCommandMap()->getCommand($packet->command);
-		$overloads = $command->getOverloads()["default"]["input"]["parameters"];
+		$this->craftingType = 0;
 
-		$optionalParameters = [];
-		$nonOptionalParameters = [];
-		foreach($overloads as $key => $overload){
-			if($overload["optional"] === true){
-				$overload["key"] = $key;
-				$optionalParameters[$key] = $overload;
-			} elseif($overload["optional"] === false){
-				$overload["key"] = $key;
-				$nonOptionalParameters[$key] = $overload;
+		if($packet->inputJson !== null){
+			$command = $this->getServer()->getCommandMap()->getCommand($commandText);
+			$overloads = $command->getOverloads()["default"]["input"]["parameters"];
+
+			$optionalParameters = [];
+			$nonOptionalParameters = [];
+			foreach($overloads as $key => $overload){
+				if($overload["optional"] === true){
+					$overload["key"] = $key;
+					$optionalParameters[$key] = $overload;
+				} elseif($overload["optional"] === false){
+					$overload["key"] = $key;
+					$nonOptionalParameters[$key] = $overload;
+				}
 			}
-		}
-		$optionalSortingArray = [];
-		foreach($optionalParameters as $key => $parameter){
-			$optionalSortingArray[$key] = $parameter["name"];
-		}
-		$nonOptionalSortingArray = [];
-		foreach($nonOptionalParameters as $key => $parameter){
-			$nonOptionalSortingArray[$key] = $parameter["name"];
-		}
-		array_multisort($optionalSortingArray, $optionalParameters);
-		array_multisort($nonOptionalSortingArray, $nonOptionalParameters);
+			$optionalSortingArray = [];
+			foreach($optionalParameters as $key => $parameter){
+				$optionalSortingArray[$key] = $parameter["name"];
+			}
+			$nonOptionalSortingArray = [];
+			foreach($nonOptionalParameters as $key => $parameter){
+				$nonOptionalSortingArray[$key] = $parameter["name"];
+			}
+			array_multisort($optionalSortingArray, $optionalParameters);
+			array_multisort($nonOptionalSortingArray, $nonOptionalParameters);
 
-		$mergedOrderedParameters = array_merge($optionalParameters, $nonOptionalParameters);
+			$mergedOrderedParameters = array_merge($optionalParameters, $nonOptionalParameters);
 
-		$inputJson = $packet->inputJson;
-		foreach($packet->inputJson as $key => $arg){
-			$inputJson[$mergedOrderedParameters[$key]["key"]] = $arg;
-		}
-		if($inputJson !== null){
+			$inputJson = $packet->inputJson;
+			foreach($packet->inputJson as $key => $arg){
+				$inputJson[$mergedOrderedParameters[$key]["key"]] = $arg;
+			}
 			foreach($inputJson as $key => $arg){
 				$commandText .= " " . $arg;
 			}
 		}
+
 		$this->server->getPluginManager()->callEvent($ev = new PlayerCommandPreprocessEvent($this, "/" . $commandText));
 		if($ev->isCancelled()){
 			return true;

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3363,7 +3363,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			$inputJson = $packet->inputJson;
 			$i = 0;
 			foreach($packet->inputJson as $key => $arg){
-				$inputJson[$mergedOrderedParameters[$i++][$key]["key"]] = $arg;
+				$inputJson[$mergedOrderedParameters[$i++]["key"]] = $arg;
 			}
 			foreach($inputJson as $key => $arg){
 				$commandText .= " " . $arg;

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3341,11 +3341,11 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 				$overload["key"] = $key;
 				$optionalParameters[$key] = $overload;
 			} elseif($overload["optional"] === false){
-				$overload["key"] = $key + count($optionalParameters);
+				$overload["key"] = $key;
 				$nonOptionalParameters[$key] = $overload;
 			}
 		}
-		$mergedOrderedParameters = array_merge(arsort($optionalParameters), arsort($nonOptionalParameters));
+		$mergedOrderedParameters = array_merge(sort($optionalParameters), sort($nonOptionalParameters));
 
 		$inputJson = $packet->inputJson;
 		foreach($packet->inputJson as $key => $arg){


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
An issue exists with the ordering of command parameters when making use of the MCPE command parameter syntax checking, having to do with the ordering of parameters, because these are ordered alphabetically client sided. (Issue can be found mentioned here: https://github.com/pmmp/PocketMine-MP/blob/master/src/pocketmine/Player.php#L3335)

This issue aims to place the arguments back on their original position to fix the issue of commands being ordered alphabetically.

For clarification:
MCPE syntax checking devides the parameters in two groups, the optional ones and the non-optional ones. Both these groups get sorted alphabetically seperately, and get merged together after this has been done. 

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
Attempts to fix the issue mentioned here: https://github.com/BlockHorizons/BlockPets/issues/5, due to the parameters being ordered incorrectly and messing up things.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
No API changes.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
Now orders parameters correctly before building the command line.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
There is no backwards incompatibility in this pull request.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
**Requires Testing**. I currently have no way to test this pull request, as my only laptop is a 32 bit one. I'll try to test this as soon as possible.

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
Hopefully soon to come.