### PR TITLE
Tile NBT usage enhancements

### DIFF
--- a/src/pocketmine/tile/Bed.php
+++ b/src/pocketmine/tile/Bed.php
@@ -25,8 +25,6 @@ namespace pocketmine\tile;
 use pocketmine\level\Level;
 use pocketmine\nbt\tag\ByteTag;
 use pocketmine\nbt\tag\CompoundTag;
-use pocketmine\nbt\tag\IntTag;
-use pocketmine\nbt\tag\StringTag;
 
 class Bed extends Spawnable{
 
@@ -42,17 +40,11 @@ class Bed extends Spawnable{
 	}
 
 	public function setColor(int $color){
-		$this->namedtag["color"] = $color & 0x0f;
+		$this->namedtag->color->setValue($color & 0x0f);
 		$this->onChanged();
 	}
 
-	public function getSpawnCompound() : CompoundTag{
-		return new CompoundTag("", [
-			new StringTag("id", Tile::BED),
-			new IntTag("x", (int) $this->x),
-			new IntTag("y", (int) $this->y),
-			new IntTag("z", (int) $this->z),
-			$this->namedtag->color
-		]);
+	public function addAdditionalSpawnData(CompoundTag $nbt){
+		$nbt->color = $this->namedtag->color;
 	}
 }

--- a/src/pocketmine/tile/Chest.php
+++ b/src/pocketmine/tile/Chest.php
@@ -277,28 +277,17 @@ class Chest extends Spawnable implements InventoryHolder, Container, Nameable{
 	}
 
 	public function getSpawnCompound() : CompoundTag{
+		$nbt = parent::getSpawnCompound();
+
 		if($this->isPaired()){
-			$c = new CompoundTag("", [
-				new StringTag("id", Tile::CHEST),
-				new IntTag("x", (int) $this->x),
-				new IntTag("y", (int) $this->y),
-				new IntTag("z", (int) $this->z),
-				new IntTag("pairx", (int) $this->namedtag["pairx"]),
-				new IntTag("pairz", (int) $this->namedtag["pairz"])
-			]);
-		}else{
-			$c = new CompoundTag("", [
-				new StringTag("id", Tile::CHEST),
-				new IntTag("x", (int) $this->x),
-				new IntTag("y", (int) $this->y),
-				new IntTag("z", (int) $this->z)
-			]);
+			$nbt->pairx = $this->namedtag->pairx;
+			$nbt->pairz = $this->namedtag->pairz;
 		}
 
 		if($this->hasName()){
-			$c->CustomName = $this->namedtag->CustomName;
+			$nbt->CustomName = $this->namedtag->CustomName;
 		}
 
-		return $c;
+		return $nbt;
 	}
 }

--- a/src/pocketmine/tile/Chest.php
+++ b/src/pocketmine/tile/Chest.php
@@ -276,9 +276,7 @@ class Chest extends Spawnable implements InventoryHolder, Container, Nameable{
 		return true;
 	}
 
