### PR TITLE
Overrides add function to return an object of the same class

### DIFF
--- a/src/pocketmine/level/Location.php
+++ b/src/pocketmine/level/Location.php
@@ -88,4 +88,19 @@ class Location extends Position{
 		}
 		return parent::equals($v);
 	}
+    
+    /**
+     * @param Vector3|int $x
+     * @param int         $y
+     * @param int         $z
+     *
+     * @return Location
+     */
+    public function add($x, $y = 0, $z = 0){
+        if($x instanceof Vector3){
+            return new Location($this->x + $x->x, $this->y + $x->y, $this->z + $x->z, $this->yaw, $this->pitch, $this->level);
+        }else{
+            return new Location($this->x + $x, $this->y + $y, $this->z + $z, $this->yaw, $this->pitch, $this->level);
+        }
+    }
 }

--- a/src/pocketmine/level/Position.php
+++ b/src/pocketmine/level/Position.php
@@ -139,4 +139,19 @@ class Position extends Vector3{
 		}
 		return parent::equals($v);
 	}
+    
+    /**
+     * @param Vector3|int $x
+     * @param int         $y
+     * @param int         $z
+     *
+     * @return Position
+     */
+    public function add($x, $y = 0, $z = 0){
+        if($x instanceof Vector3){
+            return new Position($this->x + $x->x, $this->y + $x->y, $this->z + $x->z, $this->level);
+        }else{
+            return new Position($this->x + $x, $this->y + $y, $this->z + $z, $this->level);
+        }
+    }
 }


### PR DESCRIPTION
With the current PocketMine-MP Location/Position classes, if you call "add" or "substract" functions on a Position/Location instance, it'll return a Vector3 instance instead an object of the same class.