### PR TITLE
ServerScheduler::scheduleAsyncTask() returns the worker used

### DIFF
--- a/src/pocketmine/scheduler/AsyncPool.php
+++ b/src/pocketmine/scheduler/AsyncPool.php
@@ -47,7 +47,7 @@ class AsyncPool{
 		$this->server = $server;
 		$this->size = $size;
 
-		$memoryLimit =  (int) max(-1, (int) $this->server->getProperty("memory.async-worker-hard-limit", 1024));
+		$memoryLimit = (int) max(-1, (int) $this->server->getProperty("memory.async-worker-hard-limit", 1024));
 
 		for($i = 0; $i < $this->size; ++$i){
 			$this->workerUsage[$i] = 0;
@@ -92,9 +92,9 @@ class AsyncPool{
 		$this->taskWorkers[$task->getTaskId()] = $worker;
 	}
 
-	public function submitTask(AsyncTask $task){
+	public function submitTask(AsyncTask $task) : int{
 		if(isset($this->tasks[$task->getTaskId()]) or $task->isGarbage()){
-			return;
+			return -1;
 		}
 
 		$selectedWorker = mt_rand(0, $this->size - 1);
@@ -107,6 +107,7 @@ class AsyncPool{
 		}
 
 		$this->submitTaskToWorker($task, $selectedWorker);
+		return $selectedWorker;
 	}
 
 	private function removeTask(AsyncTask $task, bool $force = false){

--- a/src/pocketmine/scheduler/ServerScheduler.php
+++ b/src/pocketmine/scheduler/ServerScheduler.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 /**
  * Task scheduling related classes
  */
+
 namespace pocketmine\scheduler;
 
 use pocketmine\plugin\Plugin;
@@ -75,16 +76,16 @@ class ServerScheduler{
 	 *
 	 * @param AsyncTask $task
 	 *
-	 * @return void
+	 * @return int
 	 */
-	public function scheduleAsyncTask(AsyncTask $task){
+	public function scheduleAsyncTask(AsyncTask $task) : int{
 		if($task->getTaskId() !== null){
 			throw new \UnexpectedValueException("Attempt to schedule the same AsyncTask instance twice");
 		}
 		$id = $this->nextId();
 		$task->setTaskId($id);
 		$task->progressUpdates = new \Threaded;
-		$this->asyncPool->submitTask($task);
+		return $this->asyncPool->submitTask($task);
 	}
 
 	/**


### PR DESCRIPTION
## Introduction
Plugins might want to keep on using the same AsyncWorker after the first AsyncTask.

A downside is that this may encourage abuse by throttling a certain AsyncWorker.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
`ServerScheduler::scheduleAsyncTask()` and `AsyncPool::submitTask` now return an `int`, which is the worker ID assigned for the task, unless it is rejected, which returns `-1`.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
nil

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
None, unless some classes extend AsyncWorker.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
nil

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
None yet. I admit that I am lazy.