### PR TITLE
Remove leftover Level::Y_MASK mess

### DIFF
--- a/src/pocketmine/level/Explosion.php
+++ b/src/pocketmine/level/Explosion.php
@@ -118,13 +118,13 @@ class Explosion{
 								}
 							}
 
-							$blockId = $currentSubChunk->getBlockId($vBlock->x & 0x0f, $vBlock->y & 0x0f, $vBlock->z & 0x0f);
+							$blockId = $currentSubChunk->getBlockId($vBlock->x & 0x0f, $vBlock->y, $vBlock->z & 0x0f);
 
 							if($blockId !== 0){
 								$blastForce -= (BlockFactory::$blastResistance[$blockId] / 5 + 0.3) * $this->stepLen;
 								if($blastForce > 0){
 									if(!isset($this->affectedBlocks[$index = Level::blockHash($vBlock->x, $vBlock->y, $vBlock->z)])){
-										$this->affectedBlocks[$index] = BlockFactory::get($blockId, $currentSubChunk->getBlockData($vBlock->x & 0x0f, $vBlock->y & 0x0f, $vBlock->z & 0x0f), $vBlock);
+										$this->affectedBlocks[$index] = BlockFactory::get($blockId, $currentSubChunk->getBlockData($vBlock->x & 0x0f, $vBlock->y, $vBlock->z & 0x0f), $vBlock);
 									}
 								}
 							}


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

This commit removes leftover Y_MASK (places where literal "0x0f"s were used).
Reference: https://github.com/pmmp/PocketMine-MP/commit/0f79b19fdcc8934756b4cbc6994896c918b58788
### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
None.
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
None.
## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
This PR is backwards compatible.
## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
Ignite TNT.