### PR TITLE
Ability to get a players quit reason

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3438,7 +3438,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 						$this->server->getLogger()->logException($e);
 					}
 
-					$this->server->getPluginManager()->callEvent($ev = new PlayerQuitEvent($this, $message));
+					$this->server->getPluginManager()->callEvent($ev = new PlayerQuitEvent($this, $message, $reason));
 					if($ev->getQuitMessage() != ""){
 						$this->server->broadcastMessage($ev->getQuitMessage());
 					}

--- a/src/pocketmine/event/player/PlayerQuitEvent.php
+++ b/src/pocketmine/event/player/PlayerQuitEvent.php
@@ -40,7 +40,7 @@ class PlayerQuitEvent extends PlayerEvent{
 	/**
 	 * @param Player                      $player
 	 * @param TranslationContainer|string $quitMessage
-     * @param string                      $quitReason
+	 * @param string                      $quitReason
 	 */
 	public function __construct(Player $player, $quitMessage, $quitReason){
 		$this->player = $player;

--- a/src/pocketmine/event/player/PlayerQuitEvent.php
+++ b/src/pocketmine/event/player/PlayerQuitEvent.php
@@ -34,14 +34,18 @@ class PlayerQuitEvent extends PlayerEvent{
 
 	/** @var TranslationContainer|string */
 	protected $quitMessage;
+	/** @var string */
+	protected $quitReason;
 
 	/**
 	 * @param Player                      $player
 	 * @param TranslationContainer|string $quitMessage
+     * @param string                      $quitReason
 	 */
-	public function __construct(Player $player, $quitMessage){
+	public function __construct(Player $player, $quitMessage, $quitReason){
 		$this->player = $player;
 		$this->quitMessage = $quitMessage;
+		$this->quitReason = $quitReason;
 	}
 
 	/**
@@ -56,5 +60,12 @@ class PlayerQuitEvent extends PlayerEvent{
 	 */
 	public function getQuitMessage(){
 		return $this->quitMessage;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getQuitReason(){
+		return $this->quitReason;
 	}
 }

--- a/src/pocketmine/event/player/PlayerQuitEvent.php
+++ b/src/pocketmine/event/player/PlayerQuitEvent.php
@@ -42,7 +42,7 @@ class PlayerQuitEvent extends PlayerEvent{
 	 * @param TranslationContainer|string $quitMessage
 	 * @param string                      $quitReason
 	 */
-	public function __construct(Player $player, $quitMessage, $quitReason){
+	public function __construct(Player $player, $quitMessage, string $quitReason){
 		$this->player = $player;
 		$this->quitMessage = $quitMessage;
 		$this->quitReason = $quitReason;
@@ -65,7 +65,7 @@ class PlayerQuitEvent extends PlayerEvent{
 	/**
 	 * @return string
 	 */
-	public function getQuitReason(){
+	public function getQuitReason() : string{
 		return $this->quitReason;
 	}
 }


### PR DESCRIPTION
### Introduction
There was no way to do this before. I don't believe plugins should be able to modify the reason though. That can be changed though if requested.

This allows the possibility for plugins to track how players leave the server.

