### PR TITLE
Changed CompoundTag access

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3764,6 +3764,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		foreach($this->achievements as $achievement => $status){
 			$achievements[$achievement] = new ByteTag($achievement, $status ? 1 : 0);
 		}
+		$this->namedtag->setTag($achievements);
 
 		$this->namedtag["playerGameType"] = $this->gamemode;
 		$this->namedtag["lastPlayed"] = (int) floor(microtime(true) * 1000);

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1302,7 +1302,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 
 		$this->resetFallDistance();
 
-		$this->namedtag->playerGameType = new IntTag("playerGameType", $this->gamemode);
+		$this->namedtag->setTag(new IntTag("playerGameType", $this->gamemode));
 		if(!$client){ //Gamemode changed by server, do not send for client changes
 			$this->sendGamemode();
 		}else{
@@ -1800,15 +1800,13 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		$this->namedtag = $this->server->getOfflinePlayerData($this->username);
 
 		$this->playedBefore = ($this->namedtag["lastPlayed"] - $this->namedtag["firstPlayed"]) > 1; // microtime(true) - microtime(true) may have less than one millisecond difference
-		if(!isset($this->namedtag->NameTag)){
-			$this->namedtag->NameTag = new StringTag("NameTag", $this->username);
-		}else{
-			$this->namedtag["NameTag"] = $this->username;
-		}
+
+		$this->namedtag->setTag(new StringTag("NameTag", $this->username));
+
 		$this->gamemode = $this->namedtag["playerGameType"] & 0x03;
 		if($this->server->getForceGamemode()){
 			$this->gamemode = $this->server->getGamemode();
-			$this->namedtag->playerGameType = new IntTag("playerGameType", $this->gamemode);
+			$this->namedtag->setTag(new IntTag("playerGameType", $this->gamemode));
 		}
 
 		$this->allowFlight = (bool) ($this->gamemode & 0x01);
@@ -1826,11 +1824,11 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		$this->achievements = [];
 
 		/** @var ByteTag $achievement */
-		foreach($this->namedtag->Achievements as $achievement){
+		foreach($this->namedtag->getTag("Achievements") as $achievement){
 			$this->achievements[$achievement->getName()] = $achievement->getValue() > 0 ? true : false;
 		}
 
-		$this->namedtag->lastPlayed = new LongTag("lastPlayed", (int) floor(microtime(true) * 1000));
+		$this->namedtag->setTag(new LongTag("lastPlayed", (int) floor(microtime(true) * 1000)));
 		if($this->server->getAutoSave()){
 			$this->server->saveOfflinePlayerData($this->username, $this->namedtag, true);
 		}
@@ -1849,7 +1847,8 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	protected function completeLoginSequence(){
 		parent::__construct($this->level, $this->namedtag);
 
-		if(!$this->hasValidSpawnPosition() and isset($this->namedtag->SpawnLevel) and ($level = $this->server->getLevelByName((string) $this->namedtag["SpawnLevel"])) instanceof Level){
+		$spawnLevelTag = $this->namedtag->getTag("SpawnLevel");
+		if(!$this->hasValidSpawnPosition() and $spawnLevelTag instanceof StringTag and ($level = $this->server->getLevelByName($spawnLevelTag->getValue())) instanceof Level){
 			$this->spawnPosition = new WeakPosition($this->namedtag["SpawnX"], $this->namedtag["SpawnY"], $this->namedtag["SpawnZ"], $level);
 		}
 
@@ -3750,7 +3749,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		parent::saveNBT();
 
 		if($this->isValid()){
-			$this->namedtag->Level = new StringTag("Level", $this->level->getFolderName());
+			$this->namedtag->setTag(new StringTag("Level", $this->level->getFolderName()));
 		}
 
 		if($this->hasValidSpawnPosition()){
@@ -3760,8 +3759,10 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			$this->namedtag["SpawnZ"] = (int) $this->spawnPosition->z;
 		}
 
+		$achievements = $this->namedtag->getTag("Achievements");
+		assert($achievements instanceof CompoundTag);
 		foreach($this->achievements as $achievement => $status){
-			$this->namedtag->Achievements[$achievement] = new ByteTag($achievement, $status === true ? 1 : 0);
+			$achievements[$achievement] = new ByteTag($achievement, $status ? 1 : 0);
 		}
 
 		$this->namedtag["playerGameType"] = $this->gamemode;

--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -734,25 +734,25 @@ class Server{
 				new DoubleTag("", $spawn->x),
 				new DoubleTag("", $spawn->y),
 				new DoubleTag("", $spawn->z)
-			]),
+			], NBT::TAG_Double),
 			new StringTag("Level", $this->getDefaultLevel()->getName()),
 			//new StringTag("SpawnLevel", $this->getDefaultLevel()->getName()),
 			//new IntTag("SpawnX", (int) $spawn->x),
 			//new IntTag("SpawnY", (int) $spawn->y),
 			//new IntTag("SpawnZ", (int) $spawn->z),
 			//new ByteTag("SpawnForced", 1), //TODO
-			new ListTag("Inventory", []),
+			new ListTag("Inventory", [], NBT::TAG_Compound),
 			new CompoundTag("Achievements", []),
 			new IntTag("playerGameType", $this->getGamemode()),
 			new ListTag("Motion", [
 				new DoubleTag("", 0.0),
 				new DoubleTag("", 0.0),
 				new DoubleTag("", 0.0)
-			]),
+			], NBT::TAG_Double),
 			new ListTag("Rotation", [
 				new FloatTag("", 0.0),
 				new FloatTag("", 0.0)
-			]),
+			], NBT::TAG_Float),
 			new FloatTag("FallDistance", 0.0),
 			new ShortTag("Fire", 0),
 			new ShortTag("Air", 300),
@@ -760,10 +760,6 @@ class Server{
 			new ByteTag("Invulnerable", 0),
 			new StringTag("NameTag", $name),
 		]);
-		$nbt->Pos->setTagType(NBT::TAG_Double);
-		$nbt->Inventory->setTagType(NBT::TAG_Compound);
-		$nbt->Motion->setTagType(NBT::TAG_Double);
-		$nbt->Rotation->setTagType(NBT::TAG_Float);
 
 		return $nbt;
 

