### PR TITLE
Fix server MOTD showing on the wrong server in server list

### DIFF
--- a/src/pocketmine/network/mcpe/RakLibInterface.php
+++ b/src/pocketmine/network/mcpe/RakLibInterface.php
@@ -179,7 +179,7 @@ class RakLibInterface implements ServerInstance, AdvancedSourceInterface{
 				ProtocolInfo::MINECRAFT_VERSION_NETWORK,
 				$info->getPlayerCount(),
 				$info->getMaxPlayerCount(),
-				"0",
+				(string) mt_rand(0, PHP_INT_MAX),
 				$this->server->getName(),
 				Server::getGamemodeName($this->server->getGamemode())
 			]) . ";"


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
The server MOTD will usually jump to another server in the list, and then update to the correct one after a bit.

### Relevant issues
Fixes #1208 


## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
None
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
nope

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
Tested and works.