### PR TITLE
Fix error on Chunk::getTile()

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1915,10 +1915,10 @@ class Level implements ChunkManager, Metadatable{
 	 * @return Tile|null
 	 */
 	public function getTile(Vector3 $pos){
-		$chunk = $this->getChunk($pos->x >> 4, $pos->z >> 4, false);
+		$chunk = $this->getChunk((int) $pos->x >> 4,(int) $pos->z >> 4, false);
 
 		if($chunk !== null){
-			return $chunk->getTile($pos->x & 0x0f, $pos->y, $pos->z & 0x0f);
+			return $chunk->getTile((int) $pos->x & 0x0f,(int) $pos->y,(int) $pos->z & 0x0f);
 		}
 
 		return null;


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
If use method Chunk::getTile(), happen error.
So, I fix this error.

Error : 
```
[14:36:53] [Server thread/CRITICAL]: /set에서 명령어 '/set 0'을 실행하는 중 예외가 발생했습니다: Argument 2 passed to pocketmine\level\format\Chunk::getTile() must be of the type integer, string given, called in phar:///home/swiftnode/leo/PocketMine-MP.phar/src/pocketmine/level/Level.php on line 1920
[14:36:53] [Server thread/CRITICAL]: TypeError: "Argument 2 passed to pocketmine\level\format\Chunk::getTile() must be of the type integer, string given, called in phar:///home/swiftnode/leo/PocketMine-MP.phar/src/pocketmine/level/Level.php on line 1920" (EXCEPTION) in "src/pocketmine/level/format/Chunk" at line 686
```

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
I change Chunk::getTile().

## Backwards compatibility
compatibility


## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations: no

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
It works good. not occur error