### PR TITLE
Fix floating text disappearing bug

### DIFF
--- a/src/pocketmine/level/particle/FloatingTextParticle.php
+++ b/src/pocketmine/level/particle/FloatingTextParticle.php
@@ -24,9 +24,10 @@ declare(strict_types=1);
 namespace pocketmine\level\particle;
 
 use pocketmine\entity\Entity;
-use pocketmine\entity\Item as ItemEntity;
+use pocketmine\item\Item;
 use pocketmine\math\Vector3;
-use pocketmine\network\mcpe\protocol\AddEntityPacket;
+use pocketmine\utils\UUID;
+use pocketmine\network\mcpe\protocol\AddPlayerPacket;
 use pocketmine\network\mcpe\protocol\RemoveEntityPacket;
 
 class FloatingTextParticle extends Particle{
@@ -78,17 +79,14 @@ class FloatingTextParticle extends Particle{
 
 		if(!$this->invisible){
 
-			$pk = new AddEntityPacket();
+			$pk = new AddPlayerPacket();
+			$pk->uuid = UUID::fromRandom();
+			$pk->username = $this->title;
 			$pk->entityRuntimeId = $this->entityId;
-			$pk->type = ItemEntity::NETWORK_ID;
 			$pk->x = $this->x;
-			$pk->y = $this->y - 0.75;
+			$pk->y = $this->y - 0.50;
 			$pk->z = $this->z;
-			$pk->speedX = 0;
-			$pk->speedY = 0;
-			$pk->speedZ = 0;
-			$pk->yaw = 0;
-			$pk->pitch = 0;
+			$pk->item = Item::get(0);
 			$flags = (
 				(1 << Entity::DATA_FLAG_CAN_SHOW_NAMETAG) |
 				(1 << Entity::DATA_FLAG_ALWAYS_SHOW_NAMETAG) |
@@ -97,6 +95,7 @@ class FloatingTextParticle extends Particle{
 			$pk->metadata = [
 				Entity::DATA_FLAGS => [Entity::DATA_TYPE_LONG, $flags],
 				Entity::DATA_NAMETAG => [Entity::DATA_TYPE_STRING, $this->title . ($this->text !== "" ? "\n" . $this->text : "")],
+				Entity::DATA_SCALE => [Entity::DATA_TYPE_FLOAT, 0],
 			];
 
 			$p[] = $pk;


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
I've noticed when using floating text with the Item entity, it seems like it despawns after awhile to the client. Since players never despawn unless they disconnect client side, this shouldn't happen anymore


## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
None

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
Floating text boxes around title is a little darker, but positioned the same.

## Backwards compatibility
Fully backwards compatible

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
Tested on my own server.