### PR TITLE
Fix some type errors on custom ExplodePacket use

### DIFF
--- a/src/pocketmine/network/mcpe/protocol/ExplodePacket.php
+++ b/src/pocketmine/network/mcpe/protocol/ExplodePacket.php
@@ -62,7 +62,7 @@ class ExplodePacket extends DataPacket{
 		$this->putUnsignedVarInt(count($this->records));
 		if(count($this->records) > 0){
 			foreach($this->records as $record){
-				$this->putSignedBlockPosition($record->x, $record->y, $record->z);
+				$this->putSignedBlockPosition((int) $record->x, (int) $record->y, (int) $record->z);
 			}
 		}
 	}


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Original error was:
`[12:25:56] [Server thread/CRITICAL]: TypeError: "Argument 1 passed to pocketmine\network\mcpe\protocol\DataPacket::putSignedBlockPosition() must be of the type integer, float given, called in /home/mrgenga/mcpm/src/pocketmine/network/mcpe/protocol/ExplodePacket.php on line 65" (EXCEPTION) in "src/pocketmine/network/mcpe/protocol/DataPacket" at line 350`
This PR fixed it
### Relevant issues
<!-- List relevant issues here -->
<!--

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
I relaunched same code and it worked without any errors.