--- a/src/pocketmine/block/BurningFurnace.php
+++ b/src/pocketmine/block/BurningFurnace.php
@@ -72,16 +72,15 @@ class BurningFurnace extends Solid{
 		$this->meta = $faces[$player instanceof Player ? $player->getDirection() : 0];
 		$this->getLevel()->setBlock($block, $this, true, true);
 		$nbt = new CompoundTag("", [
-			new ListTag("Items", []),
+			new ListTag("Items", [], NBT::TAG_Compound),
 			new StringTag("id", Tile::FURNACE),
 			new IntTag("x", $this->x),
 			new IntTag("y", $this->y),
 			new IntTag("z", $this->z)
 		]);
-		$nbt->Items->setTagType(NBT::TAG_Compound);
 
 		if($item->hasCustomName()){
-			$nbt->CustomName = new StringTag("CustomName", $item->getCustomName());
+			$nbt->setTag(new StringTag("CustomName", $item->getCustomName()));
 		}
 
 		if($item->hasCustomBlockData()){
@@ -106,18 +105,17 @@ class BurningFurnace extends Solid{
 			$furnace = $this->getLevel()->getTile($this);
 			if(!($furnace instanceof TileFurnace)){
 				$nbt = new CompoundTag("", [
-					new ListTag("Items", []),
+					new ListTag("Items", [], NBT::TAG_Compound),
 					new StringTag("id", Tile::FURNACE),
 					new IntTag("x", $this->x),
 					new IntTag("y", $this->y),
 					new IntTag("z", $this->z)
 				]);
-				$nbt->Items->setTagType(NBT::TAG_Compound);
 				$furnace = Tile::createTile("Furnace", $this->getLevel(), $nbt);
 			}
 
-			if(isset($furnace->namedtag->Lock) and $furnace->namedtag->Lock instanceof StringTag){
-				if($furnace->namedtag->Lock->getValue() !== $item->getCustomName()){
+			if(($lockTag = $furnace->namedtag->getTag("Lock")) instanceof StringTag){
+				if($lockTag->getValue() !== $item->getCustomName()){
 					return true;
 				}
 			}

--- a/src/pocketmine/block/Chest.php
+++ b/src/pocketmine/block/Chest.php
@@ -99,16 +99,15 @@ class Chest extends Transparent{
 
 		$this->getLevel()->setBlock($block, $this, true, true);
 		$nbt = new CompoundTag("", [
-			new ListTag("Items", []),
+			new ListTag("Items", [], NBT::TAG_Compound),
 			new StringTag("id", Tile::CHEST),
 			new IntTag("x", $this->x),
 			new IntTag("y", $this->y),
 			new IntTag("z", $this->z)
 		]);
-		$nbt->Items->setTagType(NBT::TAG_Compound);
 
 		if($item->hasCustomName()){
-			$nbt->CustomName = new StringTag("CustomName", $item->getCustomName());
+			$nbt->setTag(new StringTag("CustomName", $item->getCustomName()));
 		}
 
 		if($item->hasCustomBlockData()){
@@ -150,18 +149,17 @@ class Chest extends Transparent{
 				$chest = $t;
 			}else{
 				$nbt = new CompoundTag("", [
-					new ListTag("Items", []),
+					new ListTag("Items", [], NBT::TAG_Compound),
 					new StringTag("id", Tile::CHEST),
 					new IntTag("x", $this->x),
 					new IntTag("y", $this->y),
 					new IntTag("z", $this->z)
 				]);
-				$nbt->Items->setTagType(NBT::TAG_Compound);
 				$chest = Tile::createTile("Chest", $this->getLevel(), $nbt);
 			}
 
-			if(isset($chest->namedtag->Lock) and $chest->namedtag->Lock instanceof StringTag){
-				if($chest->namedtag->Lock->getValue() !== $item->getCustomName()){
+			if(($lockTag = $chest->namedtag->getTag("Lock")) instanceof StringTag){
+				if($lockTag->getValue() !== $item->getCustomName()){
 					return true;
 				}
 			}

--- a/src/pocketmine/block/EnchantingTable.php
+++ b/src/pocketmine/block/EnchantingTable.php
@@ -50,7 +50,7 @@ class EnchantingTable extends Transparent{
 		]);
 
 		if($item->hasCustomName()){
-			$nbt->CustomName = new StringTag("CustomName", $item->getCustomName());
+			$nbt->setTag(new StringTag("CustomName", $item->getCustomName()));
 		}
 
 		if($item->hasCustomBlockData()){

--- a/src/pocketmine/block/MobHead.php
+++ b/src/pocketmine/block/MobHead.php
@@ -80,7 +80,7 @@ class MobHead extends Flowable{
 				new IntTag("z", (int) $this->z)
 			]);
 			if($item->hasCustomName()){
-				$nbt->CustomName = new StringTag("CustomName", $item->getCustomName());
+				$nbt->setTag(new StringTag("CustomName", $item->getCustomName()));
 			}
 			/** @var Spawnable $tile */
 			Tile::createTile("Skull", $this->getLevel(), $nbt);

--- a/src/pocketmine/block/SignPost.php
+++ b/src/pocketmine/block/SignPost.php
@@ -72,7 +72,7 @@ class SignPost extends Transparent{
 			]);
 
 			if($player !== null){
-				$nbt->Creator = new StringTag("Creator", $player->getRawUniqueId());
+				$nbt->setTag(new StringTag("Creator", $player->getRawUniqueId()));
 			}
 
 			if($item->hasCustomBlockData()){

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -348,43 +348,45 @@ abstract class Entity extends Location implements Metadatable{
 		$this->server = $level->getServer();
 
 		$this->boundingBox = new AxisAlignedBB(0, 0, 0, 0, 0, 0);
+
+		/** @var ListTag $pos */
+		$pos = $this->namedtag->getTag("Pos");
+		/** @var ListTag $rotation */
+		$rotation = $this->namedtag->getTag("Rotation");
 		$this->setPositionAndRotation(
-			$this->temporalVector->setComponents(
-				$this->namedtag["Pos"][0],
-				$this->namedtag["Pos"][1],
-				$this->namedtag["Pos"][2]
-			),
-			$this->namedtag->Rotation[0],
-			$this->namedtag->Rotation[1]
+			$this->temporalVector->setComponents($pos[0], $pos[1], $pos[2]),
+			$rotation[0],
+			$rotation[1]
 		);
 
-
-		$this->setMotion($this->temporalVector->setComponents($this->namedtag["Motion"][0], $this->namedtag["Motion"][1], $this->namedtag["Motion"][2]));
+		/** @var ListTag $motion */
+		$motion = $this->namedtag->getTag("Motion");
+		$this->setMotion($this->temporalVector->setComponents($motion[0], $motion[1], $motion[2]));
 
 		assert(!is_nan($this->x) and !is_infinite($this->x) and !is_nan($this->y) and !is_infinite($this->y) and !is_nan($this->z) and !is_infinite($this->z));
 
-		if(!isset($this->namedtag->FallDistance)){
-			$this->namedtag->FallDistance = new FloatTag("FallDistance", 0);
+		if(!$this->namedtag->exists("FallDistance")){
+			$this->namedtag->setTag(new FloatTag("FallDistance", 0.0));
 		}
 		$this->fallDistance = $this->namedtag["FallDistance"];
 
-		if(!isset($this->namedtag->Fire)){
-			$this->namedtag->Fire = new ShortTag("Fire", 0);
+		if(!$this->namedtag->exists("Fire")){
+			$this->namedtag->setTag(new ShortTag("Fire", 0));
 		}
 		$this->fireTicks = $this->namedtag["Fire"];
 
-		if(!isset($this->namedtag->Air)){
-			$this->namedtag->Air = new ShortTag("Air", 300);
+		if(!$this->namedtag->exists("Air")){
+			$this->namedtag->setTag(new ShortTag("Air", 300));
 		}
 		$this->setDataProperty(self::DATA_AIR, self::DATA_TYPE_SHORT, $this->namedtag["Air"], false);
 
-		if(!isset($this->namedtag->OnGround)){
-			$this->namedtag->OnGround = new ByteTag("OnGround", 0);
+		if(!$this->namedtag->exists("OnGround")){
+			$this->namedtag->setTag(new ByteTag("OnGround", 0));
 		}
 		$this->onGround = $this->namedtag["OnGround"] > 0 ? true : false;
 
-		if(!isset($this->namedtag->Invulnerable)){
-			$this->namedtag->Invulnerable = new ByteTag("Invulnerable", 0);
+		if(!$this->namedtag->exists("Invulnerable")){
+			$this->namedtag->setTag(new ByteTag("Invulnerable", 0));
 		}
 		$this->invulnerable = $this->namedtag["Invulnerable"] > 0 ? true : false;
 
@@ -737,38 +739,37 @@ abstract class Entity extends Location implements Metadatable{
 
 	public function saveNBT(){
 		if(!($this instanceof Player)){
-			$this->namedtag->id = new StringTag("id", $this->getSaveId());
+			$this->namedtag->setTag(new StringTag("id", $this->getSaveId()));
 			if($this->getNameTag() !== ""){
-				$this->namedtag->CustomName = new StringTag("CustomName", $this->getNameTag());
-				$this->namedtag->CustomNameVisible = new ByteTag("CustomNameVisible", $this->isNameTagVisible() ? 1 : 0);
+				$this->namedtag->setTag(new StringTag("CustomName", $this->getNameTag()));
+				$this->namedtag->setTag(new ByteTag("CustomNameVisible", $this->isNameTagVisible() ? 1 : 0));
 			}else{
-				unset($this->namedtag->CustomName);
-				unset($this->namedtag->CustomNameVisible);
+				$this->namedtag->remove("CustomName", "CustomNameVisible");
 			}
 		}
 
-		$this->namedtag->Pos = new ListTag("Pos", [
+		$this->namedtag->setTag(new ListTag("Pos", [
 			new DoubleTag("", $this->x),
 			new DoubleTag("", $this->y),
 			new DoubleTag("", $this->z)
-		]);
+		]));
 
-		$this->namedtag->Motion = new ListTag("Motion", [
+		$this->namedtag->setTag(new ListTag("Motion", [
 			new DoubleTag("", $this->motionX),
 			new DoubleTag("", $this->motionY),
 			new DoubleTag("", $this->motionZ)
-		]);
+		]));
 
-		$this->namedtag->Rotation = new ListTag("Rotation", [
+		$this->namedtag->setTag(new ListTag("Rotation", [
 			new FloatTag("", $this->yaw),
 			new FloatTag("", $this->pitch)
-		]);
+		]));
 
-		$this->namedtag->FallDistance = new FloatTag("FallDistance", $this->fallDistance);
-		$this->namedtag->Fire = new ShortTag("Fire", $this->fireTicks);
-		$this->namedtag->Air = new ShortTag("Air", $this->getDataProperty(self::DATA_AIR));
-		$this->namedtag->OnGround = new ByteTag("OnGround", $this->onGround ? 1 : 0);
-		$this->namedtag->Invulnerable = new ByteTag("Invulnerable", $this->invulnerable ? 1 : 0);
+		$this->namedtag->setTag(new FloatTag("FallDistance", $this->fallDistance));
+		$this->namedtag->setTag(new ShortTag("Fire", $this->fireTicks));
+		$this->namedtag->setTag(new ShortTag("Air", $this->getDataProperty(self::DATA_AIR)));
+		$this->namedtag->setTag(new ByteTag("OnGround", $this->onGround ? 1 : 0));
+		$this->namedtag->setTag(new ByteTag("Invulnerable", $this->invulnerable ? 1 : 0));
 
 		if(count($this->effects) > 0){
 			$effects = [];
@@ -782,34 +783,37 @@ abstract class Entity extends Location implements Metadatable{
 				]);
 			}
 
-			$this->namedtag->ActiveEffects = new ListTag("ActiveEffects", $effects);
+			$this->namedtag->setTag(new ListTag("ActiveEffects", $effects));
 		}else{
-			unset($this->namedtag->ActiveEffects);
+			$this->namedtag->remove("ActiveEffects");
 		}
 	}
 
 	protected function initEntity(){
 		assert($this->namedtag instanceof CompoundTag);
 
-		if(isset($this->namedtag->CustomName)){
+		if($this->namedtag->exists("CustomName")){
 			$this->setNameTag($this->namedtag["CustomName"]);
-			if(isset($this->namedtag->CustomNameVisible)){
+			if($this->namedtag->exists("CustomNameVisible")){
 				$this->setNameTagVisible($this->namedtag["CustomNameVisible"] > 0);
 			}
 		}
 
 		$this->scheduleUpdate();
 
-		if(isset($this->namedtag->ActiveEffects)){
-			foreach($this->namedtag->ActiveEffects->getValue() as $e){
-				$amplifier = Binary::unsignByte($e->Amplifier->getValue()); //0-255 only
+		$effectsTag = $this->namedtag->exists("ActiveEffects");
+		if($effectsTag instanceof ListTag){
+
+			/** @var CompoundTag $e */
+			foreach($effectsTag->getValue() as $e){
+				$amplifier = Binary::unsignByte($e->getTag("Amplifier")->getValue()); //0-255 only
 
 				$effect = Effect::getEffect($e["Id"]);
 				if($effect === null){
 					continue;
 				}
 
-				$effect->setAmplifier($amplifier)->setDuration($e["Duration"])->setVisible($e["ShowParticles"] > 0);
+				$effect->setAmplifier($amplifier)->setDuration((int) $e->getTag("Duration")->getValue())->setVisible($e->getTag("ShowParticles")->getValue() > 0);
 
 				$this->addEffect($effect);
 			}

--- a/src/pocketmine/entity/FallingSand.php
+++ b/src/pocketmine/entity/FallingSand.php
@@ -52,15 +52,15 @@ class FallingSand extends Entity{
 
 	protected function initEntity(){
 		parent::initEntity();
-		if(isset($this->namedtag->TileID)){
-			$this->blockId = $this->namedtag["TileID"];
-		}elseif(isset($this->namedtag->Tile)){
-			$this->blockId = $this->namedtag["Tile"];
-			$this->namedtag["TileID"] = new IntTag("TileID", $this->blockId);
+		if(($tileId = $this->namedtag->getTag("TileID")) instanceof IntTag){
+			$this->blockId = $tileId->getValue();
+		}elseif(($tile = $this->namedtag->getTag("Tile")) instanceof IntTag){
+			$this->blockId = $tile->getValue();
+			$this->namedtag->setTag(new IntTag("TileID", $this->blockId));
 		}
 
-		if(isset($this->namedtag->Data)){
-			$this->damage = $this->namedtag["Data"];
+		if(($data = $this->namedtag->getTag("Data")) instanceof ByteTag){
+			$this->damage = $data->getValue();
 		}
 
 		if($this->blockId === 0){
@@ -141,8 +141,8 @@ class FallingSand extends Entity{
 	}
 
 	public function saveNBT(){
-		$this->namedtag->TileID = new IntTag("TileID", $this->blockId);
-		$this->namedtag->Data = new ByteTag("Data", $this->damage);
+		$this->namedtag->setTag(new IntTag("TileID", $this->blockId));
+		$this->namedtag->setTag(new ByteTag("Data", $this->damage));
 	}
 
 	public function spawnTo(Player $player){

--- a/src/pocketmine/entity/Item.php
+++ b/src/pocketmine/entity/Item.php
@@ -60,29 +60,26 @@ class Item extends Entity{
 
 		$this->setMaxHealth(5);
 		$this->setHealth($this->namedtag["Health"]);
-		if(isset($this->namedtag->Age)){
-			$this->age = $this->namedtag["Age"];
-		}
-		if(isset($this->namedtag->PickupDelay)){
-			$this->pickupDelay = $this->namedtag["PickupDelay"];
-		}
-		if(isset($this->namedtag->Owner)){
-			$this->owner = $this->namedtag["Owner"];
-		}
-		if(isset($this->namedtag->Thrower)){
-			$this->thrower = $this->namedtag["Thrower"];
-		}
 
+		$age = $this->namedtag->getTag("Age");
+		if($age instanceof ShortTag) $this->age = $age->getValue();
 
-		if(!isset($this->namedtag->Item)){
+		$pickupDelay = $this->namedtag->getTag("PickupDelay");
+		if($pickupDelay instanceof ShortTag) $this->pickupDelay = $pickupDelay->getValue();
+
+		$owner = $this->namedtag->getTag("Owner");
+		if($owner instanceof StringTag) $this->owner = $owner->getValue();
+
+		$thrower = $this->namedtag->getTag("Thrower");
+		if($thrower instanceof StringTag) $this->thrower = $thrower->getValue();
+
+		$item = $this->namedtag->getCompoundTag("Item");
+		if($item === null){
 			$this->close();
 			return;
 		}
 
-		assert($this->namedtag->Item instanceof CompoundTag);
-
-		$this->item = ItemItem::nbtDeserialize($this->namedtag->Item);
-
+		$this->item = ItemItem::nbtDeserialize($item);
 
 		$this->server->getPluginManager()->callEvent(new ItemSpawnEvent($this));
 	}
@@ -166,15 +163,15 @@ class Item extends Entity{
 
 	public function saveNBT(){
 		parent::saveNBT();
-		$this->namedtag->Item = $this->item->nbtSerialize(-1, "Item");
-		$this->namedtag->Health = new ShortTag("Health", $this->getHealth());
-		$this->namedtag->Age = new ShortTag("Age", $this->age);
-		$this->namedtag->PickupDelay = new ShortTag("PickupDelay", $this->pickupDelay);
+		$this->namedtag->setTag($this->item->nbtSerialize(-1, "Item"));
+		$this->namedtag->setTag(new ShortTag("Health", $this->getHealth()));
+		$this->namedtag->setTag(new ShortTag("Age", $this->age));
+		$this->namedtag->setTag(new ShortTag("PickupDelay", $this->pickupDelay));
 		if($this->owner !== null){
-			$this->namedtag->Owner = new StringTag("Owner", $this->owner);
+			$this->namedtag->setTag(new StringTag("Owner", $this->owner));
 		}
 		if($this->thrower !== null){
-			$this->namedtag->Thrower = new StringTag("Thrower", $this->thrower);
+			$this->namedtag->setTag(new StringTag("Thrower", $this->thrower));
 		}
 	}
 

--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -51,16 +51,22 @@ abstract class Living extends Entity implements Damageable{
 	protected function initEntity(){
 		parent::initEntity();
 
-		if(isset($this->namedtag->HealF)){
-			$this->namedtag->Health = new FloatTag("Health", (float) $this->namedtag["HealF"]);
-			unset($this->namedtag->HealF);
-		}elseif(isset($this->namedtag->Health) and !($this->namedtag->Health instanceof FloatTag)){
-			$this->namedtag->Health = new FloatTag("Health", (float) $this->namedtag->Health->getValue());
+		$health = $this->getMaxHealth();
+
+		$healFTag = $this->namedtag->getTag("HealF");
+		if($healFTag instanceof FloatTag){
+			$health = $healFTag->getValue();
+			$this->namedtag->remove("HealF");
 		}else{
-			$this->namedtag->Health = new FloatTag("Health", (float) $this->getMaxHealth());
+			$healthTag = $this->namedtag->getTag("Health");
+			if($healthTag instanceof FloatTag){
+				$health = $healthTag->getValue();
+			}
 		}
 
-		$this->setHealth($this->namedtag["Health"]);
+		$this->namedtag->setTag(new FloatTag("Health", $health));
+
+		$this->setHealth($health);
 	}
 
 	protected function addAttributes(){
@@ -102,7 +108,7 @@ abstract class Living extends Entity implements Damageable{
 
 	public function saveNBT(){
 		parent::saveNBT();
-		$this->namedtag->Health = new FloatTag("Health", $this->getHealth());
+		$this->namedtag->setTag(new FloatTag("Health", $this->getHealth()));
 	}
 
 	abstract public function getName();

--- a/src/pocketmine/entity/PrimedTNT.php
+++ b/src/pocketmine/entity/PrimedTNT.php
@@ -57,8 +57,8 @@ class PrimedTNT extends Entity implements Explosive{
 	protected function initEntity(){
 		parent::initEntity();
 
-		if(isset($this->namedtag->Fuse)){
-			$this->fuse = $this->namedtag["Fuse"];
+		if($this->namedtag->exists("Fuse")){
+			$this->fuse = $this->namedtag->getTag("Fuse")->getValue();
 		}else{
 			$this->fuse = 80;
 		}
@@ -76,7 +76,7 @@ class PrimedTNT extends Entity implements Explosive{
 
 	public function saveNBT(){
 		parent::saveNBT();
-		$this->namedtag->Fuse = new ByteTag("Fuse", $this->fuse);
+		$this->namedtag->setTag(new ByteTag("Fuse", $this->fuse));
 	}
 
 	public function onUpdate($currentTick){

--- a/src/pocketmine/entity/Projectile.php
+++ b/src/pocketmine/entity/Projectile.php
@@ -60,8 +60,8 @@ abstract class Projectile extends Entity{
 
 		$this->setMaxHealth(1);
 		$this->setHealth(1);
-		if(isset($this->namedtag->Age)){
-			$this->age = $this->namedtag["Age"];
+		if($this->namedtag->exists("Age")){
+			$this->age = $this->namedtag->getTag("Age")->getValue();
 		}
 	}
 
@@ -105,7 +105,7 @@ abstract class Projectile extends Entity{
 
 	public function saveNBT(){
 		parent::saveNBT();
-		$this->namedtag->Age = new ShortTag("Age", $this->age);
+		$this->namedtag->setTag(new ShortTag("Age", $this->age));
 	}
 
 	public function onUpdate($currentTick){

--- a/src/pocketmine/entity/Villager.php
+++ b/src/pocketmine/entity/Villager.php
@@ -33,6 +33,8 @@ class Villager extends Creature implements NPC, Ageable{
 	const PROFESSION_PRIEST = 2;
 	const PROFESSION_BLACKSMITH = 3;
 	const PROFESSION_BUTCHER = 4;
+
+	/** @deprecated This profession does not exist in Pocket Edition and will cause a client-sided crash if used. */
 	const PROFESSION_GENERIC = 5;
 
 	const NETWORK_ID = 15;
@@ -49,7 +51,7 @@ class Villager extends Creature implements NPC, Ageable{
 		parent::initEntity();
 
 		$professionTag = $this->namedtag->getTag("Profession");
-		$this->setProfession($professionTag instanceof IntTag ? $professionTag->getValue() : self::PROFESSION_GENERIC);
+		$this->setProfession(($professionTag instanceof IntTag and $professionTag->getValue() < 5 and $professionTag->getValue() >= 0) ? $professionTag->getValue() : self::PROFESSION_FARMER);
 	}
 
 	public function saveNBT(){

--- a/src/pocketmine/entity/Villager.php
+++ b/src/pocketmine/entity/Villager.php
@@ -47,9 +47,14 @@ class Villager extends Creature implements NPC, Ageable{
 
 	protected function initEntity(){
 		parent::initEntity();
-		if(!isset($this->namedtag->Profession)){
-			$this->setProfession(self::PROFESSION_GENERIC);
-		}
+
+		$professionTag = $this->namedtag->getTag("Profession");
+		$this->setProfession($professionTag instanceof IntTag ? $professionTag->getValue() : self::PROFESSION_GENERIC);
+	}
+
+	public function saveNBT(){
+		parent::saveNBT();
+		$this->namedtag->setTag(new IntTag("Profession", $this->getProfession()));
 	}
 
 	public function spawnTo(Player $player){
@@ -73,17 +78,17 @@ class Villager extends Creature implements NPC, Ageable{
 	/**
 	 * Sets the villager profession
 	 *
-	 * @param $profession
+	 * @param int $profession
 	 */
-	public function setProfession($profession){
-		$this->namedtag->Profession = new IntTag("Profession", $profession);
+	public function setProfession(int $profession){
+		$this->setDataProperty(self::DATA_VARIANT, self::DATA_TYPE_INT, $profession);
 	}
 
-	public function getProfession(){
-		return $this->namedtag["Profession"];
+	public function getProfession() : int{
+		return $this->getDataProperty(self::DATA_VARIANT);
 	}
 
-	public function isBaby(){
+	public function isBaby() : bool{
 		return $this->getDataFlag(self::DATA_FLAGS, self::DATA_FLAG_BABY);
 	}
 }

--- a/src/pocketmine/item/SpawnEgg.php
+++ b/src/pocketmine/item/SpawnEgg.php
@@ -61,7 +61,7 @@ class SpawnEgg extends Item{
 		]);
 
 		if($this->hasCustomName()){
-			$nbt->CustomName = new StringTag("CustomName", $this->getCustomName());
+			$nbt->setTag(new StringTag("CustomName", $this->getCustomName()));
 		}
 
 		$entity = Entity::createEntity($this->meta, $level, $nbt);

--- a/src/pocketmine/level/format/io/BaseLevelProvider.php
+++ b/src/pocketmine/level/format/io/BaseLevelProvider.php
@@ -52,18 +52,18 @@ abstract class BaseLevelProvider implements LevelProvider{
 		$nbt = new NBT(NBT::BIG_ENDIAN);
 		$nbt->readCompressed(file_get_contents($this->getPath() . "level.dat"));
 		$levelData = $nbt->getData();
-		if($levelData->Data instanceof CompoundTag){
-			$this->levelData = $levelData->Data;
+		if(($data = $levelData->getTag("Data")) instanceof CompoundTag){
+			$this->levelData = $data;
 		}else{
 			throw new LevelException("Invalid level.dat");
 		}
 
-		if(!isset($this->levelData->generatorName)){
-			$this->levelData->generatorName = new StringTag("generatorName", (string) Generator::getGenerator("DEFAULT"));
+		if(!$this->levelData->exists("generatorName")){
+			$this->levelData->setTag(new StringTag("generatorName", (string) Generator::getGenerator("DEFAULT")));
 		}
 
-		if(!isset($this->levelData->generatorOptions)){
-			$this->levelData->generatorOptions = new StringTag("generatorOptions", "");
+		if(!$this->levelData->exists("generatorOptions")){
+			$this->levelData->setTag(new StringTag("generatorOptions", ""));
 		}
 	}
 
@@ -88,7 +88,7 @@ abstract class BaseLevelProvider implements LevelProvider{
 	}
 
 	public function setTime($value){
-		$this->levelData->Time = new LongTag("Time", $value);
+		$this->levelData->setTag(new LongTag("Time", $value));
 	}
 
 	public function getSeed(){
@@ -96,7 +96,7 @@ abstract class BaseLevelProvider implements LevelProvider{
 	}
 
 	public function setSeed($value){
-		$this->levelData->RandomSeed = new LongTag("RandomSeed", $value);
+		$this->levelData->setTag(new LongTag("RandomSeed", $value));
 	}
 
 	public function getSpawn() : Vector3{
@@ -104,9 +104,9 @@ abstract class BaseLevelProvider implements LevelProvider{
 	}
 
 	public function setSpawn(Vector3 $pos){
-		$this->levelData->SpawnX = new IntTag("SpawnX", (int) $pos->x);
-		$this->levelData->SpawnY = new IntTag("SpawnY", (int) $pos->y);
-		$this->levelData->SpawnZ = new IntTag("SpawnZ", (int) $pos->z);
+		$this->levelData->setTag(new IntTag("SpawnX", (int) $pos->x));
+		$this->levelData->setTag(new IntTag("SpawnY", (int) $pos->y));
+		$this->levelData->setTag(new IntTag("SpawnZ", (int) $pos->z));
 	}
 
 	public function doGarbageCollection(){

--- a/src/pocketmine/level/format/io/region/McRegion.php
+++ b/src/pocketmine/level/format/io/region/McRegion.php
@@ -54,12 +54,12 @@ class McRegion extends BaseLevelProvider{
 	 */
 	public function nbtSerialize(Chunk $chunk) : string{
 		$nbt = new CompoundTag("Level", []);
-		$nbt->xPos = new IntTag("xPos", $chunk->getX());
-		$nbt->zPos = new IntTag("zPos", $chunk->getZ());
+		$nbt->setTag(new IntTag("xPos", $chunk->getX()));
+		$nbt->setTag(new IntTag("zPos", $chunk->getZ()));
 
-		$nbt->LastUpdate = new LongTag("LastUpdate", 0); //TODO
-		$nbt->TerrainPopulated = new ByteTag("TerrainPopulated", $chunk->isPopulated() ? 1 : 0);
-		$nbt->LightPopulated = new ByteTag("LightPopulated", $chunk->isLightPopulated() ? 1 : 0);
+		$nbt->setTag(new LongTag("LastUpdate", 0)); //TODO
+		$nbt->setTag(new ByteTag("TerrainPopulated", $chunk->isPopulated() ? 1 : 0));
+		$nbt->setTag(new ByteTag("LightPopulated", $chunk->isLightPopulated() ? 1 : 0));
 
 		$ids = "";
 		$data = "";
@@ -78,13 +78,13 @@ class McRegion extends BaseLevelProvider{
 			}
 		}
 
-		$nbt->Blocks = new ByteArrayTag("Blocks", $ids);
-		$nbt->Data = new ByteArrayTag("Data", $data);
-		$nbt->SkyLight = new ByteArrayTag("SkyLight", $skyLight);
-		$nbt->BlockLight = new ByteArrayTag("BlockLight", $blockLight);
+		$nbt->setTag(new ByteArrayTag("Blocks", $ids));
+		$nbt->setTag(new ByteArrayTag("Data", $data));
+		$nbt->setTag(new ByteArrayTag("SkyLight", $skyLight));
+		$nbt->setTag(new ByteArrayTag("BlockLight", $blockLight));
 
-		$nbt->Biomes = new ByteArrayTag("Biomes", $chunk->getBiomeIdArray()); //doesn't exist in regular McRegion, this is here for PocketMine-MP only
-		$nbt->HeightMap = new ByteArrayTag("HeightMap", pack("C*", ...$chunk->getHeightMapArray()));
+		$nbt->setTag(new ByteArrayTag("Biomes", $chunk->getBiomeIdArray())); //doesn't exist in regular McRegion, this is here for PocketMine-MP only
+		$nbt->setTag(new ByteArrayTag("HeightMap", pack("C*", ...$chunk->getHeightMapArray())));
 
 		$entities = [];
 
@@ -95,8 +95,7 @@ class McRegion extends BaseLevelProvider{
 			}
 		}
 
-		$nbt->Entities = new ListTag("Entities", $entities);
-		$nbt->Entities->setTagType(NBT::TAG_Compound);
+		$nbt->setTag(new ListTag("Entities", $entities, NBT::TAG_Compound));
 
 		$tiles = [];
 		foreach($chunk->getTiles() as $tile){
@@ -104,8 +103,7 @@ class McRegion extends BaseLevelProvider{
 			$tiles[] = $tile->namedtag;
 		}
 
-		$nbt->TileEntities = new ListTag("TileEntities", $tiles);
-		$nbt->TileEntities->setTagType(NBT::TAG_Compound);
+		$nbt->setTag(new ListTag("TileEntities", $tiles, NBT::TAG_Compound));
 
 		$writer = new NBT(NBT::BIG_ENDIAN);
 		$nbt->setName("Level");

--- a/src/pocketmine/nbt/tag/CompoundTag.php
+++ b/src/pocketmine/nbt/tag/CompoundTag.php
@@ -69,6 +69,53 @@ class CompoundTag extends NamedTag implements \ArrayAccess{
 		}
 	}
 
+	/**
+	 * @param string $name
+	 *
+	 * @return NamedTag|null
+	 */
+	public function getTag(string $name){
+		return $this->exists($name) ? $this->{$name} : null;
+	}
+
+	/**
+	 * @param string $name
+	 * @param bool   $create
+	 *
+	 * @return CompoundTag|null
+	 */
+	public function getCompoundTag(string $name, bool $create = false){
+		return ($this->exists($name) and $this->{$name} instanceof CompoundTag) ? $this->{$name} : ($create ? ($this->{$name} = new CompoundTag($name, [])) : null);
+	}
+
+	/**
+	 * @param NamedTag $tag
+	 */
+	public function setTag(NamedTag $tag){
+		$this->{$tag->getName()} = $tag;
+	}
+
+	/**
+	 * @param NamedTag $tag
+	 */
+	public function putTag(NamedTag $tag){
+		$this->setTag($tag);
+	}
+
+	/**
+	 * @param string $name
+	 * @return bool
+	 */
+	public function exists(string $name) : bool{
+		return isset($this->{$name}) and $this->{$name} instanceof NamedTag;
+	}
+
+	public function remove(string ...$names){
+		foreach($names as $name){
+			unset($this->{$name});
+		}
+	}
+
 	public function offsetExists($offset){
 		return isset($this->{$offset}) and $this->{$offset} instanceof Tag;
 	}

--- a/src/pocketmine/nbt/tag/ListTag.php
+++ b/src/pocketmine/nbt/tag/ListTag.php
@@ -29,6 +29,7 @@ use pocketmine\nbt\NBT;
 
 class ListTag extends NamedTag implements \ArrayAccess, \Countable{
 
+	/** @var int */
 	private $tagType = NBT::TAG_End;
 
 	/**
@@ -36,9 +37,11 @@ class ListTag extends NamedTag implements \ArrayAccess, \Countable{
 	 *
 	 * @param string     $name
 	 * @param NamedTag[] $value
+	 * @param int        $tagType
 	 */
-	public function __construct(string $name = "", array $value = []){
+	public function __construct(string $name = "", array $value = [], int $tagType = NBT::TAG_End){
 		parent::__construct($name, $value);
+		$this->tagType = $tagType;
 	}
 
 	/**

--- a/src/pocketmine/nbt/tag/Tag.php
+++ b/src/pocketmine/nbt/tag/Tag.php
@@ -28,7 +28,7 @@ namespace pocketmine\nbt\tag;
 
 use pocketmine\nbt\NBT;
 
-abstract class Tag extends \stdClass{
+abstract class Tag{
 
 	protected $value;
 

--- a/src/pocketmine/tile/EnchantTable.php
+++ b/src/pocketmine/tile/EnchantTable.php
@@ -31,20 +31,20 @@ class EnchantTable extends Spawnable implements Nameable{
 
 
 	public function getName() : string{
-		return isset($this->namedtag->CustomName) ? $this->namedtag->CustomName->getValue() : "Enchanting Table";
+		return ($t = $this->namedtag->getTag("CustomName")) instanceof StringTag ? $t->getValue() : "Enchanting Table";
 	}
 
 	public function hasName() : bool{
-		return isset($this->namedtag->CustomName);
+		return $this->namedtag->exists("CustomName");
 	}
 
 	public function setName(string $str){
 		if($str === ""){
-			unset($this->namedtag->CustomName);
+			$this->namedtag->remove("CustomName");
 			return;
 		}
 
-		$this->namedtag->CustomName = new StringTag("CustomName", $str);
+		$this->namedtag->setTag(new StringTag("CustomName", $str));
 	}
 
 	public function getSpawnCompound(){
@@ -56,7 +56,7 @@ class EnchantTable extends Spawnable implements Nameable{
 		]);
 
 		if($this->hasName()){
-			$c->CustomName = $this->namedtag->CustomName;
+			$c->setTag($this->namedtag->getTag("CustomName"));
 		}
 
 		return $c;

--- a/src/pocketmine/tile/FlowerPot.php
+++ b/src/pocketmine/tile/FlowerPot.php
@@ -89,8 +89,8 @@ class FlowerPot extends Spawnable{
 			new IntTag("x", (int) $this->x),
 			new IntTag("y", (int) $this->y),
 			new IntTag("z", (int) $this->z),
-			$this->namedtag->item,
-			$this->namedtag->mData
+			$this->namedtag->getTag("item"),
+			$this->namedtag->getTag("mData")
 		]);
 	}
 }

--- a/src/pocketmine/tile/Furnace.php
+++ b/src/pocketmine/tile/Furnace.php
@@ -44,24 +44,27 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 	protected $inventory;
 
 	public function __construct(Level $level, CompoundTag $nbt){
-		if(!isset($nbt->BurnTime) or $nbt["BurnTime"] < 0){
-			$nbt->BurnTime = new ShortTag("BurnTime", 0);
+		/** @var ShortTag $burnTime */
+		if(!(($burnTime = $nbt->getTag("BurnTime")) instanceof ShortTag) or $burnTime->getValue() < 0){
+			$nbt->setTag(new ShortTag("BurnTime", 0));
 		}
-		if(!isset($nbt->CookTime) or $nbt["CookTime"] < 0 or ($nbt["BurnTime"] === 0 and $nbt["CookTime"] > 0)){
-			$nbt->CookTime = new ShortTag("CookTime", 0);
+
+		/** @var ShortTag $cookTime */
+		if(!(($cookTime = $nbt->getTag("CookTime")) instanceof ShortTag) or $cookTime->getValue() < 0 or ($nbt->getTag("BurnTime")->getValue() === 0 and $cookTime->getValue() > 0)){
+			$nbt->setTag(new ShortTag("CookTime", 0));
 		}
-		if(!isset($nbt->MaxTime)){
-			$nbt->MaxTime = new ShortTag("BurnTime", $nbt["BurnTime"]);
-			$nbt->BurnTicks = new ShortTag("BurnTicks", 0);
+
+		if(!$nbt->exists("MaxTime")){
+			$nbt->setTag(new ShortTag("MaxTime", $nbt->getTag("BurnTime")->getValue()));
+			$nbt->setTag(new ShortTag("BurnTicks", 0));
+		}
+
+		if(!($nbt->getTag("Items") instanceof ListTag)){
+			$nbt->setTag(new ListTag("Items", [], NBT::TAG_Compound));
 		}
 
 		parent::__construct($level, $nbt);
 		$this->inventory = new FurnaceInventory($this);
-
-		if(!isset($this->namedtag->Items) or !($this->namedtag->Items instanceof ListTag)){
-			$this->namedtag->Items = new ListTag("Items", []);
-			$this->namedtag->Items->setTagType(NBT::TAG_Compound);
-		}
 
 		for($i = 0; $i < $this->getSize(); ++$i){
 			$this->inventory->setItem($i, $this->getItem($i));
@@ -73,20 +76,20 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 	}
 
 	public function getName() : string{
-		return isset($this->namedtag->CustomName) ? $this->namedtag->CustomName->getValue() : "Furnace";
+		return ($t = $this->namedtag->getTag("CustomName")) instanceof StringTag ? $t->getValue() : "Furnace";
 	}
 
 	public function hasName() : bool{
-		return isset($this->namedtag->CustomName);
+		return $this->namedtag->exists("CustomName");
 	}
 
 	public function setName(string $str){
 		if($str === ""){
-			unset($this->namedtag->CustomName);
+			$this->namedtag->remove("CustomName");
 			return;
 		}
 
-		$this->namedtag->CustomName = new StringTag("CustomName", $str);
+		$this->namedtag->setTag(new StringTag("CustomName", $str));
 	}
 
 	public function close(){
@@ -102,8 +105,7 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 	}
 
 	public function saveNBT(){
-		$this->namedtag->Items = new ListTag("Items", []);
-		$this->namedtag->Items->setTagType(NBT::TAG_Compound);
+		$this->namedtag->setTag(new ListTag("Items", [], NBT::TAG_Compound));
 		for($index = 0; $index < $this->getSize(); ++$index){
 			$this->setItem($index, $this->inventory->getItem($index));
 		}
@@ -122,7 +124,8 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 	 * @return int
 	 */
 	protected function getSlotIndex($index){
-		foreach($this->namedtag->Items as $i => $slot){
+		foreach($this->namedtag->getTag("Items") as $i => $slot){
+			/** @var CompoundTag $slot */
 			if($slot["Slot"] === $index){
 				return $i;
 			}
@@ -143,7 +146,7 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 		if($i < 0){
 			return Item::get(Item::AIR, 0, 0);
 		}else{
-			return Item::nbtDeserialize($this->namedtag->Items[$i]);
+			return Item::nbtDeserialize($this->namedtag->getTag("Items")[$i]);
 		}
 	}
 
@@ -160,20 +163,24 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 
 		$d = $item->nbtSerialize($index);
 
+		$items = $this->namedtag->getTag("Items");
+
 		if($item->getId() === Item::AIR or $item->getCount() <= 0){
 			if($i >= 0){
-				unset($this->namedtag->Items[$i]);
+				unset($items[$i]);
 			}
 		}elseif($i < 0){
 			for($i = 0; $i <= $this->getSize(); ++$i){
-				if(!isset($this->namedtag->Items[$i])){
+				if(!isset($items[$i])){
 					break;
 				}
 			}
-			$this->namedtag->Items[$i] = $d;
+			$items[$i] = $d;
 		}else{
-			$this->namedtag->Items[$i] = $d;
+			$items[$i] = $d;
 		}
+
+		$this->namedtag->setTag($items);
 
 		return true;
 	}
@@ -192,14 +199,14 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 			return;
 		}
 
-		$this->namedtag->MaxTime = new ShortTag("MaxTime", $ev->getBurnTime());
-		$this->namedtag->BurnTime = new ShortTag("BurnTime", $ev->getBurnTime());
-		$this->namedtag->BurnTicks = new ShortTag("BurnTicks", 0);
+		$this->namedtag->setTag(new ShortTag("MaxTime", $ev->getBurnTime()));
+		$this->namedtag->setTag(new ShortTag("BurnTime", $ev->getBurnTime()));
+		$this->namedtag->setTag(new ShortTag("BurnTicks", 0));
 		if($this->getBlock()->getId() === Item::FURNACE){
 			$this->getLevel()->setBlock($this, Block::get(Item::BURNING_FURNACE, $this->getBlock()->getDamage()), true);
 		}
 
-		if($this->namedtag["BurnTime"] > 0 and $ev->isBurning()){
+		if($ev->getBurnTime() > 0 and $ev->isBurning()){
 			$fuel->setCount($fuel->getCount() - 1);
 			if($fuel->getCount() === 0){
 				$fuel = Item::get(Item::AIR, 0, 0);
@@ -223,17 +230,19 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 		$smelt = $this->server->getCraftingManager()->matchFurnaceRecipe($raw);
 		$canSmelt = ($smelt instanceof FurnaceRecipe and $raw->getCount() > 0 and (($smelt->getResult()->equals($product) and $product->getCount() < $product->getMaxStackSize()) or $product->getId() === Item::AIR));
 
-		if($this->namedtag["BurnTime"] <= 0 and $canSmelt and $fuel->getFuelTime() !== null and $fuel->getCount() > 0){
+		$burnTime = $this->namedtag->getTag("BurnTime")->getValue();
+		if($burnTime <= 0 and $canSmelt and $fuel->getFuelTime() !== null and $fuel->getCount() > 0){
 			$this->checkFuel($fuel);
 		}
 
-		if($this->namedtag["BurnTime"] > 0){
-			$this->namedtag->BurnTime = new ShortTag("BurnTime", ((int) $this->namedtag["BurnTime"]) - 1);
-			$this->namedtag->BurnTicks = new ShortTag("BurnTicks", (int) ceil(($this->namedtag["BurnTime"] / $this->namedtag["MaxTime"] * 200)));
+		if($burnTime > 0){
+			$burnTime -= 1;
+			$this->namedtag->setTag(new ShortTag("BurnTime", $burnTime));
+			$this->namedtag->setTag(new ShortTag("BurnTicks", (int) ceil(($burnTime / $this->namedtag->getTag("MaxTime")->getValue() * 200))));
 
 			if($smelt instanceof FurnaceRecipe and $canSmelt){
-				$this->namedtag->CookTime = new ShortTag("CookTime", (int) ($this->namedtag["CookTime"]) + 1);
-				if($this->namedtag["CookTime"] >= 200){ //10 seconds
+				$this->namedtag->setTag(new ShortTag("CookTime", (int) ($this->namedtag["CookTime"]) + 1));
+				if($this->namedtag->getTag("CookTime")->getValue() >= 200){ //10 seconds
 					$product = Item::get($smelt->getResult()->getId(), $smelt->getResult()->getDamage(), $product->getCount() + 1);
 
 					$this->server->getPluginManager()->callEvent($ev = new FurnaceSmeltEvent($this, $raw, $product));
@@ -247,23 +256,23 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 						$this->inventory->setSmelting($raw);
 					}
 
-					$this->namedtag->CookTime = new ShortTag("CookTime", ((int) $this->namedtag["CookTime"]) - 200);
+					$this->namedtag->setTag(new ShortTag("CookTime", ((int) $this->namedtag->getTag("CookTime")->getValue()) - 200));
 				}
-			}elseif($this->namedtag["BurnTime"] <= 0){
-				$this->namedtag->BurnTime = new ShortTag("BurnTime", 0);
-				$this->namedtag->CookTime = new ShortTag("CookTime", 0);
-				$this->namedtag->BurnTicks = new ShortTag("BurnTicks", 0);
+			}elseif($burnTime <= 0){
+				$this->namedtag->setTag(new ShortTag("BurnTime", 0));
+				$this->namedtag->setTag(new ShortTag("CookTime", 0));
+				$this->namedtag->setTag(new ShortTag("BurnTicks", 0));
 			}else{
-				$this->namedtag->CookTime = new ShortTag("CookTime", 0);
+				$this->namedtag->setTag(new ShortTag("CookTime", 0));
 			}
 			$ret = true;
 		}else{
 			if($this->getBlock()->getId() === Item::BURNING_FURNACE){
 				$this->getLevel()->setBlock($this, Block::get(Item::FURNACE, $this->getBlock()->getDamage()), true);
 			}
-			$this->namedtag->BurnTime = new ShortTag("BurnTime", 0);
-			$this->namedtag->CookTime = new ShortTag("CookTime", 0);
-			$this->namedtag->BurnTicks = new ShortTag("BurnTicks", 0);
+			$this->namedtag->setTag(new ShortTag("BurnTime", 0));
+			$this->namedtag->setTag(new ShortTag("CookTime", 0));
+			$this->namedtag->setTag(new ShortTag("BurnTicks", 0));
 		}
 
 		foreach($this->getInventory()->getViewers() as $player){
@@ -272,13 +281,13 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 				$pk = new ContainerSetDataPacket();
 				$pk->windowid = $windowId;
 				$pk->property = 0; //Smelting
-				$pk->value = $this->namedtag["CookTime"];
+				$pk->value = $this->namedtag->getTag("CookTime")->getValue();
 				$player->dataPacket($pk);
 
 				$pk = new ContainerSetDataPacket();
 				$pk->windowid = $windowId;
 				$pk->property = 1; //Fire icon
-				$pk->value = $this->namedtag["BurnTicks"];
+				$pk->value = $this->namedtag->getTag("BurnTicks")->getValue();
 				$player->dataPacket($pk);
 			}
 
@@ -297,12 +306,12 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 			new IntTag("x", (int) $this->x),
 			new IntTag("y", (int) $this->y),
 			new IntTag("z", (int) $this->z),
-			new ShortTag("BurnTime", (int) $this->namedtag["BurnTime"]),
-			new ShortTag("CookTime", (int) $this->namedtag["CookTime"])
+			$this->namedtag->getTag("BurnTime"),
+			$this->namedtag->getTag("CookTime")
 		]);
 
 		if($this->hasName()){
-			$nbt->CustomName = $this->namedtag->CustomName;
+			$nbt->setTag(clone $this->namedtag->getTag("CustomName"));
 		}
 		return $nbt;
 	}

--- a/src/pocketmine/tile/ItemFrame.php
+++ b/src/pocketmine/tile/ItemFrame.php
@@ -34,12 +34,14 @@ use pocketmine\nbt\tag\StringTag;
 class ItemFrame extends Spawnable{
 
 	public function __construct(Level $level, CompoundTag $nbt){
-		if(!isset($nbt->ItemRotation)){
-			$nbt->ItemRotation = new ByteTag("ItemRotation", 0);
+		$itemRotation = $nbt->getTag("ItemRotation");
+		if(!($itemRotation instanceof ByteTag)){
+			$nbt->setTag(new ByteTag("ItemRotation", 0));
 		}
 
-		if(!isset($nbt->ItemDropChance)){
-			$nbt->ItemDropChance = new FloatTag("ItemDropChance", 1.0);
+		$itemDropChance = $nbt->getTag("ItemDropChance");
+		if(!($itemDropChance instanceof FloatTag)){
+			$nbt->setTag(new FloatTag("ItemDropChance", 1.0));
 		}
 
 		parent::__construct($level, $nbt);
@@ -50,37 +52,34 @@ class ItemFrame extends Spawnable{
 	}
 
 	public function getItem() : Item{
-		if(isset($this->namedtag->Item)){
-			return Item::nbtDeserialize($this->namedtag->Item);
-		}else{
-			return Item::get(Item::AIR);
-		}
+		$itemTag = $this->namedtag->getCompoundTag("Item");
+		return $itemTag !== null ? Item::nbtDeserialize($itemTag) : Item::get(Item::AIR, 0, 0);
 	}
 
 	public function setItem(Item $item = null){
 		if($item !== null and $item->getId() !== Item::AIR){
-			$this->namedtag->Item = $item->nbtSerialize(-1, "Item");
+			$this->namedtag->setTag($item->nbtSerialize(-1, "Item"));
 		}else{
-			unset($this->namedtag->Item);
+			$this->namedtag->remove("Item");
 		}
 		$this->onChanged();
 	}
 
 	public function getItemRotation() : int{
-		return $this->namedtag->ItemRotation->getValue();
+		return $this->namedtag->getTag("ItemRotation")->getValue();
 	}
 
 	public function setItemRotation(int $rotation){
-		$this->namedtag->ItemRotation = new ByteTag("ItemRotation", $rotation);
+		$this->namedtag->setTag(new ByteTag("ItemRotation", $rotation));
 		$this->onChanged();
 	}
 
 	public function getItemDropChance() : float{
-		return $this->namedtag->ItemDropChance->getValue();
+		return $this->namedtag->getTag("ItemDropChance")->getValue();
 	}
 
 	public function setItemDropChance(float $chance){
-		$this->namedtag->ItemDropChance = new FloatTag("ItemDropChance", $chance);
+		$this->namedtag->setTag(new FloatTag("ItemDropChance", $chance));
 		$this->onChanged();
 	}
 
@@ -90,11 +89,11 @@ class ItemFrame extends Spawnable{
 			new IntTag("x", (int) $this->x),
 			new IntTag("y", (int) $this->y),
 			new IntTag("z", (int) $this->z),
-			$this->namedtag->ItemDropChance,
-			$this->namedtag->ItemRotation,
+			$this->namedtag->getTag("ItemDropChance"),
+			$this->namedtag->getTag("ItemRotation"),
 		]);
 		if($this->hasItem()){
-			$tag->Item = $this->namedtag->Item;
+			$tag->setTag(clone $this->namedtag->getCompoundTag("Item"));
 		}
 		return $tag;
 	}

--- a/src/pocketmine/tile/Skull.php
+++ b/src/pocketmine/tile/Skull.php
@@ -48,19 +48,19 @@ class Skull extends Spawnable{
 	}
 
 	public function setType(int $type){
-		$this->namedtag->SkullType = new ByteTag("SkullType", $type);
+		$this->namedtag->setTag(new ByteTag("SkullType", $type));
 		$this->onChanged();
 	}
 
 	public function getType(){
-		return $this->namedtag["SkullType"];
+		return $this->namedtag->getTag("SkullType")->getValue();
 	}
 
 	public function getSpawnCompound(){
 		return new CompoundTag("", [
 			new StringTag("id", Tile::SKULL),
-			$this->namedtag->SkullType,
-			$this->namedtag->Rot,
+			$this->namedtag->getTag("SkullType"),
+			$this->namedtag->getTag("Rot"),
 			new IntTag("x", (int) $this->x),
 			new IntTag("y", (int) $this->y),
 			new IntTag("z", (int) $this->z)

--- a/src/pocketmine/tile/Tile.php
+++ b/src/pocketmine/tile/Tile.php
@@ -144,10 +144,10 @@ abstract class Tile extends Position{
 	}
 
 	public function saveNBT(){
-		$this->namedtag->id = new StringTag("id", $this->getSaveId());
-		$this->namedtag->x = new IntTag("x", $this->x);
-		$this->namedtag->y = new IntTag("y", $this->y);
-		$this->namedtag->z = new IntTag("z", $this->z);
+		$this->namedtag->setTag(new StringTag("id", $this->getSaveId()));
+		$this->namedtag->setTag(new IntTag("x", $this->x));
+		$this->namedtag->setTag(new IntTag("y", $this->y));
+		$this->namedtag->setTag(new IntTag("z", $this->z));
 	}
 
 	public function getCleanedNBT(){


### PR DESCRIPTION
## Introduction
There is a lot of undefinedness around anything that uses NBT in the PocketMine-MP core. This pull request aims to reduce this problem by tightening the restrictions on the way CompoundTag children are accessed, and add methods for accessing them safely instead.

## Relevant issues
- fixed #1118 
- fixed villager profession doesn't make any difference client-side

## Changes
### API changes
The method of assigning a child tag to a CompoundTag has changed. It is no longer legal to do the following:
- `$nbt->SomeTagName = new IntTag("SomeTagName", 5);`
- `unset($nbt->SomeTagName);`
- `$nbt->SomeTagName->getValue();`

You are instead encouraged to use the new CompoundTag API methods:
- `getTag(string $name)`
- `getCompoundTag(string $name)`
- `setTag(NamedTag $tag)`
- `exists(string $name)`
- `remove(string $name)`

This aims to reduce confusion between CompoundTag offsets and the tags' own names. For example, the following code:
`$nbt->SomeTagName = new IntTag("SomeOtherNameThatDoesntMatch", 5);`
will cause the IntTag to be saved with the name passed in the IntTag constructor, _not_ its field name in the CompoundTag. This duplication/inconsistency caused many bugs throughout the core code.

## Backwards compatibility
This is a backwards-compatibility break due to the API changes noted above.

## Tests
This has only been lightly tested (world loading, enchantments, spawning entities) but there are a lot of changes in this PR and I have no doubt I have introduced problems somewhere. Please test and review carefully.

Areas affected by these changes include:
- Level loading and saving (all formats)
- Entity loading and saving (all)
- Player data loading and saving
- Tile creation, spawning loading and saving.