### PR TITLE
Added precision and mode arguments to Vector3::round()

### DIFF
--- a/src/pocketmine/math/Vector3.php
+++ b/src/pocketmine/math/Vector3.php
@@ -132,8 +132,10 @@ class Vector3{
 		return new Vector3((int) floor($this->x), (int) floor($this->y), (int) floor($this->z));
 	}
 
-	public function round(){
-		return new Vector3((int) round($this->x), (int) round($this->y), (int) round($this->z));
+	public function round(int $precision = 0, int $mode = PHP_ROUND_HALF_UP){
+		return $precision > 0 ?
+			new Vector3(round($this->x, $precision, $mode), round($this->y, $precision, $mode), round($this->z, $precision, $mode)) :
+			new Vector3((int) round($this->x, $precision, $mode), (int) round($this->y, $precision, $mode), (int) round($this->z, $precision, $mode));
 	}
 
 	public function abs(){


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Vectors may be rounded with a given precision for many reasons, such as for cleaner presentation to users, etc. Some people may also prefer different modes of rounding.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
nil

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Added optional arguments `(int $precision, int $mode)` to `Vector3::round()`.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
nil

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
This is backward-incompatible for subclasses of Vector3 overriding the `round()` method. However, due to the low possibility of the existence of such classes, this should not be taken into consideration when adding such optional arguments.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
nil

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
(I'm lazy)