### PR TITLE
Added API method to allow changing /help page sizes for CommandSenders

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -328,6 +328,9 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	/** @var PermissibleBase */
 	private $perm = null;
 
+	/** @var int|null */
+	protected $lineHeight = null;
+
 	public function getLeaveMessage(){
 		return new TranslationContainer(TextFormat::YELLOW . "%multiplayer.player.left", [
 			$this->getDisplayName()
@@ -462,6 +465,17 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	 */
 	public function setRemoveFormat($remove = true){
 		$this->removeFormat = (bool) $remove;
+	}
+
+	public function getScreenLineHeight() : int{
+		return $this->lineHeight ?? 7;
+	}
+
+	public function setScreenLineHeight(int $height = null){
+		if($height !== null and $height < 1){
+			throw new \InvalidArgumentException("Line height must be at least 1");
+		}
+		$this->lineHeight = $height;
 	}
 
 	/**

--- a/src/pocketmine/command/CommandSender.php
+++ b/src/pocketmine/command/CommandSender.php
@@ -44,5 +44,17 @@ interface CommandSender extends Permissible{
 	 */
 	public function getName();
 
+	/**
+	 * Returns the line height of the command-sender's screen. Used for determining sizes for command output pagination
+	 * such as in the /help command.
+	 *
+	 * @return int
+	 */
+	public function getScreenLineHeight() : int;
 
+	/**
+	 * Sets the line height used for command output pagination for this command sender. `null` will reset it to default.
+	 * @param int|null $height
+	 */
+	public function setScreenLineHeight(int $height = null);
 }

--- a/src/pocketmine/command/ConsoleCommandSender.php
+++ b/src/pocketmine/command/ConsoleCommandSender.php
@@ -31,10 +31,14 @@ use pocketmine\permission\PermissionAttachmentInfo;
 use pocketmine\plugin\Plugin;
 use pocketmine\Server;
 use pocketmine\utils\MainLogger;
+use pocketmine\utils\Terminal;
 
 class ConsoleCommandSender implements CommandSender{
 
 	private $perm;
+
+	/** @var int|null */
+	protected $lineHeight = null;
 
 	public function __construct(){
 		$this->perm = new PermissibleBase($this);
@@ -137,6 +141,17 @@ class ConsoleCommandSender implements CommandSender{
 	 */
 	public function setOp($value){
 
+	}
+
+	public function getScreenLineHeight() : int{
+		return $this->lineHeight ?? PHP_INT_MAX;
+	}
+
+	public function setScreenLineHeight(int $height = null){
+		if($height !== null and $height < 1){
+			throw new \InvalidArgumentException("Line height must be at least 1");
+		}
+		$this->lineHeight = $height;
 	}
 
 }

--- a/src/pocketmine/command/defaults/HelpCommand.php
+++ b/src/pocketmine/command/defaults/HelpCommand.php
@@ -60,11 +60,7 @@ class HelpCommand extends VanillaCommand{
 			$pageNumber = 1;
 		}
 
-		if($sender instanceof ConsoleCommandSender){
-			$pageHeight = PHP_INT_MAX;
-		}else{
-			$pageHeight = 7;
-		}
+		$pageHeight = $sender->getScreenLineHeight();
 
 		if($command === ""){
 			/** @var Command[][] $commands */


### PR DESCRIPTION
## Introduction
Allows plugins to alter the page size for clients shown when using /help.
<!-- Explain existing problems or why this pull request is necessary -->

Using /help on a client can get irritating, especially if you have a larger screen. This change allows plugins to set a custom /help page size which suits everyone. I currently just set it to `PHP_INT_MAX` since the scrollable chat window makes it unnecessary to have multiple pages.

## Changes
### API changes
- added API method `CommandSender->getScreenLineHeight() : int`
- added API method `CommandSender->setScreenLineHeight(int)`

## Tests
tested very quickly, probably ought to check for negative page sizes.
