### PR TITLE
Add PlayerExperienceChangeEvent

### DIFF
--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -26,6 +26,7 @@ namespace pocketmine\entity;
 use pocketmine\event\entity\EntityDamageEvent;
 use pocketmine\event\entity\EntityRegainHealthEvent;
 use pocketmine\event\player\PlayerExhaustEvent;
+use pocketmine\event\player\PlayerExperienceChangeEvent;
 use pocketmine\inventory\InventoryHolder;
 use pocketmine\inventory\PlayerInventory;
 use pocketmine\item\Item as ItemItem;
@@ -243,8 +244,13 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 		return (int) $this->attributeMap->getAttribute(Attribute::EXPERIENCE_LEVEL)->getValue();
 	}
 
-	public function setXpLevel(int $level){
-		$this->attributeMap->getAttribute(Attribute::EXPERIENCE_LEVEL)->setValue($level);
+	public function setXpLevel(int $level) : bool{
+		$this->server->getPluginManager()->callEvent($ev = new PlayerExperienceChangeEvent($this, $level, $this->getXpProgress()));
+		if(!$ev->isCancelled()){
+			$this->attributeMap->getAttribute(Attribute::EXPERIENCE_LEVEL)->setValue($ev->getExpLevel());
+			return true;
+		}
+		return false;
 	}
 
 	public function getXpProgress() : float{

--- a/src/pocketmine/event/player/PlayerExperienceChangeEvent.php
+++ b/src/pocketmine/event/player/PlayerExperienceChangeEvent.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\event\player;
+
+use pocketmine\entity\Human;
+use pocketmine\event\Cancellable;
+
+class PlayerExperienceChangeEvent extends PlayerEvent implements Cancellable {
+	public static $handlerList = null;
+
+	public $progress;
+	public $expLevel;
+
+	/**
+	 * PlayerExperienceChangeEvent constructor.
+	 *
+	 * @param Human $player
+	 * @param int   $expLevel
+	 * @param float $progress
+	 */
+	public function __construct(Human $player, int $expLevel, float $progress){
+		$this->progress = $progress;
+		$this->expLevel = $expLevel;
+		$this->player = $player;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getExpLevel(){
+		return $this->expLevel;
+	}
+
+	/**
+	 * @param $level
+	 */
+	public function setExpLevel($level){
+		$this->expLevel = $level;
+	}
+
+	/**
+	 * @return float
+	 */
+	public function getProgress() : float{
+		return $this->progress;
+	}
+
+	/**
+	 * @param float $progress
+	 */
+	public function setProgress(float $progress){
+		$this->progress = $progress;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getExp(){
+		return Human::getLevelXpRequirement($this->expLevel) + $this->progress;
+	}
+
+	/**
+	 * @param $exp
+	 */
+	public function setExp($exp){
+		$this->progress = $exp / Human::getLevelXpRequirement($this->expLevel);
+	}
+}


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Sometimes plugins need to handle player experience change, so lets add PlayerExperienceChangeEvent.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Added PlayerExperienceChangeEvent

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Backwards compatible.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->

```
<?php

namespace Test {

    use pocketmine\event\Listener;
    use pocketmine\plugin\PluginBase;
    use pocketmine\event\player\PlayerExperienceChangeEvent;
                    									
	class Test extends PluginBase implements Listener {
	    
	    public function onEnable() {
	        $this->getServer()->getPluginManager()->registerEvents($this, $this);
	    }
	    
	    public function onLevelChangeEvent (PlayerExperienceChangeEvent $ev) {
	        $level = $ev->getPlayer()->getXpLevel();
	        $ev->getPlayer()->sendMessage("Your current xp level : {$level}");
	    }
	    
	}
}
```