### PR TITLE
Possible solution for #1134

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1953,8 +1953,9 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 		$this->rawUUID = $this->uuid->toBinary();
 
 		if(!Player::isValidUserName($packet->username)){
-			$this->close("", "disconnectionScreen.invalidName");
-			return true;
+			if($this->kick("disconnectionScreen.invalidName", false)){
+				return true;
+			}
 		}
 
 		if(!Player::isValidSkin($packet->skin)){


### PR DESCRIPTION
## Introduction
Allow custom username policies, you can now choose to cancel PlayerKickEvent to implement your own username policies.

### Relevant issues
Before it was impossible for plugins to allow certain usernames to be joinable via API.

Closes #1134 

## Changes
### API changes
Only additions, properly coded plugins will not break.

## Follow-up
Perhaps change more Player::close calls to Player::kick?
