### PR TITLE
Removed useless confusing array indices in CompoundTag constructors

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2532,17 +2532,17 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
 			if($item->getId() === Item::SNOWBALL){
 				$nbt = new CompoundTag("", [
-					"Pos" => new ListTag("Pos", [
+					new ListTag("Pos", [
 						new DoubleTag("", $this->x),
 						new DoubleTag("", $this->y + $this->getEyeHeight()),
 						new DoubleTag("", $this->z)
 					]),
-					"Motion" => new ListTag("Motion", [
+					new ListTag("Motion", [
 						new DoubleTag("", $aimPos->x),
 						new DoubleTag("", $aimPos->y),
 						new DoubleTag("", $aimPos->z)
 					]),
-					"Rotation" => new ListTag("Rotation", [
+					new ListTag("Rotation", [
 						new FloatTag("", $this->yaw),
 						new FloatTag("", $this->pitch)
 					]),
@@ -2627,22 +2627,22 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 						}
 
 						$nbt = new CompoundTag("", [
-							"Pos" => new ListTag("Pos", [
+							new ListTag("Pos", [
 								new DoubleTag("", $this->x),
 								new DoubleTag("", $this->y + $this->getEyeHeight()),
 								new DoubleTag("", $this->z)
 							]),
-							"Motion" => new ListTag("Motion", [
+							new ListTag("Motion", [
 								new DoubleTag("", -sin($this->yaw / 180 * M_PI) * cos($this->pitch / 180 * M_PI)),
 								new DoubleTag("", -sin($this->pitch / 180 * M_PI)),
 								new DoubleTag("", cos($this->yaw / 180 * M_PI) * cos($this->pitch / 180 * M_PI))
 							]),
-							"Rotation" => new ListTag("Rotation", [
+							new ListTag("Rotation", [
 								//yaw/pitch for arrows taken crosswise, not along the arrow shaft.
 								new FloatTag("", ($this->yaw > 180 ? 360 : 0) - $this->yaw), //arrow yaw must range from -180 to +180
 								new FloatTag("", -$this->pitch)
 							]),
-							"Fire" => new ShortTag("Fire", $this->isOnFire() ? 45 * 60 : 0)
+							new ShortTag("Fire", $this->isOnFire() ? 45 * 60 : 0)
 						]);
 
 						$diff = ($this->server->getTick() - $this->startAction);

--- a/src/pocketmine/block/Fallable.php
+++ b/src/pocketmine/block/Fallable.php
@@ -41,22 +41,22 @@ abstract class Fallable extends Solid{
 			if($down->getId() === self::AIR or ($down instanceof Liquid)){
 				$this->level->setBlock($this, Block::get(Block::AIR), true, true);
 				$fall = Entity::createEntity("FallingSand", $this->getLevel(), new CompoundTag("", [
-					"Pos" => new ListTag("Pos", [
+					new ListTag("Pos", [
 						new DoubleTag("", $this->x + 0.5),
 						new DoubleTag("", $this->y),
 						new DoubleTag("", $this->z + 0.5)
 					]),
-					"Motion" => new ListTag("Motion", [
+					new ListTag("Motion", [
 						new DoubleTag("", 0),
 						new DoubleTag("", 0),
 						new DoubleTag("", 0)
 					]),
-					"Rotation" => new ListTag("Rotation", [
+					new ListTag("Rotation", [
 						new FloatTag("", 0),
 						new FloatTag("", 0)
 					]),
-					"TileID" => new IntTag("TileID", $this->getId()),
-					"Data" => new ByteTag("Data", $this->getDamage()),
+					new IntTag("TileID", $this->getId()),
+					new ByteTag("Data", $this->getDamage()),
 				]));
 
 				$fall->spawnToAll();

--- a/src/pocketmine/block/SignPost.php
+++ b/src/pocketmine/block/SignPost.php
@@ -61,14 +61,14 @@ class SignPost extends Transparent{
 	public function place(Item $item, Block $block, Block $target, $face, $fx, $fy, $fz, Player $player = null){
 		if($face !== 0){
 			$nbt = new CompoundTag("", [
-				"id" => new StringTag("id", Tile::SIGN),
-				"x" => new IntTag("x", $block->x),
-				"y" => new IntTag("y", $block->y),
-				"z" => new IntTag("z", $block->z),
-				"Text1" => new StringTag("Text1", ""),
-				"Text2" => new StringTag("Text2", ""),
-				"Text3" => new StringTag("Text3", ""),
-				"Text4" => new StringTag("Text4", "")
+				new StringTag("id", Tile::SIGN),
+				new IntTag("x", $block->x),
+				new IntTag("y", $block->y),
+				new IntTag("z", $block->z),
+				new StringTag("Text1", ""),
+				new StringTag("Text2", ""),
+				new StringTag("Text3", ""),
+				new StringTag("Text4", "")
 			]);
 
 			if($player !== null){

--- a/src/pocketmine/block/TNT.php
+++ b/src/pocketmine/block/TNT.php
@@ -68,21 +68,21 @@ class TNT extends Solid{
 
 		$mot = (new Random())->nextSignedFloat() * M_PI * 2;
 		$tnt = Entity::createEntity("PrimedTNT", $this->getLevel(), new CompoundTag("", [
-			"Pos" => new ListTag("Pos", [
+			new ListTag("Pos", [
 				new DoubleTag("", $this->x + 0.5),
 				new DoubleTag("", $this->y),
 				new DoubleTag("", $this->z + 0.5)
 			]),
-			"Motion" => new ListTag("Motion", [
+			new ListTag("Motion", [
 				new DoubleTag("", -sin($mot) * 0.02),
 				new DoubleTag("", 0.2),
 				new DoubleTag("", -cos($mot) * 0.02)
 			]),
-			"Rotation" => new ListTag("Rotation", [
+			new ListTag("Rotation", [
 				new FloatTag("", 0),
 				new FloatTag("", 0)
 			]),
-			"Fuse" => new ByteTag("Fuse", $fuse)
+			new ByteTag("Fuse", $fuse)
 		]));
 
 		$tnt->spawnToAll();

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -774,11 +774,11 @@ abstract class Entity extends Location implements Metadatable{
 			$effects = [];
 			foreach($this->effects as $effect){
 				$effects[] = new CompoundTag("", [
-					"Id" => new ByteTag("Id", $effect->getId()),
-					"Amplifier" => new ByteTag("Amplifier", Binary::signByte($effect->getAmplifier())),
-					"Duration" => new IntTag("Duration", $effect->getDuration()),
-					"Ambient" => new ByteTag("Ambient", 0),
-					"ShowParticles" => new ByteTag("ShowParticles", $effect->isVisible() ? 1 : 0)
+					new ByteTag("Id", $effect->getId()),
+					new ByteTag("Amplifier", Binary::signByte($effect->getAmplifier())),
+					new IntTag("Duration", $effect->getDuration()),
+					new ByteTag("Ambient", 0),
+					new ByteTag("ShowParticles", $effect->isVisible() ? 1 : 0)
 				]);
 			}
 

--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -485,8 +485,8 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 
 		if(strlen($this->getSkinData()) > 0){
 			$this->namedtag->Skin = new CompoundTag("Skin", [
-				"Data" => new StringTag("Data", $this->getSkinData()),
-				"Name" => new StringTag("Name", $this->getSkinId())
+				new StringTag("Data", $this->getSkinData()),
+				new StringTag("Name", $this->getSkinId())
 			]);
 		}
 	}

--- a/src/pocketmine/item/Item.php
+++ b/src/pocketmine/item/Item.php
@@ -548,8 +548,8 @@ class Item implements ItemIds, \JsonSerializable{
 		foreach($tag->ench as $k => $entry){
 			if($entry["id"] === $ench->getId()){
 				$tag->ench->{$k} = new CompoundTag("", [
-					"id" => new ShortTag("id", $ench->getId()),
-					"lvl" => new ShortTag("lvl", $ench->getLevel())
+					new ShortTag("id", $ench->getId()),
+					new ShortTag("lvl", $ench->getLevel())
 				]);
 				$found = true;
 				break;
@@ -558,8 +558,8 @@ class Item implements ItemIds, \JsonSerializable{
 
 		if(!$found){
 			$tag->ench->{count($tag->ench) + 1} = new CompoundTag("", [
-				"id" => new ShortTag("id", $ench->getId()),
-				"lvl" => new ShortTag("lvl", $ench->getLevel())
+				new ShortTag("id", $ench->getId()),
+				new ShortTag("lvl", $ench->getLevel())
 			]);
 		}
 
@@ -643,7 +643,7 @@ class Item implements ItemIds, \JsonSerializable{
 			$tag->display->Name = new StringTag("Name", $name);
 		}else{
 			$tag->display = new CompoundTag("display", [
-				"Name" => new StringTag("Name", $name)
+				new StringTag("Name", $name)
 			]);
 		}
 
@@ -1009,9 +1009,9 @@ class Item implements ItemIds, \JsonSerializable{
 	 */
 	public function nbtSerialize(int $slot = -1, string $tagName = "") : CompoundTag{
 		$tag = new CompoundTag($tagName, [
-			"id" => new ShortTag("id", $this->id),
-			"Count" => new ByteTag("Count", Binary::signByte($this->count)),
-			"Damage" => new ShortTag("Damage", $this->meta),
+			new ShortTag("id", $this->id),
+			new ByteTag("Count", Binary::signByte($this->count)),
+			new ShortTag("Damage", $this->meta),
 		]);
 
 		if($this->hasCompoundTag()){

--- a/src/pocketmine/item/SpawnEgg.php
+++ b/src/pocketmine/item/SpawnEgg.php
@@ -44,17 +44,17 @@ class SpawnEgg extends Item{
 
 	public function onActivate(Level $level, Player $player, Block $block, Block $target, $face, $fx, $fy, $fz){
 		$nbt = new CompoundTag("", [
-			"Pos" => new ListTag("Pos", [
+			new ListTag("Pos", [
 				new DoubleTag("", $block->getX() + 0.5),
 				new DoubleTag("", $block->getY()),
 				new DoubleTag("", $block->getZ() + 0.5)
 			]),
-			"Motion" => new ListTag("Motion", [
+			new ListTag("Motion", [
 				new DoubleTag("", 0),
 				new DoubleTag("", 0),
 				new DoubleTag("", 0)
 			]),
-			"Rotation" => new ListTag("Rotation", [
+			new ListTag("Rotation", [
 				new FloatTag("", lcg_value() * 360),
 				new FloatTag("", 0)
 			]),

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1513,24 +1513,23 @@ class Level implements ChunkManager, Metadatable{
 
 		if($item->getId() > 0 and $item->getCount() > 0){
 			$itemEntity = Entity::createEntity("Item", $this, new CompoundTag("", [
-				"Pos" => new ListTag("Pos", [
+				new ListTag("Pos", [
 					new DoubleTag("", $source->getX()),
 					new DoubleTag("", $source->getY()),
 					new DoubleTag("", $source->getZ())
 				]),
-
-				"Motion" => new ListTag("Motion", [
+				new ListTag("Motion", [
 					new DoubleTag("", $motion->x),
 					new DoubleTag("", $motion->y),
 					new DoubleTag("", $motion->z)
 				]),
-				"Rotation" => new ListTag("Rotation", [
+				new ListTag("Rotation", [
 					new FloatTag("", lcg_value() * 360),
 					new FloatTag("", 0)
 				]),
-				"Health" => new ShortTag("Health", 5),
-				"Item" => $itemTag,
-				"PickupDelay" => new ShortTag("PickupDelay", $delay)
+				new ShortTag("Health", 5),
+				$itemTag,
+				new ShortTag("PickupDelay", $delay)
 			]));
 
 			$itemEntity->spawnToAll();

--- a/src/pocketmine/level/format/io/BaseLevelProvider.php
+++ b/src/pocketmine/level/format/io/BaseLevelProvider.php
@@ -123,7 +123,7 @@ abstract class BaseLevelProvider implements LevelProvider{
 	public function saveLevelData(){
 		$nbt = new NBT(NBT::BIG_ENDIAN);
 		$nbt->setData(new CompoundTag("", [
-			"Data" => $this->levelData
+			$this->levelData
 		]));
 		$buffer = $nbt->writeCompressed();
 		file_put_contents($this->getPath() . "level.dat", $buffer);

--- a/src/pocketmine/level/format/io/leveldb/LevelDB.php
+++ b/src/pocketmine/level/format/io/leveldb/LevelDB.php
@@ -155,39 +155,39 @@ class LevelDB extends BaseLevelProvider{
 
 		$levelData = new CompoundTag("", [
 			//Vanilla fields
-			"DayCycleStopTime" => new IntTag("DayCycleStopTime", -1),
-			"Difficulty" => new IntTag("Difficulty", 2),
-			"ForceGameType" => new ByteTag("ForceGameType", 0),
-			"GameType" => new IntTag("GameType", 0),
-			"Generator" => new IntTag("Generator", $generatorType),
-			"LastPlayed" => new LongTag("LastPlayed", time()),
-			"LevelName" => new StringTag("LevelName", $name),
-			"NetworkVersion" => new IntTag("NetworkVersion", ProtocolInfo::CURRENT_PROTOCOL),
-			//"Platform" => new IntTag("Platform", 2), //TODO: find out what the possible values are for
-			"RandomSeed" => new LongTag("RandomSeed", $seed),
-			"SpawnX" => new IntTag("SpawnX", 0),
-			"SpawnY" => new IntTag("SpawnY", 32767),
-			"SpawnZ" => new IntTag("SpawnZ", 0),
-			"StorageVersion" => new IntTag("StorageVersion", self::CURRENT_STORAGE_VERSION),
-			"Time" => new LongTag("Time", 0),
-			"eduLevel" => new ByteTag("eduLevel", 0),
-			"falldamage" => new ByteTag("falldamage", 1),
-			"firedamage" => new ByteTag("firedamage", 1),
-			"hasBeenLoadedInCreative" => new ByteTag("hasBeenLoadedInCreative", 1), //badly named, this actually determines whether achievements can be earned in this world...
-			"immutableWorld" => new ByteTag("immutableWorld", 0),
-			"lightningLevel" => new FloatTag("lightningLevel", 0.0),
-			"lightningTime" => new IntTag("lightningTime", 0),
-			"pvp" => new ByteTag("pvp", 1),
-			"rainLevel" => new FloatTag("rainLevel", 0.0),
-			"rainTime" => new IntTag("rainTime", 0),
-			"spawnMobs" => new ByteTag("spawnMobs", 1),
-			"texturePacksRequired" => new ByteTag("texturePacksRequired", 0), //TODO
+			new IntTag("DayCycleStopTime", -1),
+			new IntTag("Difficulty", 2),
+			new ByteTag("ForceGameType", 0),
+			new IntTag("GameType", 0),
+			new IntTag("Generator", $generatorType),
+			new LongTag("LastPlayed", time()),
+			new StringTag("LevelName", $name),
+			new IntTag("NetworkVersion", ProtocolInfo::CURRENT_PROTOCOL),
+			//new IntTag("Platform", 2), //TODO: find out what the possible values are for
+			new LongTag("RandomSeed", $seed),
+			new IntTag("SpawnX", 0),
+			new IntTag("SpawnY", 32767),
+			new IntTag("SpawnZ", 0),
+			new IntTag("StorageVersion", self::CURRENT_STORAGE_VERSION),
+			new LongTag("Time", 0),
+			new ByteTag("eduLevel", 0),
+			new ByteTag("falldamage", 1),
+			new ByteTag("firedamage", 1),
+			new ByteTag("hasBeenLoadedInCreative", 1), //badly named, this actually determines whether achievements can be earned in this world...
+			new ByteTag("immutableWorld", 0),
+			new FloatTag("lightningLevel", 0.0),
+			new IntTag("lightningTime", 0),
+			new ByteTag("pvp", 1),
+			new FloatTag("rainLevel", 0.0),
+			new IntTag("rainTime", 0),
+			new ByteTag("spawnMobs", 1),
+			new ByteTag("texturePacksRequired", 0), //TODO
 
 			//Additional PocketMine-MP fields
-			"GameRules" => new CompoundTag("GameRules", []),
-			"hardcore" => new ByteTag("hardcore", 0),
-			"generatorName" => new StringTag("generatorName", Generator::getGeneratorName($generator)),
-			"generatorOptions" => new StringTag("generatorOptions", $options["preset"] ?? "")
+			new CompoundTag("GameRules", []),
+			new ByteTag("hardcore", 0),
+			new StringTag("generatorName", Generator::getGeneratorName($generator)),
+			new StringTag("generatorOptions", $options["preset"] ?? "")
 		]);
 
 		$nbt = new NBT(NBT::LITTLE_ENDIAN);

--- a/src/pocketmine/level/format/io/region/Anvil.php
+++ b/src/pocketmine/level/format/io/region/Anvil.php
@@ -57,11 +57,11 @@ class Anvil extends McRegion{
 				continue;
 			}
 			$nbt->Sections[++$subChunks] = new CompoundTag("", [
-				"Y"          => new ByteTag("Y", $y),
-				"Blocks"     => new ByteArrayTag("Blocks", ChunkUtils::reorderByteArray($subChunk->getBlockIdArray())), //Generic in-memory chunks are currently always XZY
-				"Data"       => new ByteArrayTag("Data", ChunkUtils::reorderNibbleArray($subChunk->getBlockDataArray())),
-				"SkyLight"   => new ByteArrayTag("SkyLight", ChunkUtils::reorderNibbleArray($subChunk->getBlockSkyLightArray(), "\xff")),
-				"BlockLight" => new ByteArrayTag("BlockLight", ChunkUtils::reorderNibbleArray($subChunk->getBlockLightArray()))
+				new ByteTag("Y", $y),
+				new ByteArrayTag("Blocks", ChunkUtils::reorderByteArray($subChunk->getBlockIdArray())), //Generic in-memory chunks are currently always XZY
+				new ByteArrayTag("Data", ChunkUtils::reorderNibbleArray($subChunk->getBlockDataArray())),
+				new ByteArrayTag("SkyLight", ChunkUtils::reorderNibbleArray($subChunk->getBlockSkyLightArray(), "\xff")),
+				new ByteArrayTag("BlockLight", ChunkUtils::reorderNibbleArray($subChunk->getBlockLightArray()))
 			]);
 		}
 
@@ -93,7 +93,7 @@ class Anvil extends McRegion{
 
 		$writer = new NBT(NBT::BIG_ENDIAN);
 		$nbt->setName("Level");
-		$writer->setData(new CompoundTag("", ["Level" => $nbt]));
+		$writer->setData(new CompoundTag("", [$nbt]));
 
 		return $writer->writeCompressed(ZLIB_ENCODING_DEFLATE, RegionLoader::$COMPRESSION_LEVEL);
 	}

--- a/src/pocketmine/level/format/io/region/McRegion.php
+++ b/src/pocketmine/level/format/io/region/McRegion.php
@@ -109,7 +109,7 @@ class McRegion extends BaseLevelProvider{
 
 		$writer = new NBT(NBT::BIG_ENDIAN);
 		$nbt->setName("Level");
-		$writer->setData(new CompoundTag("", ["Level" => $nbt]));
+		$writer->setData(new CompoundTag("", [$nbt]));
 
 		return $writer->writeCompressed(ZLIB_ENCODING_DEFLATE, RegionLoader::$COMPRESSION_LEVEL);
 	}
@@ -248,27 +248,27 @@ class McRegion extends BaseLevelProvider{
 		}
 		//TODO, add extra details
 		$levelData = new CompoundTag("Data", [
-			"hardcore" => new ByteTag("hardcore", 0),
-			"initialized" => new ByteTag("initialized", 1),
-			"GameType" => new IntTag("GameType", 0),
-			"generatorVersion" => new IntTag("generatorVersion", 1), //2 in MCPE
-			"SpawnX" => new IntTag("SpawnX", 256),
-			"SpawnY" => new IntTag("SpawnY", 70),
-			"SpawnZ" => new IntTag("SpawnZ", 256),
-			"version" => new IntTag("version", static::getPcWorldFormatVersion()),
-			"DayTime" => new IntTag("DayTime", 0),
-			"LastPlayed" => new LongTag("LastPlayed", (int) (microtime(true) * 1000)),
-			"RandomSeed" => new LongTag("RandomSeed", $seed),
-			"SizeOnDisk" => new LongTag("SizeOnDisk", 0),
-			"Time" => new LongTag("Time", 0),
-			"generatorName" => new StringTag("generatorName", Generator::getGeneratorName($generator)),
-			"generatorOptions" => new StringTag("generatorOptions", isset($options["preset"]) ? $options["preset"] : ""),
-			"LevelName" => new StringTag("LevelName", $name),
-			"GameRules" => new CompoundTag("GameRules", [])
+			new ByteTag("hardcore", 0),
+			new ByteTag("initialized", 1),
+			new IntTag("GameType", 0),
+			new IntTag("generatorVersion", 1), //2 in MCPE
+			new IntTag("SpawnX", 256),
+			new IntTag("SpawnY", 70),
+			new IntTag("SpawnZ", 256),
+			new IntTag("version", static::getPcWorldFormatVersion()),
+			new IntTag("DayTime", 0),
+			new LongTag("LastPlayed", (int) (microtime(true) * 1000)),
+			new LongTag("RandomSeed", $seed),
+			new LongTag("SizeOnDisk", 0),
+			new LongTag("Time", 0),
+			new StringTag("generatorName", Generator::getGeneratorName($generator)),
+			new StringTag("generatorOptions", isset($options["preset"]) ? $options["preset"] : ""),
+			new StringTag("LevelName", $name),
+			new CompoundTag("GameRules", [])
 		]);
 		$nbt = new NBT(NBT::BIG_ENDIAN);
 		$nbt->setData(new CompoundTag("", [
-			"Data" => $levelData
+			$levelData
 		]));
 		$buffer = $nbt->writeCompressed();
 		file_put_contents($path . "level.dat", $buffer);

--- a/src/pocketmine/level/format/io/region/PMAnvil.php
+++ b/src/pocketmine/level/format/io/region/PMAnvil.php
@@ -60,11 +60,11 @@ class PMAnvil extends Anvil{
 				continue;
 			}
 			$nbt->Sections[++$subChunks] = new CompoundTag("", [
-				"Y"          => new ByteTag("Y", $y),
-				"Blocks"     => new ByteArrayTag("Blocks",     $subChunk->getBlockIdArray()),
-				"Data"       => new ByteArrayTag("Data",       $subChunk->getBlockDataArray()),
-				"SkyLight"   => new ByteArrayTag("SkyLight",   $subChunk->getBlockSkyLightArray()),
-				"BlockLight" => new ByteArrayTag("BlockLight", $subChunk->getBlockLightArray())
+				new ByteTag("Y", $y),
+				new ByteArrayTag("Blocks",     $subChunk->getBlockIdArray()),
+				new ByteArrayTag("Data",       $subChunk->getBlockDataArray()),
+				new ByteArrayTag("SkyLight",   $subChunk->getBlockSkyLightArray()),
+				new ByteArrayTag("BlockLight", $subChunk->getBlockLightArray())
 			]);
 		}
 
@@ -96,7 +96,7 @@ class PMAnvil extends Anvil{
 
 		$writer = new NBT(NBT::BIG_ENDIAN);
 		$nbt->setName("Level");
-		$writer->setData(new CompoundTag("", ["Level" => $nbt]));
+		$writer->setData(new CompoundTag("", [$nbt]));
 
 		return $writer->writeCompressed(ZLIB_ENCODING_DEFLATE, RegionLoader::$COMPRESSION_LEVEL);
 	}


### PR DESCRIPTION
## Introduction
The usage of the value parameter for CompoundTags can get very confusing seeing stuff like this, where the tag names are attempted to be used as the array keys for the tags in the CompoundTag value.

Here's the thing: those indices are completely ignored, and as such are needless extra confusion looking at the code, as well as inconsistency.

## Changes
Cosmetic cleanup and removed inconsistency

## Tests
Untested, but nothing should break, since these keys are not used anywhere
