### PR TITLE
Fix drop item behaviour make compatible with pc version

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2877,7 +2877,17 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			return true;
 		}
 
-		$this->inventory->setItemInHand(Item::get(Item::AIR, 0, 1));
+		if($packet->item->getCount() < $item->getCount()){
+			// PC edition users may drop any number of item they have
+			$item->setCount($item->getCount() - $packet->item->getCount());
+			$this->inventory->setItemInHand($item);
+
+			// do not trust item id originates from incomming packet
+			$item->setCount($packet->item->getCount());
+		}else{
+			$this->inventory->setItemInHand(Item::get(Item::AIR, 0, 1));
+		}
+
 		$motion = $this->getDirectionVector()->multiply(0.4);
 
 		$this->level->dropItem($this->add(0, 1.3, 0), $item, $motion, 40);


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Support the behaviour dropping item one by one, for the compatibility to the pc version.

I'm currently working on the BigBrother project. And I want to implement the dropping item behavior. Probably, Minecraft PE version do not support dropping item one by one, so that ppmp interpret `DropItemPacket` as dropping whole item. But this behaviour is not compatible with pc version of minecraft. So, I wrote this patch to solve this problem.

### Behavioural changes
decrement the counter of item in hand by `DropItemPacket#item->count`. `PlayerInventory#setItem()` clear inventory (holding item) if item count is 0 or negative value. this patch do not affect any PE version of minecraft client.

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
I was tested this patch on the iOS version, and PC version on Mac with BigBrother (my code base).