### PR TITLE
Changes username validation regex

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -225,7 +225,7 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 	public static function isValidUserName(string $name) : bool{
 		$lname = strtolower($name);
 		$len = strlen($name);
-		return $lname !== "rcon" and $lname !== "console" and $len >= 1 and $len <= 16 and preg_match("/[^A-Za-z0-9_]/", $name) === 0;
+		return $lname !== "rcon" and $lname !== "console" and $len >= 1 and $len <= 16 and preg_match("/\A | \Z|[^A-z0-9_ ]| {2,}|\A[0-9]/", $name) === 0;
 	}
 
 	/**


### PR DESCRIPTION
## Introduction
Currently not all valid usernames are able to join. Noticed as i have a space in mine.
According to xbox.com your gamer tag has to abide to these rules
"You can use up to 15 characters: Aa-Zz, 0-9, and single spaces. It can’t start with a number and can’t start or end with a space."


## Changes
### Behavioural changes
Changed regex in username validation to follow xbox.com guidlines


## Follow-up
Test that regex works as i only did test in a [regex tester](https://regex101.com/r/9nOPbK/1).