### PR TITLE
Fix Endless cake bug

### DIFF
--- a/src/pocketmine/block/Cake.php
+++ b/src/pocketmine/block/Cake.php
@@ -90,7 +90,7 @@ class Cake extends Transparent implements FoodSource{
 	}
 
 	public function onActivate(Item $item, Player $player = null) : bool{
-		if($player instanceof Player and $player->getHealth() < $player->getMaxHealth()){
+		if($player instanceof Player and $player->getFood() < $player->getMaxFood()){
 			$ev = new EntityEatBlockEvent($player, $this);
 
 			if(!$ev->isCancelled()){


### PR DESCRIPTION
## Introduction
This fixes the typo causing the Endless cake bug...

### Relevant issues
No issues have reported this yet... But you can test it for yourself.

## Tests
1. Place a cake down.
2. Eat the cake. (Your food level needs to be lower than the maximum food level)
   - You can use this command to get you hungry without the long wait:
     ```/effect <playername> hunger 1 255```

## Screenshot of this PR working
![image](https://user-images.githubusercontent.com/17762324/29923683-ff155004-8e1f-11e7-8630-4b474c5e7713.png)

