### PR TITLE
Quoted command args & allow playernames with spaces

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -184,7 +184,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	public static function isValidUserName(string $name) : bool{
 		$lname = strtolower($name);
 		$len = strlen($name);
-		return $lname !== "rcon" and $lname !== "console" and $len >= 1 and $len <= 16 and preg_match("/[^A-Za-z0-9_]/", $name) === 0;
+		return $lname !== "rcon" and $lname !== "console" and $len >= 1 and $len <= 16 and preg_match("/[^A-Za-z0-9_ ]/", $name) === 0;
 	}
 
 	/**

--- a/src/pocketmine/command/SimpleCommandMap.php
+++ b/src/pocketmine/command/SimpleCommandMap.php
@@ -223,7 +223,7 @@ class SimpleCommandMap implements CommandMap{
 	}
 
 	public function dispatch(CommandSender $sender, string $commandLine) : bool{
-		$args = explode(" ", $commandLine);
+		$args = array_map("stripslashes", str_getcsv($commandLine, " "));
 		$sentCommandLabel = "";
 		$target = $this->matchCommand($sentCommandLabel, $args);
 


### PR DESCRIPTION
## Introduction
blah

## Changes
### API changes
- Plugins handling commands may now receive string arguments containing spaces.

<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
- players with spaces can now be handled on a server
- allow quoting any string in a command to instruct the parser to treat it as a single argument
<!-- Any change in how the server behaves, or its performance? -->

I suppose I should mention this or someone is guaranteed to say something about it: If you, for whatever reason, previously happened to use quotes in command arguments for some reason, you will now need to escape those quotes using a backslash (`\`).
This currently also applies to things like `/say` where the argument should be rawtext and therefore quotes shouldn't be needed (this issue will be resolved when the new command API is written).

## Backwards compatibility
probably some issues, but I'm tired... TBD

## Tests
- tested joining with username `l o l`
- tested with `/op "l o l"`, works correctly
