### PR TITLE
Stop clearing chunk cache after 768 batched packets are cached.

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -893,21 +893,15 @@ class Level implements ChunkManager, Metadatable{
 		$this->server->batchPackets($target, $packets, false, false);
 	}
 
-	public function clearCache(bool $full = false){
-		if($full){
+	public function clearCache(bool $force = false){
+		if($force){
 			$this->chunkCache = [];
 			$this->blockCache = [];
 		}else{
-			if(count($this->chunkCache) > 768){
-				$this->chunkCache = [];
-			}
-
 			if(count($this->blockCache) > 2048){
 				$this->blockCache = [];
 			}
-
 		}
-
 	}
 
 	public function clearChunkCache(int $chunkX, int $chunkZ){


### PR DESCRIPTION
### Introduction
This should not need to be cleared after 768 batched packets are cached since cached chunks are automatically removed from cache when the actual chunk unloads.

At worst, memory manager will clear the cache by force if the user correctly set his/hers memory limits, though chunk cache itself does not use much memory.

Changes:
- Stop clearing cache after the array meets a size threshold of 768 packets.
- Renamed the $full parameter to $force because it sounds more accurate.