### PR TITLE
Improve usability of Sign API

### DIFF
--- a/src/pocketmine/event/block/SignChangeEvent.php
+++ b/src/pocketmine/event/block/SignChangeEvent.php
@@ -69,6 +69,9 @@ class SignChangeEvent extends BlockEvent implements Cancellable{
 	 * @return string
 	 */
 	public function getLine($index){
+		if($index < 0 or $index > 3){
+			throw new \InvalidArgumentException("Index must be in the range 0-3!");
+		}
 		return $this->lines[$index];
 	}
 
@@ -76,6 +79,9 @@ class SignChangeEvent extends BlockEvent implements Cancellable{
 	 * @param string[] $lines
 	 */
 	public function setLines(array $lines){
+		if(count($lines) > 4){
+			throw new \InvalidArgumentException("Array size cannot be greater than 4!");
+		}
 		$this->lines = $lines;
 	}
 
@@ -84,6 +90,9 @@ class SignChangeEvent extends BlockEvent implements Cancellable{
 	 * @param string $line
 	 */
 	public function setLine($index, $line){
+		if($index < 0 or $index > 3){
+			throw new \InvalidArgumentException("Index must be in the range 0-3!");
+		}
 		$this->lines[$index] = $line;
 	}
 }

--- a/src/pocketmine/event/block/SignChangeEvent.php
+++ b/src/pocketmine/event/block/SignChangeEvent.php
@@ -80,7 +80,7 @@ class SignChangeEvent extends BlockEvent implements Cancellable{
 	 */
 	public function setLines(array $lines){
 		if(count($lines) !== 4){
-			throw new \InvalidArgumentException("Array size cannot be greater than 4!");
+			throw new \InvalidArgumentException("Array size must be 4!");
 		}
 		$this->lines = $lines;
 	}

--- a/src/pocketmine/event/block/SignChangeEvent.php
+++ b/src/pocketmine/event/block/SignChangeEvent.php
@@ -73,6 +73,13 @@ class SignChangeEvent extends BlockEvent implements Cancellable{
 	}
 
 	/**
+	 * @param array string[]
+	 */
+	public function setLines(array $lines){
+		$this->lines = $lines;
+	}
+
+	/**
 	 * @param int    $index 0-3
 	 * @param string $line
 	 */

--- a/src/pocketmine/event/block/SignChangeEvent.php
+++ b/src/pocketmine/event/block/SignChangeEvent.php
@@ -79,7 +79,7 @@ class SignChangeEvent extends BlockEvent implements Cancellable{
 	 * @param string[] $lines
 	 */
 	public function setLines(array $lines){
-		if(count($lines) > 4){
+		if(count($lines) !== 4){
 			throw new \InvalidArgumentException("Array size cannot be greater than 4!");
 		}
 		$this->lines = $lines;

--- a/src/pocketmine/event/block/SignChangeEvent.php
+++ b/src/pocketmine/event/block/SignChangeEvent.php
@@ -73,7 +73,7 @@ class SignChangeEvent extends BlockEvent implements Cancellable{
 	}
 
 	/**
-	 * @param array string[]
+	 * @param string[] $lines
 	 */
 	public function setLines(array $lines){
 		$this->lines = $lines;

--- a/src/pocketmine/tile/Sign.php
+++ b/src/pocketmine/tile/Sign.php
@@ -71,6 +71,9 @@ class Sign extends Spawnable{
 	 * @param bool $update
 	 */
 	public function setLine(int $index, string $line, bool $update = true){
+		if($index < 0 or $index > 3){
+			throw new \InvalidArgumentException("Index must be in the range 0-3!");
+		}
 		$this->namedtag["Text".($index + 1)] = $line;
 		if($update){
 			$this->onChanged();
@@ -83,6 +86,9 @@ class Sign extends Spawnable{
 	 * @return string
 	 */
 	public function getLine(int $index): string{
+		if($index < 0 or $index > 3){
+			throw new \InvalidArgumentException("Index must be in the range 0-3!");
+		}
 		return $this->namedtag["Text".($index + 1)];
 	}
 

--- a/src/pocketmine/tile/Sign.php
+++ b/src/pocketmine/tile/Sign.php
@@ -71,7 +71,7 @@ class Sign extends Spawnable{
 	 * @param bool $update
 	 */
 	public function setLine(int $index, string $line, bool $update = true){
-		$this->namedtag["Text".$index + 1] = $line;
+		$this->namedtag["Text".($index + 1)] = $line;
 		if($update){
 			$this->onChanged();
 		}
@@ -83,7 +83,7 @@ class Sign extends Spawnable{
 	 * @return string
 	 */
 	public function getLine(int $index): string{
-		return $this->namedtag["Text".$index + 1];
+		return $this->namedtag["Text".($index + 1)];
 	}
 
 	public function getText(){

--- a/src/pocketmine/tile/Sign.php
+++ b/src/pocketmine/tile/Sign.php
@@ -74,7 +74,7 @@ class Sign extends Spawnable{
 		if($index < 0 or $index > 3){
 			throw new \InvalidArgumentException("Index must be in the range 0-3!");
 		}
-		$this->namedtag["Text".($index + 1)] = $line;
+		$this->namedtag["Text" . ($index + 1)] = $line;
 		if($update){
 			$this->onChanged();
 		}
@@ -85,11 +85,11 @@ class Sign extends Spawnable{
 	 *
 	 * @return string
 	 */
-	public function getLine(int $index): string{
+	public function getLine(int $index) : string{
 		if($index < 0 or $index > 3){
 			throw new \InvalidArgumentException("Index must be in the range 0-3!");
 		}
-		return $this->namedtag["Text".($index + 1)];
+		return $this->namedtag["Text" . ($index + 1)];
 	}
 
 	public function getText(){

--- a/src/pocketmine/tile/Sign.php
+++ b/src/pocketmine/tile/Sign.php
@@ -89,7 +89,7 @@ class Sign extends Spawnable{
 		if($index < 0 or $index > 3){
 			throw new \InvalidArgumentException("Index must be in the range 0-3!");
 		}
-		return $this->namedtag["Text" . ($index + 1)];
+		return (string) $this->namedtag["Text" . ($index + 1)];
 	}
 
 	public function getText(){

--- a/src/pocketmine/tile/Sign.php
+++ b/src/pocketmine/tile/Sign.php
@@ -68,7 +68,7 @@ class Sign extends Spawnable{
 	/**
 	 * @param int    $index 0-3
 	 * @param string $line
-	 * @param bool $update
+	 * @param bool   $update
 	 */
 	public function setLine(int $index, string $line, bool $update = true){
 		if($index < 0 or $index > 3){

--- a/src/pocketmine/tile/Sign.php
+++ b/src/pocketmine/tile/Sign.php
@@ -64,6 +64,27 @@ class Sign extends Spawnable{
 
 		return true;
 	}
+	
+	/**
+	 * @param int    $index 0-3
+	 * @param string $line
+	 * @param bool $update
+	 */
+	public function setLine(int $index, string $line, bool $update = true){
+		$this->namedtag["Text".$index + 1] = $line;
+		if($update){
+			$this->onChanged();
+		}
+	}
+	
+	/**
+	 * @param int $index 0-3
+	 *
+	 * @return string
+	 */
+	public function getLine(int $index): string{
+		return $this->namedtag["Text".$index + 1];
+	}
 
 	public function getText(){
 		return [


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This makes all methods available on every Sign related class. It was quite weird to have setLines in Sign but not in SignChangeEvent and setLine&getLine in SignChangeEvent and not in Sign.

### Relevant issues
none
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Added setLines() to SignChangeEvent.
Added setLine() and getLine to tile/Sign.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
none

## Backwards compatibility
doesn’t break anything
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
You can test this using [this](https://github.com/pmmp/PocketMine-MP/files/1156309/SignAPIfunctions.php.zip) Script Plugin.