### PR TITLE
requestChunkTask exception handling

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -68,6 +68,7 @@ use pocketmine\item\Item;
 use pocketmine\level\format\Chunk;
 use pocketmine\level\format\io\BaseLevelProvider;
 use pocketmine\level\format\io\LevelProvider;
+use pocketmine\level\format\io\ChunkException;
 use pocketmine\level\generator\GenerationTask;
 use pocketmine\level\generator\Generator;
 use pocketmine\level\generator\GeneratorRegisterTask;
@@ -2385,9 +2386,13 @@ class Level implements ChunkManager, Metadatable{
 					continue;
 				}
 				$this->timings->syncChunkSendPrepareTimer->startTiming();
-				$task = $this->provider->requestChunkTask($x, $z);
-				if($task !== null){
-					$this->server->getScheduler()->scheduleAsyncTask($task);
+				try{
+					$this->server->getScheduler()->scheduleAsyncTask($this->provider->requestChunkTask($x, $z));
+				}
+				catch(ChunkException $e){
+					unset($this->chunkSendQueue[$index]);
+					unset($this->chunkSendTasks[$index]);
+					$this->server->getLogger()->logException($e);
 				}
 				$this->timings->syncChunkSendPrepareTimer->stopTiming();
 			}

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -2388,8 +2388,7 @@ class Level implements ChunkManager, Metadatable{
 				$this->timings->syncChunkSendPrepareTimer->startTiming();
 				try{
 					$this->server->getScheduler()->scheduleAsyncTask($this->provider->requestChunkTask($x, $z));
-				}
-				catch(ChunkException $e){
+				}catch(ChunkException $e){
 					unset($this->chunkSendQueue[$index]);
 					unset($this->chunkSendTasks[$index]);
 					$this->server->getLogger()->logException($e);


### PR DESCRIPTION
## requestChunkTask exception handling

### Explanation
requestChunkTask throws an exception, since the exception is not caught and handled, chunks will never leave the sendChunkTasks and chunkSendQueue array, forever looping around each tick / not releasing memory.

Found this when I was using a corrupt world.

I doubt try/catch will effect performance in any way

### API changes
None.

### Changes
- Properly handle ChunkException with try/catch