### PR TITLE
Remove Entity->length

### DIFF
--- a/src/pocketmine/entity/Arrow.php
+++ b/src/pocketmine/entity/Arrow.php
@@ -32,7 +32,6 @@ class Arrow extends Projectile{
 	const NETWORK_ID = 80;
 
 	public $width = 0.5;
-	public $length = 0.5;
 	public $height = 0.5;
 
 	protected $gravity = 0.05;

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -296,8 +296,6 @@ abstract class Entity extends Location implements Metadatable{
 	public $height;
 	/** @var float */
 	public $width;
-	/** @var float */
-	public $length;
 
 	/** @var float */
 	protected $baseOffset = 0.0;

--- a/src/pocketmine/entity/FallingSand.php
+++ b/src/pocketmine/entity/FallingSand.php
@@ -38,7 +38,6 @@ class FallingSand extends Entity{
 	const NETWORK_ID = 66;
 
 	public $width = 0.98;
-	public $length = 0.98;
 	public $height = 0.98;
 
 	protected $baseOffset = 0.49;

--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -59,7 +59,6 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 	protected $rawUUID;
 
 	public $width = 0.6;
-	public $length = 0.6;
 	public $height = 1.8;
 	public $eyeHeight = 1.62;
 

--- a/src/pocketmine/entity/Item.php
+++ b/src/pocketmine/entity/Item.php
@@ -46,7 +46,6 @@ class Item extends Entity{
 	protected $item;
 
 	public $width = 0.25;
-	public $length = 0.25;
 	public $height = 0.25;
 	protected $baseOffset = 0.125;
 

--- a/src/pocketmine/entity/PrimedTNT.php
+++ b/src/pocketmine/entity/PrimedTNT.php
@@ -35,7 +35,6 @@ class PrimedTNT extends Entity implements Explosive{
 	const NETWORK_ID = 65;
 
 	public $width = 0.98;
-	public $length = 0.98;
 	public $height = 0.98;
 
 	protected $baseOffset = 0.49;

--- a/src/pocketmine/entity/Snowball.php
+++ b/src/pocketmine/entity/Snowball.php
@@ -32,7 +32,6 @@ class Snowball extends Projectile{
 	const NETWORK_ID = 81;
 
 	public $width = 0.25;
-	public $length = 0.25;
 	public $height = 0.25;
 
 	protected $gravity = 0.03;

--- a/src/pocketmine/entity/Squid.php
+++ b/src/pocketmine/entity/Squid.php
@@ -36,7 +36,6 @@ class Squid extends WaterAnimal{
 	const NETWORK_ID = 17;
 
 	public $width = 0.95;
-	public $length = 0.95;
 	public $height = 0.95;
 
 	/** @var Vector3 */

--- a/src/pocketmine/entity/Villager.php
+++ b/src/pocketmine/entity/Villager.php
@@ -38,7 +38,6 @@ class Villager extends Creature implements NPC, Ageable{
 	const NETWORK_ID = 15;
 
 	public $width = 0.6;
-	public $length = 0.6;
 	public $height = 1.8;
 
 	public function getName() : string{

--- a/src/pocketmine/entity/Zombie.php
+++ b/src/pocketmine/entity/Zombie.php
@@ -33,7 +33,6 @@ class Zombie extends Monster{
 	const NETWORK_ID = 32;
 
 	public $width = 0.6;
-	public $length = 0.6;
 	public $height = 1.8;
 
 	public function getName() : string{


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This commit removes an unused variable (Entity->length). I believe this was supposed to be an alias to Entity->width, would still be a bad idea.

### API changes
<!-- Any additions to the API that should be documented in release notes? -->
None
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
None
## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
This commit is backwards compatible.
