### PR TITLE
Fix errors on AxisAlignedBB, caused by null $x,y,z

### DIFF
--- a/src/pocketmine/block/Block.php
+++ b/src/pocketmine/block/Block.php
@@ -473,6 +473,9 @@ class Block extends Position implements BlockIds, Metadatable{
 	 * @return AxisAlignedBB|null
 	 */
 	protected function recalculateBoundingBox(){
+		if($this->x === null || $this->y === null || $this->z === null){
+			return null;
+		}
 		return new AxisAlignedBB(
 			$this->x,
 			$this->y,


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Original error was: 
```[01:51:15] [Server thread/CRITICAL]: TypeError: "Argument 1 passed to pocketmine\math\AxisAlignedBB::__construct() must be of the type float, null given, called in /home/mrgenga/prizik/src/pocketmine/block/Block.php on line 748" (EXCEPTION) in "src/pocketmine/math/AxisAlignedBB" at line 43```
### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1248

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
No.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
No.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
No.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
Nothing.

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
I successfully loaded my map after this change.