### PR TITLE
Moar typehints

### DIFF
--- a/src/pocketmine/CrashDump.php
+++ b/src/pocketmine/CrashDump.php
@@ -38,7 +38,9 @@ class CrashDump{
 	private $fp;
 	private $time;
 	private $data = [];
-	private $encodedData = null;
+	/** @var string */
+	private $encodedData = "";
+	/** @var string */
 	private $path;
 
 	public function __construct(Server $server){
@@ -64,7 +66,7 @@ class CrashDump{
 		$this->encodeData();
 	}
 
-	public function getPath(){
+	public function getPath() : string{
 		return $this->path;
 	}
 
@@ -72,7 +74,7 @@ class CrashDump{
 		return $this->encodedData;
 	}
 
-	public function getData(){
+	public function getData() : array{
 		return $this->data;
 	}
 

--- a/src/pocketmine/IPlayer.php
+++ b/src/pocketmine/IPlayer.php
@@ -30,7 +30,7 @@ interface IPlayer extends ServerOperator{
 	/**
 	 * @return bool
 	 */
-	public function isOnline();
+	public function isOnline() : bool;
 
 	/**
 	 * @return string
@@ -40,22 +40,22 @@ interface IPlayer extends ServerOperator{
 	/**
 	 * @return bool
 	 */
-	public function isBanned();
+	public function isBanned() : bool;
 
 	/**
 	 * @param bool $banned
 	 */
-	public function setBanned($banned);
+	public function setBanned(bool $banned);
 
 	/**
 	 * @return bool
 	 */
-	public function isWhitelisted();
+	public function isWhitelisted() : bool;
 
 	/**
 	 * @param bool $value
 	 */
-	public function setWhitelisted($value);
+	public function setWhitelisted(bool $value);
 
 	/**
 	 * @return Player|null
@@ -73,8 +73,8 @@ interface IPlayer extends ServerOperator{
 	public function getLastPlayed();
 
 	/**
-	 * @return mixed
+	 * @return bool
 	 */
-	public function hasPlayedBefore();
+	public function hasPlayedBefore() : bool;
 
 }

--- a/src/pocketmine/MemoryManager.php
+++ b/src/pocketmine/MemoryManager.php
@@ -116,11 +116,11 @@ class MemoryManager{
 		gc_enable();
 	}
 
-	public function isLowMemory(){
+	public function isLowMemory() : bool{
 		return $this->lowMemory;
 	}
 
-	public function canUseChunkCache(){
+	public function canUseChunkCache() : bool{
 		return !($this->lowMemory and $this->chunkTrigger);
 	}
 

--- a/src/pocketmine/OfflinePlayer.php
+++ b/src/pocketmine/OfflinePlayer.php
@@ -48,7 +48,7 @@ class OfflinePlayer implements IPlayer, Metadatable{
 		}
 	}
 
-	public function isOnline(){
+	public function isOnline() : bool{
 		return $this->getPlayer() !== null;
 	}
 
@@ -60,11 +60,11 @@ class OfflinePlayer implements IPlayer, Metadatable{
 		return $this->server;
 	}
 
-	public function isOp(){
+	public function isOp() : bool{
 		return $this->server->isOp(strtolower($this->getName()));
 	}
 
-	public function setOp($value){
+	public function setOp(bool $value){
 		if($value === $this->isOp()){
 			return;
 		}
@@ -76,11 +76,11 @@ class OfflinePlayer implements IPlayer, Metadatable{
 		}
 	}
 
-	public function isBanned(){
+	public function isBanned() : bool{
 		return $this->server->getNameBans()->isBanned(strtolower($this->getName()));
 	}
 
-	public function setBanned($value){
+	public function setBanned(bool $value){
 		if($value === true){
 			$this->server->getNameBans()->addBan($this->getName(), null, null, null);
 		}else{
@@ -88,11 +88,11 @@ class OfflinePlayer implements IPlayer, Metadatable{
 		}
 	}
 
-	public function isWhitelisted(){
+	public function isWhitelisted() : bool{
 		return $this->server->isWhitelisted(strtolower($this->getName()));
 	}
 
-	public function setWhitelisted($value){
+	public function setWhitelisted(bool $value){
 		if($value === true){
 			$this->server->addWhitelist(strtolower($this->getName()));
 		}else{
@@ -112,7 +112,7 @@ class OfflinePlayer implements IPlayer, Metadatable{
 		return $this->namedtag instanceof CompoundTag ? $this->namedtag["lastPlayed"] : null;
 	}
 
-	public function hasPlayedBefore(){
+	public function hasPlayedBefore() : bool{
 		return $this->namedtag instanceof CompoundTag;
 	}
 

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -77,7 +77,6 @@ use pocketmine\inventory\BigShapedRecipe;
 use pocketmine\inventory\BigShapelessRecipe;
 use pocketmine\inventory\FurnaceInventory;
 use pocketmine\inventory\Inventory;
-use pocketmine\inventory\InventoryHolder;
 use pocketmine\inventory\PlayerInventory;
 use pocketmine\inventory\ShapedRecipe;
 use pocketmine\inventory\ShapelessRecipe;
@@ -196,6 +195,7 @@ use pocketmine\network\mcpe\protocol\UseItemPacket;
 use pocketmine\network\SourceInterface;
 use pocketmine\permission\PermissibleBase;
 use pocketmine\permission\PermissionAttachment;
+use pocketmine\permission\PermissionAttachmentInfo;
 use pocketmine\plugin\Plugin;
 use pocketmine\resourcepacks\ResourcePack;
 use pocketmine\tile\ItemFrame;
@@ -283,7 +283,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer, Netwo
 	protected $sleeping = null;
 	protected $clientID = null;
 
-	private $loaderId = null;
+	private $loaderId = 0;
 
 	protected $stepHeight = 0.6;
 
@@ -350,11 +350,11 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer, Netwo
 		return $this->clientSecret;
 	}
 
-	public function isBanned(){
+	public function isBanned() : bool{
 		return $this->server->getNameBans()->isBanned($this->iusername);
 	}
 
-	public function setBanned($value){
+	public function setBanned(bool $value){
 		if($value === true){
 			$this->server->getNameBans()->addBan($this->getName(), null, null, null);
 			$this->kick("You have been banned");
@@ -363,11 +363,11 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer, Netwo
 		}
 	}
 
-	public function isWhitelisted(){
+	public function isWhitelisted() : bool{
 		return $this->server->isWhitelisted($this->iusername);
 	}
 
-	public function setWhitelisted($value){
+	public function setWhitelisted(bool $value){
 		if($value === true){
 			$this->server->addWhitelist($this->iusername);
 		}else{
@@ -387,12 +387,12 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer, Netwo
 		return $this->namedtag instanceof CompoundTag ? $this->namedtag["lastPlayed"] : null;
 	}
 
-	public function hasPlayedBefore(){
+	public function hasPlayedBefore() : bool{
 		return $this->playedBefore;
 	}
 
-	public function setAllowFlight($value){
-		$this->allowFlight = (bool) $value;
+	public function setAllowFlight(bool $value){
+		$this->allowFlight = $value;
 		$this->sendSettings();
 	}
 
@@ -453,7 +453,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer, Netwo
 	/**
 	 * @return bool
 	 */
-	public function getRemoveFormat(){
+	public function getRemoveFormat() : bool{
 		return $this->removeFormat;
 	}
 
@@ -480,7 +480,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer, Netwo
 	 *
 	 * @return bool
 	 */
-	public function canSee(Player $player){
+	public function canSee(Player $player) : bool{
 		return !isset($this->hiddenPlayers[$player->getRawUniqueId()]);
 	}
 
@@ -539,21 +539,21 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer, Netwo
 	/**
 	 * @return bool
 	 */
-	public function isOnline(){
+	public function isOnline() : bool{
 		return $this->connected === true and $this->loggedIn === true;
 	}
 
 	/**
 	 * @return bool
 	 */
-	public function isOp(){
+	public function isOp() : bool{
 		return $this->server->isOp($this->getName());
 	}
 
 	/**
 	 * @param bool $value
 	 */
-	public function setOp($value){
+	public function setOp(bool $value){
 		if($value === $this->isOp()){
 			return;
 		}
@@ -572,7 +572,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer, Netwo
 	 *
 	 * @return bool
 	 */
-	public function isPermissionSet($name){
+	public function isPermissionSet($name) : bool{
 		return $this->perm->isPermissionSet($name);
 	}
 
@@ -583,7 +583,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer, Netwo
 	 *
 	 * @throws \InvalidStateException if the player is closed
 	 */
-	public function hasPermission($name){
+	public function hasPermission($name) : bool{
 		if($this->closed){
 			throw new \InvalidStateException("Trying to get permissions of closed player");
 		}
@@ -629,9 +629,9 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer, Netwo
 	}
 
 	/**
-	 * @return permission\PermissionAttachmentInfo[]
+	 * @return PermissionAttachmentInfo[]
 	 */
-	public function getEffectivePermissions(){
+	public function getEffectivePermissions() : array{
 		return $this->perm->getEffectivePermissions();
 	}
 
@@ -698,7 +698,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer, Netwo
 	 *
 	 * @return bool
 	 */
-	public function hasAchievement($achievementId){
+	public function hasAchievement(string $achievementId) : bool{
 		if(!isset(Achievement::$list[$achievementId])){
 			return false;
 		}
@@ -709,7 +709,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer, Netwo
 	/**
 	 * @return bool
 	 */
-	public function isConnected(){
+	public function isConnected() : bool{
 		return $this->connected === true;
 	}
 
@@ -718,7 +718,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer, Netwo
 	 *
 	 * @return string
 	 */
-	public function getDisplayName(){
+	public function getDisplayName() : string{
 		return $this->displayName;
 	}
 
@@ -744,14 +744,14 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer, Netwo
 	 *
 	 * @return string
 	 */
-	public function getAddress(){
+	public function getAddress() : string{
 		return $this->ip;
 	}
 
 	/**
 	 * @return int
 	 */
-	public function getPort(){
+	public function getPort() : int{
 		return $this->port;
 	}
 
@@ -762,7 +762,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer, Netwo
 	/**
 	 * @return bool
 	 */
-	public function isSleeping(){
+	public function isSleeping() : bool{
 		return $this->sleeping !== null;
 	}
 
@@ -1035,7 +1035,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer, Netwo
 	 *
 	 * @return bool
 	 */
-	public function batchDataPacket(DataPacket $packet){
+	public function batchDataPacket(DataPacket $packet) : bool{
 		if($this->connected === false){
 			return false;
 		}
@@ -1133,9 +1133,9 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer, Netwo
 	/**
 	 * @param Vector3 $pos
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
-	public function sleepOn(Vector3 $pos){
+	public function sleepOn(Vector3 $pos) : bool{
 		if(!$this->isOnline()){
 			return false;
 		}
@@ -1209,7 +1209,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer, Netwo
 	 *
 	 * @return bool
 	 */
-	public function awardAchievement($achievementId){
+	public function awardAchievement(string $achievementId) : bool{
 		if(isset(Achievement::$list[$achievementId]) and !$this->hasAchievement($achievementId)){
 			foreach(Achievement::$list[$achievementId]["requires"] as $requirementId){
 				if(!$this->hasAchievement($requirementId)){
@@ -1233,7 +1233,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer, Netwo
 	/**
 	 * @return int
 	 */
-	public function getGamemode(){
+	public function getGamemode() : int{
 		return $this->gamemode;
 	}
 
@@ -1265,7 +1265,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer, Netwo
 	 *
 	 * @return bool
 	 */
-	public function setGamemode(int $gm, bool $client = false){
+	public function setGamemode(int $gm, bool $client = false) : bool{
 		if($gm < 0 or $gm > 3 or $this->gamemode === $gm){
 			return false;
 		}
@@ -1402,7 +1402,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer, Netwo
 		return $this->isCreative();
 	}
 
-	public function getDrops(){
+	public function getDrops() : array{
 		if(!$this->isCreative()){
 			return parent::getDrops();
 		}
@@ -3477,11 +3477,11 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer, Netwo
 	 * Kicks a player from the server
 	 *
 	 * @param string $reason
-	 * @param bool   $isAdmin
+	 * @param bool $isAdmin
 	 *
 	 * @return bool
 	 */
-	public function kick($reason = "", $isAdmin = true){
+	public function kick($reason = "", bool $isAdmin = true) : bool{
 		$this->server->getPluginManager()->callEvent($ev = new PlayerKickEvent($this, $reason, $this->getLeaveMessage()));
 		if(!$ev->isCancelled()){
 			if($isAdmin){
@@ -4137,11 +4137,11 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer, Netwo
 
 	}
 
-	public function getLoaderId(){
+	public function getLoaderId() : int{
 		return $this->loaderId;
 	}
 
-	public function isLoaderActive(){
+	public function isLoaderActive() : bool{
 		return $this->isConnected();
 	}
 }

--- a/src/pocketmine/PocketMine.php
+++ b/src/pocketmine/PocketMine.php
@@ -79,7 +79,7 @@ namespace pocketmine {
 	use raklib\RakLib;
 
 	const VERSION = "1.6.2dev";
-	const API_VERSION = "3.0.0-ALPHA6";
+	const API_VERSION = "3.0.0-ALPHA7";
 	const CODENAME = "Unleashed";
 
 	/*

--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -1042,12 +1042,12 @@ class Server{
 	 *
 	 * @return bool
 	 */
-	public function generateLevel(string $name, $seed = null, $generator = null, array $options = []){
+	public function generateLevel(string $name, int $seed = null, $generator = null, array $options = []) : bool{
 		if(trim($name) === "" or $this->isLevelGenerated($name)){
 			return false;
 		}
 
-		$seed = $seed === null ? Binary::readInt(random_bytes(4)) : (int) $seed;
+		$seed = $seed ?? Binary::readInt(random_bytes(4));
 
 		if(!isset($options["preset"])){
 			$options["preset"] = $this->getConfigString("generator-settings", "");
@@ -1327,7 +1327,7 @@ class Server{
 	 *
 	 * @return bool
 	 */
-	public function isWhitelisted(string $name){
+	public function isWhitelisted(string $name) : bool{
 		return !$this->hasWhitelist() or $this->operators->exists($name, true) or $this->whitelist->exists($name, true);
 	}
 
@@ -1336,7 +1336,7 @@ class Server{
 	 *
 	 * @return bool
 	 */
-	public function isOp(string $name){
+	public function isOp(string $name) : bool{
 		return $this->operators->exists($name, true);
 	}
 
@@ -1764,7 +1764,7 @@ class Server{
 	 *
 	 * @return int
 	 */
-	public function broadcastTitle(string $title, string $subtitle = "", int $fadeIn = -1, int $stay = -1, int $fadeOut = -1, $recipients = null){
+	public function broadcastTitle(string $title, string $subtitle = "", int $fadeIn = -1, int $stay = -1, int $fadeOut = -1, array $recipients = null) : int{
 		if(!is_array($recipients)){
 			/** @var Player[] $recipients */
 			$recipients = [];
@@ -1933,7 +1933,7 @@ class Server{
 	 *
 	 * @return bool
 	 */
-	public function dispatchCommand(CommandSender $sender, string $commandLine){
+	public function dispatchCommand(CommandSender $sender, string $commandLine) : bool{
 		if($this->commandMap->dispatch($sender, $commandLine)){
 			return true;
 		}
@@ -2056,6 +2056,9 @@ class Server{
 
 	}
 
+	/**
+	 * @return QueryRegenerateEvent
+	 */
 	public function getQueryInformation(){
 		return $this->queryRegenerateTask;
 	}
@@ -2430,7 +2433,7 @@ class Server{
 	/**
 	 * Tries to execute a server tick
 	 */
-	private function tick(){
+	private function tick() : bool{
 		$tickTime = microtime(true);
 		if(($tickTime - $this->nextTick) < -0.025){ //Allow half a tick of diff
 			return false;

--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -576,7 +576,7 @@ class Server{
 	}
 
 	/**
-	 * @return \AttachableThreadedLogger
+	 * @return MainLogger
 	 */
 	public function getLogger(){
 		return $this->logger;

--- a/src/pocketmine/ThreadManager.php
+++ b/src/pocketmine/ThreadManager.php
@@ -60,7 +60,7 @@ class ThreadManager extends \Volatile{
 	/**
 	 * @return Worker[]|Thread[]
 	 */
-	public function getAll(){
+	public function getAll() : array{
 		$array = [];
 		foreach($this as $key => $thread){
 			$array[$key] = $thread;

--- a/src/pocketmine/Worker.php
+++ b/src/pocketmine/Worker.php
@@ -88,7 +88,7 @@ abstract class Worker extends \Worker{
 		ThreadManager::getInstance()->remove($this);
 	}
 
-	public function getThreadName(){
+	public function getThreadName() : string{
 		return (new \ReflectionClass($this))->getShortName();
 	}
 }

--- a/src/pocketmine/command/Command.php
+++ b/src/pocketmine/command/Command.php
@@ -100,7 +100,7 @@ abstract class Command{
 	 *
 	 * @return array
 	 */
-	public function generateCustomCommandData(Player $player){
+	public function generateCustomCommandData(Player $player) : array{
 		//TODO: fix command permission filtering on join
 		/*if(!$this->testPermissionSilent($player)){
 			return null;
@@ -202,7 +202,7 @@ abstract class Command{
 		return $this->label;
 	}
 
-	public function setLabel(string $name){
+	public function setLabel(string $name) : bool{
 		$this->nextLabel = $name;
 		if(!$this->isRegistered()){
 			if($this->timings instanceof TimingsHandler){

--- a/src/pocketmine/command/Command.php
+++ b/src/pocketmine/command/Command.php
@@ -74,7 +74,7 @@ abstract class Command{
 	 * @param string   $usageMessage
 	 * @param string[] $aliases
 	 */
-	public function __construct($name, $description = "", $usageMessage = null, array $aliases = []){
+	public function __construct(string $name, string $description = "", string $usageMessage = null, array $aliases = []){
 		$this->commandData = self::generateDefaultData();
 		$this->name = $name;
 		$this->setLabel($name);
@@ -118,7 +118,7 @@ abstract class Command{
 	/**
 	 * @return array
 	 */
-	public function getOverloads(): array{
+	public function getOverloads() : array{
 		return $this->commandData["overloads"];
 	}
 
@@ -129,12 +129,12 @@ abstract class Command{
 	 *
 	 * @return mixed
 	 */
-	abstract public function execute(CommandSender $sender, $commandLabel, array $args);
+	abstract public function execute(CommandSender $sender, string $commandLabel, array $args);
 
 	/**
 	 * @return string
 	 */
-	public function getName(){
+	public function getName() : string{
 		return $this->name;
 	}
 
@@ -149,7 +149,7 @@ abstract class Command{
 	/**
 	 * @param string|null $permission
 	 */
-	public function setPermission($permission){
+	public function setPermission(string $permission = null){
 		if($permission !== null){
 			$this->commandData["pocketminePermission"] = $permission;
 		}else{
@@ -162,7 +162,7 @@ abstract class Command{
 	 *
 	 * @return bool
 	 */
-	public function testPermission(CommandSender $target){
+	public function testPermission(CommandSender $target) : bool{
 		if($this->testPermissionSilent($target)){
 			return true;
 		}
@@ -181,7 +181,7 @@ abstract class Command{
 	 *
 	 * @return bool
 	 */
-	public function testPermissionSilent(CommandSender $target){
+	public function testPermissionSilent(CommandSender $target) : bool{
 		if(($perm = $this->getPermission()) === null or $perm === ""){
 			return true;
 		}
@@ -198,11 +198,11 @@ abstract class Command{
 	/**
 	 * @return string
 	 */
-	public function getLabel(){
+	public function getLabel() : string{
 		return $this->label;
 	}
 
-	public function setLabel($name){
+	public function setLabel(string $name){
 		$this->nextLabel = $name;
 		if(!$this->isRegistered()){
 			if($this->timings instanceof TimingsHandler){
@@ -224,7 +224,7 @@ abstract class Command{
 	 *
 	 * @return bool
 	 */
-	public function register(CommandMap $commandMap){
+	public function register(CommandMap $commandMap) : bool{
 		if($this->allowChangesFrom($commandMap)){
 			$this->commandMap = $commandMap;
 
@@ -239,7 +239,7 @@ abstract class Command{
 	 *
 	 * @return bool
 	 */
-	public function unregister(CommandMap $commandMap){
+	public function unregister(CommandMap $commandMap) : bool{
 		if($this->allowChangesFrom($commandMap)){
 			$this->commandMap = null;
 			$this->activeAliases = $this->commandData["aliases"];
@@ -256,42 +256,42 @@ abstract class Command{
 	 *
 	 * @return bool
 	 */
-	private function allowChangesFrom(CommandMap $commandMap){
+	private function allowChangesFrom(CommandMap $commandMap) : bool{
 		return $this->commandMap === null or $this->commandMap === $commandMap;
 	}
 
 	/**
 	 * @return bool
 	 */
-	public function isRegistered(){
+	public function isRegistered() : bool{
 		return $this->commandMap !== null;
 	}
 
 	/**
 	 * @return string[]
 	 */
-	public function getAliases(){
+	public function getAliases() : array{
 		return $this->activeAliases;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getPermissionMessage(){
+	public function getPermissionMessage() : string{
 		return $this->permissionMessage;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getDescription(){
+	public function getDescription() : string{
 		return $this->commandData["description"];
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getUsage(){
+	public function getUsage() : string{
 		return $this->usageMessage;
 	}
 
@@ -308,21 +308,21 @@ abstract class Command{
 	/**
 	 * @param string $description
 	 */
-	public function setDescription($description){
+	public function setDescription(string $description){
 		$this->commandData["description"] = $description;
 	}
 
 	/**
 	 * @param string $permissionMessage
 	 */
-	public function setPermissionMessage($permissionMessage){
+	public function setPermissionMessage(string $permissionMessage){
 		$this->permissionMessage = $permissionMessage;
 	}
 
 	/**
 	 * @param string $usage
 	 */
-	public function setUsage($usage){
+	public function setUsage(string $usage){
 		$this->usageMessage = $usage;
 	}
 
@@ -337,11 +337,11 @@ abstract class Command{
 	}
 
 	/**
-	 * @param CommandSender $source
-	 * @param string        $message
-	 * @param bool          $sendToSource
+	 * @param CommandSender        $source
+	 * @param TextContainer|string $message
+	 * @param bool                 $sendToSource
 	 */
-	public static function broadcastCommandMessage(CommandSender $source, $message, $sendToSource = true){
+	public static function broadcastCommandMessage(CommandSender $source, $message, bool $sendToSource = true){
 		if($message instanceof TextContainer){
 			$m = clone $message;
 			$result = "[" . $source->getName() . ": " . ($source->getServer()->getLanguage()->get($m->getText()) !== $m->getText() ? "%" : "") . $m->getText() . "]";
@@ -377,7 +377,7 @@ abstract class Command{
 	/**
 	 * @return string
 	 */
-	public function __toString(){
+	public function __toString() : string{
 		return $this->name;
 	}
 }

--- a/src/pocketmine/command/CommandExecutor.php
+++ b/src/pocketmine/command/CommandExecutor.php
@@ -34,6 +34,6 @@ interface CommandExecutor{
 	 *
 	 * @return bool
 	 */
-	public function onCommand(CommandSender $sender, Command $command, $label, array $args);
+	public function onCommand(CommandSender $sender, Command $command, string $label, array $args) : bool;
 
 }

--- a/src/pocketmine/command/CommandMap.php
+++ b/src/pocketmine/command/CommandMap.php
@@ -47,7 +47,7 @@ interface CommandMap{
 	 *
 	 * @return bool
 	 */
-	public function dispatch(CommandSender $sender, $cmdLine);
+	public function dispatch(CommandSender $sender, string $cmdLine) : bool;
 
 	/**
 	 * @return void

--- a/src/pocketmine/command/CommandMap.php
+++ b/src/pocketmine/command/CommandMap.php
@@ -27,17 +27,19 @@ namespace pocketmine\command;
 interface CommandMap{
 
 	/**
-	 * @param string    $fallbackPrefix
+	 * @param string $fallbackPrefix
 	 * @param Command[] $commands
 	 */
-	public function registerAll($fallbackPrefix, array $commands);
+	public function registerAll(string $fallbackPrefix, array $commands);
 
 	/**
-	 * @param string  $fallbackPrefix
-	 * @param Command $command
-	 * @param string  $label
+	 * @param string      $fallbackPrefix
+	 * @param Command     $command
+	 * @param string|null $label
+	 *
+	 * @return
 	 */
-	public function register($fallbackPrefix, Command $command, $label = null);
+	public function register(string $fallbackPrefix, Command $command, string $label = null);
 
 	/**
 	 * @param CommandSender $sender
@@ -55,9 +57,9 @@ interface CommandMap{
 	/**
 	 * @param string $name
 	 *
-	 * @return Command
+	 * @return Command|null
 	 */
-	public function getCommand($name);
+	public function getCommand(string $name);
 
 
 }

--- a/src/pocketmine/command/CommandMap.php
+++ b/src/pocketmine/command/CommandMap.php
@@ -37,9 +37,9 @@ interface CommandMap{
 	 * @param Command     $command
 	 * @param string|null $label
 	 *
-	 * @return
+	 * @return bool
 	 */
-	public function register(string $fallbackPrefix, Command $command, string $label = null);
+	public function register(string $fallbackPrefix, Command $command, string $label = null) : bool;
 
 	/**
 	 * @param CommandSender $sender

--- a/src/pocketmine/command/ConsoleCommandSender.php
+++ b/src/pocketmine/command/ConsoleCommandSender.php
@@ -31,7 +31,6 @@ use pocketmine\permission\PermissionAttachmentInfo;
 use pocketmine\plugin\Plugin;
 use pocketmine\Server;
 use pocketmine\utils\MainLogger;
-use pocketmine\utils\Terminal;
 
 class ConsoleCommandSender implements CommandSender{
 
@@ -49,7 +48,7 @@ class ConsoleCommandSender implements CommandSender{
 	 *
 	 * @return bool
 	 */
-	public function isPermissionSet($name){
+	public function isPermissionSet($name) : bool{
 		return $this->perm->isPermissionSet($name);
 	}
 
@@ -58,7 +57,7 @@ class ConsoleCommandSender implements CommandSender{
 	 *
 	 * @return bool
 	 */
-	public function hasPermission($name){
+	public function hasPermission($name) : bool{
 		return $this->perm->hasPermission($name);
 	}
 
@@ -89,14 +88,14 @@ class ConsoleCommandSender implements CommandSender{
 	/**
 	 * @return PermissionAttachmentInfo[]
 	 */
-	public function getEffectivePermissions(){
+	public function getEffectivePermissions() : array{
 		return $this->perm->getEffectivePermissions();
 	}
 
 	/**
 	 * @return bool
 	 */
-	public function isPlayer(){
+	public function isPlayer() : bool{
 		return false;
 	}
 
@@ -132,14 +131,14 @@ class ConsoleCommandSender implements CommandSender{
 	/**
 	 * @return bool
 	 */
-	public function isOp(){
+	public function isOp() : bool{
 		return true;
 	}
 
 	/**
 	 * @param bool $value
 	 */
-	public function setOp($value){
+	public function setOp(bool $value){
 
 	}
 

--- a/src/pocketmine/command/FormattedCommandAlias.php
+++ b/src/pocketmine/command/FormattedCommandAlias.php
@@ -34,12 +34,12 @@ class FormattedCommandAlias extends Command{
 	 * @param string   $alias
 	 * @param string[] $formatStrings
 	 */
-	public function __construct($alias, array $formatStrings){
+	public function __construct(string $alias, array $formatStrings){
 		parent::__construct($alias);
 		$this->formatStrings = $formatStrings;
 	}
 
-	public function execute(CommandSender $sender, $commandLabel, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 
 		$commands = [];
 		$result = false;
@@ -71,9 +71,8 @@ class FormattedCommandAlias extends Command{
 	 * @param array  $args
 	 *
 	 * @return string
-	 * @throws \InvalidArgumentException
 	 */
-	private function buildCommand($formatString, array $args){
+	private function buildCommand(string $formatString, array $args) : string{
 		$index = strpos($formatString, '$');
 		while($index !== false){
 			$start = $index;
@@ -153,7 +152,7 @@ class FormattedCommandAlias extends Command{
 	 *
 	 * @return bool
 	 */
-	private static function inRange($i, $j, $k){
+	private static function inRange(int $i, int $j, int $k) : bool{
 		return $i >= $j and $i <= $k;
 	}
 

--- a/src/pocketmine/command/PluginCommand.php
+++ b/src/pocketmine/command/PluginCommand.php
@@ -45,7 +45,7 @@ class PluginCommand extends Command implements PluginIdentifiableCommand{
 		$this->usageMessage = "";
 	}
 
-	public function execute(CommandSender $sender, $commandLabel, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 
 		if(!$this->owningPlugin->isEnabled()){
 			return false;
@@ -64,7 +64,7 @@ class PluginCommand extends Command implements PluginIdentifiableCommand{
 		return $success;
 	}
 
-	public function getExecutor(){
+	public function getExecutor() : CommandExecutor{
 		return $this->executor;
 	}
 
@@ -78,7 +78,7 @@ class PluginCommand extends Command implements PluginIdentifiableCommand{
 	/**
 	 * @return Plugin
 	 */
-	public function getPlugin(){
+	public function getPlugin() : Plugin{
 		return $this->owningPlugin;
 	}
 }

--- a/src/pocketmine/command/PluginIdentifiableCommand.php
+++ b/src/pocketmine/command/PluginIdentifiableCommand.php
@@ -30,5 +30,5 @@ interface PluginIdentifiableCommand{
 	/**
 	 * @return Plugin
 	 */
-	public function getPlugin();
+	public function getPlugin() : Plugin;
 }

--- a/src/pocketmine/command/SimpleCommandMap.php
+++ b/src/pocketmine/command/SimpleCommandMap.php
@@ -137,7 +137,14 @@ class SimpleCommandMap implements CommandMap{
 		}
 	}
 
-	public function register(string $fallbackPrefix, Command $command, string $label = null){
+	/**
+	 * @param string      $fallbackPrefix
+	 * @param Command     $command
+	 * @param string|null $label
+	 *
+	 * @return bool
+	 */
+	public function register(string $fallbackPrefix, Command $command, string $label = null) : bool{
 		if($label === null){
 			$label = $command->getName();
 		}
@@ -163,7 +170,15 @@ class SimpleCommandMap implements CommandMap{
 		return $registered;
 	}
 
-	private function registerAlias(Command $command, $isAlias, $fallbackPrefix, $label){
+	/**
+	 * @param Command $command
+	 * @param bool $isAlias
+	 * @param string $fallbackPrefix
+	 * @param string $label
+	 *
+	 * @return bool
+	 */
+	private function registerAlias(Command $command, bool $isAlias, string $fallbackPrefix, string $label) : bool{
 		$this->knownCommands[$fallbackPrefix . ":" . $label] = $command;
 		if(($command instanceof VanillaCommand or $isAlias) and isset($this->knownCommands[$label])){
 			return false;

--- a/src/pocketmine/command/SimpleCommandMap.php
+++ b/src/pocketmine/command/SimpleCommandMap.php
@@ -207,7 +207,7 @@ class SimpleCommandMap implements CommandMap{
 		return null;
 	}
 
-	public function dispatch(CommandSender $sender, $commandLine){
+	public function dispatch(CommandSender $sender, string $commandLine) : bool{
 		$args = explode(" ", $commandLine);
 		$sentCommandLabel = "";
 		$target = $this->matchCommand($sentCommandLabel, $args);
@@ -248,7 +248,7 @@ class SimpleCommandMap implements CommandMap{
 	/**
 	 * @return Command[]
 	 */
-	public function getCommands(){
+	public function getCommands() : array{
 		return $this->knownCommands;
 	}
 

--- a/src/pocketmine/command/SimpleCommandMap.php
+++ b/src/pocketmine/command/SimpleCommandMap.php
@@ -131,13 +131,13 @@ class SimpleCommandMap implements CommandMap{
 	}
 
 
-	public function registerAll($fallbackPrefix, array $commands){
+	public function registerAll(string $fallbackPrefix, array $commands){
 		foreach($commands as $command){
 			$this->register($fallbackPrefix, $command);
 		}
 	}
 
-	public function register($fallbackPrefix, Command $command, $label = null){
+	public function register(string $fallbackPrefix, Command $command, string $label = null){
 		if($label === null){
 			$label = $command->getName();
 		}
@@ -241,7 +241,7 @@ class SimpleCommandMap implements CommandMap{
 		$this->setDefaultCommands();
 	}
 
-	public function getCommand($name){
+	public function getCommand(string $name){
 		return $this->knownCommands[$name] ?? null;
 	}
 

--- a/src/pocketmine/command/defaults/BanCommand.php
+++ b/src/pocketmine/command/defaults/BanCommand.php
@@ -40,7 +40,7 @@ class BanCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.ban.player");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/BanIpCommand.php
+++ b/src/pocketmine/command/defaults/BanIpCommand.php
@@ -40,7 +40,7 @@ class BanIpCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.ban.ip");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/BanListCommand.php
+++ b/src/pocketmine/command/defaults/BanListCommand.php
@@ -39,7 +39,7 @@ class BanListCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.ban.list");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/DefaultGamemodeCommand.php
+++ b/src/pocketmine/command/defaults/DefaultGamemodeCommand.php
@@ -39,7 +39,7 @@ class DefaultGamemodeCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.defaultgamemode");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/DeopCommand.php
+++ b/src/pocketmine/command/defaults/DeopCommand.php
@@ -41,7 +41,7 @@ class DeopCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.op.take");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/DifficultyCommand.php
+++ b/src/pocketmine/command/defaults/DifficultyCommand.php
@@ -41,7 +41,7 @@ class DifficultyCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.difficulty");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/DumpMemoryCommand.php
+++ b/src/pocketmine/command/defaults/DumpMemoryCommand.php
@@ -38,7 +38,7 @@ class DumpMemoryCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.dumpmemory");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/EffectCommand.php
+++ b/src/pocketmine/command/defaults/EffectCommand.php
@@ -40,7 +40,7 @@ class EffectCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.effect");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/EnchantCommand.php
+++ b/src/pocketmine/command/defaults/EnchantCommand.php
@@ -40,7 +40,7 @@ class EnchantCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.enchant");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/GamemodeCommand.php
+++ b/src/pocketmine/command/defaults/GamemodeCommand.php
@@ -42,7 +42,7 @@ class GamemodeCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.gamemode");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/GarbageCollectorCommand.php
+++ b/src/pocketmine/command/defaults/GarbageCollectorCommand.php
@@ -37,7 +37,7 @@ class GarbageCollectorCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.gc");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/GiveCommand.php
+++ b/src/pocketmine/command/defaults/GiveCommand.php
@@ -44,7 +44,7 @@ class GiveCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.give");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/HelpCommand.php
+++ b/src/pocketmine/command/defaults/HelpCommand.php
@@ -41,7 +41,7 @@ class HelpCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.help");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/HelpCommand.php
+++ b/src/pocketmine/command/defaults/HelpCommand.php
@@ -25,7 +25,6 @@ namespace pocketmine\command\defaults;
 
 use pocketmine\command\Command;
 use pocketmine\command\CommandSender;
-use pocketmine\command\ConsoleCommandSender;
 use pocketmine\event\TranslationContainer;
 use pocketmine\utils\TextFormat;
 

--- a/src/pocketmine/command/defaults/KickCommand.php
+++ b/src/pocketmine/command/defaults/KickCommand.php
@@ -41,7 +41,7 @@ class KickCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.kick");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/KillCommand.php
+++ b/src/pocketmine/command/defaults/KillCommand.php
@@ -43,7 +43,7 @@ class KillCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.kill.self;pocketmine.command.kill.other");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/ListCommand.php
+++ b/src/pocketmine/command/defaults/ListCommand.php
@@ -38,7 +38,7 @@ class ListCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.list");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/MeCommand.php
+++ b/src/pocketmine/command/defaults/MeCommand.php
@@ -40,7 +40,7 @@ class MeCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.me");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/OpCommand.php
+++ b/src/pocketmine/command/defaults/OpCommand.php
@@ -41,7 +41,7 @@ class OpCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.op.give");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/PardonCommand.php
+++ b/src/pocketmine/command/defaults/PardonCommand.php
@@ -39,7 +39,7 @@ class PardonCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.unban.player");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/PardonIpCommand.php
+++ b/src/pocketmine/command/defaults/PardonIpCommand.php
@@ -39,7 +39,7 @@ class PardonIpCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.unban.ip");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/ParticleCommand.php
+++ b/src/pocketmine/command/defaults/ParticleCommand.php
@@ -72,7 +72,7 @@ class ParticleCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.particle");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/PluginsCommand.php
+++ b/src/pocketmine/command/defaults/PluginsCommand.php
@@ -39,7 +39,7 @@ class PluginsCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.plugins");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/ReloadCommand.php
+++ b/src/pocketmine/command/defaults/ReloadCommand.php
@@ -39,7 +39,7 @@ class ReloadCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.reload");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/SaveCommand.php
+++ b/src/pocketmine/command/defaults/SaveCommand.php
@@ -38,7 +38,7 @@ class SaveCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.save.perform");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/SaveOffCommand.php
+++ b/src/pocketmine/command/defaults/SaveOffCommand.php
@@ -38,7 +38,7 @@ class SaveOffCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.save.disable");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/SaveOnCommand.php
+++ b/src/pocketmine/command/defaults/SaveOnCommand.php
@@ -38,7 +38,7 @@ class SaveOnCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.save.enable");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/SayCommand.php
+++ b/src/pocketmine/command/defaults/SayCommand.php
@@ -41,7 +41,7 @@ class SayCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.say");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/SeedCommand.php
+++ b/src/pocketmine/command/defaults/SeedCommand.php
@@ -38,7 +38,7 @@ class SeedCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.seed");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/SetWorldSpawnCommand.php
+++ b/src/pocketmine/command/defaults/SetWorldSpawnCommand.php
@@ -42,7 +42,7 @@ class SetWorldSpawnCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.setworldspawn");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/SpawnpointCommand.php
+++ b/src/pocketmine/command/defaults/SpawnpointCommand.php
@@ -43,7 +43,7 @@ class SpawnpointCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.spawnpoint");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/StatusCommand.php
+++ b/src/pocketmine/command/defaults/StatusCommand.php
@@ -38,7 +38,7 @@ class StatusCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.status");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/StopCommand.php
+++ b/src/pocketmine/command/defaults/StopCommand.php
@@ -38,7 +38,7 @@ class StopCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.stop");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/TeleportCommand.php
+++ b/src/pocketmine/command/defaults/TeleportCommand.php
@@ -42,7 +42,7 @@ class TeleportCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.teleport");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/TellCommand.php
+++ b/src/pocketmine/command/defaults/TellCommand.php
@@ -41,7 +41,7 @@ class TellCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.tell");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/TimeCommand.php
+++ b/src/pocketmine/command/defaults/TimeCommand.php
@@ -42,7 +42,7 @@ class TimeCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.time.add;pocketmine.command.time.set;pocketmine.command.time.start;pocketmine.command.time.stop");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(count($args) < 1){
 			throw new InvalidCommandSyntaxException();
 		}

--- a/src/pocketmine/command/defaults/TimingsCommand.php
+++ b/src/pocketmine/command/defaults/TimingsCommand.php
@@ -44,7 +44,7 @@ class TimingsCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.timings");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/TitleCommand.php
+++ b/src/pocketmine/command/defaults/TitleCommand.php
@@ -38,7 +38,7 @@ class TitleCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.title");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/TransferServerCommand.php
+++ b/src/pocketmine/command/defaults/TransferServerCommand.php
@@ -40,7 +40,7 @@ class TransferServerCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.transferserver");
 	}
 
-	public function execute(CommandSender $sender, $commandLabel, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(count($args) < 1){
 			throw new InvalidCommandSyntaxException();
 		}elseif(!($sender instanceof Player)){

--- a/src/pocketmine/command/defaults/VersionCommand.php
+++ b/src/pocketmine/command/defaults/VersionCommand.php
@@ -41,7 +41,7 @@ class VersionCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.version");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/command/defaults/WhitelistCommand.php
+++ b/src/pocketmine/command/defaults/WhitelistCommand.php
@@ -40,7 +40,7 @@ class WhitelistCommand extends VanillaCommand{
 		$this->setPermission("pocketmine.command.whitelist.reload;pocketmine.command.whitelist.enable;pocketmine.command.whitelist.disable;pocketmine.command.whitelist.list;pocketmine.command.whitelist.add;pocketmine.command.whitelist.remove");
 	}
 
-	public function execute(CommandSender $sender, $currentAlias, array $args){
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
 		if(!$this->testPermission($sender)){
 			return true;
 		}

--- a/src/pocketmine/entity/FallingSand.php
+++ b/src/pocketmine/entity/FallingSand.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace pocketmine\entity;
 
 use pocketmine\block\Block;
-use pocketmine\block\Liquid;
 use pocketmine\event\entity\EntityBlockChangeEvent;
 use pocketmine\event\entity\EntityDamageEvent;
 use pocketmine\item\Item as ItemItem;

--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -99,7 +99,7 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 	/**
 	 * @return string
 	 */
-	public function getRawUniqueId(){
+	public function getRawUniqueId() : string{
 		return $this->rawUUID;
 	}
 
@@ -431,7 +431,7 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 		return $this->getNameTag();
 	}
 
-	public function getDrops(){
+	public function getDrops() : array{
 		return $this->inventory !== null ? array_values($this->inventory->getContents()) : [];
 	}
 

--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -33,7 +33,6 @@ use pocketmine\event\Timings;
 use pocketmine\item\Item as ItemItem;
 use pocketmine\math\Vector3;
 use pocketmine\nbt\tag\FloatTag;
-use pocketmine\nbt\tag\ShortTag;
 use pocketmine\network\mcpe\protocol\EntityEventPacket;
 use pocketmine\utils\BlockIterator;
 
@@ -275,7 +274,7 @@ abstract class Living extends Entity implements Damageable{
 	/**
 	 * @return ItemItem[]
 	 */
-	public function getDrops(){
+	public function getDrops() : array{
 		return [];
 	}
 

--- a/src/pocketmine/entity/Squid.php
+++ b/src/pocketmine/entity/Squid.php
@@ -164,7 +164,7 @@ class Squid extends WaterAnimal{
 		parent::spawnTo($player);
 	}
 
-	public function getDrops(){
+	public function getDrops() : array{
 		return [
 			ItemItem::get(ItemItem::DYE, 0, mt_rand(1, 3))
 		];

--- a/src/pocketmine/entity/Zombie.php
+++ b/src/pocketmine/entity/Zombie.php
@@ -57,7 +57,7 @@ class Zombie extends Monster{
 		parent::spawnTo($player);
 	}
 
-	public function getDrops(){
+	public function getDrops() : array{
 		$drops = [
 			ItemItem::get(ItemItem::FEATHER, 0, 1)
 		];

--- a/src/pocketmine/event/Cancellable.php
+++ b/src/pocketmine/event/Cancellable.php
@@ -31,7 +31,7 @@ interface Cancellable{
 	/**
 	 * @return bool
 	 */
-	public function isCancelled();
+	public function isCancelled() : bool;
 
 	/**
 	 * @param bool $value

--- a/src/pocketmine/event/Timings.php
+++ b/src/pocketmine/event/Timings.php
@@ -176,7 +176,7 @@ abstract class Timings{
 	 *
 	 * @return TimingsHandler
 	 */
-	public static function getPluginTaskTimings(TaskHandler $task, int $period){
+	public static function getPluginTaskTimings(TaskHandler $task, int $period) : TimingsHandler{
 		$ftask = $task->getTask();
 		if($ftask instanceof PluginTask and $ftask->getOwner() !== null){
 			$plugin = $ftask->getOwner()->getDescription()->getFullName();
@@ -208,7 +208,7 @@ abstract class Timings{
 	 *
 	 * @return TimingsHandler
 	 */
-	public static function getEntityTimings(Entity $entity){
+	public static function getEntityTimings(Entity $entity) : TimingsHandler{
 		$entityType = (new \ReflectionClass($entity))->getShortName();
 		if(!isset(self::$entityTypeTimingMap[$entityType])){
 			if($entity instanceof Player){
@@ -226,7 +226,7 @@ abstract class Timings{
 	 *
 	 * @return TimingsHandler
 	 */
-	public static function getTileEntityTimings(Tile $tile){
+	public static function getTileEntityTimings(Tile $tile) : TimingsHandler{
 		$tileType = (new \ReflectionClass($tile))->getShortName();
 		if(!isset(self::$tileEntityTypeTimingMap[$tileType])){
 			self::$tileEntityTypeTimingMap[$tileType] = new TimingsHandler("** tickTileEntity - " . $tileType, self::$tickTileEntityTimer);
@@ -240,7 +240,7 @@ abstract class Timings{
 	 *
 	 * @return TimingsHandler
 	 */
-	public static function getReceiveDataPacketTimings(DataPacket $pk){
+	public static function getReceiveDataPacketTimings(DataPacket $pk) : TimingsHandler{
 		if(!isset(self::$packetReceiveTimingMap[$pk::NETWORK_ID])){
 			$pkName = (new \ReflectionClass($pk))->getShortName();
 			self::$packetReceiveTimingMap[$pk::NETWORK_ID] = new TimingsHandler("** receivePacket - " . $pkName . " [0x" . dechex($pk::NETWORK_ID) . "]", self::$playerNetworkReceiveTimer);
@@ -255,7 +255,7 @@ abstract class Timings{
 	 *
 	 * @return TimingsHandler
 	 */
-	public static function getSendDataPacketTimings(DataPacket $pk){
+	public static function getSendDataPacketTimings(DataPacket $pk) : TimingsHandler{
 		if(!isset(self::$packetSendTimingMap[$pk::NETWORK_ID])){
 			$pkName = (new \ReflectionClass($pk))->getShortName();
 			self::$packetSendTimingMap[$pk::NETWORK_ID] = new TimingsHandler("** sendPacket - " . $pkName . " [0x" . dechex($pk::NETWORK_ID) . "]", self::$playerNetworkTimer);

--- a/src/pocketmine/event/block/BlockFormEvent.php
+++ b/src/pocketmine/event/block/BlockFormEvent.php
@@ -23,8 +23,6 @@ declare(strict_types=1);
 
 namespace pocketmine\event\block;
 
-use pocketmine\block\Block;
-
 class BlockFormEvent extends BlockGrowEvent{
 	public static $handlerList = null;
 

--- a/src/pocketmine/event/player/PlayerBucketFillEvent.php
+++ b/src/pocketmine/event/player/PlayerBucketFillEvent.php
@@ -23,10 +23,6 @@ declare(strict_types=1);
 
 namespace pocketmine\event\player;
 
-use pocketmine\block\Block;
-use pocketmine\item\Item;
-use pocketmine\Player;
-
 class PlayerBucketFillEvent extends PlayerBucketEvent{
 	public static $handlerList = null;
 }

--- a/src/pocketmine/event/player/PlayerExhaustEvent.php
+++ b/src/pocketmine/event/player/PlayerExhaustEvent.php
@@ -26,7 +26,6 @@ namespace pocketmine\event\player;
 use pocketmine\entity\Human;
 use pocketmine\event\Cancellable;
 use pocketmine\event\entity\EntityEvent;
-use pocketmine\Player;
 
 class PlayerExhaustEvent extends EntityEvent implements Cancellable{
 	public static $handlerList = null;

--- a/src/pocketmine/inventory/BaseInventory.php
+++ b/src/pocketmine/inventory/BaseInventory.php
@@ -84,32 +84,32 @@ abstract class BaseInventory implements Inventory{
 		$this->slots = [];
 	}
 
-	public function getSize(){
+	public function getSize() : int{
 		return $this->size;
 	}
 
-	public function setSize($size){
-		$this->size = (int) $size;
+	public function setSize(int $size){
+		$this->size = $size;
 	}
 
-	public function getMaxStackSize(){
+	public function getMaxStackSize() : int{
 		return $this->maxStackSize;
 	}
 
-	public function getName(){
+	public function getName() : string{
 		return $this->name;
 	}
 
-	public function getTitle(){
+	public function getTitle() : string{
 		return $this->title;
 	}
 
-	public function getItem($index){
+	public function getItem(int $index) : Item{
 		assert($index >= 0, "Inventory slot should not be negative");
 		return isset($this->slots[$index]) ? clone $this->slots[$index] : Item::get(Item::AIR, 0, 0);
 	}
 
-	public function getContents(){
+	public function getContents() : array{
 		return $this->slots;
 	}
 
@@ -134,7 +134,7 @@ abstract class BaseInventory implements Inventory{
 		}
 	}
 
-	public function setItem($index, Item $item){
+	public function setItem(int $index, Item $item) : bool{
 		$item = clone $item;
 		if($index < 0 or $index >= $this->size){
 			return false;
@@ -159,7 +159,7 @@ abstract class BaseInventory implements Inventory{
 		return true;
 	}
 
-	public function contains(Item $item){
+	public function contains(Item $item) : bool{
 		$count = max(1, $item->getCount());
 		$checkDamage = !$item->hasAnyDamageValue();
 		$checkTags = $item->hasCompoundTag();
@@ -175,7 +175,7 @@ abstract class BaseInventory implements Inventory{
 		return false;
 	}
 
-	public function all(Item $item){
+	public function all(Item $item) : array{
 		$slots = [];
 		$checkDamage = !$item->hasAnyDamageValue();
 		$checkTags = $item->hasCompoundTag();
@@ -199,7 +199,7 @@ abstract class BaseInventory implements Inventory{
 		}
 	}
 
-	public function first(Item $item){
+	public function first(Item $item) : int{
 		$count = max(1, $item->getCount());
 		$checkDamage = !$item->hasAnyDamageValue();
 		$checkTags = $item->hasCompoundTag();
@@ -213,7 +213,7 @@ abstract class BaseInventory implements Inventory{
 		return -1;
 	}
 
-	public function firstEmpty(){
+	public function firstEmpty() : int{
 		for($i = 0; $i < $this->size; ++$i){
 			if($this->getItem($i)->getId() === Item::AIR){
 				return $i;
@@ -223,7 +223,7 @@ abstract class BaseInventory implements Inventory{
 		return -1;
 	}
 
-	public function canAddItem(Item $item){
+	public function canAddItem(Item $item) : bool{
 		$item = clone $item;
 		$checkDamage = !$item->hasAnyDamageValue();
 		$checkTags = $item->hasCompoundTag();
@@ -245,7 +245,7 @@ abstract class BaseInventory implements Inventory{
 		return false;
 	}
 
-	public function addItem(Item ...$slots){
+	public function addItem(Item ...$slots) : array{
 		/** @var Item[] $itemSlots */
 		/** @var Item[] $slots */
 		$itemSlots = [];
@@ -302,7 +302,7 @@ abstract class BaseInventory implements Inventory{
 		return $itemSlots;
 	}
 
-	public function removeItem(Item ...$slots){
+	public function removeItem(Item ...$slots) : array{
 		/** @var Item[] $itemSlots */
 		/** @var Item[] $slots */
 		$itemSlots = [];
@@ -338,7 +338,7 @@ abstract class BaseInventory implements Inventory{
 		return $itemSlots;
 	}
 
-	public function clear($index){
+	public function clear(int $index) : bool{
 		if(isset($this->slots[$index])){
 			$item = Item::get(Item::AIR, 0, 0);
 			$old = $this->slots[$index];
@@ -372,7 +372,7 @@ abstract class BaseInventory implements Inventory{
 	/**
 	 * @return Player[]
 	 */
-	public function getViewers(){
+	public function getViewers() : array{
 		return $this->viewers;
 	}
 
@@ -380,11 +380,11 @@ abstract class BaseInventory implements Inventory{
 		return $this->holder;
 	}
 
-	public function setMaxStackSize($size){
-		$this->maxStackSize = (int) $size;
+	public function setMaxStackSize(int $size){
+		$this->maxStackSize = $size;
 	}
 
-	public function open(Player $who){
+	public function open(Player $who) : bool{
 		$who->getServer()->getPluginManager()->callEvent($ev = new InventoryOpenEvent($this, $who));
 		if($ev->isCancelled()){
 			return false;
@@ -459,7 +459,7 @@ abstract class BaseInventory implements Inventory{
 		}
 	}
 
-	public function getType(){
+	public function getType() : InventoryType{
 		return $this->type;
 	}
 

--- a/src/pocketmine/inventory/BaseTransaction.php
+++ b/src/pocketmine/inventory/BaseTransaction.php
@@ -43,31 +43,31 @@ class BaseTransaction implements Transaction{
 	 * @param Item      $sourceItem
 	 * @param Item      $targetItem
 	 */
-	public function __construct(Inventory $inventory, $slot, Item $sourceItem, Item $targetItem){
+	public function __construct(Inventory $inventory, int $slot, Item $sourceItem, Item $targetItem){
 		$this->inventory = $inventory;
-		$this->slot = (int) $slot;
+		$this->slot = $slot;
 		$this->sourceItem = clone $sourceItem;
 		$this->targetItem = clone $targetItem;
 		$this->creationTime = microtime(true);
 	}
 
-	public function getCreationTime(){
+	public function getCreationTime() : float{
 		return $this->creationTime;
 	}
 
-	public function getInventory(){
+	public function getInventory() : Inventory{
 		return $this->inventory;
 	}
 
-	public function getSlot(){
+	public function getSlot() : int{
 		return $this->slot;
 	}
 
-	public function getSourceItem(){
+	public function getSourceItem() : Item{
 		return clone $this->sourceItem;
 	}
 
-	public function getTargetItem(){
+	public function getTargetItem() : Item{
 		return clone $this->targetItem;
 	}
 }

--- a/src/pocketmine/inventory/CraftingInventory.php
+++ b/src/pocketmine/inventory/CraftingInventory.php
@@ -56,7 +56,7 @@ class CraftingInventory extends BaseInventory{
 		return $this->resultInventory;
 	}
 
-	public function getSize(){
+	public function getSize() : int{
 		return $this->getResultInventory()->getSize() + parent::getSize();
 	}
 }

--- a/src/pocketmine/inventory/CraftingManager.php
+++ b/src/pocketmine/inventory/CraftingManager.php
@@ -161,14 +161,14 @@ class CraftingManager{
 	/**
 	 * @return Recipe[]
 	 */
-	public function getRecipes(){
+	public function getRecipes() : array{
 		return $this->recipes;
 	}
 
 	/**
 	 * @return FurnaceRecipe[]
 	 */
-	public function getFurnaceRecipes(){
+	public function getFurnaceRecipes() : array{
 		return $this->furnaceRecipes;
 	}
 
@@ -239,7 +239,7 @@ class CraftingManager{
 	 * @param ShapelessRecipe $recipe
 	 * @return bool
 	 */
-	public function matchRecipe(ShapelessRecipe $recipe){
+	public function matchRecipe(ShapelessRecipe $recipe) : bool{
 		if(!isset($this->recipeLookup[$idx = $recipe->getResult()->getId() . ":" . $recipe->getResult()->getDamage()])){
 			return false;
 		}

--- a/src/pocketmine/inventory/DoubleChestInventory.php
+++ b/src/pocketmine/inventory/DoubleChestInventory.php
@@ -50,19 +50,19 @@ class DoubleChestInventory extends ChestInventory implements InventoryHolder{
 		return $this->left->getHolder();
 	}
 
-	public function getItem($index){
+	public function getItem(int $index) : Item{
 		return $index < $this->left->getSize() ? $this->left->getItem($index) : $this->right->getItem($index - $this->right->getSize());
 	}
 
-	public function setItem($index, Item $item){
+	public function setItem(int $index, Item $item) : bool{
 		return $index < $this->left->getSize() ? $this->left->setItem($index, $item) : $this->right->setItem($index - $this->right->getSize(), $item);
 	}
 
-	public function clear($index){
+	public function clear(int $index) : bool{
 		return $index < $this->left->getSize() ? $this->left->clear($index) : $this->right->clear($index - $this->right->getSize());
 	}
 
-	public function getContents(){
+	public function getContents() : array{
 		$contents = [];
 		for($i = 0; $i < $this->getSize(); ++$i){
 			$contents[$i] = $this->getItem($i);
@@ -129,14 +129,14 @@ class DoubleChestInventory extends ChestInventory implements InventoryHolder{
 	/**
 	 * @return ChestInventory
 	 */
-	public function getLeftSide(){
+	public function getLeftSide() : ChestInventory{
 		return $this->left;
 	}
 
 	/**
 	 * @return ChestInventory
 	 */
-	public function getRightSide(){
+	public function getRightSide() : ChestInventory{
 		return $this->right;
 	}
 }

--- a/src/pocketmine/inventory/FurnaceInventory.php
+++ b/src/pocketmine/inventory/FurnaceInventory.php
@@ -41,21 +41,21 @@ class FurnaceInventory extends ContainerInventory{
 	/**
 	 * @return Item
 	 */
-	public function getResult(){
+	public function getResult() : Item{
 		return $this->getItem(2);
 	}
 
 	/**
 	 * @return Item
 	 */
-	public function getFuel(){
+	public function getFuel() : Item{
 		return $this->getItem(1);
 	}
 
 	/**
 	 * @return Item
 	 */
-	public function getSmelting(){
+	public function getSmelting() : Item{
 		return $this->getItem(0);
 	}
 
@@ -64,7 +64,7 @@ class FurnaceInventory extends ContainerInventory{
 	 *
 	 * @return bool
 	 */
-	public function setResult(Item $item){
+	public function setResult(Item $item) : bool{
 		return $this->setItem(2, $item);
 	}
 
@@ -73,7 +73,7 @@ class FurnaceInventory extends ContainerInventory{
 	 *
 	 * @return bool
 	 */
-	public function setFuel(Item $item){
+	public function setFuel(Item $item) : bool{
 		return $this->setItem(1, $item);
 	}
 
@@ -82,7 +82,7 @@ class FurnaceInventory extends ContainerInventory{
 	 *
 	 * @return bool
 	 */
-	public function setSmelting(Item $item){
+	public function setSmelting(Item $item) : bool{
 		return $this->setItem(0, $item);
 	}
 

--- a/src/pocketmine/inventory/FurnaceRecipe.php
+++ b/src/pocketmine/inventory/FurnaceRecipe.php
@@ -29,6 +29,7 @@ use pocketmine\utils\UUID;
 
 class FurnaceRecipe implements Recipe{
 
+	/** @var UUID|null */
 	private $id = null;
 
 	/** @var Item */
@@ -46,10 +47,16 @@ class FurnaceRecipe implements Recipe{
 		$this->ingredient = clone $ingredient;
 	}
 
+	/**
+	 * @return UUID|null
+	 */
 	public function getId(){
 		return $this->id;
 	}
 
+	/**
+	 * @param UUID $id
+	 */
 	public function setId(UUID $id){
 		if($this->id !== null){
 			throw new \InvalidStateException("Id is already set");
@@ -68,14 +75,14 @@ class FurnaceRecipe implements Recipe{
 	/**
 	 * @return Item
 	 */
-	public function getInput(){
+	public function getInput() : Item{
 		return clone $this->ingredient;
 	}
 
 	/**
 	 * @return Item
 	 */
-	public function getResult(){
+	public function getResult() : Item{
 		return clone $this->output;
 	}
 

--- a/src/pocketmine/inventory/Inventory.php
+++ b/src/pocketmine/inventory/Inventory.php
@@ -32,37 +32,48 @@ use pocketmine\Player;
 interface Inventory{
 	const MAX_STACK = 64;
 
-	public function getSize();
+	/**
+	 * @return int
+	 */
+	public function getSize() : int;
 
-	public function getMaxStackSize();
+	/**
+	 * @return int
+	 */
+	public function getMaxStackSize() : int;
 
 	/**
 	 * @param int $size
 	 */
-	public function setMaxStackSize($size);
+	public function setMaxStackSize(int $size);
 
-	public function getName();
+	/**
+	 * @return string
+	 */
+	public function getName() : string;
 
-	public function getTitle();
+	/**
+	 * @return string
+	 */
+	public function getTitle() : string;
 
 	/**
 	 * @param int $index
 	 *
 	 * @return Item
 	 */
-	public function getItem($index);
+	public function getItem(int $index) : Item;
 
 	/**
 	 * Puts an Item in a slot.
 	 * If a plugin refuses the update or $index is invalid, it'll return false
-	 * If a source Player is specified, it won't send a Inventory update to it
 	 *
 	 * @param int  $index
 	 * @param Item $item
 	 *
 	 * @return bool
 	 */
-	public function setItem($index, Item $item);
+	public function setItem(int $index, Item $item) : bool;
 
 	/**
 	 * Stores the given Items in the inventory. This will try to fill
@@ -74,7 +85,7 @@ interface Inventory{
 	 *
 	 * @return Item[]
 	 */
-	public function addItem(Item ...$slots);
+	public function addItem(Item ...$slots) : array;
 
 	/**
 	 * Checks if a given Item can be added to the inventory
@@ -83,7 +94,7 @@ interface Inventory{
 	 *
 	 * @return bool
 	 */
-	public function canAddItem(Item $item);
+	public function canAddItem(Item $item) : bool;
 
 	/**
 	 * Removes the given Item from the inventory.
@@ -93,12 +104,12 @@ interface Inventory{
 	 *
 	 * @return Item[]
 	 */
-	public function removeItem(Item ...$slots);
+	public function removeItem(Item ...$slots) : array;
 
 	/**
 	 * @return Item[]
 	 */
-	public function getContents();
+	public function getContents() : array;
 
 	/**
 	 * @param Item[] $items
@@ -124,7 +135,7 @@ interface Inventory{
 	 *
 	 * @return bool
 	 */
-	public function contains(Item $item);
+	public function contains(Item $item) : bool;
 
 	/**
 	 * Will return all the Items that has the same id and metadata (if not null).
@@ -134,7 +145,7 @@ interface Inventory{
 	 *
 	 * @return Item[]
 	 */
-	public function all(Item $item);
+	public function all(Item $item) : array;
 
 	/**
 	 * Will return the first slot has the same id and metadata (if not null) as the Item.
@@ -144,14 +155,14 @@ interface Inventory{
 	 *
 	 * @return int
 	 */
-	public function first(Item $item);
+	public function first(Item $item) : int;
 
 	/**
 	 * Returns the first empty slot, or -1 if not found
 	 *
 	 * @return int
 	 */
-	public function firstEmpty();
+	public function firstEmpty() : int;
 
 	/**
 	 * Will remove all the Items that has the same id and metadata (if not null)
@@ -167,7 +178,7 @@ interface Inventory{
 	 *
 	 * @return bool
 	 */
-	public function clear($index);
+	public function clear(int $index) : bool;
 
 	/**
 	 * Clears all the slots
@@ -180,12 +191,12 @@ interface Inventory{
 	 *
 	 * @return Player[]
 	 */
-	public function getViewers();
+	public function getViewers() : array;
 
 	/**
 	 * @return InventoryType
 	 */
-	public function getType();
+	public function getType() : InventoryType;
 
 	/**
 	 * @return InventoryHolder
@@ -204,7 +215,7 @@ interface Inventory{
 	 *
 	 * @return bool
 	 */
-	public function open(Player $who);
+	public function open(Player $who) : bool;
 
 	public function close(Player $who);
 

--- a/src/pocketmine/inventory/InventoryType.php
+++ b/src/pocketmine/inventory/InventoryType.php
@@ -91,21 +91,21 @@ class InventoryType{
 	/**
 	 * @return int
 	 */
-	public function getDefaultSize(){
+	public function getDefaultSize() : int{
 		return $this->size;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getDefaultTitle(){
+	public function getDefaultTitle() : string{
 		return $this->title;
 	}
 
 	/**
 	 * @return int
 	 */
-	public function getNetworkType(){
+	public function getNetworkType() : int{
 		return $this->typeId;
 	}
 }

--- a/src/pocketmine/inventory/PlayerInventory.php
+++ b/src/pocketmine/inventory/PlayerInventory.php
@@ -46,11 +46,11 @@ class PlayerInventory extends BaseInventory{
 		parent::__construct($player, InventoryType::get(InventoryType::PLAYER));
 	}
 
-	public function getSize(){
+	public function getSize() : int{
 		return parent::getSize() - 4; //Remove armor slots
 	}
 
-	public function setSize($size){
+	public function setSize(int $size){
 		parent::setSize($size + 4);
 		$this->sendContents($this->getViewers());
 	}
@@ -315,7 +315,7 @@ class PlayerInventory extends BaseInventory{
 		return $this->setItem($this->getSize() + 3, $boots);
 	}
 
-	public function setItem($index, Item $item){
+	public function setItem(int $index, Item $item) : bool{
 		if($index < 0 or $index >= $this->size){
 			return false;
 		}elseif($item->getId() === 0 or $item->getCount() <= 0){
@@ -346,7 +346,7 @@ class PlayerInventory extends BaseInventory{
 		return true;
 	}
 
-	public function clear($index){
+	public function clear(int $index) : bool{
 		if(isset($this->slots[$index])){
 			$item = Item::get(Item::AIR, 0, 0);
 			$old = $this->slots[$index];

--- a/src/pocketmine/inventory/Recipe.php
+++ b/src/pocketmine/inventory/Recipe.php
@@ -31,14 +31,17 @@ interface Recipe{
 	/**
 	 * @return Item
 	 */
-	public function getResult();
+	public function getResult() : Item;
 
 	public function registerToCraftingManager();
 
 	/**
-	 * @return UUID
+	 * @return UUID|null
 	 */
 	public function getId();
 
+	/**
+	 * @param UUID $id
+	 */
 	public function setId(UUID $id);
 }

--- a/src/pocketmine/inventory/ShapedRecipe.php
+++ b/src/pocketmine/inventory/ShapedRecipe.php
@@ -32,6 +32,7 @@ class ShapedRecipe implements Recipe{
 	/** @var Item */
 	private $output;
 
+	/** @var UUID|null */
 	private $id = null;
 
 	/** @var string[] */
@@ -49,7 +50,7 @@ class ShapedRecipe implements Recipe{
 	 *
 	 * @throws \Exception
 	 */
-	public function __construct(Item $result, $height, $width){
+	public function __construct(Item $result, int $height, int $width){
 		for($h = 0; $h < $height; $h++){
 			if($width === 0 or $width > 3){
 				throw new \InvalidStateException("Crafting rows should be 1, 2, 3 wide, not $width");
@@ -60,18 +61,24 @@ class ShapedRecipe implements Recipe{
 		$this->output = clone $result;
 	}
 
-	public function getWidth(){
+	public function getWidth() : int{
 		return count($this->ingredients[0]);
 	}
 
-	public function getHeight(){
+	public function getHeight() : int{
 		return count($this->ingredients);
 	}
 
-	public function getResult(){
+	/**
+	 * @return Item
+	 */
+	public function getResult() : Item{
 		return $this->output;
 	}
 
+	/**
+	 * @return UUID|null
+	 */
 	public function getId(){
 		return $this->id;
 	}
@@ -84,7 +91,14 @@ class ShapedRecipe implements Recipe{
 		$this->id = $id;
 	}
 
-	public function addIngredient($x, $y, Item $item){
+	/**
+	 * @param int $x
+	 * @param int $y
+	 * @param Item $item
+	 *
+	 * @return $this
+	 */
+	public function addIngredient(int $x, int $y, Item $item){
 		$this->ingredients[$y][$x] = clone $item;
 		return $this;
 	}
@@ -96,7 +110,7 @@ class ShapedRecipe implements Recipe{
 	 * @return $this
 	 * @throws \Exception
 	 */
-	public function setIngredient($key, Item $item){
+	public function setIngredient(string $key, Item $item){
 		if(!array_key_exists($key, $this->shape)){
 			throw new \Exception("Symbol does not appear in the shape: " . $key);
 		}
@@ -106,7 +120,11 @@ class ShapedRecipe implements Recipe{
 		return $this;
 	}
 
-	protected function fixRecipe($key, $item){
+	/**
+	 * @param string $key
+	 * @param Item $item
+	 */
+	protected function fixRecipe(string $key, Item $item){
 		foreach($this->shapeItems[$key] as $entry){
 			$this->ingredients[$entry->y][$entry->x] = clone $item;
 		}
@@ -115,7 +133,7 @@ class ShapedRecipe implements Recipe{
 	/**
 	 * @return Item[][]
 	 */
-	public function getIngredientMap(){
+	public function getIngredientMap() : array{
 		$ingredients = [];
 		foreach($this->ingredients as $y => $row){
 			$ingredients[$y] = [];
@@ -132,18 +150,19 @@ class ShapedRecipe implements Recipe{
 	}
 
 	/**
-	 * @param $x
-	 * @param $y
-	 * @return null|Item
+	 * @param int $x
+	 * @param int $y
+	 *
+	 * @return Item
 	 */
-	public function getIngredient($x, $y){
+	public function getIngredient(int $x, int $y){
 		return $this->ingredients[$y][$x] ?? Item::get(Item::AIR);
 	}
 
 	/**
 	 * @return string[]
 	 */
-	public function getShape(){
+	public function getShape() : array{
 		return $this->shape;
 	}
 

--- a/src/pocketmine/inventory/ShapedRecipe.php
+++ b/src/pocketmine/inventory/ShapedRecipe.php
@@ -155,7 +155,7 @@ class ShapedRecipe implements Recipe{
 	 *
 	 * @return Item
 	 */
-	public function getIngredient(int $x, int $y){
+	public function getIngredient(int $x, int $y) : Item{
 		return $this->ingredients[$y][$x] ?? Item::get(Item::AIR);
 	}
 

--- a/src/pocketmine/inventory/ShapelessRecipe.php
+++ b/src/pocketmine/inventory/ShapelessRecipe.php
@@ -70,7 +70,7 @@ class ShapelessRecipe implements Recipe{
 	 *
 	 * @throws \InvalidArgumentException
 	 */
-	public function addIngredient(Item $item){
+	public function addIngredient(Item $item) : ShapelessRecipe{
 		if(count($this->ingredients) >= 9){
 			throw new \InvalidArgumentException("Shapeless recipes cannot have more than 9 ingredients");
 		}

--- a/src/pocketmine/inventory/ShapelessRecipe.php
+++ b/src/pocketmine/inventory/ShapelessRecipe.php
@@ -31,6 +31,7 @@ class ShapelessRecipe implements Recipe{
 	/** @var Item */
 	private $output;
 
+	/** @var UUID|null */
 	private $id = null;
 
 	/** @var Item[] */
@@ -40,10 +41,16 @@ class ShapelessRecipe implements Recipe{
 		$this->output = clone $result;
 	}
 
+	/**
+	 * @return UUID|null
+	 */
 	public function getId(){
 		return $this->id;
 	}
 
+	/**
+	 * @param UUID $id
+	 */
 	public function setId(UUID $id){
 		if($this->id !== null){
 			throw new \InvalidStateException("Id is already set");
@@ -52,14 +59,14 @@ class ShapelessRecipe implements Recipe{
 		$this->id = $id;
 	}
 
-	public function getResult(){
+	public function getResult() : Item{
 		return clone $this->output;
 	}
 
 	/**
 	 * @param Item $item
 	 *
-	 * @returns ShapelessRecipe
+	 * @return ShapelessRecipe
 	 *
 	 * @throws \InvalidArgumentException
 	 */
@@ -101,7 +108,7 @@ class ShapelessRecipe implements Recipe{
 	/**
 	 * @return Item[]
 	 */
-	public function getIngredientList(){
+	public function getIngredientList() : array{
 		$ingredients = [];
 		foreach($this->ingredients as $ingredient){
 			$ingredients[] = clone $ingredient;
@@ -113,7 +120,7 @@ class ShapelessRecipe implements Recipe{
 	/**
 	 * @return int
 	 */
-	public function getIngredientCount(){
+	public function getIngredientCount() : int{
 		$count = 0;
 		foreach($this->ingredients as $ingredient){
 			$count += $ingredient->getCount();

--- a/src/pocketmine/inventory/SimpleTransactionGroup.php
+++ b/src/pocketmine/inventory/SimpleTransactionGroup.php
@@ -54,19 +54,25 @@ class SimpleTransactionGroup implements TransactionGroup{
 	/**
 	 * @return Player
 	 */
-	public function getSource(){
+	public function getSource() : Player{
 		return $this->source;
 	}
 
-	public function getCreationTime(){
+	public function getCreationTime() : float{
 		return $this->creationTime;
 	}
 
-	public function getInventories(){
+	/**
+	 * @return Inventory[]
+	 */
+	public function getInventories() : array{
 		return $this->inventories;
 	}
 
-	public function getTransactions(){
+	/**
+	 * @return Transaction[]
+	 */
+	public function getTransactions() : array{
 		return $this->transactions;
 	}
 
@@ -93,7 +99,7 @@ class SimpleTransactionGroup implements TransactionGroup{
 	 *
 	 * @return bool
 	 */
-	protected function matchItems(array &$needItems, array &$haveItems){
+	protected function matchItems(array &$needItems, array &$haveItems) : bool{
 		foreach($this->transactions as $key => $ts){
 			if($ts->getTargetItem()->getId() !== Item::AIR){
 				$needItems[] = $ts->getTargetItem();
@@ -128,7 +134,7 @@ class SimpleTransactionGroup implements TransactionGroup{
 		return true;
 	}
 
-	public function canExecute(){
+	public function canExecute() : bool{
 		$haveItems = [];
 		$needItems = [];
 
@@ -149,7 +155,10 @@ class SimpleTransactionGroup implements TransactionGroup{
 		return false;
 	}
 
-	public function execute(){
+	/**
+	 * @return bool
+	 */
+	public function execute() : bool{
 		if($this->hasExecuted() or !$this->canExecute()){
 			return false;
 		}
@@ -175,7 +184,7 @@ class SimpleTransactionGroup implements TransactionGroup{
 		return true;
 	}
 
-	public function hasExecuted(){
+	public function hasExecuted() : bool{
 		return $this->hasExecuted;
 	}
 }

--- a/src/pocketmine/inventory/Transaction.php
+++ b/src/pocketmine/inventory/Transaction.php
@@ -30,25 +30,25 @@ interface Transaction{
 	/**
 	 * @return Inventory
 	 */
-	public function getInventory();
+	public function getInventory() : Inventory;
 
 	/**
 	 * @return int
 	 */
-	public function getSlot();
+	public function getSlot() : int;
 
 	/**
 	 * @return Item
 	 */
-	public function getSourceItem();
+	public function getSourceItem() : Item;
 
 	/**
 	 * @return Item
 	 */
-	public function getTargetItem();
+	public function getTargetItem() : Item;
 
 	/**
 	 * @return float
 	 */
-	public function getCreationTime();
+	public function getCreationTime() : float;
 }

--- a/src/pocketmine/inventory/TransactionGroup.php
+++ b/src/pocketmine/inventory/TransactionGroup.php
@@ -28,17 +28,17 @@ interface TransactionGroup{
 	/**
 	 * @return float
 	 */
-	public function getCreationTime();
+	public function getCreationTime() : float;
 
 	/**
 	 * @return Transaction[]
 	 */
-	public function getTransactions();
+	public function getTransactions() : array;
 
 	/**
 	 * @return Inventory[]
 	 */
-	public function getInventories();
+	public function getInventories() : array;
 
 	/**
 	 * @param Transaction $transaction
@@ -48,16 +48,16 @@ interface TransactionGroup{
 	/**
 	 * @return bool
 	 */
-	public function canExecute();
+	public function canExecute() : bool;
 
 	/**
 	 * @return bool
 	 */
-	public function execute();
+	public function execute() : bool;
 
 	/**
 	 * @return bool
 	 */
-	public function hasExecuted();
+	public function hasExecuted() : bool;
 
 }

--- a/src/pocketmine/lang/BaseLang.php
+++ b/src/pocketmine/lang/BaseLang.php
@@ -106,7 +106,7 @@ class BaseLang{
 	 *
 	 * @return string
 	 */
-	public function translateString($str, array $params = [], $onlyPrefix = null){
+	public function translateString(string $str, array $params = [], string $onlyPrefix = null) : string{
 		$baseText = $this->get($str);
 		$baseText = $this->parseTranslation(($baseText !== null and ($onlyPrefix === null or strpos($str, $onlyPrefix) === 0)) ? $baseText : $str, $onlyPrefix);
 
@@ -152,7 +152,13 @@ class BaseLang{
 		return $id;
 	}
 
-	protected function parseTranslation($text, $onlyPrefix = null){
+	/**
+	 * @param string      $text
+	 * @param string|null $onlyPrefix
+	 *
+	 * @return string
+	 */
+	protected function parseTranslation(string $text, string $onlyPrefix = null) : string{
 		$newString = "";
 
 		$replaceString = null;

--- a/src/pocketmine/level/ChunkLoader.php
+++ b/src/pocketmine/level/ChunkLoader.php
@@ -45,14 +45,14 @@ interface ChunkLoader{
 	 *
 	 * @return int
 	 */
-	public function getLoaderId();
+	public function getLoaderId() : int;
 
 	/**
 	 * Returns if the chunk loader is currently active
 	 *
 	 * @return bool
 	 */
-	public function isLoaderActive();
+	public function isLoaderActive() : bool;
 
 	/**
 	 * @return Position

--- a/src/pocketmine/level/ChunkManager.php
+++ b/src/pocketmine/level/ChunkManager.php
@@ -130,7 +130,7 @@ interface ChunkManager{
 	 *
 	 * @return int
 	 */
-	public function getSeed();
+	public function getSeed() : int;
 
 	/**
 	 * Returns the height of the world

--- a/src/pocketmine/level/Explosion.php
+++ b/src/pocketmine/level/Explosion.php
@@ -63,7 +63,7 @@ class Explosion{
 	/**
 	 * @return bool
 	 */
-	public function explodeA(){
+	public function explodeA() : bool{
 		if($this->size < 0.1){
 			return false;
 		}
@@ -114,7 +114,7 @@ class Explosion{
 		return true;
 	}
 
-	public function explodeB(){
+	public function explodeB() : bool{
 		$send = [];
 		$updateBlocks = [];
 

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -292,7 +292,7 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	public static function generateChunkLoaderId(ChunkLoader $loader) : int{
-		if($loader->getLoaderId() === 0 or $loader->getLoaderId() === null){
+		if($loader->getLoaderId() === 0){
 			return self::$chunkLoaderCounter++;
 		}else{
 			throw new \InvalidStateException("ChunkLoader has a loader id already assigned: " . $loader->getLoaderId());
@@ -2774,9 +2774,9 @@ class Level implements ChunkManager, Metadatable{
 	/**
 	 * Gets the level seed
 	 *
-	 * @return int|string int value of seed, or the string numeric representation of a long in 32-bit systems
+	 * @return int
 	 */
-	public function getSeed(){
+	public function getSeed() : int{
 		return $this->provider->getSeed();
 	}
 

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -173,7 +173,7 @@ class Level implements ChunkManager, Metadatable{
 	/** @var Player[][] */
 	private $playerLoaders = [];
 
-	/** @var DataPacket[] */
+	/** @var DataPacket[][] */
 	private $chunkPackets = [];
 
 	/** @var float[] */

--- a/src/pocketmine/level/Location.php
+++ b/src/pocketmine/level/Location.php
@@ -55,7 +55,7 @@ class Location extends Position{
 	 *
 	 * @return Location
 	 */
-	public static function fromObject(Vector3 $pos, Level $level = null, $yaw = 0.0, $pitch = 0.0){
+	public static function fromObject(Vector3 $pos, Level $level = null, $yaw = 0.0, $pitch = 0.0) : Location{
 		return new Location($pos->x, $pos->y, $pos->z, $yaw, $pitch, $level ?? (($pos instanceof Position) ? $pos->level : null));
 	}
 
@@ -80,7 +80,7 @@ class Location extends Position{
 		return "Location (level=" . ($this->isValid() ? $this->getLevel()->getName() : "null") . ", x=$this->x, y=$this->y, z=$this->z, yaw=$this->yaw, pitch=$this->pitch)";
 	}
 
-	public function equals(Vector3 $v){
+	public function equals(Vector3 $v) : bool{
 		if($v instanceof Location){
 			return parent::equals($v) and $v->yaw == $this->yaw and $v->pitch == $this->pitch;
 		}

--- a/src/pocketmine/level/MovingObjectPosition.php
+++ b/src/pocketmine/level/MovingObjectPosition.php
@@ -52,15 +52,15 @@ class MovingObjectPosition{
 	}
 
 	/**
-	 * @param int     $x
-	 * @param int     $y
-	 * @param int     $z
-	 * @param int     $side
+	 * @param int $x
+	 * @param int $y
+	 * @param int $z
+	 * @param int $side
 	 * @param Vector3 $hitVector
 	 *
 	 * @return MovingObjectPosition
 	 */
-	public static function fromBlock($x, $y, $z, $side, Vector3 $hitVector){
+	public static function fromBlock(int $x, int $y, int $z, int $side, Vector3 $hitVector) : MovingObjectPosition{
 		$ob = new MovingObjectPosition;
 		$ob->typeOfHit = 0;
 		$ob->blockX = $x;
@@ -75,7 +75,7 @@ class MovingObjectPosition{
 	 *
 	 * @return MovingObjectPosition
 	 */
-	public static function fromEntity(Entity $entity){
+	public static function fromEntity(Entity $entity) : MovingObjectPosition{
 		$ob = new MovingObjectPosition;
 		$ob->typeOfHit = 1;
 		$ob->entityHit = $entity;

--- a/src/pocketmine/level/Position.php
+++ b/src/pocketmine/level/Position.php
@@ -95,7 +95,7 @@ class Position extends Vector3{
 	 *
 	 * @return bool
 	 */
-	public function isValid(){
+	public function isValid() : bool{
 		return $this->getLevel() instanceof Level;
 	}
 
@@ -133,7 +133,7 @@ class Position extends Vector3{
 		return $this;
 	}
 
-	public function equals(Vector3 $v){
+	public function equals(Vector3 $v) : bool{
 		if($v instanceof Position){
 			return parent::equals($v) and $v->getLevel() === $this->getLevel();
 		}

--- a/src/pocketmine/level/SimpleChunkManager.php
+++ b/src/pocketmine/level/SimpleChunkManager.php
@@ -164,7 +164,7 @@ class SimpleChunkManager implements ChunkManager{
 	 *
 	 * @return int
 	 */
-	public function getSeed(){
+	public function getSeed() : int{
 		return $this->seed;
 	}
 

--- a/src/pocketmine/level/format/Chunk.php
+++ b/src/pocketmine/level/format/Chunk.php
@@ -28,7 +28,6 @@ namespace pocketmine\level\format;
 
 use pocketmine\block\Block;
 use pocketmine\entity\Entity;
-use pocketmine\level\format\ChunkException;
 use pocketmine\level\Level;
 use pocketmine\nbt\NBT;
 use pocketmine\nbt\tag\CompoundTag;
@@ -989,7 +988,7 @@ class Chunk{
 	 *
 	 * @return Chunk
 	 */
-	public static function fastDeserialize(string $data){
+	public static function fastDeserialize(string $data) : Chunk{
 		$stream = new BinaryStream();
 		$stream->setBuffer($data);
 		$data = null;

--- a/src/pocketmine/level/format/io/BaseLevelProvider.php
+++ b/src/pocketmine/level/format/io/BaseLevelProvider.php
@@ -76,7 +76,7 @@ abstract class BaseLevelProvider implements LevelProvider{
 		return $this->level->getServer();
 	}
 
-	public function getLevel(){
+	public function getLevel() : Level{
 		return $this->level;
 	}
 

--- a/src/pocketmine/level/format/io/LevelProvider.php
+++ b/src/pocketmine/level/format/io/LevelProvider.php
@@ -174,7 +174,7 @@ interface LevelProvider{
 	/**
 	 * @return string
 	 */
-	public function getName();
+	public function getName() : string;
 
 	/**
 	 * @return int|string int, or the string numeric representation of a long in 32-bit systems
@@ -216,7 +216,7 @@ interface LevelProvider{
 	/**
 	 * @return Level
 	 */
-	public function getLevel();
+	public function getLevel() : Level;
 
 	public function close();
 

--- a/src/pocketmine/level/format/io/leveldb/LevelDB.php
+++ b/src/pocketmine/level/format/io/leveldb/LevelDB.php
@@ -25,7 +25,6 @@ namespace pocketmine\level\format\io\leveldb;
 
 use pocketmine\entity\Entity;
 use pocketmine\level\format\Chunk;
-use pocketmine\level\format\ChunkException;
 use pocketmine\level\format\io\BaseLevelProvider;
 use pocketmine\level\format\io\ChunkUtils;
 use pocketmine\level\format\io\exception\UnsupportedChunkFormatException;
@@ -576,7 +575,7 @@ class LevelDB extends BaseLevelProvider{
 	/**
 	 * @return \LevelDB
 	 */
-	public function getDatabase(){
+	public function getDatabase() : \LevelDB{
 		return $this->db;
 	}
 

--- a/src/pocketmine/level/format/io/region/McRegion.php
+++ b/src/pocketmine/level/format/io/region/McRegion.php
@@ -422,7 +422,7 @@ class McRegion extends BaseLevelProvider{
 	 *
 	 * @return Chunk
 	 */
-	public function getEmptyChunk(int $chunkX, int $chunkZ){
+	public function getEmptyChunk(int $chunkX, int $chunkZ) : Chunk{
 		return Chunk::getEmptyChunk($chunkX, $chunkZ);
 	}
 

--- a/src/pocketmine/level/generator/Flat.php
+++ b/src/pocketmine/level/generator/Flat.php
@@ -50,11 +50,11 @@ class Flat extends Generator{
 	private $populators = [];
 	private $structure, $chunks, $options, $floorLevel, $preset;
 
-	public function getSettings(){
+	public function getSettings() : array{
 		return $this->options;
 	}
 
-	public function getName(){
+	public function getName() : string{
 		return "flat";
 	}
 
@@ -155,7 +155,7 @@ class Flat extends Generator{
 		*/
 	}
 
-	public function generateChunk($chunkX, $chunkZ){
+	public function generateChunk(int $chunkX, int $chunkZ){
 		if($this->chunk === null){
 			if(isset($this->options["preset"]) and $this->options["preset"] != ""){
 				$this->parsePreset($this->options["preset"], $chunkX, $chunkZ);
@@ -169,7 +169,7 @@ class Flat extends Generator{
 		$this->level->setChunk($chunkX, $chunkZ, $chunk);
 	}
 
-	public function populateChunk($chunkX, $chunkZ){
+	public function populateChunk(int $chunkX, int $chunkZ){
 		$this->random->setSeed(0xdeadbeef ^ ($chunkX << 8) ^ $chunkZ ^ $this->level->getSeed());
 		foreach($this->populators as $populator){
 			$populator->populate($this->level, $chunkX, $chunkZ, $this->random);
@@ -177,7 +177,7 @@ class Flat extends Generator{
 
 	}
 
-	public function getSpawn(){
+	public function getSpawn() : Vector3{
 		return new Vector3(128, $this->floorLevel, 128);
 	}
 }

--- a/src/pocketmine/level/generator/Generator.php
+++ b/src/pocketmine/level/generator/Generator.php
@@ -29,12 +29,13 @@ namespace pocketmine\level\generator;
 use pocketmine\level\ChunkManager;
 use pocketmine\level\generator\noise\Noise;
 use pocketmine\level\generator\normal\Normal;
+use pocketmine\math\Vector3;
 use pocketmine\utils\Random;
 
 abstract class Generator{
 	private static $list = [];
 
-	public static function addGenerator($object, $name){
+	public static function addGenerator($object, $name) : bool{
 		if(is_subclass_of($object, Generator::class) and !isset(Generator::$list[$name = strtolower($name)])){
 			Generator::$list[$name] = $object;
 
@@ -47,7 +48,7 @@ abstract class Generator{
 	/**
 	 * @return string[]
 	 */
-	public static function getGeneratorList(){
+	public static function getGeneratorList() : array{
 		return array_keys(Generator::$list);
 	}
 
@@ -76,17 +77,15 @@ abstract class Generator{
 
 	/**
 	 * @param Noise $noise
-	 * @param int   $xSize
-	 * @param int   $samplingRate
-	 * @param int   $x
-	 * @param int   $y
-	 * @param int   $z
+	 * @param int $xSize
+	 * @param int $samplingRate
+	 * @param int $x
+	 * @param int $y
+	 * @param int $z
 	 *
 	 * @return \SplFixedArray
-	 *
-	 * @throws \InvalidArgumentCountException
 	 */
-	public static function getFastNoise1D(Noise $noise, $xSize, $samplingRate, $x, $y, $z){
+	public static function getFastNoise1D(Noise $noise, int $xSize, int $samplingRate, int $x, int $y, int $z) : \SplFixedArray{
 		if($samplingRate === 0){
 			throw new \InvalidArgumentException("samplingRate cannot be 0");
 		}
@@ -112,19 +111,16 @@ abstract class Generator{
 
 	/**
 	 * @param Noise $noise
-	 * @param int   $xSize
-	 * @param int   $zSize
-	 * @param int   $samplingRate
-	 * @param int   $x
-	 * @param int   $y
-	 * @param int   $z
+	 * @param int $xSize
+	 * @param int $zSize
+	 * @param int $samplingRate
+	 * @param int $x
+	 * @param int $y
+	 * @param int $z
 	 *
 	 * @return \SplFixedArray
-	 *
-	 * @throws \InvalidArgumentException
-	 * @throws \InvalidArgumentCountException
 	 */
-	public static function getFastNoise2D(Noise $noise, $xSize, $zSize, $samplingRate, $x, $y, $z){
+	public static function getFastNoise2D(Noise $noise, int $xSize, int $zSize, int $samplingRate, int $x, int $y, int $z) : \SplFixedArray{
 		assert($samplingRate !== 0, new \InvalidArgumentException("samplingRate cannot be 0"));
 
 		assert($xSize % $samplingRate === 0, new \InvalidArgumentCountException("xSize % samplingRate must return 0"));
@@ -162,22 +158,19 @@ abstract class Generator{
 
 	/**
 	 * @param Noise $noise
-	 * @param int   $xSize
-	 * @param int   $ySize
-	 * @param int   $zSize
-	 * @param int   $xSamplingRate
-	 * @param int   $ySamplingRate
-	 * @param int   $zSamplingRate
-	 * @param int   $x
-	 * @param int   $y
-	 * @param int   $z
+	 * @param int $xSize
+	 * @param int $ySize
+	 * @param int $zSize
+	 * @param int $xSamplingRate
+	 * @param int $ySamplingRate
+	 * @param int $zSamplingRate
+	 * @param int $x
+	 * @param int $y
+	 * @param int $z
 	 *
-	 * @return \SplFixedArray
-	 *
-	 * @throws \InvalidArgumentException
-	 * @throws \InvalidArgumentCountException
+	 * @return array
 	 */
-	public static function getFastNoise3D(Noise $noise, $xSize, $ySize, $zSize, $xSamplingRate, $ySamplingRate, $zSamplingRate, $x, $y, $z){
+	public static function getFastNoise3D(Noise $noise, int $xSize, int $ySize, int $zSize, int $xSamplingRate, int $ySamplingRate, int $zSamplingRate, int $x, int $y, int $z) : array{
 
 		assert($xSamplingRate !== 0, new \InvalidArgumentException("xSamplingRate cannot be 0"));
 		assert($zSamplingRate !== 0, new \InvalidArgumentException("zSamplingRate cannot be 0"));
@@ -239,13 +232,13 @@ abstract class Generator{
 
 	abstract public function init(ChunkManager $level, Random $random);
 
-	abstract public function generateChunk($chunkX, $chunkZ);
+	abstract public function generateChunk(int $chunkX, int $chunkZ);
 
-	abstract public function populateChunk($chunkX, $chunkZ);
+	abstract public function populateChunk(int $chunkX, int $chunkZ);
 
-	abstract public function getSettings();
+	abstract public function getSettings() : array;
 
-	abstract public function getName();
+	abstract public function getName() : string;
 
-	abstract public function getSpawn();
+	abstract public function getSpawn() : Vector3;
 }

--- a/src/pocketmine/level/generator/biome/Biome.php
+++ b/src/pocketmine/level/generator/biome/Biome.php
@@ -70,7 +70,9 @@ abstract class Biome{
 	/** @var Populator[] */
 	private $populators = [];
 
+	/** @var int */
 	private $minElevation;
+	/** @var int */
 	private $maxElevation;
 
 	private $groundCover = [];
@@ -78,9 +80,9 @@ abstract class Biome{
 	protected $rainfall = 0.5;
 	protected $temperature = 0.5;
 
-	protected static function register($id, Biome $biome){
-		self::$biomes[(int) $id] = $biome;
-		$biome->setId((int) $id);
+	protected static function register(int $id, Biome $biome){
+		self::$biomes[$id] = $biome;
+		$biome->setId($id);
 	}
 
 	public static function init(){
@@ -102,11 +104,11 @@ abstract class Biome{
 	}
 
 	/**
-	 * @param $id
+	 * @param int $id
 	 *
 	 * @return Biome
 	 */
-	public static function getBiome($id){
+	public static function getBiome(int $id) : Biome{
 		return self::$biomes[$id] ?? self::$biomes[self::OCEAN];
 	}
 
@@ -118,38 +120,47 @@ abstract class Biome{
 		$this->populators[] = $populator;
 	}
 
-	public function populateChunk(ChunkManager $level, $chunkX, $chunkZ, Random $random){
+	/**
+	 * @param ChunkManager $level
+	 * @param int          $chunkX
+	 * @param int          $chunkZ
+	 * @param Random       $random
+	 */
+	public function populateChunk(ChunkManager $level, int $chunkX, int $chunkZ, Random $random){
 		foreach($this->populators as $populator){
 			$populator->populate($level, $chunkX, $chunkZ, $random);
 		}
 	}
 
-	public function getPopulators(){
+	/**
+	 * @return Populator[]
+	 */
+	public function getPopulators() : array{
 		return $this->populators;
 	}
 
-	public function setId($id){
+	public function setId(int $id){
 		if(!$this->registered){
 			$this->registered = true;
 			$this->id = $id;
 		}
 	}
 
-	public function getId(){
+	public function getId() : int{
 		return $this->id;
 	}
 
-	abstract public function getName();
+	abstract public function getName() : string;
 
-	public function getMinElevation(){
+	public function getMinElevation() : int{
 		return $this->minElevation;
 	}
 
-	public function getMaxElevation(){
+	public function getMaxElevation() : int{
 		return $this->maxElevation;
 	}
 
-	public function setElevation($min, $max){
+	public function setElevation(int $min, int $max){
 		$this->minElevation = $min;
 		$this->maxElevation = $max;
 	}
@@ -157,7 +168,7 @@ abstract class Biome{
 	/**
 	 * @return Block[]
 	 */
-	public function getGroundCover(){
+	public function getGroundCover() : array{
 		return $this->groundCover;
 	}
 
@@ -168,11 +179,11 @@ abstract class Biome{
 		$this->groundCover = $covers;
 	}
 
-	public function getTemperature(){
+	public function getTemperature() : float{
 		return $this->temperature;
 	}
 
-	public function getRainfall(){
+	public function getRainfall() : float{
 		return $this->rainfall;
 	}
 }

--- a/src/pocketmine/level/generator/biome/BiomeSelector.php
+++ b/src/pocketmine/level/generator/biome/BiomeSelector.php
@@ -78,7 +78,7 @@ class BiomeSelector{
 	 *
 	 * @return Biome
 	 */
-	public function pickBiome($x, $z){
+	public function pickBiome($x, $z) : Biome{
 		$temperature = (int) ($this->getTemperature($x, $z) * 63);
 		$rainfall = (int) ($this->getRainfall($x, $z) * 63);
 

--- a/src/pocketmine/level/generator/hell/HellBiome.php
+++ b/src/pocketmine/level/generator/hell/HellBiome.php
@@ -27,7 +27,7 @@ use pocketmine\level\generator\biome\Biome;
 
 class HellBiome extends Biome{
 
-	public function getName(){
+	public function getName() : string{
 		return "Hell";
 	}
 }

--- a/src/pocketmine/level/generator/hell/Nether.php
+++ b/src/pocketmine/level/generator/hell/Nether.php
@@ -81,11 +81,11 @@ class Nether extends Generator{
 		}
 	}
 
-	public function getName(){
+	public function getName() : string{
 		return "nether";
 	}
 
-	public function getSettings(){
+	public function getSettings() : array{
 		return [];
 	}
 
@@ -110,7 +110,7 @@ class Nether extends Generator{
 		$this->populators[] = $ores;*/
 	}
 
-	public function generateChunk($chunkX, $chunkZ){
+	public function generateChunk(int $chunkX, int $chunkZ){
 		$this->random->setSeed(0xdeadbeef ^ ($chunkX << 8) ^ $chunkZ ^ $this->level->getSeed());
 
 		$noise = Generator::getFastNoise3D($this->noiseBase, 16, 128, 16, 4, 8, 4, $chunkX * 16, 0, $chunkZ * 16);
@@ -145,7 +145,7 @@ class Nether extends Generator{
 		}
 	}
 
-	public function populateChunk($chunkX, $chunkZ){
+	public function populateChunk(int $chunkX, int $chunkZ){
 		$this->random->setSeed(0xdeadbeef ^ ($chunkX << 8) ^ $chunkZ ^ $this->level->getSeed());
 		foreach($this->populators as $populator){
 			$populator->populate($this->level, $chunkX, $chunkZ, $this->random);
@@ -156,7 +156,7 @@ class Nether extends Generator{
 		$biome->populateChunk($this->level, $chunkX, $chunkZ, $this->random);
 	}
 
-	public function getSpawn(){
+	public function getSpawn() : Vector3{
 		return new Vector3(127.5, 128, 127.5);
 	}
 

--- a/src/pocketmine/level/generator/noise/Noise.php
+++ b/src/pocketmine/level/generator/noise/Noise.php
@@ -36,7 +36,7 @@ abstract class Noise{
 	protected $persistence;
 	protected $expansion;
 
-	public static function floor($x){
+	public static function floor($x) : int{
 		return $x >= 0 ? (int) $x : (int) ($x - 1);
 	}
 

--- a/src/pocketmine/level/generator/normal/Normal.php
+++ b/src/pocketmine/level/generator/normal/Normal.php
@@ -90,15 +90,15 @@ class Normal extends Generator{
 		}
 	}
 
-	public function getName(){
+	public function getName() : string{
 		return "normal";
 	}
 
-	public function getSettings(){
+	public function getSettings() : array{
 		return [];
 	}
 
-	public function pickBiome($x, $z){
+	public function pickBiome(int $x, int $z){
 		$hash = $x * 2345803 ^ $z * 9236449 ^ $this->level->getSeed();
 		$hash *= $hash + 223;
 		$xNoise = $hash >> 20 & 3;
@@ -189,7 +189,7 @@ class Normal extends Generator{
 		$this->populators[] = $ores;
 	}
 
-	public function generateChunk($chunkX, $chunkZ){
+	public function generateChunk(int $chunkX, int $chunkZ){
 		$this->random->setSeed(0xdeadbeef ^ ($chunkX << 8) ^ $chunkZ ^ $this->level->getSeed());
 
 		$noise = Generator::getFastNoise3D($this->noiseBase, 16, 128, 16, 4, 8, 4, $chunkX * 16, 0, $chunkZ * 16);
@@ -256,7 +256,7 @@ class Normal extends Generator{
 		}
 	}
 
-	public function populateChunk($chunkX, $chunkZ){
+	public function populateChunk(int $chunkX, int $chunkZ){
 		$this->random->setSeed(0xdeadbeef ^ ($chunkX << 8) ^ $chunkZ ^ $this->level->getSeed());
 		foreach($this->populators as $populator){
 			$populator->populate($this->level, $chunkX, $chunkZ, $this->random);
@@ -267,7 +267,7 @@ class Normal extends Generator{
 		$biome->populateChunk($this->level, $chunkX, $chunkZ, $this->random);
 	}
 
-	public function getSpawn(){
+	public function getSpawn() : Vector3{
 		return new Vector3(127.5, 128, 127.5);
 	}
 

--- a/src/pocketmine/level/generator/normal/biome/DesertBiome.php
+++ b/src/pocketmine/level/generator/normal/biome/DesertBiome.php
@@ -34,7 +34,7 @@ class DesertBiome extends SandyBiome{
 		$this->rainfall = 0;
 	}
 
-	public function getName(){
+	public function getName() : string{
 		return "Desert";
 	}
 }

--- a/src/pocketmine/level/generator/normal/biome/ForestBiome.php
+++ b/src/pocketmine/level/generator/normal/biome/ForestBiome.php
@@ -59,7 +59,7 @@ class ForestBiome extends GrassyBiome{
 		}
 	}
 
-	public function getName(){
+	public function getName() : string{
 		return $this->type === self::TYPE_BIRCH ? "Birch Forest" : "Forest";
 	}
 }

--- a/src/pocketmine/level/generator/normal/biome/IcePlainsBiome.php
+++ b/src/pocketmine/level/generator/normal/biome/IcePlainsBiome.php
@@ -41,7 +41,7 @@ class IcePlainsBiome extends SnowyBiome{
 		$this->rainfall = 0.8;
 	}
 
-	public function getName(){
+	public function getName() : string{
 		return "Ice Plains";
 	}
 }

--- a/src/pocketmine/level/generator/normal/biome/MountainsBiome.php
+++ b/src/pocketmine/level/generator/normal/biome/MountainsBiome.php
@@ -48,7 +48,7 @@ class MountainsBiome extends GrassyBiome{
 		$this->rainfall = 0.5;
 	}
 
-	public function getName(){
+	public function getName() : string{
 		return "Mountains";
 	}
 }

--- a/src/pocketmine/level/generator/normal/biome/OceanBiome.php
+++ b/src/pocketmine/level/generator/normal/biome/OceanBiome.php
@@ -41,7 +41,7 @@ class OceanBiome extends GrassyBiome{
 		$this->rainfall = 0.5;
 	}
 
-	public function getName(){
+	public function getName() : string{
 		return "Ocean";
 	}
 }

--- a/src/pocketmine/level/generator/normal/biome/PlainBiome.php
+++ b/src/pocketmine/level/generator/normal/biome/PlainBiome.php
@@ -41,7 +41,7 @@ class PlainBiome extends GrassyBiome{
 		$this->rainfall = 0.4;
 	}
 
-	public function getName(){
+	public function getName() : string{
 		return "Plains";
 	}
 }

--- a/src/pocketmine/level/generator/normal/biome/RiverBiome.php
+++ b/src/pocketmine/level/generator/normal/biome/RiverBiome.php
@@ -41,7 +41,7 @@ class RiverBiome extends GrassyBiome{
 		$this->rainfall = 0.7;
 	}
 
-	public function getName(){
+	public function getName() : string{
 		return "River";
 	}
 }

--- a/src/pocketmine/level/generator/normal/biome/SmallMountainsBiome.php
+++ b/src/pocketmine/level/generator/normal/biome/SmallMountainsBiome.php
@@ -32,7 +32,7 @@ class SmallMountainsBiome extends MountainsBiome{
 		$this->setElevation(63, 97);
 	}
 
-	public function getName(){
+	public function getName() : string{
 		return "Small Mountains";
 	}
 }

--- a/src/pocketmine/level/generator/normal/biome/SwampBiome.php
+++ b/src/pocketmine/level/generator/normal/biome/SwampBiome.php
@@ -34,7 +34,7 @@ class SwampBiome extends GrassyBiome{
 		$this->rainfall = 0.9;
 	}
 
-	public function getName(){
+	public function getName() : string{
 		return "Swamp";
 	}
 }

--- a/src/pocketmine/level/generator/normal/biome/TaigaBiome.php
+++ b/src/pocketmine/level/generator/normal/biome/TaigaBiome.php
@@ -47,7 +47,7 @@ class TaigaBiome extends SnowyBiome{
 		$this->rainfall = 0.8;
 	}
 
-	public function getName(){
+	public function getName() : string{
 		return "Taiga";
 	}
 }

--- a/src/pocketmine/level/generator/object/BigTree.php
+++ b/src/pocketmine/level/generator/object/BigTree.php
@@ -41,7 +41,7 @@ class BigTree extends Tree{
 	private $addLogVines = false;
 	private $addCocoaPlants = false;
 
-	public function canPlaceObject(ChunkManager $level, $x, $y, $z, Random $random){
+	public function canPlaceObject(ChunkManager $level, int $x, int $y, int $z, Random $random) : bool{
 		return false;
 	}
 

--- a/src/pocketmine/level/generator/object/Pond.php
+++ b/src/pocketmine/level/generator/object/Pond.php
@@ -37,7 +37,7 @@ class Pond{
 		$this->random = $random;
 	}
 
-	public function canPlaceObject(ChunkManager $level, Vector3 $pos){
+	public function canPlaceObject(ChunkManager $level, Vector3 $pos) : bool{
 		return false;
 	}
 

--- a/src/pocketmine/level/generator/object/Tree.php
+++ b/src/pocketmine/level/generator/object/Tree.php
@@ -75,7 +75,7 @@ abstract class Tree{
 	}
 
 
-	public function canPlaceObject(ChunkManager $level, $x, $y, $z, Random $random){
+	public function canPlaceObject(ChunkManager $level, int $x, int $y, int $z, Random $random) : bool{
 		$radiusToCheck = 0;
 		for($yy = 0; $yy < $this->treeHeight + 3; ++$yy){
 			if($yy == 1 or $yy === $this->treeHeight){

--- a/src/pocketmine/math/AxisAlignedBB.php
+++ b/src/pocketmine/math/AxisAlignedBB.php
@@ -54,7 +54,7 @@ class AxisAlignedBB{
 		return $this;
 	}
 
-	public function addCoord($x, $y, $z){
+	public function addCoord($x, $y, $z) : AxisAlignedBB{
 		$minX = $this->minX;
 		$minY = $this->minY;
 		$minZ = $this->minZ;
@@ -83,7 +83,7 @@ class AxisAlignedBB{
 		return new AxisAlignedBB($minX, $minY, $minZ, $maxX, $maxY, $maxZ);
 	}
 
-	public function grow($x, $y, $z){
+	public function grow($x, $y, $z) : AxisAlignedBB{
 		return new AxisAlignedBB($this->minX - $x, $this->minY - $y, $this->minZ - $z, $this->maxX + $x, $this->maxY + $y, $this->maxZ + $z);
 	}
 
@@ -109,7 +109,7 @@ class AxisAlignedBB{
 		return $this;
 	}
 
-	public function shrink($x, $y, $z){
+	public function shrink($x, $y, $z) : AxisAlignedBB{
 		return new AxisAlignedBB($this->minX + $x, $this->minY + $y, $this->minZ + $z, $this->maxX - $x, $this->maxY - $y, $this->maxZ - $z);
 	}
 
@@ -134,7 +134,7 @@ class AxisAlignedBB{
 		return $this;
 	}
 
-	public function getOffsetBoundingBox($x, $y, $z){
+	public function getOffsetBoundingBox($x, $y, $z) : AxisAlignedBB{
 		return new AxisAlignedBB($this->minX + $x, $this->minY + $y, $this->minZ + $z, $this->maxX + $x, $this->maxY + $y, $this->maxZ + $z);
 	}
 
@@ -207,7 +207,7 @@ class AxisAlignedBB{
 		return $z;
 	}
 
-	public function intersectsWith(AxisAlignedBB $bb){
+	public function intersectsWith(AxisAlignedBB $bb) : bool{
 		if($bb->maxX > $this->minX and $bb->minX < $this->maxX){
 			if($bb->maxY > $this->minY and $bb->minY < $this->maxY){
 				return $bb->maxZ > $this->minZ and $bb->minZ < $this->maxZ;
@@ -217,7 +217,7 @@ class AxisAlignedBB{
 		return false;
 	}
 
-	public function isVectorInside(Vector3 $vector){
+	public function isVectorInside(Vector3 $vector) : bool{
 		if($vector->x <= $this->minX or $vector->x >= $this->maxX){
 			return false;
 		}
@@ -232,18 +232,24 @@ class AxisAlignedBB{
 		return ($this->maxX - $this->minX + $this->maxY - $this->minY + $this->maxZ - $this->minZ) / 3;
 	}
 
-	public function isVectorInYZ(Vector3 $vector){
+	public function isVectorInYZ(Vector3 $vector) : bool{
 		return $vector->y >= $this->minY and $vector->y <= $this->maxY and $vector->z >= $this->minZ and $vector->z <= $this->maxZ;
 	}
 
-	public function isVectorInXZ(Vector3 $vector){
+	public function isVectorInXZ(Vector3 $vector) : bool{
 		return $vector->x >= $this->minX and $vector->x <= $this->maxX and $vector->z >= $this->minZ and $vector->z <= $this->maxZ;
 	}
 
-	public function isVectorInXY(Vector3 $vector){
+	public function isVectorInXY(Vector3 $vector) : bool{
 		return $vector->x >= $this->minX and $vector->x <= $this->maxX and $vector->y >= $this->minY and $vector->y <= $this->maxY;
 	}
 
+	/**
+	 * @param Vector3 $pos1
+	 * @param Vector3 $pos2
+	 *
+	 * @return MovingObjectPosition|null
+	 */
 	public function calculateIntercept(Vector3 $pos1, Vector3 $pos2){
 		$v1 = $pos1->getIntermediateWithXValue($pos2, $this->minX);
 		$v2 = $pos1->getIntermediateWithXValue($pos2, $this->maxX);

--- a/src/pocketmine/math/Math.php
+++ b/src/pocketmine/math/Math.php
@@ -29,12 +29,12 @@ namespace pocketmine\math;
 
 abstract class Math{
 
-	public static function floorFloat($n){
+	public static function floorFloat($n) : int{
 		$i = (int) $n;
 		return $n >= $i ? $i : $i - 1;
 	}
 
-	public static function ceilFloat($n){
+	public static function ceilFloat($n) : int{
 		$i = (int) ($n + 1);
 		return $n >= $i ? $i : $i - 1;
 	}

--- a/src/pocketmine/math/Vector3.php
+++ b/src/pocketmine/math/Vector3.php
@@ -234,7 +234,7 @@ class Vector3{
 		);
 	}
 
-	public function equals(Vector3 $v){
+	public function equals(Vector3 $v) : bool{
 		return $this->x == $v->x and $this->y == $v->y and $this->z == $v->z;
 	}
 

--- a/src/pocketmine/metadata/BlockMetadataStore.php
+++ b/src/pocketmine/metadata/BlockMetadataStore.php
@@ -35,7 +35,7 @@ class BlockMetadataStore extends MetadataStore{
 		$this->owningLevel = $owningLevel;
 	}
 
-	public function disambiguate(Metadatable $block, $metadataKey){
+	public function disambiguate(Metadatable $block, string $metadataKey) : string{
 		if(!($block instanceof Block)){
 			throw new \InvalidArgumentException("Argument must be a Block instance");
 		}

--- a/src/pocketmine/metadata/EntityMetadataStore.php
+++ b/src/pocketmine/metadata/EntityMetadataStore.php
@@ -27,7 +27,7 @@ use pocketmine\entity\Entity;
 
 class EntityMetadataStore extends MetadataStore{
 
-	public function disambiguate(Metadatable $entity, $metadataKey){
+	public function disambiguate(Metadatable $entity, string $metadataKey) : string{
 		if(!($entity instanceof Entity)){
 			throw new \InvalidArgumentException("Argument must be an Entity instance");
 		}

--- a/src/pocketmine/metadata/LevelMetadataStore.php
+++ b/src/pocketmine/metadata/LevelMetadataStore.php
@@ -27,7 +27,7 @@ use pocketmine\level\Level;
 
 class LevelMetadataStore extends MetadataStore{
 
-	public function disambiguate(Metadatable $level, $metadataKey){
+	public function disambiguate(Metadatable $level, string $metadataKey) : string{
 		if(!($level instanceof Level)){
 			throw new \InvalidArgumentException("Argument must be a Level instance");
 		}

--- a/src/pocketmine/metadata/MetadataStore.php
+++ b/src/pocketmine/metadata/MetadataStore.php
@@ -138,5 +138,5 @@ abstract class MetadataStore{
 	 *
 	 * @throws \InvalidArgumentException
 	 */
-	abstract public function disambiguate(Metadatable $subject, $metadataKey);
+	abstract public function disambiguate(Metadatable $subject, string $metadataKey) : string;
 }

--- a/src/pocketmine/metadata/PlayerMetadataStore.php
+++ b/src/pocketmine/metadata/PlayerMetadataStore.php
@@ -27,7 +27,7 @@ use pocketmine\IPlayer;
 
 class PlayerMetadataStore extends MetadataStore{
 
-	public function disambiguate(Metadatable $player, $metadataKey){
+	public function disambiguate(Metadatable $player, string $metadataKey) : string{
 		if(!($player instanceof IPlayer)){
 			throw new \InvalidArgumentException("Argument must be an IPlayer instance");
 		}

--- a/src/pocketmine/nbt/JsonNBTParser.php
+++ b/src/pocketmine/nbt/JsonNBTParser.php
@@ -237,7 +237,7 @@ class JsonNBTParser{
 	 * @return string
 	 * @throws \Exception
 	 */
-	private static function readKey(string $data, int &$offset){
+	private static function readKey(string $data, int &$offset) : string{
 		$key = "";
 
 		$len = strlen($data);

--- a/src/pocketmine/nbt/NBT.php
+++ b/src/pocketmine/nbt/NBT.php
@@ -109,7 +109,7 @@ class NBT{
 		}
 	}
 
-	public static function matchList(ListTag $tag1, ListTag $tag2){
+	public static function matchList(ListTag $tag1, ListTag $tag2) : bool{
 		if($tag1->getName() !== $tag2->getName() or $tag1->getCount() !== $tag2->getCount()){
 			return false;
 		}
@@ -141,7 +141,7 @@ class NBT{
 		return true;
 	}
 
-	public static function matchTree(CompoundTag $tag1, CompoundTag $tag2){
+	public static function matchTree(CompoundTag $tag1, CompoundTag $tag2) : bool{
 		if($tag1->getName() !== $tag2->getName() or $tag1->getCount() !== $tag2->getCount()){
 			return false;
 		}
@@ -188,7 +188,7 @@ class NBT{
 		$this->buffer .= $v;
 	}
 
-	public function feof(){
+	public function feof() : bool{
 		return !isset($this->buffer{$this->offset});
 	}
 
@@ -269,11 +269,11 @@ class NBT{
 		$tag->write($this, $network);
 	}
 
-	public function getByte(){
+	public function getByte() : int{
 		return Binary::readByte($this->get(1));
 	}
 
-	public function getSignedByte(){
+	public function getSignedByte() : int{
 		return Binary::readSignedByte($this->get(1));
 	}
 
@@ -281,7 +281,7 @@ class NBT{
 		$this->buffer .= Binary::writeByte($v);
 	}
 
-	public function getShort(){
+	public function getShort() : int{
 		return $this->endianness === self::BIG_ENDIAN ? Binary::readShort($this->get(2)) : Binary::readLShort($this->get(2));
 	}
 
@@ -293,7 +293,7 @@ class NBT{
 		$this->buffer .= $this->endianness === self::BIG_ENDIAN ? Binary::writeShort($v) : Binary::writeLShort($v);
 	}
 
-	public function getInt(bool $network = false){
+	public function getInt(bool $network = false) : int{
 		if($network === true){
 			return Binary::readVarInt($this->buffer, $this->offset);
 		}
@@ -308,7 +308,7 @@ class NBT{
 		}
 	}
 
-	public function getLong(){
+	public function getLong() : int{
 		return $this->endianness === self::BIG_ENDIAN ? Binary::readLong($this->get(8)) : Binary::readLLong($this->get(8));
 	}
 
@@ -316,7 +316,7 @@ class NBT{
 		$this->buffer .= $this->endianness === self::BIG_ENDIAN ? Binary::writeLong($v) : Binary::writeLLong($v);
 	}
 
-	public function getFloat(){
+	public function getFloat() : float{
 		return $this->endianness === self::BIG_ENDIAN ? Binary::readFloat($this->get(4)) : Binary::readLFloat($this->get(4));
 	}
 
@@ -324,7 +324,7 @@ class NBT{
 		$this->buffer .= $this->endianness === self::BIG_ENDIAN ? Binary::writeFloat($v) : Binary::writeLFloat($v);
 	}
 
-	public function getDouble(){
+	public function getDouble() : float{
 		return $this->endianness === self::BIG_ENDIAN ? Binary::readDouble($this->get(8)) : Binary::readLDouble($this->get(8));
 	}
 
@@ -346,7 +346,7 @@ class NBT{
 		$this->buffer .= $v;
 	}
 
-	public function getArray(){
+	public function getArray() : array{
 		$data = [];
 		self::toArray($data, $this->data);
 		return $data;

--- a/src/pocketmine/network/SourceInterface.php
+++ b/src/pocketmine/network/SourceInterface.php
@@ -42,7 +42,7 @@ interface SourceInterface{
 	 * @param bool       $needACK
 	 * @param bool       $immediate
 	 *
-	 * @return int
+	 * @return int|null
 	 */
 	public function putPacket(Player $player, DataPacket $packet, $needACK = false, $immediate = true);
 

--- a/src/pocketmine/network/upnp/UPnP.php
+++ b/src/pocketmine/network/upnp/UPnP.php
@@ -29,14 +29,15 @@ namespace pocketmine\network\upnp;
 use pocketmine\utils\Utils;
 
 abstract class UPnP{
-	public static function PortForward($port){
+
+	public static function PortForward(int $port) : bool{
 		if(Utils::$online === false){
 			return false;
 		}
 		if(Utils::getOS() != "win" or !class_exists("COM")){
 			return false;
 		}
-		$port = (int) $port;
+
 		$myLocalIP = gethostbyname(trim(`hostname`));
 		try{
 			/** @noinspection PhpUndefinedClassInspection */
@@ -54,14 +55,14 @@ abstract class UPnP{
 		return true;
 	}
 
-	public static function RemovePortForward($port){
+	public static function RemovePortForward(int $port) : bool{
 		if(Utils::$online === false){
 			return false;
 		}
 		if(Utils::getOS() != "win" or !class_exists("COM")){
 			return false;
 		}
-		$port = (int) $port;
+
 		try{
 			/** @noinspection PhpUndefinedClassInspection */
 			$com = new \COM("HNetCfg.NATUPnP") or false;

--- a/src/pocketmine/permission/BanEntry.php
+++ b/src/pocketmine/permission/BanEntry.php
@@ -28,24 +28,27 @@ use pocketmine\utils\MainLogger;
 class BanEntry{
 	public static $format = "Y-m-d H:i:s O";
 
+	/** @var string */
 	private $name;
 	/** @var \DateTime */
 	private $creationDate = null;
+	/** @var string */
 	private $source = "(Unknown)";
 	/** @var \DateTime */
 	private $expirationDate = null;
+	/** @var string */
 	private $reason = "Banned by an operator.";
 
-	public function __construct($name){
+	public function __construct(string $name){
 		$this->name = strtolower($name);
 		$this->creationDate = new \DateTime();
 	}
 
-	public function getName(){
+	public function getName() : string{
 		return $this->name;
 	}
 
-	public function getCreated(){
+	public function getCreated() : \DateTime{
 		return $this->creationDate;
 	}
 
@@ -53,40 +56,40 @@ class BanEntry{
 		$this->creationDate = $date;
 	}
 
-	public function getSource(){
+	public function getSource() : string{
 		return $this->source;
 	}
 
-	public function setSource($source){
+	public function setSource(string $source){
 		$this->source = $source;
 	}
 
-	public function getExpires(){
+	public function getExpires() : \DateTime{
 		return $this->expirationDate;
 	}
 
 	/**
 	 * @param \DateTime $date
 	 */
-	public function setExpires($date){
+	public function setExpires(\DateTime $date){
 		$this->expirationDate = $date;
 	}
 
-	public function hasExpired(){
+	public function hasExpired() : bool{
 		$now = new \DateTime();
 
 		return $this->expirationDate === null ? false : $this->expirationDate < $now;
 	}
 
-	public function getReason(){
+	public function getReason() : string{
 		return $this->reason;
 	}
 
-	public function setReason($reason){
+	public function setReason(string $reason){
 		$this->reason = $reason;
 	}
 
-	public function getString(){
+	public function getString() : string{
 		$str = "";
 		$str .= $this->getName();
 		$str .= "|";

--- a/src/pocketmine/permission/BanList.php
+++ b/src/pocketmine/permission/BanList.php
@@ -40,28 +40,28 @@ class BanList{
 	/**
 	 * @param string $file
 	 */
-	public function __construct($file){
+	public function __construct(string $file){
 		$this->file = $file;
 	}
 
 	/**
 	 * @return bool
 	 */
-	public function isEnabled(){
+	public function isEnabled() : bool{
 		return $this->enabled === true;
 	}
 
 	/**
 	 * @param bool $flag
 	 */
-	public function setEnabled($flag){
-		$this->enabled = (bool) $flag;
+	public function setEnabled(bool $flag){
+		$this->enabled = $flag;
 	}
 
 	/**
 	 * @return BanEntry[]
 	 */
-	public function getEntries(){
+	public function getEntries() : array{
 		$this->removeExpired();
 
 		return $this->list;
@@ -72,7 +72,7 @@ class BanList{
 	 *
 	 * @return bool
 	 */
-	public function isBanned($name){
+	public function isBanned(string $name) : bool{
 		$name = strtolower($name);
 		if(!$this->isEnabled()){
 			return false;
@@ -99,7 +99,7 @@ class BanList{
 	 *
 	 * @return BanEntry
 	 */
-	public function addBan($target, $reason = null, $expires = null, $source = null){
+	public function addBan(string $target, string $reason = null, \DateTime $expires = null, string $source = null) : BanEntry{
 		$entry = new BanEntry($target);
 		$entry->setSource($source != null ? $source : $entry->getSource());
 		$entry->setExpires($expires);
@@ -114,7 +114,7 @@ class BanList{
 	/**
 	 * @param string $name
 	 */
-	public function remove($name){
+	public function remove(string $name){
 		$name = strtolower($name);
 		if(isset($this->list[$name])){
 			unset($this->list[$name]);
@@ -148,7 +148,10 @@ class BanList{
 		}
 	}
 
-	public function save($flag = true){
+	/**
+	 * @param bool $flag
+	 */
+	public function save(bool $flag = true){
 		$this->removeExpired();
 		$fp = @fopen($this->file, "w");
 		if(is_resource($fp)){

--- a/src/pocketmine/permission/DefaultPermissions.php
+++ b/src/pocketmine/permission/DefaultPermissions.php
@@ -34,7 +34,7 @@ abstract class DefaultPermissions{
 	 *
 	 * @return Permission
 	 */
-	public static function registerPermission(Permission $perm, Permission $parent = null){
+	public static function registerPermission(Permission $perm, Permission $parent = null) : Permission{
 		if($parent instanceof Permission){
 			$parent->getChildren()[$perm->getName()] = true;
 

--- a/src/pocketmine/permission/Permissible.php
+++ b/src/pocketmine/permission/Permissible.php
@@ -34,16 +34,16 @@ interface Permissible extends ServerOperator{
 	 *
 	 * @return bool
 	 */
-	public function isPermissionSet($name);
+	public function isPermissionSet($name) : bool;
 
 	/**
 	 * Returns the permission value if overridden, or the default value if not
 	 *
 	 * @param string|Permission $name
 	 *
-	 * @return mixed
+	 * @return bool
 	 */
-	public function hasPermission($name);
+	public function hasPermission($name) : bool;
 
 	/**
 	 * @param Plugin $plugin
@@ -68,8 +68,8 @@ interface Permissible extends ServerOperator{
 	public function recalculatePermissions();
 
 	/**
-	 * @return Permission[]
+	 * @return PermissionAttachmentInfo[]
 	 */
-	public function getEffectivePermissions();
+	public function getEffectivePermissions() : array;
 
 }

--- a/src/pocketmine/permission/PermissibleBase.php
+++ b/src/pocketmine/permission/PermissibleBase.php
@@ -63,7 +63,7 @@ class PermissibleBase implements Permissible{
 	/**
 	 * @return bool
 	 */
-	public function isOp(){
+	public function isOp() : bool{
 		if($this->opable === null){
 			return false;
 		}else{
@@ -76,7 +76,7 @@ class PermissibleBase implements Permissible{
 	 *
 	 * @throws \Exception
 	 */
-	public function setOp($value){
+	public function setOp(bool $value){
 		if($this->opable === null){
 			throw new \LogicException("Cannot change op value as no ServerOperator is set");
 		}else{
@@ -89,7 +89,7 @@ class PermissibleBase implements Permissible{
 	 *
 	 * @return bool
 	 */
-	public function isPermissionSet($name){
+	public function isPermissionSet($name) : bool{
 		return isset($this->permissions[$name instanceof Permission ? $name->getName() : $name]);
 	}
 
@@ -98,7 +98,7 @@ class PermissibleBase implements Permissible{
 	 *
 	 * @return bool
 	 */
-	public function hasPermission($name){
+	public function hasPermission($name) : bool{
 		if($name instanceof Permission){
 			$name = $name->getName();
 		}
@@ -214,7 +214,7 @@ class PermissibleBase implements Permissible{
 	/**
 	 * @return PermissionAttachmentInfo[]
 	 */
-	public function getEffectivePermissions(){
+	public function getEffectivePermissions() : array{
 		return $this->permissions;
 	}
 }

--- a/src/pocketmine/permission/Permission.php
+++ b/src/pocketmine/permission/Permission.php
@@ -111,28 +111,28 @@ class Permission{
 	/**
 	 * @return string
 	 */
-	public function getName(){
+	public function getName() : string{
 		return $this->name;
 	}
 
 	/**
 	 * @return string[]
 	 */
-	public function &getChildren(){
+	public function &getChildren() : array{
 		return $this->children;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getDefault(){
+	public function getDefault() : string{
 		return $this->defaultValue;
 	}
 
 	/**
 	 * @param string $value
 	 */
-	public function setDefault($value){
+	public function setDefault(string $value){
 		if($value !== $this->defaultValue){
 			$this->defaultValue = $value;
 			$this->recalculatePermissibles();
@@ -142,7 +142,7 @@ class Permission{
 	/**
 	 * @return string
 	 */
-	public function getDescription(){
+	public function getDescription() : string{
 		return $this->description;
 	}
 
@@ -156,7 +156,7 @@ class Permission{
 	/**
 	 * @return Permissible[]
 	 */
-	public function getPermissibles(){
+	public function getPermissibles() : array{
 		return Server::getInstance()->getPluginManager()->getPermissionSubscriptions($this->name);
 	}
 
@@ -201,7 +201,7 @@ class Permission{
 	 *
 	 * @return Permission[]
 	 */
-	public static function loadPermissions(array $data, $default = self::DEFAULT_OP){
+	public static function loadPermissions(array $data, $default = self::DEFAULT_OP) : array{
 		$result = [];
 		foreach($data as $key => $entry){
 			$result[] = self::loadPermission($key, $entry, $default, $result);

--- a/src/pocketmine/permission/ServerOperator.php
+++ b/src/pocketmine/permission/ServerOperator.php
@@ -30,14 +30,12 @@ interface ServerOperator{
 	 *
 	 * @return bool
 	 */
-	public function isOp();
+	public function isOp() : bool;
 
 	/**
 	 * Sets the operator permission for the current object
 	 *
 	 * @param bool $value
-	 *
-	 * @return void
 	 */
-	public function setOp($value);
+	public function setOp(bool $value);
 }

--- a/src/pocketmine/plugin/PharPluginLoader.php
+++ b/src/pocketmine/plugin/PharPluginLoader.php
@@ -48,10 +48,8 @@ class PharPluginLoader implements PluginLoader{
 	 * @param string $file
 	 *
 	 * @return Plugin|null
-	 *
-	 * @throws \Exception
 	 */
-	public function loadPlugin($file){
+	public function loadPlugin(string $file){
 		if(($description = $this->getPluginDescription($file)) instanceof PluginDescription){
 			$this->server->getLogger()->info($this->server->getLanguage()->translateString("pocketmine.plugin.load", [$description->getFullName()]));
 			$dataFolder = dirname($file) . DIRECTORY_SEPARATOR . $description->getName();
@@ -80,9 +78,9 @@ class PharPluginLoader implements PluginLoader{
 	 *
 	 * @param string $file
 	 *
-	 * @return PluginDescription|null
+	 * @return null|PluginDescription
 	 */
-	public function getPluginDescription($file){
+	public function getPluginDescription(string $file){
 		$phar = new \Phar($file);
 		if(isset($phar["plugin.yml"])){
 			$pluginYml = $phar["plugin.yml"];
@@ -99,7 +97,7 @@ class PharPluginLoader implements PluginLoader{
 	 *
 	 * @return string
 	 */
-	public function getPluginFilters(){
+	public function getPluginFilters() : string{
 		return "/\\.phar$/i";
 	}
 

--- a/src/pocketmine/plugin/Plugin.php
+++ b/src/pocketmine/plugin/Plugin.php
@@ -50,7 +50,7 @@ interface Plugin extends CommandExecutor{
 	/**
 	 * @return bool
 	 */
-	public function isEnabled();
+	public function isEnabled() : bool;
 
 	/**
 	 * Called when the plugin is disabled
@@ -58,61 +58,78 @@ interface Plugin extends CommandExecutor{
 	 */
 	public function onDisable();
 
-	public function isDisabled();
+	/**
+	 * @return bool
+	 */
+	public function isDisabled() : bool;
 
 	/**
 	 * Gets the plugin's data folder to save files and configuration.
 	 * This directory name has a trailing slash.
+	 *
+	 * @return string
 	 */
-	public function getDataFolder();
+	public function getDataFolder() : string;
 
 	/**
 	 * @return PluginDescription
 	 */
-	public function getDescription();
+	public function getDescription() : PluginDescription;
 
 	/**
 	 * Gets an embedded resource in the plugin file.
 	 *
 	 * @param string $filename
+	 *
+	 * @return
 	 */
-	public function getResource($filename);
+	public function getResource(string $filename);
 
 	/**
 	 * Saves an embedded resource to its relative location in the data folder
 	 *
 	 * @param string $filename
-	 * @param bool   $replace
+	 * @param bool $replace
+	 *
+	 * @return bool
 	 */
-	public function saveResource($filename, $replace = false);
+	public function saveResource(string $filename, bool $replace = false) : bool;
 
 	/**
 	 * Returns all the resources packaged with the plugin
+	 *
+	 * @return string[]
 	 */
-	public function getResources();
+	public function getResources() : array;
 
 	/**
 	 * @return Config
 	 */
-	public function getConfig();
+	public function getConfig() : Config;
 
 	public function saveConfig();
 
-	public function saveDefaultConfig();
+	/**
+	 * @return bool
+	 */
+	public function saveDefaultConfig() : bool;
 
 	public function reloadConfig();
 
 	/**
 	 * @return Server
 	 */
-	public function getServer();
+	public function getServer() : Server;
 
-	public function getName();
+	/**
+	 * @return string
+	 */
+	public function getName() : string;
 
 	/**
 	 * @return PluginLogger
 	 */
-	public function getLogger();
+	public function getLogger() : PluginLogger;
 
 	/**
 	 * @return PluginLoader

--- a/src/pocketmine/plugin/PluginBase.php
+++ b/src/pocketmine/plugin/PluginBase.php
@@ -48,9 +48,11 @@ abstract class PluginBase implements Plugin{
 
 	/** @var string */
 	private $dataFolder;
-	private $config;
+	/** @var Config|null */
+	private $config = null;
 	/** @var string */
 	private $configFile;
+	/** @var string */
 	private $file;
 
 	/** @var PluginLogger */
@@ -74,14 +76,14 @@ abstract class PluginBase implements Plugin{
 	/**
 	 * @return bool
 	 */
-	final public function isEnabled(){
+	final public function isEnabled() : bool{
 		return $this->isEnabled === true;
 	}
 
 	/**
 	 * @param bool $boolean
 	 */
-	final public function setEnabled($boolean = true){
+	final public function setEnabled(bool $boolean = true){
 		if($this->isEnabled !== $boolean){
 			$this->isEnabled = $boolean;
 			if($this->isEnabled === true){
@@ -95,15 +97,15 @@ abstract class PluginBase implements Plugin{
 	/**
 	 * @return bool
 	 */
-	final public function isDisabled(){
+	final public function isDisabled() : bool{
 		return $this->isEnabled === false;
 	}
 
-	final public function getDataFolder(){
+	final public function getDataFolder() : string{
 		return $this->dataFolder;
 	}
 
-	final public function getDescription(){
+	final public function getDescription() : PluginDescription{
 		return $this->description;
 	}
 
@@ -123,14 +125,14 @@ abstract class PluginBase implements Plugin{
 	/**
 	 * @return PluginLogger
 	 */
-	public function getLogger(){
+	public function getLogger() : PluginLogger{
 		return $this->logger;
 	}
 
 	/**
 	 * @return bool
 	 */
-	final public function isInitialized(){
+	final public function isInitialized() : bool{
 		return $this->initialized;
 	}
 
@@ -167,7 +169,7 @@ abstract class PluginBase implements Plugin{
 	/**
 	 * @return bool
 	 */
-	protected function isPhar(){
+	protected function isPhar() : bool{
 		return strpos($this->file, "phar://") === 0;
 	}
 
@@ -177,9 +179,9 @@ abstract class PluginBase implements Plugin{
 	 *
 	 * @param string $filename
 	 *
-	 * @return resource|null Resource data, or null
+	 * @return null|resource Resource data, or null
 	 */
-	public function getResource($filename){
+	public function getResource(string $filename){
 		$filename = rtrim(str_replace("\\", "/", $filename), "/");
 		if(file_exists($this->file . "resources/" . $filename)){
 			return fopen($this->file . "resources/" . $filename, "rb");
@@ -190,11 +192,11 @@ abstract class PluginBase implements Plugin{
 
 	/**
 	 * @param string $filename
-	 * @param bool   $replace
+	 * @param bool $replace
 	 *
 	 * @return bool
 	 */
-	public function saveResource($filename, $replace = false){
+	public function saveResource(string $filename, bool $replace = false) : bool{
 		if(trim($filename) === ""){
 			return false;
 		}
@@ -223,7 +225,7 @@ abstract class PluginBase implements Plugin{
 	 *
 	 * @return string[]
 	 */
-	public function getResources(){
+	public function getResources() : array{
 		$resources = [];
 		if(is_dir($this->file . "resources/")){
 			foreach(new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($this->file . "resources/")) as $resource){
@@ -237,8 +239,8 @@ abstract class PluginBase implements Plugin{
 	/**
 	 * @return Config
 	 */
-	public function getConfig(){
-		if(!isset($this->config)){
+	public function getConfig() : Config{
+		if($this->config === null){
 			$this->reloadConfig();
 		}
 
@@ -251,7 +253,7 @@ abstract class PluginBase implements Plugin{
 		}
 	}
 
-	public function saveDefaultConfig(){
+	public function saveDefaultConfig() : bool{
 		if(!file_exists($this->configFile)){
 			return $this->saveResource("config.yml", false);
 		}
@@ -269,25 +271,28 @@ abstract class PluginBase implements Plugin{
 	/**
 	 * @return Server
 	 */
-	final public function getServer(){
+	final public function getServer() : Server{
 		return $this->server;
 	}
 
 	/**
 	 * @return string
 	 */
-	final public function getName(){
+	final public function getName() : string{
 		return $this->description->getName();
 	}
 
 	/**
 	 * @return string
 	 */
-	final public function getFullName(){
+	final public function getFullName() : string{
 		return $this->description->getFullName();
 	}
 
-	protected function getFile(){
+	/**
+	 * @return string
+	 */
+	protected function getFile() : string{
 		return $this->file;
 	}
 

--- a/src/pocketmine/plugin/PluginBase.php
+++ b/src/pocketmine/plugin/PluginBase.php
@@ -156,11 +156,11 @@ abstract class PluginBase implements Plugin{
 	 * @param CommandSender $sender
 	 * @param Command       $command
 	 * @param string        $label
-	 * @param array         $args
+	 * @param string[]      $args
 	 *
 	 * @return bool
 	 */
-	public function onCommand(CommandSender $sender, Command $command, $label, array $args){
+	public function onCommand(CommandSender $sender, Command $command, string $label, array $args) : bool{
 		return false;
 	}
 

--- a/src/pocketmine/plugin/PluginDescription.php
+++ b/src/pocketmine/plugin/PluginDescription.php
@@ -33,12 +33,17 @@ class PluginDescription{
 	private $depend = [];
 	private $softDepend = [];
 	private $loadBefore = [];
+	/** @var string */
 	private $version;
 	private $commands = [];
-	private $description = null;
+	/** @var string */
+	private $description = "";
+	/** @var string[] */
 	private $authors = [];
-	private $website = null;
-	private $prefix = null;
+	/** @var string */
+	private $website = "";
+	/** @var string */
+	private $prefix = "";
 	private $order = PluginLoadOrder::POSTWORLD;
 
 	/**
@@ -131,42 +136,42 @@ class PluginDescription{
 	/**
 	 * @return string
 	 */
-	public function getFullName(){
+	public function getFullName() : string{
 		return $this->name . " v" . $this->version;
 	}
 
 	/**
 	 * @return array
 	 */
-	public function getCompatibleApis(){
+	public function getCompatibleApis() : array{
 		return $this->api;
 	}
 
 	/**
-	 * @return array
+	 * @return string[]
 	 */
-	public function getAuthors(){
+	public function getAuthors() : array{
 		return $this->authors;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getPrefix(){
+	public function getPrefix() : string{
 		return $this->prefix;
 	}
 
 	/**
 	 * @return array
 	 */
-	public function getCommands(){
+	public function getCommands() : array{
 		return $this->commands;
 	}
 
 	/**
 	 * @return array
 	 */
-	public function getRequiredExtensions(){
+	public function getRequiredExtensions() : array{
 		return $this->extensions;
 	}
 
@@ -210,49 +215,49 @@ class PluginDescription{
 	/**
 	 * @return array
 	 */
-	public function getDepend(){
+	public function getDepend() : array{
 		return $this->depend;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getDescription(){
+	public function getDescription() : string{
 		return $this->description;
 	}
 
 	/**
 	 * @return array
 	 */
-	public function getLoadBefore(){
+	public function getLoadBefore() : array{
 		return $this->loadBefore;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getMain(){
+	public function getMain() : string{
 		return $this->main;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getName(){
+	public function getName() : string{
 		return $this->name;
 	}
 
 	/**
 	 * @return int
 	 */
-	public function getOrder(){
+	public function getOrder() : int{
 		return $this->order;
 	}
 
 	/**
 	 * @return Permission[]
 	 */
-	public function getPermissions(){
+	public function getPermissions() : array{
 		return $this->permissions;
 	}
 
@@ -266,14 +271,14 @@ class PluginDescription{
 	/**
 	 * @return string
 	 */
-	public function getVersion(){
+	public function getVersion() : string{
 		return $this->version;
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getWebsite(){
+	public function getWebsite() : string{
 		return $this->website;
 	}
 }

--- a/src/pocketmine/plugin/PluginLoader.php
+++ b/src/pocketmine/plugin/PluginLoader.php
@@ -33,25 +33,25 @@ interface PluginLoader{
 	 *
 	 * @param string $file
 	 *
-	 * @return Plugin
+	 * @return Plugin|null
 	 */
-	public function loadPlugin($file);
+	public function loadPlugin(string $file);
 
 	/**
 	 * Gets the PluginDescription from the file
 	 *
 	 * @param string $file
 	 *
-	 * @return PluginDescription
+	 * @return null|PluginDescription
 	 */
-	public function getPluginDescription($file);
+	public function getPluginDescription(string $file);
 
 	/**
 	 * Returns the filename regex patterns that this loader accepts
 	 *
 	 * @return string
 	 */
-	public function getPluginFilters();
+	public function getPluginFilters() : string;
 
 	/**
 	 * @param Plugin $plugin

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -626,7 +626,13 @@ class PluginManager{
 				}
 
 				if(isset($data["permission"])){
-					$newCmd->setPermission($data["permission"]);
+					if(is_bool($data["permission"])){
+						$newCmd->setPermission($data["permission"] ? "true" : "false");
+					}elseif(is_string($data["permission"])){
+						$newCmd->setPermission($data["permission"]);
+					}else{
+						throw new \InvalidArgumentException("Permission must be a string or boolean, " . gettype($data["permission"] . " given"));
+					}
 				}
 
 				if(isset($data["permission-message"])){

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -119,7 +119,7 @@ class PluginManager{
 	 *
 	 * @return bool
 	 */
-	public function registerInterface($loaderName){
+	public function registerInterface(string $loaderName) : bool{
 		if(is_subclass_of($loaderName, PluginLoader::class)){
 			$loader = new $loaderName($this->server);
 		}else{
@@ -134,7 +134,7 @@ class PluginManager{
 	/**
 	 * @return Plugin[]
 	 */
-	public function getPlugins(){
+	public function getPlugins() : array{
 		return $this->plugins;
 	}
 
@@ -372,7 +372,7 @@ class PluginManager{
 	 *
 	 * @return bool
 	 */
-	public function addPermission(Permission $permission){
+	public function addPermission(Permission $permission) : bool{
 		if(!isset($this->permissions[$permission->getName()])){
 			$this->permissions[$permission->getName()] = $permission;
 			$this->calculatePermissionDefault($permission);
@@ -471,9 +471,9 @@ class PluginManager{
 	/**
 	 * @param string $permission
 	 *
-	 * @return Permissible[]
+	 * @return array|Permissible[]
 	 */
-	public function getPermissionSubscriptions($permission){
+	public function getPermissionSubscriptions(string $permission) : array{
 		if(isset($this->permSubs[$permission])){
 			return $this->permSubs[$permission];
 			$subs = [];
@@ -522,7 +522,7 @@ class PluginManager{
 	 *
 	 * @return Permissible[]
 	 */
-	public function getDefaultPermSubscriptions($op){
+	public function getDefaultPermSubscriptions(bool $op) : array{
 		$subs = [];
 
 		if($op === true){
@@ -555,7 +555,7 @@ class PluginManager{
 	/**
 	 * @return Permission[]
 	 */
-	public function getPermissions(){
+	public function getPermissions() : array{
 		return $this->permissions;
 	}
 
@@ -594,7 +594,7 @@ class PluginManager{
 	 *
 	 * @return PluginCommand[]
 	 */
-	protected function parseYamlCommands(Plugin $plugin){
+	protected function parseYamlCommands(Plugin $plugin) : array{
 		$pluginCmds = [];
 
 		foreach($plugin->getDescription()->getCommands() as $key => $data){
@@ -799,7 +799,7 @@ class PluginManager{
 	 *
 	 * @return HandlerList
 	 */
-	private function getEventListeners($event){
+	private function getEventListeners($event) : HandlerList{
 		if($event::$handlerList === null){
 			$event::$handlerList = new HandlerList();
 		}
@@ -810,15 +810,15 @@ class PluginManager{
 	/**
 	 * @return bool
 	 */
-	public function useTimings(){
+	public function useTimings() : bool{
 		return self::$useTimings;
 	}
 
 	/**
 	 * @param bool $use
 	 */
-	public function setUseTimings($use){
-		self::$useTimings = (bool) $use;
+	public function setUseTimings(bool $use){
+		self::$useTimings = $use;
 	}
 
 }

--- a/src/pocketmine/plugin/RegisteredListener.php
+++ b/src/pocketmine/plugin/RegisteredListener.php
@@ -69,21 +69,21 @@ class RegisteredListener{
 	/**
 	 * @return Listener
 	 */
-	public function getListener(){
+	public function getListener() : Listener{
 		return $this->listener;
 	}
 
 	/**
 	 * @return Plugin
 	 */
-	public function getPlugin(){
+	public function getPlugin() : Plugin{
 		return $this->plugin;
 	}
 
 	/**
 	 * @return int
 	 */
-	public function getPriority(){
+	public function getPriority() : int{
 		return $this->priority;
 	}
 
@@ -106,7 +106,7 @@ class RegisteredListener{
 	/**
 	 * @return bool
 	 */
-	public function isIgnoringCancelled(){
+	public function isIgnoringCancelled() : bool{
 		return $this->ignoreCancelled === true;
 	}
 }

--- a/src/pocketmine/plugin/ScriptPluginLoader.php
+++ b/src/pocketmine/plugin/ScriptPluginLoader.php
@@ -49,10 +49,8 @@ class ScriptPluginLoader implements PluginLoader{
 	 * @param string $file
 	 *
 	 * @return Plugin|null
-	 *
-	 * @throws \Exception
 	 */
-	public function loadPlugin($file){
+	public function loadPlugin(string $file){
 		if(($description = $this->getPluginDescription($file)) instanceof PluginDescription){
 			$this->server->getLogger()->info($this->server->getLanguage()->translateString("pocketmine.plugin.load", [$description->getFullName()]));
 			$dataFolder = dirname($file) . DIRECTORY_SEPARATOR . $description->getName();
@@ -82,9 +80,9 @@ class ScriptPluginLoader implements PluginLoader{
 	 *
 	 * @param string $file
 	 *
-	 * @return PluginDescription|null
+	 * @return null|PluginDescription
 	 */
-	public function getPluginDescription($file){
+	public function getPluginDescription(string $file){
 		$content = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
 
 		$data = [];
@@ -122,7 +120,7 @@ class ScriptPluginLoader implements PluginLoader{
 	 *
 	 * @return string
 	 */
-	public function getPluginFilters(){
+	public function getPluginFilters() : string{
 		return "/\\.php$/i";
 	}
 

--- a/src/pocketmine/resourcepacks/ResourcePackInfoEntry.php
+++ b/src/pocketmine/resourcepacks/ResourcePackInfoEntry.php
@@ -28,7 +28,7 @@ class ResourcePackInfoEntry{
 	protected $version;
 	protected $packSize;
 
-	public function __construct(string $packId, string $version, $packSize = 0){
+	public function __construct(string $packId, string $version, int $packSize = 0){
 		$this->packId = $packId;
 		$this->version = $version;
 		$this->packSize = $packSize;
@@ -42,7 +42,7 @@ class ResourcePackInfoEntry{
 		return $this->version;
 	}
 
-	public function getPackSize(){
+	public function getPackSize() : int{
 		return $this->packSize;
 	}
 

--- a/src/pocketmine/resourcepacks/ZippedResourcePack.php
+++ b/src/pocketmine/resourcepacks/ZippedResourcePack.php
@@ -34,7 +34,7 @@ class ZippedResourcePack implements ResourcePack{
 	 * @param \stdClass $manifest
 	 * @return bool
 	 */
-	public static function verifyManifest(\stdClass $manifest){
+	public static function verifyManifest(\stdClass $manifest) : bool{
 		if(!isset($manifest->format_version) or !isset($manifest->header) or !isset($manifest->modules)){
 			return false;
 		}

--- a/src/pocketmine/scheduler/AsyncPool.php
+++ b/src/pocketmine/scheduler/AsyncPool.php
@@ -43,9 +43,9 @@ class AsyncPool{
 	/** @var int[] */
 	private $workerUsage = [];
 
-	public function __construct(Server $server, $size){
+	public function __construct(Server $server, int $size){
 		$this->server = $server;
-		$this->size = (int) $size;
+		$this->size = $size;
 
 		for($i = 0; $i < $this->size; ++$i){
 			$this->workerUsage[$i] = 0;
@@ -55,12 +55,11 @@ class AsyncPool{
 		}
 	}
 
-	public function getSize(){
+	public function getSize() : int{
 		return $this->size;
 	}
 
-	public function increaseSize($newSize){
-		$newSize = (int) $newSize;
+	public function increaseSize(int $newSize){
 		if($newSize > $this->size){
 			for($i = $this->size; $i < $newSize; ++$i){
 				$this->workerUsage[$i] = 0;
@@ -72,12 +71,11 @@ class AsyncPool{
 		}
 	}
 
-	public function submitTaskToWorker(AsyncTask $task, $worker){
+	public function submitTaskToWorker(AsyncTask $task, int $worker){
 		if(isset($this->tasks[$task->getTaskId()]) or $task->isGarbage()){
 			return;
 		}
 
-		$worker = (int) $worker;
 		if($worker < 0 or $worker >= $this->size){
 			throw new \InvalidArgumentException("Invalid worker $worker");
 		}
@@ -106,7 +104,7 @@ class AsyncPool{
 		$this->submitTaskToWorker($task, $selectedWorker);
 	}
 
-	private function removeTask(AsyncTask $task, $force = false){
+	private function removeTask(AsyncTask $task, bool $force = false){
 		if(isset($this->taskWorkers[$task->getTaskId()])){
 			if(!$force and ($task->isRunning() or !$task->isGarbage())){
 				return;

--- a/src/pocketmine/scheduler/AsyncTask.php
+++ b/src/pocketmine/scheduler/AsyncTask.php
@@ -25,7 +25,6 @@ namespace pocketmine\scheduler;
 
 use pocketmine\Collectable;
 use pocketmine\Server;
-use pocketmine\utils\MainLogger;
 
 /**
  * Class used to run async tasks in other threads.
@@ -47,7 +46,7 @@ abstract class AsyncTask extends Collectable{
 	private $result = null;
 	private $serialized = false;
 	private $cancelRun = false;
-	/** @var int */
+	/** @var int|null */
 	private $taskId = null;
 
 	private $crashed = false;
@@ -90,7 +89,7 @@ abstract class AsyncTask extends Collectable{
 		$this->setGarbage();
 	}
 
-	public function isCrashed(){
+	public function isCrashed() : bool{
 		return $this->crashed;
 	}
 
@@ -105,14 +104,14 @@ abstract class AsyncTask extends Collectable{
 		$this->cancelRun = true;
 	}
 
-	public function hasCancelledRun(){
+	public function hasCancelledRun() : bool{
 		return $this->cancelRun === true;
 	}
 
 	/**
 	 * @return bool
 	 */
-	public function hasResult(){
+	public function hasResult() : bool{
 		return $this->result !== null;
 	}
 
@@ -120,15 +119,18 @@ abstract class AsyncTask extends Collectable{
 	 * @param mixed $result
 	 * @param bool  $serialize
 	 */
-	public function setResult($result, $serialize = true){
+	public function setResult($result, bool $serialize = true){
 		$this->result = $serialize ? serialize($result) : $result;
 		$this->serialized = $serialize;
 	}
 
-	public function setTaskId($taskId){
+	public function setTaskId(int $taskId){
 		$this->taskId = $taskId;
 	}
 
+	/**
+	 * @return int|null
+	 */
 	public function getTaskId(){
 		return $this->taskId;
 	}
@@ -140,7 +142,7 @@ abstract class AsyncTask extends Collectable{
 	 * @param string $identifier
 	 * @return mixed
 	 */
-	public function getFromThreadStore($identifier){
+	public function getFromThreadStore(string $identifier){
 		global $store;
 		return ($this->isGarbage() or !isset($store[$identifier])) ? null : $store[$identifier];
 	}
@@ -152,7 +154,7 @@ abstract class AsyncTask extends Collectable{
 	 * @param string $identifier
 	 * @param mixed  $value
 	 */
-	public function saveToThreadStore($identifier, $value){
+	public function saveToThreadStore(string $identifier, $value){
 		global $store;
 		if(!$this->isGarbage()){
 			$store[$identifier] = $value;

--- a/src/pocketmine/scheduler/AsyncWorker.php
+++ b/src/pocketmine/scheduler/AsyncWorker.php
@@ -31,7 +31,7 @@ class AsyncWorker extends Worker{
 	private $logger;
 	private $id;
 
-	public function __construct(MainLogger $logger, $id){
+	public function __construct(MainLogger $logger, int $id){
 		$this->logger = $logger;
 		$this->id = $id;
 	}
@@ -53,7 +53,7 @@ class AsyncWorker extends Worker{
 		$this->logger->logException($e);
 	}
 
-	public function getThreadName(){
+	public function getThreadName() : string{
 		return "Asynchronous Worker #" . $this->id;
 	}
 }

--- a/src/pocketmine/scheduler/FileWriteTask.php
+++ b/src/pocketmine/scheduler/FileWriteTask.php
@@ -25,19 +25,27 @@ namespace pocketmine\scheduler;
 
 class FileWriteTask extends AsyncTask{
 
+	/** @var string */
 	private $path;
+	/** @var mixed */
 	private $contents;
+	/** @var int */
 	private $flags;
 
-	public function __construct($path, $contents, $flags = 0){
+	/**
+	 * @param string $path
+	 * @param mixed  $contents
+	 * @param int    $flags
+	 */
+	public function __construct(string $path, $contents, int $flags = 0){
 		$this->path = $path;
 		$this->contents = $contents;
-		$this->flags = (int) $flags;
+		$this->flags = $flags;
 	}
 
 	public function onRun(){
 		try{
-			file_put_contents($this->path, $this->contents, (int) $this->flags);
+			file_put_contents($this->path, $this->contents, $this->flags);
 		}catch(\Throwable $e){
 
 		}

--- a/src/pocketmine/scheduler/PluginTask.php
+++ b/src/pocketmine/scheduler/PluginTask.php
@@ -43,7 +43,7 @@ abstract class PluginTask extends Task{
 	/**
 	 * @return Plugin
 	 */
-	final public function getOwner(){
+	final public function getOwner() : Plugin{
 		return $this->owner;
 	}
 

--- a/src/pocketmine/scheduler/SendUsageTask.php
+++ b/src/pocketmine/scheduler/SendUsageTask.php
@@ -38,7 +38,12 @@ class SendUsageTask extends AsyncTask{
 	public $endpoint;
 	public $data;
 
-	public function __construct(Server $server, $type, $playerList = []){
+	/**
+	 * @param Server $server
+	 * @param int    $type
+	 * @param array  $playerList
+	 */
+	public function __construct(Server $server, int $type, array $playerList = []){
 		$endpoint = "http://" . $server->getProperty("anonymous-statistics.host", "stats.pocketmine.net") . "/";
 
 		$data = [];

--- a/src/pocketmine/scheduler/ServerScheduler.php
+++ b/src/pocketmine/scheduler/ServerScheduler.php
@@ -294,7 +294,7 @@ class ServerScheduler{
 		return $this->handle(new TaskHandler(get_class($task), $task, $this->nextId(), $delay, $period));
 	}
 
-	private function handle(TaskHandler $handler){
+	private function handle(TaskHandler $handler) : TaskHandler{
 		if($handler->isDelayed()){
 			$nextRun = $this->currentTick + $handler->getDelay();
 		}else{

--- a/src/pocketmine/scheduler/ServerScheduler.php
+++ b/src/pocketmine/scheduler/ServerScheduler.php
@@ -180,11 +180,11 @@ class ServerScheduler{
 		return true;
 	}
 
-	public function getAsyncTaskPoolSize(){
+	public function getAsyncTaskPoolSize() : int{
 		return $this->asyncPool->getSize();
 	}
 
-	public function increaseAsyncTaskPoolSize($newSize){
+	public function increaseAsyncTaskPoolSize(int $newSize){
 		$this->asyncPool->increaseSize($newSize);
 	}
 
@@ -194,8 +194,8 @@ class ServerScheduler{
 	 *
 	 * @return null|TaskHandler
 	 */
-	public function scheduleDelayedTask(Task $task, $delay){
-		return $this->addTask($task, (int) $delay, -1);
+	public function scheduleDelayedTask(Task $task, int $delay){
+		return $this->addTask($task, $delay, -1);
 	}
 
 	/**
@@ -204,8 +204,8 @@ class ServerScheduler{
 	 *
 	 * @return null|TaskHandler
 	 */
-	public function scheduleRepeatingTask(Task $task, $period){
-		return $this->addTask($task, -1, (int) $period);
+	public function scheduleRepeatingTask(Task $task, int $period){
+		return $this->addTask($task, -1, $period);
 	}
 
 	/**
@@ -215,14 +215,14 @@ class ServerScheduler{
 	 *
 	 * @return null|TaskHandler
 	 */
-	public function scheduleDelayedRepeatingTask(Task $task, $delay, $period){
-		return $this->addTask($task, (int) $delay, (int) $period);
+	public function scheduleDelayedRepeatingTask(Task $task, int $delay, int $period){
+		return $this->addTask($task, $delay, $period);
 	}
 
 	/**
 	 * @param int $taskId
 	 */
-	public function cancelTask($taskId){
+	public function cancelTask(int $taskId){
 		if($taskId !== null and isset($this->tasks[$taskId])){
 			$this->tasks[$taskId]->cancel();
 			unset($this->tasks[$taskId]);
@@ -259,20 +259,20 @@ class ServerScheduler{
 	 *
 	 * @return bool
 	 */
-	public function isQueued($taskId){
+	public function isQueued(int $taskId) : bool{
 		return isset($this->tasks[$taskId]);
 	}
 
 	/**
 	 * @param Task $task
-	 * @param      $delay
-	 * @param      $period
+	 * @param int  $delay
+	 * @param int  $period
 	 *
 	 * @return null|TaskHandler
 	 *
 	 * @throws PluginException
 	 */
-	private function addTask(Task $task, $delay, $period){
+	private function addTask(Task $task, int $delay, int $period){
 		if($task instanceof PluginTask){
 			if(!($task->getOwner() instanceof Plugin)){
 				throw new PluginException("Invalid owner of PluginTask " . get_class($task));
@@ -311,7 +311,7 @@ class ServerScheduler{
 	/**
 	 * @param int $currentTick
 	 */
-	public function mainThreadHeartbeat($currentTick){
+	public function mainThreadHeartbeat(int $currentTick){
 		$this->currentTick = $currentTick;
 		while($this->isReady($this->currentTick)){
 			/** @var TaskHandler $task */
@@ -341,14 +341,14 @@ class ServerScheduler{
 		$this->asyncPool->collectTasks();
 	}
 
-	private function isReady($currentTicks){
+	private function isReady(int $currentTicks) : bool{
 		return count($this->tasks) > 0 and $this->queue->current()->getNextRun() <= $currentTicks;
 	}
 
 	/**
 	 * @return int
 	 */
-	private function nextId(){
+	private function nextId() : int{
 		return $this->ids++;
 	}
 

--- a/src/pocketmine/scheduler/Task.php
+++ b/src/pocketmine/scheduler/Task.php
@@ -32,7 +32,7 @@ abstract class Task{
 	private $taskHandler = null;
 
 	/**
-	 * @return TaskHandler
+	 * @return TaskHandler|null
 	 */
 	final public function getHandler(){
 		return $this->taskHandler;
@@ -41,7 +41,7 @@ abstract class Task{
 	/**
 	 * @return int
 	 */
-	final public function getTaskId(){
+	final public function getTaskId() : int{
 		if($this->taskHandler !== null){
 			return $this->taskHandler->getTaskId();
 		}
@@ -50,9 +50,9 @@ abstract class Task{
 	}
 
 	/**
-	 * @param TaskHandler $taskHandler
+	 * @param TaskHandler|null $taskHandler
 	 */
-	final public function setHandler($taskHandler){
+	final public function setHandler(TaskHandler $taskHandler = null){
 		if($this->taskHandler === null or $taskHandler === null){
 			$this->taskHandler = $taskHandler;
 		}

--- a/src/pocketmine/scheduler/Task.php
+++ b/src/pocketmine/scheduler/Task.php
@@ -61,11 +61,11 @@ abstract class Task{
 	/**
 	 * Actions to execute when run
 	 *
-	 * @param $currentTick
+	 * @param int $currentTick
 	 *
 	 * @return void
 	 */
-	abstract public function onRun($currentTick);
+	abstract public function onRun(int $currentTick);
 
 	/**
 	 * Actions to execute if the Task is cancelled

--- a/src/pocketmine/scheduler/TaskHandler.php
+++ b/src/pocketmine/scheduler/TaskHandler.php
@@ -58,7 +58,7 @@ class TaskHandler{
 	 * @param int    $delay
 	 * @param int    $period
 	 */
-	public function __construct($timingName, Task $task, $taskId, $delay = -1, $period = -1){
+	public function __construct(string $timingName, Task $task, int $taskId, int $delay = -1, int $period = -1){
 		$this->task = $task;
 		$this->taskId = $taskId;
 		$this->delay = $delay;
@@ -71,63 +71,63 @@ class TaskHandler{
 	/**
 	 * @return bool
 	 */
-	public function isCancelled(){
+	public function isCancelled() : bool{
 		return $this->cancelled === true;
 	}
 
 	/**
 	 * @return int
 	 */
-	public function getNextRun(){
+	public function getNextRun() : int{
 		return $this->nextRun;
 	}
 
 	/**
 	 * @param int $ticks
 	 */
-	public function setNextRun($ticks){
+	public function setNextRun(int $ticks){
 		$this->nextRun = $ticks;
 	}
 
 	/**
 	 * @return int
 	 */
-	public function getTaskId(){
+	public function getTaskId() : int{
 		return $this->taskId;
 	}
 
 	/**
 	 * @return Task
 	 */
-	public function getTask(){
+	public function getTask() : Task{
 		return $this->task;
 	}
 
 	/**
 	 * @return int
 	 */
-	public function getDelay(){
+	public function getDelay() : int{
 		return $this->delay;
 	}
 
 	/**
 	 * @return bool
 	 */
-	public function isDelayed(){
+	public function isDelayed() : bool{
 		return $this->delay > 0;
 	}
 
 	/**
 	 * @return bool
 	 */
-	public function isRepeating(){
+	public function isRepeating() : bool{
 		return $this->period > 0;
 	}
 
 	/**
 	 * @return int
 	 */
-	public function getPeriod(){
+	public function getPeriod() : int{
 		return $this->period;
 	}
 
@@ -150,14 +150,14 @@ class TaskHandler{
 	/**
 	 * @param int $currentTick
 	 */
-	public function run($currentTick){
+	public function run(int $currentTick){
 		$this->task->onRun($currentTick);
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getTaskName(){
+	public function getTaskName() : string{
 		if($this->timingName !== null){
 			return $this->timingName;
 		}

--- a/src/pocketmine/tile/Chest.php
+++ b/src/pocketmine/tile/Chest.php
@@ -84,7 +84,7 @@ class Chest extends Spawnable implements InventoryHolder, Container, Nameable{
 	/**
 	 * @return int
 	 */
-	public function getSize(){
+	public function getSize() : int{
 		return 27;
 	}
 
@@ -93,9 +93,9 @@ class Chest extends Spawnable implements InventoryHolder, Container, Nameable{
 	 *
 	 * @return int
 	 */
-	protected function getSlotIndex($index){
+	protected function getSlotIndex(int $index){
 		foreach($this->namedtag->Items as $i => $slot){
-			if((int) $slot["Slot"] === (int) $index){
+			if((int) $slot["Slot"] === $index){
 				return (int) $i;
 			}
 		}
@@ -110,7 +110,7 @@ class Chest extends Spawnable implements InventoryHolder, Container, Nameable{
 	 *
 	 * @return Item
 	 */
-	public function getItem($index){
+	public function getItem(int $index) : Item{
 		$i = $this->getSlotIndex($index);
 		if($i < 0){
 			return Item::get(Item::AIR, 0, 0);
@@ -124,10 +124,8 @@ class Chest extends Spawnable implements InventoryHolder, Container, Nameable{
 	 *
 	 * @param int  $index
 	 * @param Item $item
-	 *
-	 * @return bool
 	 */
-	public function setItem($index, Item $item){
+	public function setItem(int $index, Item $item){
 		$i = $this->getSlotIndex($index);
 
 		$d = $item->nbtSerialize($index);
@@ -146,8 +144,6 @@ class Chest extends Spawnable implements InventoryHolder, Container, Nameable{
 		}else{
 			$this->namedtag->Items[$i] = $d;
 		}
-
-		return true;
 	}
 
 	/**
@@ -280,7 +276,7 @@ class Chest extends Spawnable implements InventoryHolder, Container, Nameable{
 		return true;
 	}
 
-	public function getSpawnCompound(){
+	public function getSpawnCompound() : CompoundTag{
 		if($this->isPaired()){
 			$c = new CompoundTag("", [
 				new StringTag("id", Tile::CHEST),

--- a/src/pocketmine/tile/Container.php
+++ b/src/pocketmine/tile/Container.php
@@ -32,16 +32,16 @@ interface Container{
 	 *
 	 * @return Item
 	 */
-	public function getItem($index);
+	public function getItem(int $index) : Item;
 
 	/**
 	 * @param int  $index
 	 * @param Item $item
 	 */
-	public function setItem($index, Item $item);
+	public function setItem(int $index, Item $item);
 
 	/**
 	 * @return int
 	 */
-	public function getSize();
+	public function getSize() : int;
 }

--- a/src/pocketmine/tile/EnchantTable.php
+++ b/src/pocketmine/tile/EnchantTable.php
@@ -47,7 +47,7 @@ class EnchantTable extends Spawnable implements Nameable{
 		$this->namedtag->CustomName = new StringTag("CustomName", $str);
 	}
 
-	public function getSpawnCompound(){
+	public function getSpawnCompound() : CompoundTag{
 		$c = new CompoundTag("", [
 			new StringTag("id", Tile::ENCHANT_TABLE),
 			new IntTag("x", (int) $this->x),

--- a/src/pocketmine/tile/Furnace.php
+++ b/src/pocketmine/tile/Furnace.php
@@ -112,7 +112,7 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 	/**
 	 * @return int
 	 */
-	public function getSize(){
+	public function getSize() : int{
 		return 3;
 	}
 
@@ -121,7 +121,7 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 	 *
 	 * @return int
 	 */
-	protected function getSlotIndex($index){
+	protected function getSlotIndex(int $index) : int{
 		foreach($this->namedtag->Items as $i => $slot){
 			if($slot["Slot"] === $index){
 				return $i;
@@ -138,7 +138,7 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 	 *
 	 * @return Item
 	 */
-	public function getItem($index){
+	public function getItem(int $index) : Item{
 		$i = $this->getSlotIndex($index);
 		if($i < 0){
 			return Item::get(Item::AIR, 0, 0);
@@ -152,10 +152,8 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 	 *
 	 * @param int  $index
 	 * @param Item $item
-	 *
-	 * @return bool
 	 */
-	public function setItem($index, Item $item){
+	public function setItem(int $index, Item $item){
 		$i = $this->getSlotIndex($index);
 
 		$d = $item->nbtSerialize($index);
@@ -174,8 +172,6 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 		}else{
 			$this->namedtag->Items[$i] = $d;
 		}
-
-		return true;
 	}
 
 	/**
@@ -208,7 +204,7 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 		}
 	}
 
-	public function onUpdate(){
+	public function onUpdate() : bool{
 		if($this->closed === true){
 			return false;
 		}
@@ -291,7 +287,7 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 		return $ret;
 	}
 
-	public function getSpawnCompound(){
+	public function getSpawnCompound() : CompoundTag{
 		$nbt = new CompoundTag("", [
 			new StringTag("id", Tile::FURNACE),
 			new IntTag("x", (int) $this->x),

--- a/src/pocketmine/tile/ItemFrame.php
+++ b/src/pocketmine/tile/ItemFrame.php
@@ -84,7 +84,7 @@ class ItemFrame extends Spawnable{
 		$this->onChanged();
 	}
 
-	public function getSpawnCompound(){
+	public function getSpawnCompound() : CompoundTag{
 		$tag = new CompoundTag("", [
 			new StringTag("id", Tile::ITEM_FRAME),
 			new IntTag("x", (int) $this->x),

--- a/src/pocketmine/tile/Sign.php
+++ b/src/pocketmine/tile/Sign.php
@@ -74,7 +74,7 @@ class Sign extends Spawnable{
 		];
 	}
 
-	public function getSpawnCompound(){
+	public function getSpawnCompound() : CompoundTag{
 		return new CompoundTag("", [
 			new StringTag("id", Tile::SIGN),
 			$this->namedtag->Text1,

--- a/src/pocketmine/tile/Skull.php
+++ b/src/pocketmine/tile/Skull.php
@@ -56,7 +56,7 @@ class Skull extends Spawnable{
 		return $this->namedtag["SkullType"];
 	}
 
-	public function getSpawnCompound(){
+	public function getSpawnCompound() : CompoundTag{
 		return new CompoundTag("", [
 			new StringTag("id", Tile::SKULL),
 			$this->namedtag->SkullType,

--- a/src/pocketmine/tile/Spawnable.php
+++ b/src/pocketmine/tile/Spawnable.php
@@ -77,7 +77,7 @@ abstract class Spawnable extends Tile{
 	/**
 	 * @return CompoundTag
 	 */
-	abstract public function getSpawnCompound();
+	abstract public function getSpawnCompound() : CompoundTag;
 
 	/**
 	 * Called when a player updates a block entity's NBT data

--- a/src/pocketmine/tile/Tile.php
+++ b/src/pocketmine/tile/Tile.php
@@ -100,7 +100,7 @@ abstract class Tile extends Position{
 	 *
 	 * @return bool
 	 */
-	public static function registerTile($className){
+	public static function registerTile($className) : bool{
 		$class = new \ReflectionClass($className);
 		if(is_a($className, Tile::class, true) and !$class->isAbstract()){
 			self::$knownTiles[$class->getShortName()] = $className;
@@ -116,7 +116,7 @@ abstract class Tile extends Position{
 	 *
 	 * @return string
 	 */
-	public function getSaveId(){
+	public function getSaveId() : string{
 		return self::$shortNames[static::class];
 	}
 
@@ -166,11 +166,14 @@ abstract class Tile extends Position{
 	/**
 	 * @return Block
 	 */
-	public function getBlock(){
+	public function getBlock() : Block{
 		return $this->level->getBlock($this);
 	}
 
-	public function onUpdate(){
+	/**
+	 * @return bool
+	 */
+	public function onUpdate() : bool{
 		return false;
 	}
 

--- a/src/pocketmine/updater/AutoUpdater.php
+++ b/src/pocketmine/updater/AutoUpdater.php
@@ -81,7 +81,7 @@ class AutoUpdater{
 	 *
 	 * @return bool
 	 */
-	public function hasUpdate(){
+	public function hasUpdate() : bool{
 		return $this->hasUpdate;
 	}
 
@@ -164,7 +164,7 @@ class AutoUpdater{
 	 *
 	 * @return string
 	 */
-	public function getChannel(){
+	public function getChannel() : string{
 		$channel = strtolower($this->server->getProperty("auto-updater.preferred-channel", "stable"));
 		if($channel !== "stable" and $channel !== "beta" and $channel !== "alpha" and $channel !== "development"){
 			$channel = "stable";

--- a/src/pocketmine/utils/Binary.php
+++ b/src/pocketmine/utils/Binary.php
@@ -282,7 +282,7 @@ class Binary{
 	 *
 	 * @return float
 	 */
-	public static function readRoundedFloat(string $str, int $accuracy){
+	public static function readRoundedFloat(string $str, int $accuracy) : float{
 		return round(self::readFloat($str), $accuracy);
 	}
 
@@ -315,7 +315,7 @@ class Binary{
 	 *
 	 * @return float
 	 */
-	public static function readRoundedLFloat(string $str, int $accuracy){
+	public static function readRoundedLFloat(string $str, int $accuracy) : float{
 		return round(self::readLFloat($str), $accuracy);
 	}
 
@@ -335,7 +335,7 @@ class Binary{
 	 * @param float $value
 	 * @return string
 	 */
-	public static function printFloat(float $value){
+	public static function printFloat(float $value) : string{
 		return preg_replace("/(\\.\\d+?)0+$/", "$1", sprintf("%F", $value));
 	}
 

--- a/src/pocketmine/utils/Config.php
+++ b/src/pocketmine/utils/Config.php
@@ -110,7 +110,7 @@ class Config{
 	 *
 	 * @return bool
 	 */
-	public function load(string $file, int $type = Config::DETECT, array $default = []){
+	public function load(string $file, int $type = Config::DETECT, array $default = []) : bool{
 		$this->correct = true;
 		$this->file = $file;
 
@@ -171,7 +171,7 @@ class Config{
 	/**
 	 * @return bool
 	 */
-	public function check(){
+	public function check() : bool{
 		return $this->correct === true;
 	}
 
@@ -434,7 +434,7 @@ class Config{
 	 *
 	 * @return array
 	 */
-	public function getAll($keys = false){
+	public function getAll(bool $keys = false) : array{
 		return ($keys === true ? array_keys($this->config) : $this->config);
 	}
 
@@ -446,12 +446,12 @@ class Config{
 	}
 
 	/**
-	 * @param $default
-	 * @param $data
+	 * @param array $default
+	 * @param array &$data
 	 *
 	 * @return int
 	 */
-	private function fillDefaults($default, &$data){
+	private function fillDefaults(array $default, &$data) : int{
 		$changed = 0;
 		foreach($default as $k => $v){
 			if(is_array($v)){
@@ -484,7 +484,7 @@ class Config{
 	/**
 	 * @return string
 	 */
-	private function writeProperties(){
+	private function writeProperties() : string{
 		$content = "#Properties Config file\r\n#" . date("D M j H:i:s T Y") . "\r\n";
 		foreach($this->config as $k => $v){
 			if(is_bool($v) === true){

--- a/src/pocketmine/utils/Random.php
+++ b/src/pocketmine/utils/Random.php
@@ -86,7 +86,7 @@ class Random{
 	 *
 	 * @return int
 	 */
-	public function nextInt(){
+	public function nextInt() : int{
 		return $this->nextSignedInt() & 0x7fffffff;
 	}
 
@@ -95,7 +95,7 @@ class Random{
 	 *
 	 * @return int
 	 */
-	public function nextSignedInt(){
+	public function nextSignedInt() : int{
 		$t = ($this->x ^ ($this->x << 11)) & 0xffffffff;
 
 		$this->x = $this->y;
@@ -112,7 +112,7 @@ class Random{
 	 *
 	 * @return float
 	 */
-	public function nextFloat(){
+	public function nextFloat() : float{
 		return $this->nextInt() / 0x7fffffff;
 	}
 
@@ -121,7 +121,7 @@ class Random{
 	 *
 	 * @return float
 	 */
-	public function nextSignedFloat(){
+	public function nextSignedFloat() : float{
 		return $this->nextSignedInt() / 0x7fffffff;
 	}
 
@@ -130,7 +130,7 @@ class Random{
 	 *
 	 * @return bool
 	 */
-	public function nextBoolean(){
+	public function nextBoolean() : bool{
 		return ($this->nextSignedInt() & 0x01) === 0;
 	}
 
@@ -138,15 +138,15 @@ class Random{
 	 * Returns a random integer between $start and $end
 	 *
 	 * @param int $start default 0
-	 * @param int $end   default 0x7fffffff
+	 * @param int $end default 0x7fffffff
 	 *
 	 * @return int
 	 */
-	public function nextRange($start = 0, $end = 0x7fffffff){
+	public function nextRange(int $start = 0, int $end = 0x7fffffff) : int{
 		return $start + ($this->nextInt() % ($end + 1 - $start));
 	}
 
-	public function nextBoundedInt($bound){
+	public function nextBoundedInt(int $bound) : int{
 		return $this->nextInt() % $bound;
 	}
 

--- a/src/pocketmine/utils/TextFormat.php
+++ b/src/pocketmine/utils/TextFormat.php
@@ -60,7 +60,7 @@ abstract class TextFormat{
 	 *
 	 * @return array
 	 */
-	public static function tokenize($string){
+	public static function tokenize($string) : array{
 		return preg_split("/(" . TextFormat::ESCAPE . "[0123456789abcdefklmnor])/", $string, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
 	}
 
@@ -86,7 +86,7 @@ abstract class TextFormat{
 	 *
 	 * @return string
 	 */
-	public static function toJSON($string){
+	public static function toJSON($string) : string{
 		if(!is_array($string)){
 			$string = self::tokenize($string);
 		}
@@ -274,7 +274,7 @@ abstract class TextFormat{
 	 *
 	 * @return string
 	 */
-	public static function toHTML($string){
+	public static function toHTML($string) : string{
 		if(!is_array($string)){
 			$string = self::tokenize($string);
 		}
@@ -390,7 +390,7 @@ abstract class TextFormat{
 	 *
 	 * @return string
 	 */
-	public static function toANSI($string){
+	public static function toANSI($string) : string{
 		if(!is_array($string)){
 			$string = self::tokenize($string);
 		}

--- a/src/pocketmine/utils/UUID.php
+++ b/src/pocketmine/utils/UUID.php
@@ -31,7 +31,7 @@ class UUID{
 	public function __construct(int $part1 = 0, int $part2 = 0, int $part3 = 0, int $part4 = 0, int $version = null){
 		$this->parts = [$part1, $part2, $part3, $part4];
 
-		$this->version = $version === null ? ($this->parts[1] & 0xf000) >> 12 : $version;
+		$this->version = $version ?? ($this->parts[1] & 0xf000) >> 12;
 	}
 
 	public function getVersion() : int{

--- a/src/pocketmine/utils/UUID.php
+++ b/src/pocketmine/utils/UUID.php
@@ -28,20 +28,17 @@ class UUID{
 	private $parts = [0, 0, 0, 0];
 	private $version = null;
 
-	public function __construct($part1 = 0, $part2 = 0, $part3 = 0, $part4 = 0, $version = null){
-		$this->parts[0] = (int) $part1;
-		$this->parts[1] = (int) $part2;
-		$this->parts[2] = (int) $part3;
-		$this->parts[3] = (int) $part4;
+	public function __construct(int $part1 = 0, int $part2 = 0, int $part3 = 0, int $part4 = 0, int $version = null){
+		$this->parts = [$part1, $part2, $part3, $part4];
 
-		$this->version = $version === null ? ($this->parts[1] & 0xf000) >> 12 : (int) $version;
+		$this->version = $version === null ? ($this->parts[1] & 0xf000) >> 12 : $version;
 	}
 
-	public function getVersion(){
+	public function getVersion() : int{
 		return $this->version;
 	}
 
-	public function equals(UUID $uuid){
+	public function equals(UUID $uuid) : bool{
 		return $uuid->parts[0] === $this->parts[0] and $uuid->parts[1] === $this->parts[1] and $uuid->parts[2] === $this->parts[2] and $uuid->parts[3] === $this->parts[3];
 	}
 
@@ -52,7 +49,7 @@ class UUID{
 	 * @param int    $version
 	 * @return UUID
 	 */
-	public static function fromString($uuid, $version = null){
+	public static function fromString(string $uuid, int $version = null) : UUID{
 		return self::fromBinary(hex2bin(str_replace("-", "", trim($uuid))), $version);
 	}
 
@@ -62,8 +59,10 @@ class UUID{
 	 * @param string $uuid
 	 * @param int    $version
 	 * @return UUID
+	 *
+	 * @throws \InvalidArgumentException
 	 */
-	public static function fromBinary($uuid, $version = null){
+	public static function fromBinary(string $uuid, int $version = null) : UUID{
 		if(strlen($uuid) !== 16){
 			throw new \InvalidArgumentException("Must have exactly 16 bytes");
 		}
@@ -77,21 +76,21 @@ class UUID{
 	 * @param string[] ...$data
 	 * @return UUID
 	 */
-	public static function fromData(string ...$data){
+	public static function fromData(string ...$data) : UUID{
 		$hash = hash("md5", implode($data), true);
 
 		return self::fromBinary($hash, 3);
 	}
 
-	public static function fromRandom(){
+	public static function fromRandom() : UUID{
 		return self::fromData(Binary::writeInt(time()), Binary::writeShort(getmypid()), Binary::writeShort(getmyuid()), Binary::writeInt(mt_rand(-0x7fffffff, 0x7fffffff)), Binary::writeInt(mt_rand(-0x7fffffff, 0x7fffffff)));
 	}
 
-	public function toBinary(){
+	public function toBinary() : string{
 		return Binary::writeInt($this->parts[0]) . Binary::writeInt($this->parts[1]) . Binary::writeInt($this->parts[2]) . Binary::writeInt($this->parts[3]);
 	}
 
-	public function toString(){
+	public function toString() : string{
 		$hex = bin2hex($this->toBinary());
 
 		//xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx 8-4-4-4-12
@@ -101,7 +100,7 @@ class UUID{
 		return substr($hex, 0, 8) . "-" . substr($hex, 8, 4) . "-" . substr($hex, 12, 4) . "-" . substr($hex, 16, 4) . "-" . substr($hex, 20, 12);
 	}
 
-	public function __toString(){
+	public function __toString() : string{
 		return $this->toString();
 	}
 

--- a/src/pocketmine/utils/Utils.php
+++ b/src/pocketmine/utils/Utils.php
@@ -64,7 +64,7 @@ class Utils{
 	 *
 	 * @return UUID
 	 */
-	public static function getMachineUniqueId($extra = ""){
+	public static function getMachineUniqueId(string $extra = "") : UUID{
 		if(self::$serverUniqueId !== null and $extra === ""){
 			return self::$serverUniqueId;
 		}
@@ -188,7 +188,7 @@ class Utils{
 	 *
 	 * @return string
 	 */
-	public static function getOS($recalculate = false){
+	public static function getOS(bool $recalculate = false) : string{
 		if(self::$os === null or $recalculate){
 			$uname = php_uname("s");
 			if(stripos($uname, "Darwin") !== false){
@@ -215,8 +215,10 @@ class Utils{
 		return self::$os;
 	}
 
-
-	public static function getRealMemoryUsage(){
+	/**
+	 * @return int[]
+	 */
+	public static function getRealMemoryUsage() : array{
 		$stack = 0;
 		$heap = 0;
 
@@ -279,7 +281,11 @@ class Utils{
 		return count(ThreadManager::getInstance()->getAll()) + 3; //RakLib + MainLogger + Main Thread
 	}
 
-	public static function getCoreCount($recalculate = false){
+	/**
+	 * @param bool $recalculate
+	 * @return int
+	 */
+	public static function getCoreCount(bool $recalculate = false) : int{
 		static $processors = 0;
 
 		if($processors > 0 and !$recalculate){
@@ -321,7 +327,7 @@ class Utils{
 	 *
 	 * @return string
 	 */
-	public static function hexdump($bin){
+	public static function hexdump(string $bin) : string{
 		$output = "";
 		$bin = str_split($bin, 16);
 		foreach($bin as $counter => $line){
@@ -337,11 +343,11 @@ class Utils{
 	/**
 	 * Returns a string that can be printed, replaces non-printable characters
 	 *
-	 * @param $str
+	 * @param mixed $str
 	 *
 	 * @return string
 	 */
-	public static function printable($str){
+	public static function printable($str) : string{
 		if(!is_string($str)){
 			return gettype($str);
 		}
@@ -476,7 +482,7 @@ class Utils{
 		}
 	}
 
-	public static function javaStringHash($string){
+	public static function javaStringHash(string $string) : int{
 		$hash = 0;
 		for($i = 0, $len = strlen($string); $i < $len; $i++){
 			$ord = ord($string{$i});

--- a/src/pocketmine/utils/VersionString.php
+++ b/src/pocketmine/utils/VersionString.php
@@ -33,6 +33,11 @@ class VersionString{
 	private $minor;
 	private $development = false;
 
+	/**
+	 * VersionString constructor.
+	 *
+	 * @param int|string $version
+	 */
 	public function __construct($version = \pocketmine\VERSION){
 		if(is_int($version)){
 			$this->minor = $version & 0x1F;
@@ -40,9 +45,9 @@ class VersionString{
 			$this->generation = ($version >> 9) & 0x0F;
 		}else{
 			$version = preg_split("/([A-Za-z]*)[ _\\-]?([0-9]*)\\.([0-9]*)\\.{0,1}([0-9]*)(dev|)(-[\\0-9]{1,}|)/", $version, -1, PREG_SPLIT_DELIM_CAPTURE);
-			$this->generation = isset($version[2]) ? (int) $version[2] : 0; //0-15
-			$this->major = isset($version[3]) ? (int) $version[3] : 0; //0-15
-			$this->minor = isset($version[4]) ? (int) $version[4] : 0; //0-31
+			$this->generation = (int) ($version[2] ?? 0); //0-15
+			$this->major = (int) ($version[3] ?? 0); //0-15
+			$this->minor = (int) ($version[4] ?? 0); //0-31
 			$this->development = $version[5] === "dev";
 			if($version[6] !== ""){
 				$this->build = (int) (substr($version[6], 1));
@@ -52,43 +57,49 @@ class VersionString{
 		}
 	}
 
-	public function getNumber(){
+	public function getNumber() : int{
 		return (int) (($this->generation << 9) + ($this->major << 5) + $this->minor);
 	}
 
-	public function getGeneration(){
+	public function getGeneration() : int{
 		return $this->generation;
 	}
 
-	public function getMajor(){
+	public function getMajor() : int{
 		return $this->major;
 	}
 
-	public function getMinor(){
+	public function getMinor() : int{
 		return $this->minor;
 	}
 
-	public function getRelease(){
+	public function getRelease() : string{
 		return $this->generation . "." . $this->major . ($this->minor > 0 ? "." . $this->minor : "");
 	}
 
-	public function getBuild(){
+	public function getBuild() : int{
 		return $this->build;
 	}
 
-	public function isDev(){
-		return $this->development === true;
+	public function isDev() : bool{
+		return $this->development;
 	}
 
-	public function get($build = false){
+	public function get(bool $build = false) : string{
 		return $this->getRelease() . ($this->development === true ? "dev" : "") . (($this->build > 0 and $build === true) ? "-" . $this->build : "");
 	}
 
-	public function __toString(){
+	public function __toString() : string{
 		return $this->get();
 	}
 
-	public function compare($target, $diff = false){
+	/**
+	 * @param VersionString|int|string $target
+	 * @param bool                     $diff
+	 *
+	 * @return int
+	 */
+	public function compare($target, bool $diff = false) : int{
 		if(($target instanceof VersionString) === false){
 			$target = new VersionString($target);
 		}

--- a/src/pocketmine/wizard/SetupWizard.php
+++ b/src/pocketmine/wizard/SetupWizard.php
@@ -45,7 +45,7 @@ class SetupWizard{
 
 	}
 
-	public function run(){
+	public function run() : bool{
 		$this->message("PocketMine-MP set-up wizard");
 
 		$langs = BaseLang::getLanguageList();
@@ -91,7 +91,7 @@ class SetupWizard{
 		return true;
 	}
 
-	private function showLicense(){
+	private function showLicense() : bool{
 		$this->message($this->lang->get("welcome_to_pocketmine"));
 		echo <<<LICENSE
 
@@ -244,7 +244,7 @@ LICENSE;
 		$this->writeLine("[!] " . $message);
 	}
 
-	private function getInput(string $message, string $default = "", string $options = ""){
+	private function getInput(string $message, string $default = "", string $options = "") : string{
 		$message = "[?] " . $message;
 
 		if($options !== "" or $default !== ""){


### PR DESCRIPTION
to be continued

Note that this will not be a complete set of changes for the following reasons:
- A lot of refactoring has taken places like this on other branches and I don't want to cause any more merge conflicts than strictly necessary
- When we upgrade to PHP 7.1 there will be additions of nullable type hints and `void` return types.