### PR TITLE
Disallow large-chests from opening when a non-transparent block is above

### DIFF
--- a/src/pocketmine/block/Chest.php
+++ b/src/pocketmine/block/Chest.php
@@ -136,18 +136,11 @@ class Chest extends Transparent{
 
 	public function onActivate(Item $item, Player $player = null) : bool{
 		if($player instanceof Player){
-			$top = $this->getSide(Vector3::SIDE_UP);
-			if(!$top->isTransparent()){
-				return true;
-			}
 
 			$t = $this->getLevel()->getTile($this);
 			$chest = null;
 			if($t instanceof TileChest){
 				$chest = $t;
-				if($chest->getPair() instanceof TileChest and !$chest->getPair()->getBlock()->getSide(Vector3::SIDE_UP)->isTransparent()){
-					return true;
-				}
 			}else{
 				$nbt = new CompoundTag("", [
 					new ListTag("Items", []),
@@ -160,10 +153,12 @@ class Chest extends Transparent{
 				$chest = Tile::createTile("Chest", $this->getLevel(), $nbt);
 			}
 
-			if(isset($chest->namedtag->Lock) and $chest->namedtag->Lock instanceof StringTag){
-				if($chest->namedtag->Lock->getValue() !== $item->getCustomName()){
-					return true;
-				}
+			if(
+				!$this->getSide(Vector3::SIDE_UP)->isTransparent() or
+				($chest->isPaired() and !$chest->getPair()->getBlock()->getSide(Vector3::SIDE_UP)->isTransparent()) or
+				(isset($chest->namedtag->Lock) and $chest->namedtag->Lock instanceof StringTag and $chest->namedtag->Lock->getValue() !== $item->getCustomName())
+			){
+				return true;
 			}
 
 			$player->addWindow($chest->getInventory());

--- a/src/pocketmine/block/Chest.php
+++ b/src/pocketmine/block/Chest.php
@@ -137,7 +137,7 @@ class Chest extends Transparent{
 	public function onActivate(Item $item, Player $player = null) : bool{
 		if($player instanceof Player){
 			$top = $this->getSide(Vector3::SIDE_UP);
-			if($top->isTransparent() !== true){
+			if(!$top->isTransparent()){
 				return true;
 			}
 
@@ -145,6 +145,9 @@ class Chest extends Transparent{
 			$chest = null;
 			if($t instanceof TileChest){
 				$chest = $t;
+				if($chest->getPair() instanceof TileChest and !$chest->getPair()->getBlock()->getSide(Vector3::SIDE_UP)->isTransparent()){
+					return true;
+				}
 			}else{
 				$nbt = new CompoundTag("", [
 					new ListTag("Items", []),


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

In PocketMine, you can open double chests having a non-transparent block above them. This goes against the vanilla MCPE behaviour.


### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

* Fixes #1165

## Changes
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
Large chests having a non-transparent block above either of the chests cannot be opened.

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
**Can be opened:**
- Place slabs/glowstone above one side of a double chest.
-  Place slabs/glowstone above both sides of the double chest.

**Cannot be opened:**
- Place stone above one side of a double chest.
- Place stone above both sides of the double chest.