### PR TITLE
Return the dropped item entity when using Level->dropItem to be able to further manipulate it

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1531,6 +1531,8 @@ class Level implements ChunkManager, Metadatable{
 	 * @param Item    $item
 	 * @param Vector3 $motion
 	 * @param int     $delay
+	 *
+	 * @return DroppedItem|null
 	 */
 	public function dropItem(Vector3 $source, Item $item, Vector3 $motion = null, int $delay = 10){
 		$motion = $motion ?? new Vector3(lcg_value() * 0.2 - 0.1, 0.2, lcg_value() * 0.2 - 0.1);
@@ -1559,7 +1561,9 @@ class Level implements ChunkManager, Metadatable{
 			]));
 
 			$itemEntity->spawnToAll();
+			return $itemEntity;
 		}
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This pull request is very simple and returns the ItemEntity dropped using Level->dropItem.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Level->dropItem now returns either null, or the item entity dropped if successful.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
No considerable changes.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? --> This pull request is 100% backwards compatible. It only adds something.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

--> -