-	public function getSpawnCompound() : CompoundTag{
-		$nbt = parent::getSpawnCompound();
-
+	public function addAdditionalSpawnData(CompoundTag $nbt){
 		if($this->isPaired()){
 			$nbt->pairx = $this->namedtag->pairx;
 			$nbt->pairz = $this->namedtag->pairz;
@@ -287,7 +285,5 @@ class Chest extends Spawnable implements InventoryHolder, Container, Nameable{
 		if($this->hasName()){
 			$nbt->CustomName = $this->namedtag->CustomName;
 		}
-
-		return $nbt;
 	}
 }

--- a/src/pocketmine/tile/Chest.php
+++ b/src/pocketmine/tile/Chest.php
@@ -95,7 +95,7 @@ class Chest extends Spawnable implements InventoryHolder, Container, Nameable{
 	 */
 	protected function getSlotIndex(int $index){
 		foreach($this->namedtag->Items as $i => $slot){
-			if((int) $slot->Slot->getValue() === $index){
+			if($slot->Slot->getValue() === $index){
 				return (int) $i;
 			}
 		}

--- a/src/pocketmine/tile/Chest.php
+++ b/src/pocketmine/tile/Chest.php
@@ -74,7 +74,7 @@ class Chest extends Spawnable implements InventoryHolder, Container, Nameable{
 	}
 
 	public function saveNBT(){
-		$this->namedtag->Items = new ListTag("Items", []);
+		$this->namedtag->Items->setValue([]);
 		$this->namedtag->Items->setTagType(NBT::TAG_Compound);
 		for($index = 0; $index < $this->getSize(); ++$index){
 			$this->setItem($index, $this->inventory->getItem($index));
@@ -95,7 +95,7 @@ class Chest extends Spawnable implements InventoryHolder, Container, Nameable{
 	 */
 	protected function getSlotIndex(int $index){
 		foreach($this->namedtag->Items as $i => $slot){
-			if((int) $slot["Slot"] === $index){
+			if((int) $slot->Slot->getValue() === $index){
 				return (int) $i;
 			}
 		}
@@ -225,7 +225,7 @@ class Chest extends Spawnable implements InventoryHolder, Container, Nameable{
 	 */
 	public function getPair(){
 		if($this->isPaired()){
-			$tile = $this->getLevel()->getTile(new Vector3((int) $this->namedtag["pairx"], $this->y, (int) $this->namedtag["pairz"]));
+			$tile = $this->getLevel()->getTile(new Vector3($this->namedtag->pairx->getValue(), $this->y, $this->namedtag->pairz->getValue()));
 			if($tile instanceof Chest){
 				return $tile;
 			}

--- a/src/pocketmine/tile/EnchantTable.php
+++ b/src/pocketmine/tile/EnchantTable.php
@@ -46,13 +46,9 @@ class EnchantTable extends Spawnable implements Nameable{
 		$this->namedtag->CustomName = new StringTag("CustomName", $str);
 	}
 
-	public function getSpawnCompound() : CompoundTag{
-		$nbt = parent::getSpawnCompound();
-
+	public function addAdditionalSpawnData(CompoundTag $nbt){
 		if($this->hasName()){
 			$nbt->CustomName = $this->namedtag->CustomName;
 		}
-
-		return $nbt;
 	}
 }

--- a/src/pocketmine/tile/EnchantTable.php
+++ b/src/pocketmine/tile/EnchantTable.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace pocketmine\tile;
 
 use pocketmine\nbt\tag\CompoundTag;
-use pocketmine\nbt\tag\IntTag;
 use pocketmine\nbt\tag\StringTag;
 
 class EnchantTable extends Spawnable implements Nameable{
@@ -48,17 +47,12 @@ class EnchantTable extends Spawnable implements Nameable{
 	}
 
 	public function getSpawnCompound() : CompoundTag{
-		$c = new CompoundTag("", [
-			new StringTag("id", Tile::ENCHANT_TABLE),
-			new IntTag("x", (int) $this->x),
-			new IntTag("y", (int) $this->y),
-			new IntTag("z", (int) $this->z)
-		]);
+		$nbt = parent::getSpawnCompound();
 
 		if($this->hasName()){
-			$c->CustomName = $this->namedtag->CustomName;
+			$nbt->CustomName = $this->namedtag->CustomName;
 		}
 
-		return $c;
+		return $nbt;
 	}
 }

--- a/src/pocketmine/tile/FlowerPot.php
+++ b/src/pocketmine/tile/FlowerPot.php
@@ -65,12 +65,12 @@ class FlowerPot extends Spawnable{
 	}
 
 	public function getItem() : Item{
-		return Item::get((int) ($this->namedtag["item"] ?? 0), (int) ($this->namedtag["mData"] ?? 0), 1);
+		return Item::get($this->namedtag->item->getValue(), $this->namedtag->mData->getValue(), 1);
 	}
 
 	public function setItem(Item $item){
-		$this->namedtag["item"] = $item->getId();
-		$this->namedtag["mData"] = $item->getDamage();
+		$this->namedtag->item->setValue($item->getId());
+		$this->namedtag->mData->setValue($item->getDamage());
 		$this->onChanged();
 	}
 

--- a/src/pocketmine/tile/FlowerPot.php
+++ b/src/pocketmine/tile/FlowerPot.php
@@ -28,7 +28,6 @@ use pocketmine\level\Level;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\IntTag;
 use pocketmine\nbt\tag\ShortTag;
-use pocketmine\nbt\tag\StringTag;
 
 class FlowerPot extends Spawnable{
 
@@ -84,13 +83,9 @@ class FlowerPot extends Spawnable{
 	}
 
 	public function getSpawnCompound() : CompoundTag{
-		return new CompoundTag("", [
-			new StringTag("id", Tile::FLOWER_POT),
-			new IntTag("x", (int) $this->x),
-			new IntTag("y", (int) $this->y),
-			new IntTag("z", (int) $this->z),
-			$this->namedtag->item,
-			$this->namedtag->mData
-		]);
+		$nbt = parent::getSpawnCompound();
+		$nbt->item = $this->namedtag->item;
+		$nbt->mData = $this->namedtag->mData;
+		return $nbt;
 	}
 }

--- a/src/pocketmine/tile/FlowerPot.php
+++ b/src/pocketmine/tile/FlowerPot.php
@@ -82,10 +82,8 @@ class FlowerPot extends Spawnable{
 		return $this->getItem()->getId() === Item::AIR;
 	}
 
-	public function getSpawnCompound() : CompoundTag{
-		$nbt = parent::getSpawnCompound();
+	public function addAdditionalSpawnData(CompoundTag $nbt){
 		$nbt->item = $this->namedtag->item;
 		$nbt->mData = $this->namedtag->mData;
-		return $nbt;
 	}
 }

--- a/src/pocketmine/tile/Furnace.php
+++ b/src/pocketmine/tile/Furnace.php
@@ -169,7 +169,7 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 			}
 			$this->namedtag->Items[$i] = $d;
 		}else{
-			$this->namedtag->Items[$i]= $d;
+			$this->namedtag->Items[$i] = $d;
 		}
 	}
 

--- a/src/pocketmine/tile/Furnace.php
+++ b/src/pocketmine/tile/Furnace.php
@@ -44,14 +44,14 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 	protected $inventory;
 
 	public function __construct(Level $level, CompoundTag $nbt){
-		if(!isset($nbt->BurnTime) or $nbt["BurnTime"] < 0){
+		if(!isset($nbt->BurnTime) or $nbt->BurnTime->getValue() < 0){
 			$nbt->BurnTime = new ShortTag("BurnTime", 0);
 		}
-		if(!isset($nbt->CookTime) or $nbt["CookTime"] < 0 or ($nbt["BurnTime"] === 0 and $nbt["CookTime"] > 0)){
+		if(!isset($nbt->CookTime) or $nbt->CookTime->getValue() < 0 or ($nbt->BurnTime->getValue() === 0 and $nbt->CookTime->getValue() > 0)){
 			$nbt->CookTime = new ShortTag("CookTime", 0);
 		}
 		if(!isset($nbt->MaxTime)){
-			$nbt->MaxTime = new ShortTag("BurnTime", $nbt["BurnTime"]);
+			$nbt->MaxTime = new ShortTag("BurnTime", $nbt->BurnTime->getValue());
 			$nbt->BurnTicks = new ShortTag("BurnTicks", 0);
 		}
 
@@ -67,7 +67,7 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 			$this->inventory->setItem($i, $this->getItem($i));
 		}
 
-		if($this->namedtag["BurnTime"] > 0){
+		if($this->namedtag->BurnTime->getValue() > 0){
 			$this->scheduleUpdate();
 		}
 	}
@@ -102,7 +102,7 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 	}
 
 	public function saveNBT(){
-		$this->namedtag->Items = new ListTag("Items", []);
+		$this->namedtag->Items->setValue([]);
 		$this->namedtag->Items->setTagType(NBT::TAG_Compound);
 		for($index = 0; $index < $this->getSize(); ++$index){
 			$this->setItem($index, $this->inventory->getItem($index));
@@ -123,7 +123,7 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 	 */
 	protected function getSlotIndex(int $index) : int{
 		foreach($this->namedtag->Items as $i => $slot){
-			if((int) $slot["Slot"] === $index){
+			if((int) $slot->Slot->getValue() === $index){
 				return (int) $i;
 			}
 		}
@@ -170,7 +170,7 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 			}
 			$this->namedtag->Items[$i] = $d;
 		}else{
-			$this->namedtag->Items[$i] = $d;
+			$this->namedtag->Items[$i]= $d;
 		}
 	}
 
@@ -188,14 +188,14 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 			return;
 		}
 
-		$this->namedtag->MaxTime = new ShortTag("MaxTime", $ev->getBurnTime());
-		$this->namedtag->BurnTime = new ShortTag("BurnTime", $ev->getBurnTime());
+		$this->namedtag->MaxTime->setValue($ev->getBurnTime());
+		$this->namedtag->BurnTime->setValue($ev->getBurnTime());
 		$this->namedtag->BurnTicks = new ShortTag("BurnTicks", 0);
 		if($this->getBlock()->getId() === Item::FURNACE){
 			$this->getLevel()->setBlock($this, Block::get(Item::BURNING_FURNACE, $this->getBlock()->getDamage()), true);
 		}
 
-		if($this->namedtag["BurnTime"] > 0 and $ev->isBurning()){
+		if($this->namedtag->BurnTime->getValue() > 0 and $ev->isBurning()){
 			$fuel->setCount($fuel->getCount() - 1);
 			if($fuel->getCount() === 0){
 				$fuel = Item::get(Item::AIR, 0, 0);
@@ -219,17 +219,17 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 		$smelt = $this->server->getCraftingManager()->matchFurnaceRecipe($raw);
 		$canSmelt = ($smelt instanceof FurnaceRecipe and $raw->getCount() > 0 and (($smelt->getResult()->equals($product) and $product->getCount() < $product->getMaxStackSize()) or $product->getId() === Item::AIR));
 
-		if($this->namedtag["BurnTime"] <= 0 and $canSmelt and $fuel->getFuelTime() !== null and $fuel->getCount() > 0){
+		if($this->namedtag->BurnTime->getValue() <= 0 and $canSmelt and $fuel->getFuelTime() !== null and $fuel->getCount() > 0){
 			$this->checkFuel($fuel);
 		}
 
-		if($this->namedtag["BurnTime"] > 0){
-			$this->namedtag->BurnTime = new ShortTag("BurnTime", ((int) $this->namedtag["BurnTime"]) - 1);
-			$this->namedtag->BurnTicks = new ShortTag("BurnTicks", (int) ceil($this->namedtag["BurnTime"] / $this->namedtag["MaxTime"] * 200));
+		if($this->namedtag->BurnTime->getValue() > 0){
+			$this->namedtag->BurnTime->setValue($this->namedtag->BurnTime->getValue() - 1);
+			$this->namedtag->BurnTicks = new ShortTag("BurnTicks", (int) ceil($this->namedtag->BurnTime->getValue() / $this->namedtag->MaxTime->getValue() * 200));
 
 			if($smelt instanceof FurnaceRecipe and $canSmelt){
-				$this->namedtag->CookTime = new ShortTag("CookTime", ((int) $this->namedtag["CookTime"]) + 1);
-				if($this->namedtag["CookTime"] >= 200){ //10 seconds
+				$this->namedtag->CookTime->setValue($this->namedtag->CookTime->getValue() + 1);
+				if($this->namedtag->CookTime->getValue() >= 200){ //10 seconds
 					$product = Item::get($smelt->getResult()->getId(), $smelt->getResult()->getDamage(), $product->getCount() + 1);
 
 					$this->server->getPluginManager()->callEvent($ev = new FurnaceSmeltEvent($this, $raw, $product));
@@ -243,23 +243,23 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 						$this->inventory->setSmelting($raw);
 					}
 
-					$this->namedtag->CookTime = new ShortTag("CookTime", ((int) $this->namedtag["CookTime"]) - 200);
+					$this->namedtag->CookTime->setValue($this->namedtag->CookTime->getValue() - 200);
 				}
-			}elseif($this->namedtag["BurnTime"] <= 0){
-				$this->namedtag->BurnTime = new ShortTag("BurnTime", 0);
-				$this->namedtag->CookTime = new ShortTag("CookTime", 0);
-				$this->namedtag->BurnTicks = new ShortTag("BurnTicks", 0);
+			}elseif($this->namedtag->BurnTime->getValue() <= 0){
+				$this->namedtag->BurnTime->setValue(0);
+				$this->namedtag->CookTime->setValue(0);
+				$this->namedtag->BurnTicks->setValue(0);
 			}else{
-				$this->namedtag->CookTime = new ShortTag("CookTime", 0);
+				$this->namedtag->CookTime->setValue(0);
 			}
 			$ret = true;
 		}else{
 			if($this->getBlock()->getId() === Item::BURNING_FURNACE){
 				$this->getLevel()->setBlock($this, Block::get(Item::FURNACE, $this->getBlock()->getDamage()), true);
 			}
-			$this->namedtag->BurnTime = new ShortTag("BurnTime", 0);
-			$this->namedtag->CookTime = new ShortTag("CookTime", 0);
-			$this->namedtag->BurnTicks = new ShortTag("BurnTicks", 0);
+			$this->namedtag->BurnTime->setValue(0);
+			$this->namedtag->CookTime->setValue(0);
+			$this->namedtag->BurnTicks->setValue(0);
 		}
 
 		foreach($this->getInventory()->getViewers() as $player){
@@ -268,13 +268,13 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 				$pk = new ContainerSetDataPacket();
 				$pk->windowid = $windowId;
 				$pk->property = 0; //Smelting
-				$pk->value = $this->namedtag["CookTime"];
+				$pk->value = $this->namedtag->CookTime->getValue();
 				$player->dataPacket($pk);
 
 				$pk = new ContainerSetDataPacket();
 				$pk->windowid = $windowId;
 				$pk->property = 1; //Fire icon
-				$pk->value = $this->namedtag["BurnTicks"];
+				$pk->value = $this->namedtag->BurnTicks->getValue();
 				$player->dataPacket($pk);
 			}
 

--- a/src/pocketmine/tile/Furnace.php
+++ b/src/pocketmine/tile/Furnace.php
@@ -122,7 +122,7 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 	 */
 	protected function getSlotIndex(int $index) : int{
 		foreach($this->namedtag->Items as $i => $slot){
-			if((int) $slot->Slot->getValue() === $index){
+			if($slot->Slot->getValue() === $index){
 				return (int) $i;
 			}
 		}

--- a/src/pocketmine/tile/Furnace.php
+++ b/src/pocketmine/tile/Furnace.php
@@ -33,7 +33,6 @@ use pocketmine\item\Item;
 use pocketmine\level\Level;
 use pocketmine\nbt\NBT;
 use pocketmine\nbt\tag\CompoundTag;
-use pocketmine\nbt\tag\IntTag;
 use pocketmine\nbt\tag\ListTag;
 use pocketmine\nbt\tag\ShortTag;
 use pocketmine\nbt\tag\StringTag;

--- a/src/pocketmine/tile/Furnace.php
+++ b/src/pocketmine/tile/Furnace.php
@@ -286,14 +286,12 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 		return $ret;
 	}
 
-	public function getSpawnCompound() : CompoundTag{
-		$nbt = parent::getSpawnCompound();
+	public function addAdditionalSpawnData(CompoundTag $nbt){
 		$nbt->BurnTime = $this->namedtag->BurnTime;
 		$nbt->CookTime = $this->namedtag->CookTime;
 
 		if($this->hasName()){
 			$nbt->CustomName = $this->namedtag->CustomName;
 		}
-		return $nbt;
 	}
 }

--- a/src/pocketmine/tile/Furnace.php
+++ b/src/pocketmine/tile/Furnace.php
@@ -288,14 +288,9 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 	}
 
 	public function getSpawnCompound() : CompoundTag{
-		$nbt = new CompoundTag("", [
-			new StringTag("id", Tile::FURNACE),
-			new IntTag("x", (int) $this->x),
-			new IntTag("y", (int) $this->y),
-			new IntTag("z", (int) $this->z),
-			new ShortTag("BurnTime", (int) $this->namedtag["BurnTime"]),
-			new ShortTag("CookTime", (int) $this->namedtag["CookTime"])
-		]);
+		$nbt = parent::getSpawnCompound();
+		$nbt->BurnTime = $this->namedtag->BurnTime;
+		$nbt->CookTime = $this->namedtag->CookTime;
 
 		if($this->hasName()){
 			$nbt->CustomName = $this->namedtag->CustomName;

--- a/src/pocketmine/tile/ItemFrame.php
+++ b/src/pocketmine/tile/ItemFrame.php
@@ -82,15 +82,13 @@ class ItemFrame extends Spawnable{
 		$this->onChanged();
 	}
 
-	public function getSpawnCompound() : CompoundTag{
-		$nbt = parent::getSpawnCompound();
+	public function addAdditionalSpawnData(CompoundTag $nbt){
 		$nbt->ItemDropChance = $this->namedtag->ItemDropChance;
 		$nbt->ItemRotation = $this->namedtag->ItemRotation;
 
 		if($this->hasItem()){
 			$nbt->Item = $this->namedtag->Item;
 		}
-		return $nbt;
 	}
 
 }

--- a/src/pocketmine/tile/ItemFrame.php
+++ b/src/pocketmine/tile/ItemFrame.php
@@ -85,18 +85,14 @@ class ItemFrame extends Spawnable{
 	}
 
 	public function getSpawnCompound() : CompoundTag{
-		$tag = new CompoundTag("", [
-			new StringTag("id", Tile::ITEM_FRAME),
-			new IntTag("x", (int) $this->x),
-			new IntTag("y", (int) $this->y),
-			new IntTag("z", (int) $this->z),
-			$this->namedtag->ItemDropChance,
-			$this->namedtag->ItemRotation,
-		]);
+		$nbt = parent::getSpawnCompound();
+		$nbt->ItemDropChance = $this->namedtag->ItemDropChance;
+		$nbt->ItemRotation = $this->namedtag->ItemRotation;
+
 		if($this->hasItem()){
-			$tag->Item = $this->namedtag->Item;
+			$nbt->Item = $this->namedtag->Item;
 		}
-		return $tag;
+		return $nbt;
 	}
 
 }

--- a/src/pocketmine/tile/ItemFrame.php
+++ b/src/pocketmine/tile/ItemFrame.php
@@ -28,8 +28,6 @@ use pocketmine\level\Level;
 use pocketmine\nbt\tag\ByteTag;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\FloatTag;
-use pocketmine\nbt\tag\IntTag;
-use pocketmine\nbt\tag\StringTag;
 
 class ItemFrame extends Spawnable{
 
@@ -71,7 +69,7 @@ class ItemFrame extends Spawnable{
 	}
 
 	public function setItemRotation(int $rotation){
-		$this->namedtag->ItemRotation = new ByteTag("ItemRotation", $rotation);
+		$this->namedtag->ItemRotation->setValue($rotation);
 		$this->onChanged();
 	}
 
@@ -80,7 +78,7 @@ class ItemFrame extends Spawnable{
 	}
 
 	public function setItemDropChance(float $chance){
-		$this->namedtag->ItemDropChance = new FloatTag("ItemDropChance", $chance);
+		$this->namedtag->ItemDropChance->setValue($chance);
 		$this->onChanged();
 	}
 

--- a/src/pocketmine/tile/Nameable.php
+++ b/src/pocketmine/tile/Nameable.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace pocketmine\tile;
 
-
 interface Nameable{
 
 

--- a/src/pocketmine/tile/Sign.php
+++ b/src/pocketmine/tile/Sign.php
@@ -102,16 +102,12 @@ class Sign extends Spawnable{
 	}
 
 	public function getSpawnCompound() : CompoundTag{
-		return new CompoundTag("", [
-			new StringTag("id", Tile::SIGN),
-			$this->namedtag->Text1,
-			$this->namedtag->Text2,
-			$this->namedtag->Text3,
-			$this->namedtag->Text4,
-			new IntTag("x", (int) $this->x),
-			new IntTag("y", (int) $this->y),
-			new IntTag("z", (int) $this->z)
-		]);
+		$nbt = parent::getSpawnCompound();
+		for($i = 1; $i <= 4; $i++){
+			$textKey = 'Text'.$i;
+			$nbt->$textKey = $this->namedtag->$textKey;
+		}
+		return $nbt;
 	}
 
 	public function updateCompoundTag(CompoundTag $nbt, Player $player) : bool{

--- a/src/pocketmine/tile/Sign.php
+++ b/src/pocketmine/tile/Sign.php
@@ -86,7 +86,7 @@ class Sign extends Spawnable{
 		if($index < 0 or $index > 3){
 			throw new \InvalidArgumentException("Index must be in the range 0-3!");
 		}
-		return $this->namedtag{"Text" . ($index + 1)}->getValue();
+		return $this->namedtag->{"Text" . ($index + 1)}->getValue();
 	}
 
 	public function getText(){
@@ -100,7 +100,7 @@ class Sign extends Spawnable{
 
 	public function addAdditionalSpawnData(CompoundTag $nbt){
 		for($i = 1; $i <= 4; $i++){
-			$textKey = "Text$i";
+			$textKey = "Text" . $i;
 			$nbt->$textKey = $this->namedtag->$textKey;
 		}
 		return $nbt;

--- a/src/pocketmine/tile/Sign.php
+++ b/src/pocketmine/tile/Sign.php
@@ -26,7 +26,6 @@ namespace pocketmine\tile;
 use pocketmine\event\block\SignChangeEvent;
 use pocketmine\level\Level;
 use pocketmine\nbt\tag\CompoundTag;
-use pocketmine\nbt\tag\IntTag;
 use pocketmine\nbt\tag\StringTag;
 use pocketmine\Player;
 use pocketmine\utils\TextFormat;
@@ -56,10 +55,10 @@ class Sign extends Spawnable{
 	}
 
 	public function setText($line1 = "", $line2 = "", $line3 = "", $line4 = ""){
-		$this->namedtag->Text1 = new StringTag("Text1", $line1);
-		$this->namedtag->Text2 = new StringTag("Text2", $line2);
-		$this->namedtag->Text3 = new StringTag("Text3", $line3);
-		$this->namedtag->Text4 = new StringTag("Text4", $line4);
+		$this->namedtag->Text1->setValue($line1);
+		$this->namedtag->Text2->setValue($line2);
+		$this->namedtag->Text3->setValue($line3);
+		$this->namedtag->Text4->setValue($line4);
 		$this->onChanged();
 
 		return true;
@@ -74,7 +73,7 @@ class Sign extends Spawnable{
 		if($index < 0 or $index > 3){
 			throw new \InvalidArgumentException("Index must be in the range 0-3!");
 		}
-		$this->namedtag["Text" . ($index + 1)] = $line;
+		$this->namedtag->{"Text" . ($index + 1)}->setValue($line);
 		if($update){
 			$this->onChanged();
 		}
@@ -89,15 +88,15 @@ class Sign extends Spawnable{
 		if($index < 0 or $index > 3){
 			throw new \InvalidArgumentException("Index must be in the range 0-3!");
 		}
-		return (string) $this->namedtag["Text" . ($index + 1)];
+		return $this->namedtag{"Text" . ($index + 1)}->getValue();
 	}
 
 	public function getText(){
 		return [
-			$this->namedtag["Text1"],
-			$this->namedtag["Text2"],
-			$this->namedtag["Text3"],
-			$this->namedtag["Text4"]
+			$this->namedtag->Text1->getValue(),
+			$this->namedtag->Text2->getValue(),
+			$this->namedtag->Text3->getValue(),
+			$this->namedtag->Text4->getValue()
 		];
 	}
 
@@ -116,13 +115,13 @@ class Sign extends Spawnable{
 		}
 
 		$ev = new SignChangeEvent($this->getBlock(), $player, [
-			TextFormat::clean($nbt["Text1"], ($removeFormat = $player->getRemoveFormat())),
-			TextFormat::clean($nbt["Text2"], $removeFormat),
-			TextFormat::clean($nbt["Text3"], $removeFormat),
-			TextFormat::clean($nbt["Text4"], $removeFormat)
+			TextFormat::clean($nbt->Text1->getValue(), ($removeFormat = $player->getRemoveFormat())),
+			TextFormat::clean($nbt->Text2->getValue(), $removeFormat),
+			TextFormat::clean($nbt->Text3->getValue(), $removeFormat),
+			TextFormat::clean($nbt->Text4->getValue(), $removeFormat)
 		]);
 
-		if(!isset($this->namedtag->Creator) or $this->namedtag["Creator"] !== $player->getRawUniqueId()){
+		if(!isset($this->namedtag->Creator) or $this->namedtag->Creator->getValue() !== $player->getRawUniqueId()){
 			$ev->setCancelled();
 		}
 

--- a/src/pocketmine/tile/Sign.php
+++ b/src/pocketmine/tile/Sign.php
@@ -54,7 +54,7 @@ class Sign extends Spawnable{
 		unset($this->namedtag->Creator);
 	}
 
-	public function setText($line1 = "", $line2 = "", $line3 = "", $line4 = ""){
+	public function setText(string $line1 = "", string $line2 = "", string $line3 = "", string $line4 = ""){
 		$this->namedtag->Text1->setValue($line1);
 		$this->namedtag->Text2->setValue($line2);
 		$this->namedtag->Text3->setValue($line3);

--- a/src/pocketmine/tile/Sign.php
+++ b/src/pocketmine/tile/Sign.php
@@ -98,8 +98,7 @@ class Sign extends Spawnable{
 		];
 	}
 
-	public function getSpawnCompound() : CompoundTag{
-		$nbt = parent::getSpawnCompound();
+	public function addAdditionalSpawnData(CompoundTag $nbt){
 		for($i = 1; $i <= 4; $i++){
 			$textKey = "Text$i";
 			$nbt->$textKey = $this->namedtag->$textKey;

--- a/src/pocketmine/tile/Sign.php
+++ b/src/pocketmine/tile/Sign.php
@@ -54,16 +54,14 @@ class Sign extends Spawnable{
 		unset($this->namedtag->Creator);
 	}
 
-	public function setText(string $line1 = "", string $line2 = "", string $line3 = "", string $line4 = ""){
+	public function setText($line1 = "", $line2 = "", $line3 = "", $line4 = ""){
 		$this->namedtag->Text1->setValue($line1);
 		$this->namedtag->Text2->setValue($line2);
 		$this->namedtag->Text3->setValue($line3);
 		$this->namedtag->Text4->setValue($line4);
 		$this->onChanged();
-
-		return true;
 	}
-	
+
 	/**
 	 * @param int    $index 0-3
 	 * @param string $line
@@ -78,7 +76,7 @@ class Sign extends Spawnable{
 			$this->onChanged();
 		}
 	}
-	
+
 	/**
 	 * @param int $index 0-3
 	 *

--- a/src/pocketmine/tile/Sign.php
+++ b/src/pocketmine/tile/Sign.php
@@ -104,7 +104,7 @@ class Sign extends Spawnable{
 	public function getSpawnCompound() : CompoundTag{
 		$nbt = parent::getSpawnCompound();
 		for($i = 1; $i <= 4; $i++){
-			$textKey = 'Text'.$i;
+			$textKey = "Text$i";
 			$nbt->$textKey = $this->namedtag->$textKey;
 		}
 		return $nbt;

--- a/src/pocketmine/tile/Skull.php
+++ b/src/pocketmine/tile/Skull.php
@@ -57,13 +57,9 @@ class Skull extends Spawnable{
 	}
 
 	public function getSpawnCompound() : CompoundTag{
-		return new CompoundTag("", [
-			new StringTag("id", Tile::SKULL),
-			$this->namedtag->SkullType,
-			$this->namedtag->Rot,
-			new IntTag("x", (int) $this->x),
-			new IntTag("y", (int) $this->y),
-			new IntTag("z", (int) $this->z)
-		]);
+		$nbt = parent::getSpawnCompound();
+		$nbt->SkullType = $this->namedtag->SkullType;
+		$nbt->Rot = $this->namedtag->Rot;
+		return $nbt;
 	}
 }

--- a/src/pocketmine/tile/Skull.php
+++ b/src/pocketmine/tile/Skull.php
@@ -54,10 +54,8 @@ class Skull extends Spawnable{
 		return $this->namedtag->SkullType->getValue();
 	}
 
-	public function getSpawnCompound() : CompoundTag{
-		$nbt = parent::getSpawnCompound();
+	public function addAdditionalSpawnData(CompoundTag $nbt){
 		$nbt->SkullType = $this->namedtag->SkullType;
 		$nbt->Rot = $this->namedtag->Rot;
-		return $nbt;
 	}
 }

--- a/src/pocketmine/tile/Skull.php
+++ b/src/pocketmine/tile/Skull.php
@@ -26,8 +26,6 @@ namespace pocketmine\tile;
 use pocketmine\level\Level;
 use pocketmine\nbt\tag\ByteTag;
 use pocketmine\nbt\tag\CompoundTag;
-use pocketmine\nbt\tag\IntTag;
-use pocketmine\nbt\tag\StringTag;
 
 class Skull extends Spawnable{
 	const TYPE_SKELETON = 0;
@@ -48,12 +46,12 @@ class Skull extends Spawnable{
 	}
 
 	public function setType(int $type){
-		$this->namedtag->SkullType = new ByteTag("SkullType", $type);
+		$this->namedtag->SkullType->setValue($type);
 		$this->onChanged();
 	}
 
-	public function getType(){
-		return $this->namedtag["SkullType"];
+	public function getType() : int{
+		return $this->namedtag->SkullType->getValue();
 	}
 
 	public function getSpawnCompound() : CompoundTag{

--- a/src/pocketmine/tile/Spawnable.php
+++ b/src/pocketmine/tile/Spawnable.php
@@ -77,7 +77,14 @@ abstract class Spawnable extends Tile{
 	/**
 	 * @return CompoundTag
 	 */
-	abstract public function getSpawnCompound() : CompoundTag;
+	public function getSpawnCompound() : CompoundTag{
+		return new CompoundTag("", [
+			$this->namedtag->id,
+			$this->namedtag->x,
+			$this->namedtag->y,
+			$this->namedtag->z
+		]);
+	}
 
 	/**
 	 * Called when a player updates a block entity's NBT data

--- a/src/pocketmine/tile/Spawnable.php
+++ b/src/pocketmine/tile/Spawnable.php
@@ -77,14 +77,24 @@ abstract class Spawnable extends Tile{
 	/**
 	 * @return CompoundTag
 	 */
-	public function getSpawnCompound() : CompoundTag{
-		return new CompoundTag("", [
+	final public function getSpawnCompound() : CompoundTag{
+		$nbt = new CompoundTag("", [
 			$this->namedtag->id,
 			$this->namedtag->x,
 			$this->namedtag->y,
 			$this->namedtag->z
 		]);
+		$this->addAdditionalSpawnData($nbt);
+		return $nbt;
 	}
+
+	/**
+	 * An extension to getSpawnCompound() for
+	 * further modifying the generic tile NBT.
+	 *
+	 * @param CompoundTag $nbt
+	 */
+	abstract public function addAdditionalSpawnData(CompoundTag $nbt);
 
 	/**
 	 * Called when a player updates a block entity's NBT data

--- a/src/pocketmine/tile/Tile.php
+++ b/src/pocketmine/tile/Tile.php
@@ -33,8 +33,6 @@ use pocketmine\level\format\Chunk;
 use pocketmine\level\Level;
 use pocketmine\level\Position;
 use pocketmine\nbt\tag\CompoundTag;
-use pocketmine\nbt\tag\IntTag;
-use pocketmine\nbt\tag\StringTag;
 
 abstract class Tile extends Position{
 
@@ -126,15 +124,15 @@ abstract class Tile extends Position{
 		$this->namedtag = $nbt;
 		$this->server = $level->getServer();
 		$this->setLevel($level);
-		$this->chunk = $level->getChunk($this->namedtag["x"] >> 4, $this->namedtag["z"] >> 4, false);
+		$this->chunk = $level->getChunk($this->namedtag->x->getValue() >> 4, $this->namedtag->z->getValue() >> 4, false);
 		assert($this->chunk !== null);
 
 		$this->name = "";
 		$this->lastUpdate = microtime(true);
 		$this->id = Tile::$tileCount++;
-		$this->x = (int) $this->namedtag["x"];
-		$this->y = (int) $this->namedtag["y"];
-		$this->z = (int) $this->namedtag["z"];
+		$this->x = $this->namedtag->x->getValue();
+		$this->y = $this->namedtag->y->getValue();
+		$this->z = $this->namedtag->z->getValue();
 
 		$this->chunk->addTile($this);
 		$this->getLevel()->addTile($this);
@@ -146,10 +144,10 @@ abstract class Tile extends Position{
 	}
 
 	public function saveNBT(){
-		$this->namedtag->id = new StringTag("id", $this->getSaveId());
-		$this->namedtag->x = new IntTag("x", $this->x);
-		$this->namedtag->y = new IntTag("y", $this->y);
-		$this->namedtag->z = new IntTag("z", $this->z);
+		$this->namedtag->id->setValue($this->getSaveId());
+		$this->namedtag->x->setValue($this->x);
+		$this->namedtag->y->setValue($this->y);
+		$this->namedtag->z->setValue($this->z);
 	}
 
 	public function getCleanedNBT(){


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
It looks like for every time PocketMine needs to change the value of a tile's NBT tag, it creates a totally new NBT tag and assigns it a value.
```php
/** @var \pocketmine\tile\Furnace $furnace */

//onUpdate()...
if($furnace->namedtag["BurnTime"] > 0){
    $furnace->namedtag["BurnTime"] = new ShortTag("BurnTime", ((int) $furnace->namedtag["BurnTime"]) - 1);
}
```

Its pointless. You can change the tag's value using `Tag::setValue($value)`.
It also seems pointless to `(mixed)` cast every nbt tag. This can be avoided by using `Tag::getValue()`.
```php
//Before:
if($furnace->namedtag["BurnTime"] > 0){
    $furnace->namedtag["BurnTime"] = new ShortTag("BurnTime", ((int) $furnace->namedtag["BurnTime"]) - 1);
}

//After:
if($furnace->namedtag->BurnTime->getValue() > 0){
    $furnace->namedtag->BurnTime->setValue($furnace->namedtag->BurnTime->getValue() - 1);
}
```

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
This pull request goes hand in hand with #1116. You can still assign an index to a CompoundTag array, but it's going to be useless.
If you are modifying a tile, please use the new way which again, is what's explained in #1116.

```php
//Do NOT:
$tileNBT = new CompoundTag("", [
    "x" => new IntTag("x", 100)
]);
var_dump((int) $tileNBT["x"]);

//Do:
$tileNBT = new CompoundTag("", [
    new IntTag("x", 100)
]);
var_dump($tileNBT->x->getValue());

"------------------------------"

//Do NOT:
$tileNBT["x"] = new IntTag("x", ((int) $tileNBT["x"]) + 10);

//Do:
$tileNBT->x->setValue($tileNBT->x->getValue() + 10);
```

Spawnable::getSpawnCompound() is no longer an abstract function and returns generic tile NBT.

Added abstract function `addAdditionalSpawnData(CompoundTag $nbt)` which is where all the tile-specific nbt tags are applied.
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
This can be considered a 'micro-optimization' since we aren't creating multiple new NBT tags every tick as seen in case of Furnace.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
This PR is backwards compatible.


## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
Tests done:
**Chest**
Place a chest. Put some items in it. Close the chest. Restart the server. Open the chest. Works just like it should.

**Enchanting Table:**
Place an enchanting table. Open it. Close it. Restart the server. Open it. Close it. Works.

**Flower Pot:**
Place a flower pot. Add a flower (tried with cactus). Restart the server. Works.

**Item Frame:**
Place an item frame. Rotate item 45° (1 tap). Restart the server. Works.

**Sign:**
Place a sign. Fill up all four lines. Restart the server. Works.
Place a sign. Fill up the 2nd and 4th line. Restart the server. Works.

**Skull:**
Place a skull with `rotation % 90 !== 0`. Restart the server. Works.
Place a skull with `rotation % 90 === 0`. Restart the server. Works.


## API Changes made after initial changes
Spawnable::getSpawnCompound() is now a final function. It will return the common NBT tag for tiles...
```php
final public function getSpawnCompound() : CompoundTag{
    return new CompoundTag("", [
        $this->namedtag->id,
        $this->namedtag->x,
        $this->namedtag->y,
        $this->namedtag->z
    ]);
}
```