### PR TITLE
Allow spaces in player's username

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -225,7 +225,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	public static function isValidUserName(string $name) : bool{
 		$lname = strtolower($name);
 		$len = strlen($name);
-		return $lname !== "rcon" and $lname !== "console" and $len >= 1 and $len <= 15 and stristr($name, "\n") == false and stristr($name, "\t") == false and preg_match("/[^A-Za-z0-9_\s]/", $name) === 0;
+		return $lname !== "rcon" and $lname !== "console" and $len >= 1 and $len <= 15 and stristr($name, "\n") === false and stristr($name, "\t") === false and preg_match("/[^A-Za-z0-9_\s]/", $name) === 0;
 	}
 
 	/**

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -225,7 +225,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	public static function isValidUserName(string $name) : bool{
 		$lname = strtolower($name);
 		$len = strlen($name);
-		return $lname !== "rcon" and $lname !== "console" and $len >= 1 and $len <= 16 and preg_match("/[^A-Za-z0-9_]/", $name) === 0;
+		return $lname !== "rcon" and $lname !== "console" and $len >= 1 and $len <= 16 and preg_match("/[^A-Za-z0-9_\s]/", $name) === 0;
 	}
 
 	/**

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -225,7 +225,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	public static function isValidUserName(string $name) : bool{
 		$lname = strtolower($name);
 		$len = strlen($name);
-		return $lname !== "rcon" and $lname !== "console" and $len >= 1 and $len <= 16 and preg_match("/[^A-Za-z0-9_\s]/", $name) === 0;
+		return $lname !== "rcon" and $lname !== "console" and $len >= 1 and $len <= 15 and stristr($name, "\n") == false and stristr($name, "\t") == false and preg_match("/[^A-Za-z0-9_\s]/", $name) === 0;
 	}
 
 	/**


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
XBOX Live gamertags support spaces. Without this, it limits gameplay to some players logged into xbox live.

## Changes
### Behavioral Changes
Allows players with gamertags with spaces to join

## Follow-up
Finish custom command data, so players with spaced names can be called correctly in commands

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
Try to join the server with a username that contains spaces, such as "Name With Spaces" xD


