### PR TITLE
Added new events for network interface handling, close #1232

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -1612,14 +1612,15 @@ class Server{
 
 			register_shutdown_function([$this, "crashDump"]);
 
-			$this->queryRegenerateTask = new QueryRegenerateEvent($this, 5);
-			$this->network->registerInterface(new RakLibInterface($this));
-
 			$this->pluginManager->loadPlugins($this->pluginPath);
 
 			$this->updater = new AutoUpdater($this, $this->getProperty("auto-updater.host", "update.pmmp.io"));
 
 			$this->enablePlugins(PluginLoadOrder::STARTUP);
+
+			$this->queryRegenerateTask = new QueryRegenerateEvent($this, 5);
+			$this->network->registerInterface(new RakLibInterface($this));
+
 
 			LevelProviderManager::addProvider(Anvil::class);
 			LevelProviderManager::addProvider(McRegion::class);

--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -1612,13 +1612,14 @@ class Server{
 
 			register_shutdown_function([$this, "crashDump"]);
 
+			$this->queryRegenerateTask = new QueryRegenerateEvent($this, 5);
+
 			$this->pluginManager->loadPlugins($this->pluginPath);
 
 			$this->updater = new AutoUpdater($this, $this->getProperty("auto-updater.host", "update.pmmp.io"));
 
 			$this->enablePlugins(PluginLoadOrder::STARTUP);
 
-			$this->queryRegenerateTask = new QueryRegenerateEvent($this, 5);
 			$this->network->registerInterface(new RakLibInterface($this));
 
 

--- a/src/pocketmine/event/server/NetworkInterfaceCrashEvent.php
+++ b/src/pocketmine/event/server/NetworkInterfaceCrashEvent.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\event\server;
+
+use pocketmine\network\SourceInterface;
+
+/**
+ * Called when a network interface crashes, with relevant crash information.
+ */
+class NetworkInterfaceCrashEvent extends NetworkInterfaceEvent{
+	public static $handlerList = null;
+
+	/**
+	 * @var \Throwable
+	 */
+	private $exception;
+
+	public function __construct(SourceInterface $interface, \Throwable $throwable){
+		parent::__construct($interface);
+		$this->exception = $throwable;
+	}
+
+	/**
+	 * @return \Throwable
+	 */
+	public function getCrashInformation() : \Throwable{
+		return $this->exception;
+	}
+}

--- a/src/pocketmine/event/server/NetworkInterfaceEvent.php
+++ b/src/pocketmine/event/server/NetworkInterfaceEvent.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\event\server;
+
+use pocketmine\network\SourceInterface;
+
+class NetworkInterfaceEvent extends ServerEvent{
+	/** @var SourceInterface */
+	protected $interface;
+
+	/**
+	 * @param SourceInterface $interface
+	 */
+	public function __construct(SourceInterface $interface){
+		$this->interface = $interface;
+	}
+
+	/**
+	 * @return SourceInterface
+	 */
+	public function getInterface() : SourceInterface{
+		return $this->interface;
+	}
+}

--- a/src/pocketmine/event/server/NetworkInterfaceRegisterEvent.php
+++ b/src/pocketmine/event/server/NetworkInterfaceRegisterEvent.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\event\server;
+
+use pocketmine\event\Cancellable;
+use pocketmine\network\SourceInterface;
+
+/**
+ * Called when a network interface is registered into the network, for example the RakLib interface.
+ */
+class NetworkInterfaceRegisterEvent extends NetworkInterfaceEvent implements Cancellable{
+	public static $handlerList = null;
+
+}

--- a/src/pocketmine/event/server/NetworkInterfaceUnregisterEvent.php
+++ b/src/pocketmine/event/server/NetworkInterfaceUnregisterEvent.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\event\server;
+
+/**
+ * Called when a network interface is unregistered
+ */
+class NetworkInterfaceUnregisterEvent extends NetworkInterfaceEvent{
+	public static $handlerList = null;
+
+}

--- a/src/pocketmine/network/Network.php
+++ b/src/pocketmine/network/Network.php
@@ -26,6 +26,9 @@ declare(strict_types=1);
  */
 namespace pocketmine\network;
 
+use pocketmine\event\server\NetworkInterfaceCrashEvent;
+use pocketmine\event\server\NetworkInterfaceRegisterEvent;
+use pocketmine\event\server\NetworkInterfaceUnregisterEvent;
 use pocketmine\network\mcpe\protocol\PacketPool;
 use pocketmine\Server;
 
@@ -90,6 +93,8 @@ class Network{
 					$logger->logException($e);
 				}
 
+				$this->server->getPluginManager()->callEvent(new NetworkInterfaceCrashEvent($interface, $e));
+
 				$interface->emergencyShutdown();
 				$this->unregisterInterface($interface);
 				$logger->critical($this->server->getLanguage()->translateString("pocketmine.server.networkError", [get_class($interface), $e->getMessage()]));
@@ -101,20 +106,25 @@ class Network{
 	 * @param SourceInterface $interface
 	 */
 	public function registerInterface(SourceInterface $interface){
-		$this->interfaces[$hash = spl_object_hash($interface)] = $interface;
-		if($interface instanceof AdvancedSourceInterface){
-			$this->advancedInterfaces[$hash] = $interface;
-			$interface->setNetwork($this);
+		$this->server->getPluginManager()->callEvent($ev = new NetworkInterfaceRegisterEvent($interface));
+		if(!$ev->isCancelled()){
+			$this->interfaces[$hash = spl_object_hash($interface)] = $interface;
+			if($interface instanceof AdvancedSourceInterface){
+				$this->advancedInterfaces[$hash] = $interface;
+				$interface->setNetwork($this);
+			}
+			$interface->setName($this->name);
+		}else{
+			$interface->shutdown();
 		}
-		$interface->setName($this->name);
 	}
 
 	/**
 	 * @param SourceInterface $interface
 	 */
 	public function unregisterInterface(SourceInterface $interface){
-		unset($this->interfaces[$hash = spl_object_hash($interface)],
-			$this->advancedInterfaces[$hash]);
+		$this->server->getPluginManager()->callEvent(new NetworkInterfaceUnregisterEvent($interface));
+		unset($this->interfaces[$hash = spl_object_hash($interface)], $this->advancedInterfaces[$hash]);
 	}
 
 	/**

--- a/src/pocketmine/network/Network.php
+++ b/src/pocketmine/network/Network.php
@@ -108,14 +108,13 @@ class Network{
 	public function registerInterface(SourceInterface $interface){
 		$this->server->getPluginManager()->callEvent($ev = new NetworkInterfaceRegisterEvent($interface));
 		if(!$ev->isCancelled()){
+			$interface->start();
 			$this->interfaces[$hash = spl_object_hash($interface)] = $interface;
 			if($interface instanceof AdvancedSourceInterface){
 				$this->advancedInterfaces[$hash] = $interface;
 				$interface->setNetwork($this);
 			}
 			$interface->setName($this->name);
-		}else{
-			$interface->shutdown();
 		}
 	}
 

--- a/src/pocketmine/network/SourceInterface.php
+++ b/src/pocketmine/network/SourceInterface.php
@@ -35,6 +35,11 @@ use pocketmine\Player;
 interface SourceInterface{
 
 	/**
+	 * Performs actions needed to start the interface after it is registered.
+	 */
+	public function start();
+
+	/**
 	 * Sends a DataPacket to the interface, returns an unique identifier for the packet if $needACK is true
 	 *
 	 * @param Player     $player

--- a/src/pocketmine/network/mcpe/RakLibInterface.php
+++ b/src/pocketmine/network/mcpe/RakLibInterface.php
@@ -67,8 +67,12 @@ class RakLibInterface implements ServerInstance, AdvancedSourceInterface{
 		$this->server = $server;
 		$this->identifiers = [];
 
-		$this->rakLib = new RakLibServer($this->server->getLogger(), $this->server->getLoader(), $this->server->getPort(), $this->server->getIp() === "" ? "0.0.0.0" : $this->server->getIp());
+		$this->rakLib = new RakLibServer($this->server->getLogger(), $this->server->getLoader(), $this->server->getPort(), $this->server->getIp() === "" ? "0.0.0.0" : $this->server->getIp(), false);
 		$this->interface = new ServerHandler($this->rakLib, $this);
+	}
+
+	public function start(){
+		$this->rakLib->start();
 	}
 
 	public function setNetwork(Network $network){


### PR DESCRIPTION
## Introduction
Added events to allow plugins to do their own network interface handling.

### Relevant issues
- close #1232

## Changes
### API changes
- added `NetworkInterfaceRegisterEvent` (cancellable), `NetworkInterfaceUnregisterEvent`, and `NetworkInterfaceCrashEvent`.

### Behavioural changes
- Possible behavioural changes possible for plugins which used onLoad() and load-order Startup, however I think this is null and void anyway because of the AutoUpdater now being asynchronous. The change allows plugins which are loaded with STARTUP order to cancel registration of the RakLibInterface.

## Backwards compatibility
see above

## Follow-up
It's quite annoying the way many things within PocketMine-MP _do_ things during their constructors, such as starting a thread, registering themselves to whatever, etc. It makes it quite inconvenient to simply unregister things. In this PR, the RakLib thread will still be started when the interface is registered, only to be stopped moments later when the interface is closed due to the event being cancelled. A follow-up to this should be to find a suitable way to move this behaviour from the constructor to a dedicated method so that this does not occur.

## Tests
https://gist.github.com/dktapps/103824e007ccb114bd701de4a2ecd39c - A plugin to remove the default RakLibInterface.