### PR TITLE
Fix enchantment typo

### DIFF
--- a/src/pocketmine/item/enchantment/Enchantment.php
+++ b/src/pocketmine/item/enchantment/Enchantment.php
@@ -105,7 +105,7 @@ class Enchantment{
 		return new Enchantment(self::TYPE_INVALID, "unknown", 0, 0, 0);
 	}
 
-	public static function getEffectByName($name){
+	public static function getEnchantmentByName($name){
 		if(defined(Enchantment::class . "::TYPE_" . strtoupper($name))){
 			return self::getEnchantment(constant(Enchantment::class . "::TYPE_" . strtoupper($name)));
 		}


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Enchantments file was copied from effects file, so somebody forgot to change one `Effect` to `Enchantment`

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
This is backwards incompatible(plugins was using Enchantment::getEffectByName needs to be updated)

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
