### PR TITLE
Make use of awesome new pack() codes for floats

### DIFF
--- a/src/pocketmine/utils/Binary.php
+++ b/src/pocketmine/utils/Binary.php
@@ -285,7 +285,7 @@ class Binary{
 	 */
 	public static function readFloat(string $str) : float{
 		self::checkLength($str, 4);
-		return (ENDIANNESS === self::BIG_ENDIAN ? unpack("f", $str)[1] : unpack("f", strrev($str))[1]);
+		return unpack("G", $str)[1];
 	}
 
 	/**
@@ -307,7 +307,7 @@ class Binary{
 	 * @return string
 	 */
 	public static function writeFloat(float $value) : string{
-		return ENDIANNESS === self::BIG_ENDIAN ? pack("f", $value) : strrev(pack("f", $value));
+		return pack("G", $value);
 	}
 
 	/**
@@ -318,7 +318,7 @@ class Binary{
 	 */
 	public static function readLFloat(string $str) : float{
 		self::checkLength($str, 4);
-		return (ENDIANNESS === self::BIG_ENDIAN ? unpack("f", strrev($str))[1] : unpack("f", $str)[1]);
+		return unpack("g", $str)[1];
 	}
 
 	/**
@@ -340,7 +340,7 @@ class Binary{
 	 * @return string
 	 */
 	public static function writeLFloat(float $value) : string{
-		return ENDIANNESS === self::BIG_ENDIAN ? strrev(pack("f", $value)) : pack("f", $value);
+		return pack("g", $value);
 	}
 
 	/**
@@ -361,7 +361,7 @@ class Binary{
 	 */
 	public static function readDouble(string $str) : float{
 		self::checkLength($str, 8);
-		return ENDIANNESS === self::BIG_ENDIAN ? unpack("d", $str)[1] : unpack("d", strrev($str))[1];
+		return unpack("E", $str)[1];
 	}
 
 	/**
@@ -371,7 +371,7 @@ class Binary{
 	 * @return string
 	 */
 	public static function writeDouble(float $value) : string{
-		return ENDIANNESS === self::BIG_ENDIAN ? pack("d", $value) : strrev(pack("d", $value));
+		return pack("E", $value);
 	}
 
 	/**
@@ -382,7 +382,7 @@ class Binary{
 	 */
 	public static function readLDouble(string $str) : float{
 		self::checkLength($str, 8);
-		return ENDIANNESS === self::BIG_ENDIAN ? unpack("d", strrev($str))[1] : unpack("d", $str)[1];
+		return unpack("e", $str)[1];
 	}
 
 	/**
@@ -391,7 +391,7 @@ class Binary{
 	 * @return string
 	 */
 	public static function writeLDouble(float $value) : string{
-		return ENDIANNESS === self::BIG_ENDIAN ? strrev(pack("d", $value)) : pack("d", $value);
+		return pack("e", $value);
 	}
 
 	/**


### PR DESCRIPTION
## Introduction
PHP 7.0.15, 7.1.1 and 7.2.0 introduce new pack()/unpack() codes for floats which are non-dependent on machine endianness.

Why these were never a thing sooner, I do not know, but this PR removes endianness checks for writing floats and replaces them with their fixed endian replacements.

The new codes are as follows:
- `e`: Little-endian double
- `E`: Big-endian double
- `g`: Little-endian float
- `G`: Big-endian float

## Changes
There should be no behavioural changes, however we really need more unit tests...

## Backwards compatibility
No issues since we're already requiring PHP 7.2.

## Follow-up
The same changes can be made to RakLib `Binary`, although it would be preferable to pull this code out into its own library.
## Tests
TBD
