### PR TITLE
Added capability to specify compatible protocol versions in plugin.yml

### DIFF
--- a/src/pocketmine/plugin/PluginDescription.php
+++ b/src/pocketmine/plugin/PluginDescription.php
@@ -23,12 +23,15 @@ declare(strict_types=1);
 
 namespace pocketmine\plugin;
 
+use pocketmine\network\mcpe\protocol\ProtocolInfo;
 use pocketmine\permission\Permission;
 
 class PluginDescription{
 	private $name;
 	private $main;
 	private $api;
+	/** @var int[] */
+	private $compatibleMcpeProtocols = [];
 	private $extensions = [];
 	private $depend = [];
 	private $softDepend = [];
@@ -75,6 +78,8 @@ class PluginDescription{
 		if(stripos($this->main, "pocketmine\\") === 0){
 			throw new PluginException("Invalid PluginDescription main, cannot start within the PocketMine namespace");
 		}
+
+		$this->compatibleMcpeProtocols = array_map("intval", (array) ($plugin["mcpe-protocol"] ?? []));
 
 		if(isset($plugin["commands"]) and is_array($plugin["commands"])){
 			$this->commands = $plugin["commands"];
@@ -145,6 +150,13 @@ class PluginDescription{
 	 */
 	public function getCompatibleApis() : array{
 		return $this->api;
+	}
+
+	/**
+	 * @return int[]
+	 */
+	public function getCompatibleMcpeProtocols() : array{
+		return $this->compatibleMcpeProtocols;
 	}
 
 	/**

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -32,6 +32,7 @@ use pocketmine\event\HandlerList;
 use pocketmine\event\Listener;
 use pocketmine\event\Timings;
 use pocketmine\event\TimingsHandler;
+use pocketmine\network\mcpe\protocol\ProtocolInfo;
 use pocketmine\permission\Permissible;
 use pocketmine\permission\Permission;
 use pocketmine\Server;
@@ -256,6 +257,24 @@ class PluginManager{
 							if($compatible === false){
 								$this->server->getLogger()->error($this->server->getLanguage()->translateString("pocketmine.plugin.loadError", [$name, "%pocketmine.plugin.incompatibleAPI"]));
 								continue;
+							}
+
+							if(count($pluginMcpeProtocols = $description->getCompatibleMcpeProtocols()) > 0){
+								$serverMcpeProtocols = [ProtocolInfo::CURRENT_PROTOCOL];
+								if(count(array_intersect($pluginMcpeProtocols, $serverMcpeProtocols)) === 0){
+									$this->server->getLogger()->error($this->server->getLanguage()->translateString(
+										"pocketmine.plugin.loadError",
+										[
+											$name,
+											$this->server->getLanguage()->translateString(
+												"%pocketmine.plugin.incompatibleProtocol",
+												[
+													implode(", ", $pluginMcpeProtocols)
+												])
+										]
+									));
+									continue;
+								}
 							}
 
 							$plugins[$name] = $file;


### PR DESCRIPTION
## Introduction
Very often these days I see plugins which use packets to do things that the API doesn't provide the capability to do. This is problematic due to the way the protocol can, and will, change with every version of the game, because MCPE protocol changes are not covered by the PocketMine-MP API.

This pull request adds the capability for a plugin developer to specify a list of MCPE protocol versions that the plugin is compatible with. This provides a solution for the possibility of plugins crashing when things are changed/added/removed with each MCPE update without requiring an API bump.

Plugins can now declare the `mcpe-protocol` attribute in plugin.yml, containing a list of protocol versions that the plugin is compatible with.
## Changes
### API changes
- added `PluginDescription->getCompatibleMcpeProtocols()`

<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
- Plugins which declare the `mcpe-protocol` attribute will now not be loaded if the server protocol version does not match the plugin's protocol version(s).

## Backwards compatibility
No BC breaks are introduced with this PR. Plugins which do not declare the new attribute will be loaded as normal.

## Tests
TBD