### PR TITLE
Added basic support for blocks with multiple AABBs, fixed stairs

### DIFF
--- a/src/pocketmine/block/Air.php
+++ b/src/pocketmine/block/Air.php
@@ -71,6 +71,10 @@ class Air extends Transparent{
 		return null;
 	}
 
+	public function getBoundingBoxes() : array{
+		return [];
+	}
+
 	public function getHardness() : float{
 		return -1;
 	}

--- a/src/pocketmine/block/Air.php
+++ b/src/pocketmine/block/Air.php
@@ -71,7 +71,7 @@ class Air extends Transparent{
 		return null;
 	}
 
-	public function getBoundingBoxes() : array{
+	public function getCollisionBoxes() : array{
 		return [];
 	}
 

--- a/src/pocketmine/block/Block.php
+++ b/src/pocketmine/block/Block.php
@@ -70,8 +70,8 @@ class Block extends Position implements BlockIds, Metadatable{
 	public $boundingBox = null;
 
 
-	/** @var AxisAlignedBB[] */
-	protected $collisionBoxes = [];
+	/** @var AxisAlignedBB[]|null */
+	protected $collisionBoxes = null;
 
 	/**
 	 * @param int         $id     The block type's ID, 0-255
@@ -515,7 +515,7 @@ class Block extends Position implements BlockIds, Metadatable{
 	 * @return AxisAlignedBB[]
 	 */
 	public function getCollisionBoxes() : array{
-		if(empty($this->collisionBoxes) === 0){
+		if($this->collisionBoxes === null){
 			$this->collisionBoxes = $this->recalculateCollisionBoxes();
 		}
 

--- a/src/pocketmine/block/Block.php
+++ b/src/pocketmine/block/Block.php
@@ -71,7 +71,7 @@ class Block extends Position implements BlockIds, Metadatable{
 
 
 	/** @var AxisAlignedBB[] */
-	protected $boundingBoxes = [];
+	protected $collisionBoxes = [];
 
 	/**
 	 * @param int         $id     The block type's ID, 0-255
@@ -493,7 +493,7 @@ class Block extends Position implements BlockIds, Metadatable{
 	 * @return bool
 	 */
 	public function collidesWithBB(AxisAlignedBB $bb) : bool{
-		$bbs = $this->getBoundingBoxes();
+		$bbs = $this->getCollisionBoxes();
 
 		foreach($bbs as $bb2){
 			if($bb->intersectsWith($bb2)){
@@ -514,18 +514,18 @@ class Block extends Position implements BlockIds, Metadatable{
 	/**
 	 * @return AxisAlignedBB[]
 	 */
-	public function getBoundingBoxes() : array{
-		if(count($this->boundingBoxes) === 0){
-			$this->boundingBoxes = $this->recalculateBoundingBoxes();
+	public function getCollisionBoxes() : array{
+		if(empty($this->collisionBoxes) === 0){
+			$this->collisionBoxes = $this->recalculateCollisionBoxes();
 		}
 
-		return $this->boundingBoxes;
+		return $this->collisionBoxes;
 	}
 
 	/**
 	 * @return AxisAlignedBB[]
 	 */
-	protected function recalculateBoundingBoxes() : array{
+	protected function recalculateCollisionBoxes() : array{
 		if($bb = $this->recalculateBoundingBox()){
 			return [$bb];
 		}
@@ -534,7 +534,6 @@ class Block extends Position implements BlockIds, Metadatable{
 	}
 
 	/**
-	 * @deprecated
 	 * @return AxisAlignedBB|null
 	 */
 	public function getBoundingBox() : ?AxisAlignedBB{
@@ -545,7 +544,6 @@ class Block extends Position implements BlockIds, Metadatable{
 	}
 
 	/**
-	 * @deprecated
 	 * @return AxisAlignedBB|null
 	 */
 	protected function recalculateBoundingBox() : ?AxisAlignedBB{
@@ -566,7 +564,7 @@ class Block extends Position implements BlockIds, Metadatable{
 	 * @return MovingObjectPosition|null
 	 */
 	public function calculateIntercept(Vector3 $pos1, Vector3 $pos2) : ?MovingObjectPosition{
-		$bbs = $this->getBoundingBoxes();
+		$bbs = $this->getCollisionBoxes();
 		if(empty($bbs)){
 			return null;
 		}

--- a/src/pocketmine/block/Stair.php
+++ b/src/pocketmine/block/Stair.php
@@ -31,7 +31,7 @@ use pocketmine\Player;
 
 abstract class Stair extends Transparent{
 
-	protected function recalculateBoundingBoxes() : array{
+	protected function recalculateCollisionBoxes() : array{
 		//TODO: handle corners
 
 		$bbs = [$this->recalculateBoundingBox()];

--- a/src/pocketmine/block/Stair.php
+++ b/src/pocketmine/block/Stair.php
@@ -37,7 +37,7 @@ abstract class Stair extends Transparent{
 		$bbs = [$this->recalculateBoundingBox()];
 
 		$yMin = ($this->meta & 0x04) === 0 ? 0.5 : 0;
-		$yMax = ($this->meta & 0x04) === 0 ? 1 : 0.5;
+		$yMax = $yMin + 0.5;
 
 		$rotationMeta = $this->meta & 0x03;
 

--- a/src/pocketmine/block/Stair.php
+++ b/src/pocketmine/block/Stair.php
@@ -34,66 +34,53 @@ abstract class Stair extends Transparent{
 	protected function recalculateCollisionBoxes() : array{
 		//TODO: handle corners
 
-		$bbs = [$this->recalculateBoundingBox()];
+		$minYSlab = ($this->meta & 0x04) === 0 ? 0 : 0.5;
+		$maxYSlab = $minYSlab + 0.5;
 
-		$yMin = ($this->meta & 0x04) === 0 ? 0.5 : 0;
-		$yMax = $yMin + 0.5;
+		$bbs = [
+			new AxisAlignedBB(
+				$this->x,
+				$this->y + $minYSlab,
+				$this->z,
+				$this->x + 1,
+				$this->y + $maxYSlab,
+				$this->z + 1
+			)
+		];
+
+		$minY = ($this->meta & 0x04) === 0 ? 0.5 : 0;
+		$maxY = $minY + 0.5;
 
 		$rotationMeta = $this->meta & 0x03;
 
-		$xMin = 0;
-		$xMax = 1;
-
-		$zMin = 0;
-		$zMax = 1;
+		$minX = $minZ = 0;
+		$maxX = $maxZ = 1;
 
 		switch($rotationMeta){
 			case 0:
-				$xMin = 0.5;
+				$minX = 0.5;
 				break;
 			case 1:
-				$xMax = 0.5;
+				$maxX = 0.5;
 				break;
 			case 2:
-				$zMin = 0.5;
+				$minZ = 0.5;
 				break;
 			case 3:
-				$zMax = 0.5;
+				$maxZ = 0.5;
 				break;
 		}
 
 		$bbs[] = new AxisAlignedBB(
-			$this->x + $xMin,
-			$this->y + $yMin,
-			$this->z + $zMin,
-			$this->x + $xMax,
-			$this->y + $yMax,
-			$this->z + $zMax
+			$this->x + $minX,
+			$this->y + $minY,
+			$this->z + $minZ,
+			$this->x + $maxX,
+			$this->y + $maxY,
+			$this->z + $maxZ
 		);
 
 		return $bbs;
-	}
-
-	protected function recalculateBoundingBox() : ?AxisAlignedBB{
-		if(($this->getDamage() & 0x04) > 0){
-			return new AxisAlignedBB(
-				$this->x,
-				$this->y + 0.5,
-				$this->z,
-				$this->x + 1,
-				$this->y + 1,
-				$this->z + 1
-			);
-		}else{
-			return new AxisAlignedBB(
-				$this->x,
-				$this->y,
-				$this->z,
-				$this->x + 1,
-				$this->y + 0.5,
-				$this->z + 1
-			);
-		}
 	}
 
 	public function place(Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $facePos, Player $player = null) : bool{

--- a/src/pocketmine/block/Stair.php
+++ b/src/pocketmine/block/Stair.php
@@ -31,84 +31,50 @@ use pocketmine\Player;
 
 abstract class Stair extends Transparent{
 
-	/*
-	public function collidesWithBB(AxisAlignedBB $bb, &$list = []){
-		$damage = $this->getDamage();
-		$j = $damage & 0x03;
+	protected function recalculateBoundingBoxes() : array{
+		//TODO: handle corners
 
-		$f = 0;
-		$f1 = 0.5;
-		$f2 = 0.5;
-		$f3 = 1;
+		$bbs = [$this->recalculateBoundingBox()];
 
-		if(($damage & 0x04) > 0){
-			$f = 0.5;
-			$f1 = 1;
-			$f2 = 0;
-			$f3 = 0.5;
+		$yMin = ($this->meta & 0x04) === 0 ? 0.5 : 0;
+		$yMax = ($this->meta & 0x04) === 0 ? 1 : 0.5;
+
+		$rotationMeta = $this->meta & 0x03;
+
+		$xMin = 0;
+		$xMax = 1;
+
+		$zMin = 0;
+		$zMax = 1;
+
+		switch($rotationMeta){
+			case 0:
+				$xMin = 0.5;
+				break;
+			case 1:
+				$xMax = 0.5;
+				break;
+			case 2:
+				$zMin = 0.5;
+				break;
+			case 3:
+				$zMax = 0.5;
+				break;
 		}
 
-		if($bb->intersectsWith($bb2 = AxisAlignedBB::getBoundingBoxFromPool(
-			$this->x,
-			$this->y + $f,
-			$this->z,
-			$this->x + 1,
-			$this->y + $f1,
-			$this->z + 1
-		))){
-			$list[] = $bb2;
-		}
+		$bbs[] = new AxisAlignedBB(
+			$this->x + $xMin,
+			$this->y + $yMin,
+			$this->z + $zMin,
+			$this->x + $xMax,
+			$this->y + $yMax,
+			$this->z + $zMax
+		);
 
-		if($j === 0){
-			if($bb->intersectsWith($bb2 = AxisAlignedBB::getBoundingBoxFromPool(
-				$this->x + 0.5,
-				$this->y + $f2,
-				$this->z,
-				$this->x + 1,
-				$this->y + $f3,
-				$this->z + 1
-			))){
-				$list[] = $bb2;
-			}
-		}elseif($j === 1){
-			if($bb->intersectsWith($bb2 = AxisAlignedBB::getBoundingBoxFromPool(
-				$this->x,
-				$this->y + $f2,
-				$this->z,
-				$this->x + 0.5,
-				$this->y + $f3,
-				$this->z + 1
-			))){
-				$list[] = $bb2;
-			}
-		}elseif($j === 2){
-			if($bb->intersectsWith($bb2 = AxisAlignedBB::getBoundingBoxFromPool(
-				$this->x,
-				$this->y + $f2,
-				$this->z + 0.5,
-				$this->x + 1,
-				$this->y + $f3,
-				$this->z + 1
-			))){
-				$list[] = $bb2;
-			}
-		}elseif($j === 3){
-			if($bb->intersectsWith($bb2 = AxisAlignedBB::getBoundingBoxFromPool(
-				$this->x,
-				$this->y + $f2,
-				$this->z,
-				$this->x + 1,
-				$this->y + $f3,
-				$this->z + 0.5
-			))){
-				$list[] = $bb2;
-			}
-		}
+		return $bbs;
 	}
-	*/
 
 	protected function recalculateBoundingBox() : ?AxisAlignedBB{
-
 		if(($this->getDamage() & 0x04) > 0){
 			return new AxisAlignedBB(
 				$this->x,

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -1497,9 +1497,7 @@ abstract class Entity extends Location implements Metadatable{
 	public function isInsideOfSolid() : bool{
 		$block = $this->level->getBlock($this->temporalVector->setComponents(Math::floorFloat($this->x), Math::floorFloat($y = ($this->y + $this->getEyeHeight())), Math::floorFloat($this->z)));
 
-		$bb = $block->getBoundingBox();
-
-		return $bb !== null and $block->isSolid() and !$block->isTransparent() and $bb->intersectsWith($this->getBoundingBox());
+		return $block->isSolid() and !$block->isTransparent() and $block->collidesWithBB($this->getBoundingBox());
 	}
 
 	public function fastMove(float $dx, float $dy, float $dz) : bool{

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1791,7 +1791,7 @@ class Level implements ChunkManager, Metadatable{
 			return false;
 		}
 
-		if($hand->isSolid() === true){
+		if($hand->isSolid()){
 			foreach($hand->getCollisionBoxes() as $collisionBox){
 				$entities = $this->getCollidingEntities($collisionBox);
 				foreach($entities as $e){

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1157,18 +1157,12 @@ class Level implements ChunkManager, Metadatable{
 			if($pos->isSolid()){
 				return true;
 			}
-			$bbs = $pos->getCollisionBoxes();
+			$bb = $pos->getBoundingBox();
 		}else{
-			$bbs = $this->getBlock($pos)->getCollisionBoxes();
+			$bb = $this->getBlock($pos)->getBoundingBox();
 		}
 
-		foreach($bbs as $bb){
-			if($bb->getAverageEdgeLength() >= 1){
-				return true;
-			}
-		}
-
-		return false;
+		return $bb !== null and $bb->getAverageEdgeLength() >= 1;
 	}
 
 	/**

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1797,7 +1797,7 @@ class Level implements ChunkManager, Metadatable{
 			return false;
 		}
 
-		if($hand->isSolid() === true and $hand->getBoundingBox() !== null){
+		if($hand->isSolid() === true){
 			foreach($hand->getBoundingBoxes() as $collisionBox){
 				$entities = $this->getCollidingEntities($collisionBox);
 				foreach($entities as $e){

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1157,9 +1157,9 @@ class Level implements ChunkManager, Metadatable{
 			if($pos->isSolid()){
 				return true;
 			}
-			$bbs = $pos->getBoundingBoxes();
+			$bbs = $pos->getCollisionBoxes();
 		}else{
-			$bbs = $this->getBlock($pos)->getBoundingBoxes();
+			$bbs = $this->getBlock($pos)->getCollisionBoxes();
 		}
 
 		foreach($bbs as $bb){
@@ -1194,7 +1194,7 @@ class Level implements ChunkManager, Metadatable{
 				for($y = $minY; $y <= $maxY; ++$y){
 					$block = $this->getBlock($this->temporalVector->setComponents($x, $y, $z));
 					if(!$block->canPassThrough() and $block->collidesWithBB($bb)){
-						foreach($block->getBoundingBoxes() as $blockBB){
+						foreach($block->getCollisionBoxes() as $blockBB){
 							$collides[] = $blockBB;
 						}
 					}
@@ -1798,7 +1798,7 @@ class Level implements ChunkManager, Metadatable{
 		}
 
 		if($hand->isSolid() === true){
-			foreach($hand->getBoundingBoxes() as $collisionBox){
+			foreach($hand->getCollisionBoxes() as $collisionBox){
 				$entities = $this->getCollidingEntities($collisionBox);
 				foreach($entities as $e){
 					if($e instanceof Arrow or $e instanceof DroppedItem or ($e instanceof Player and $e->isSpectator())){


### PR DESCRIPTION
## Introduction
Blocks such as stairs do not have a simple cuboid collision box. Because PocketMine-MP has (until now) considered stairs to have the same collision box as slabs, this has caused many issues with movement and anti-flight anti-cheat.

### Relevant issues
fixes #1211 and a ton of other "moved wrongly!" complaints

## Changes
- separation of concepts of "bounding box" and "collision boxes" (bounding box encapsulates the block, collision boxes are the things that entities collide with)

### API changes
- added API method `Block->getCollisionBoxes()`


### Behavioural changes
- fixed kicked for flying when walking on stairs
- fixed arrows being able to be shot through the top part of blocks

## Follow-up
This DOES NOT account for the following (literal) corner cases:
![image](https://user-images.githubusercontent.com/14214667/31503306-30618ac0-af67-11e7-8c42-9752fbc8037b.png)
![image](https://user-images.githubusercontent.com/14214667/31503328-4357db7a-af67-11e7-92de-bb4e0a32b579.png)
This should be done in the future.

## Tests
- tested extensively using zero-gravity arrows and as a player subjected to anti-cheat.