### PR TITLE
Fix BossEventPacket

### DIFF
--- a/src/pocketmine/network/mcpe/protocol/BossEventPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/BossEventPacket.php
@@ -75,8 +75,10 @@ class BossEventPacket extends DataPacket{
 			case self::TYPE_SHOW:
 				$this->title = $this->getString();
 				$this->healthPercent = $this->getLFloat();
+				break;
 			case self::TYPE_UNKNOWN_6:
 				$this->unknownShort = $this->getLShort();
+				break;
 			case self::TYPE_TEXTURE:
 				$this->color = $this->getUnsignedVarInt();
 				$this->overlay = $this->getUnsignedVarInt();
@@ -103,8 +105,10 @@ class BossEventPacket extends DataPacket{
 			case self::TYPE_SHOW:
 				$this->putString($this->title);
 				$this->putLFloat($this->healthPercent);
+				break;
 			case self::TYPE_UNKNOWN_6:
 				$this->putLShort($this->unknownShort);
+				break;
 			case self::TYPE_TEXTURE:
 				$this->putUnsignedVarInt($this->color);
 				$this->putUnsignedVarInt($this->overlay);


### PR DESCRIPTION

## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
I was trying to send this packet to a player, but kept getting errors about parameters being null and what not, so I looked into it and I saw that two breaks were missing in the switch statements for encode and decode.

### Relevant issues

Not any that I could find, but it does fix an issue with sending BossEventPacket

## Changes
### API changes
N/A

### Behavioural changes
N/A

## Backwards compatibility
Compatible with the api3/blocks branch

## Follow-up
Whether this was intended by Dylan or not is beyond me, but I believe it was an accident.
