### PR TITLE
Update Grass.php

### DIFF
--- a/src/pocketmine/block/Grass.php
+++ b/src/pocketmine/block/Grass.php
@@ -65,6 +65,10 @@ class Grass extends Solid{
 
 	public function onUpdate(int $type){
 		if($type === Level::BLOCK_UPDATE_RANDOM){
+			if($this->getSide(Vector3::SIDE_UP)->getId()===Block::SUGARCANE_BLOCK){
+				return Level::BLOCK_UPDATE_RANDOM;
+			}
+			
 			$lightAbove = $this->level->getFullLightAt($this->x, $this->y + 1, $this->z);
 			if($lightAbove < 4 and BlockFactory::$lightFilter[$this->level->getBlockIdAt($this->x, $this->y + 1, $this->z)] >= 3){ //2 plus 1 standard filter amount
 				//grass dies


### PR DESCRIPTION
Sorry for formatting, quickfix for Sugarcane killing grass block which should not happen in my opinon. Maybe a fix in the lightning code would also fix this instead of this quickfix

## Introduction
Grass simply turns to Dirt when a Sugarcane block is above it.

### Relevant issues
<!-- List relevant issues here -->
Didn't find any issue, also this is not a major issue or some kind of that.