### PR TITLE
setText now nullable instead of overwriting with empty lines

### DIFF
--- a/src/pocketmine/tile/Sign.php
+++ b/src/pocketmine/tile/Sign.php
@@ -54,7 +54,18 @@ class Sign extends Spawnable{
 		unset($this->namedtag->Creator);
 	}
 
-	public function setText($line1 = null, $line2 = null, $line3 = null, $line4 = null){
+	/**
+	 * Changes contents of the specific lines to the string provided. 
+	 * Leaves contents of the specifc lines as is if null is provided.
+	 *
+	 * @param null|string $line1
+	 * @param null|string $line2
+	 * @param null|string $line3
+	 * @param null|string $line4
+	 *
+	 * @return bool
+	 */
+	public function setText($line1 = "", $line2 = "", $line3 = "", $line4 = ""){
 		if($line1 !== null){
 			$this->namedtag->Text1->setValue("Text1", $line1);
 		}

--- a/src/pocketmine/tile/Sign.php
+++ b/src/pocketmine/tile/Sign.php
@@ -55,10 +55,18 @@ class Sign extends Spawnable{
 	}
 
 	public function setText($line1 = null, $line2 = null, $line3 = null, $line4 = null){
-		if($line1 !== null) $this->namedtag->Text1->setValue("Text1", $line1);
-		if($line2 !== null) $this->namedtag->Text2->setValue("Text2", $line2);
-		if($line3 !== null) $this->namedtag->Text3->setValue("Text3", $line3);
-		if($line4 !== null) $this->namedtag->Text4->setValue("Text4", $line4);
+		if($line1 !== null){
+			$this->namedtag->Text1->setValue("Text1", $line1);
+		}
+		if($line2 !== null){
+			$this->namedtag->Text2->setValue("Text2", $line2);
+		}
+		if($line3 !== null){
+			$this->namedtag->Text3->setValue("Text3", $line3);
+		}
+		if($line4 !== null){
+			$this->namedtag->Text4->setValue("Text4", $line4);
+		}
 		$this->onChanged();
 	}
 

--- a/src/pocketmine/tile/Sign.php
+++ b/src/pocketmine/tile/Sign.php
@@ -54,11 +54,11 @@ class Sign extends Spawnable{
 		unset($this->namedtag->Creator);
 	}
 
-	public function setText($line1 = "", $line2 = "", $line3 = "", $line4 = ""){
-		$this->namedtag->Text1->setValue($line1);
-		$this->namedtag->Text2->setValue($line2);
-		$this->namedtag->Text3->setValue($line3);
-		$this->namedtag->Text4->setValue($line4);
+	public function setText($line1 = null, $line2 = null, $line3 = null, $line4 = null){
+		if($line1 !== null) $this->namedtag->Text1->setValue("Text1", $line1);
+		if($line2 !== null) $this->namedtag->Text2->setValue("Text2", $line2);
+		if($line3 !== null) $this->namedtag->Text3->setValue("Text3", $line3);
+		if($line4 !== null) $this->namedtag->Text4->setValue("Text4", $line4);
 		$this->onChanged();
 	}
 


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This PR is created upon an idea by @SOF3. As it was not really fitting into the PR, because it is BC breaking here it is to be easily discussed apart from other changes.

### Relevant issues
none
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
Instead of needing to reset or provide lines when using setText() now having null on any line will preserve it.

### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
none
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
If a plugin relied on setText() to reset with its default params it will not work anymore. This is a rare use case though. Any other use case will still work, because either empty strings are provided or actual text is being written.
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
TODO: Check if core uses setText as explained above in Breaking changes.
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
TODO: write ScriptPlugin…
<!-- Attach scripts or actions to test this pull request, as well as the result -->