### PR TITLE
Fix errors due to Block::$x, $y, $z being null

### DIFF
--- a/src/pocketmine/block/Block.php
+++ b/src/pocketmine/block/Block.php
@@ -311,6 +311,7 @@ class Block extends Position implements BlockIds, Metadatable{
 	 * @param int $meta
 	 */
 	public function __construct($id, $meta = 0){
+		parent::__construct();
 		$this->id = (int) $id;
 		$this->meta = (int) $meta;
 	}


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

While creating an empty block object, `Block::$x`, `Block::$y` and `Block::$z` are null. This can cause `Block::getBoundingBox()` to return an error due to the block coordinate variables being `null` rather than being float|int. A way to reproduce such an error is by calling `Level::getSafeSpawn()` on plugin enable (see Tests).

## Changes
`Block::$x`, `Block::$y` and `Block::$z` are never null, they are always integers.

### Behavioural changes
--

## Backwards compatibility
This PR is backwards compatible.

## Follow-up
--

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
```php
/** @var \pocketmine\Server $server */
if(!$server->isLevelLoaded("world")){
    $server->loadLevel("world");
}
$spawn = $server->getLevelByName("world")->getSafeSpawn();
```
_That script would spew the following error before this commit:_
```
[18:19:31] [Server thread/CRITICAL]: TypeError: "Argument 1 passed to pocketmine\math\AxisAlignedBB::__construct() must be of the type float, null given, called in /root/sylphhcf/src/pocketmine/block/Block.php on line 675" (EXCEPTION) in "src/pocketmine/math/AxisAlignedBB" at line 43
[18:19:31] [Server thread/DEBUG]: #0 src/pocketmine/block/Block(675): pocketmine\math\AxisAlignedBB->__construct(NULL , NULL , NULL , integer 1, integer 1, integer 1)
[18:19:31] [Server thread/DEBUG]: #1 src/pocketmine/block/Block(660): pocketmine\block\Block->recalculateBoundingBox()
[18:19:31] [Server thread/DEBUG]: #2 src/pocketmine/level/Level(1165): pocketmine\block\Block->getBoundingBox()
[18:19:31] [Server thread/DEBUG]: #3 src/pocketmine/level/Level(2688): pocketmine\level\Level->isFullBlock(pocketmine\block\UnknownBlock object)
[18:19:31] [Server thread/DEBUG]: #4 plugins/SylphCore-master/src/SylphCore/EventListener(64): pocketmine\level\Level->getSafeSpawn()
[18:19:31] [Server thread/DEBUG]: #5 plugins/SylphCore-master/src/SylphCore/SylphCore(160): SylphCore\EventListener->__construct(SylphCore\SylphCore object)
[18:19:31] [Server thread/DEBUG]: #6 src/pocketmine/plugin/PluginBase(90): SylphCore\SylphCore->onEnable()
[18:19:31] [Server thread/DEBUG]: #7 plugins/PocketMine-DevTools.phar/src/FolderPluginLoader/FolderPluginLoader(125): pocketmine\plugin\PluginBase->setEnabled(boolean 1)
[18:19:31] [Server thread/DEBUG]: #8 src/pocketmine/plugin/PluginManager(584): FolderPluginLoader\FolderPluginLoader->enablePlugin(SylphCore\SylphCore object)
[18:19:31] [Server thread/DEBUG]: #9 src/pocketmine/Server(1908): pocketmine\plugin\PluginManager->enablePlugin(SylphCore\SylphCore object)
[18:19:31] [Server thread/DEBUG]: #10 src/pocketmine/Server(1894): pocketmine\Server->enablePlugin(SylphCore\SylphCore object)
[18:19:31] [Server thread/DEBUG]: #11 src/pocketmine/Server(1680): pocketmine\Server->enablePlugins(integer 1)
[18:19:31] [Server thread/DEBUG]: #12 src/pocketmine/PocketMine(511): pocketmine\Server->__construct(BaseClassLoader object, pocketmine\utils\MainLogger object, string /root/sylphhcf/, string /root/sylphhcf/, string /root/sylphhcf/plugins/)

```