### PR TITLE
Made Item->setLore() fluent

### DIFF
--- a/src/pocketmine/item/Item.php
+++ b/src/pocketmine/item/Item.php
@@ -687,6 +687,11 @@ class Item implements ItemIds, \JsonSerializable{
 		return [];
 	}
 
+	/**
+	 * @param string[] $lines
+	 *
+	 * @return $this
+	 */
 	public function setLore(array $lines){
 		$tag = $this->getNamedTag() ?? new CompoundTag("", []);
 		if(!isset($tag->display)){
@@ -700,6 +705,8 @@ class Item implements ItemIds, \JsonSerializable{
 		}
 
 		$this->setNamedTag($tag);
+
+		return $this;
 	}
 
 	/**


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
setLore() does not return the modified Item instance
### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Item::setLore() now returns Item
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
No changes
## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Full compatability
## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
None
## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
Untested, but should not effect anything due to the returned value not being used by the core.