### PR TITLE
Fixed plugins with unknown dependencies saying they have circular dep…

### DIFF
--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -306,7 +306,8 @@ class PluginManager{
 									$name,
 									$this->server->getLanguage()->translateString("%pocketmine.plugin.unknownDependency", [$dependency])
 								]));
-								break;
+								unset($plugins[$name]);
+								continue 2;
 							}
 						}
 


### PR DESCRIPTION
…endencies, close #356

## Introduction
see #356 

At this point in the load order we already know all available plugins which might be loaded. If a plugin is found to have a missing dependency, it will not be able to be loaded, so it should be removed from the list of plugins to attempt to load, and continue to the next plugin.

Please excuse this fix coming after so long, nobody wanted to go near this code because it's so spaghettified. I am also not 100% sure this won't have side-effects - please test and review.

### Relevant issues
fixes #356 

## Changes
1x behavioural bugfix, 0x breaking API changes

## Tests
This plugin.yml will correctly report a circular dependency and will not be loaded:
```
name: test
main: dktapps\test\Main
version: 0.0.1
api: [3.0.0-ALPHA7]
load: POSTWORLD
depend: [test]
commands:
 examplecommand:
  description: "Skeleton plugin example command"
  usage: "/examplecommand"
  permission: skeleton.command
permissions:
 skeleton:
  default: true
  description: "Example root permission node"
  children:
   skeleton.command:
    default: true
    description: "Allows the use of /examplecommand"
```

this will report, ONE TIME ONLY, that a dependency is missing and will not be loaded
```
name: test
main: dktapps\test\Main
version: 0.0.1
api: [3.0.0-ALPHA7]
load: POSTWORLD
depend: [somePluginThatDoesntExist]
commands:
 examplecommand:
  description: "Skeleton plugin example command"
  usage: "/examplecommand"
  permission: skeleton.command
permissions:
 skeleton:
  default: true
  description: "Example root permission node"
  children:
   skeleton.command:
    default: true
    description: "Allows the use of /examplecommand"
```