### PR TITLE
Implemented FloatingTextParticle as an entity

### DIFF
--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -238,6 +238,7 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 		Entity::registerEntity(Zombie::class, false, ['Zombie',	'minecraft:zombie']);
 
 		Entity::registerEntity(Human::class, true);
+		Entity::registerEntity(FloatingText::class, true);
 	}
 
 

--- a/src/pocketmine/entity/FloatingText.php
+++ b/src/pocketmine/entity/FloatingText.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\entity;
+
+use pocketmine\item\Item as ItemItem;
+use pocketmine\item\ItemFactory;
+use pocketmine\nbt\tag\StringTag;
+use pocketmine\network\mcpe\protocol\AddPlayerPacket;
+use pocketmine\Player;
+use pocketmine\utils\UUID;
+
+class FloatingText extends Entity{
+
+	protected $title;
+	protected $text;
+
+	protected function initEntity(){
+		parent::initEntity();
+
+		$this->setTitle($this->namedtag["Title"] ?? "");
+		$this->setText($this->namedtag["Text"] ?? "");
+
+		$this->setNameTagVisible();
+		$this->setNameTagAlwaysVisible();
+		$this->setScale(0.01);
+	}
+
+	public function getTitle() : string{
+		return $this->title;
+	}
+
+	public function setTitle(string $title) : void{
+		$this->title = $title;
+
+		$this->updateNameTag();
+	}
+
+	public function getText() : string{
+		return $this->text;
+	}
+
+	public function setText(string $text) : void{
+		$this->text = $text;
+
+		$this->updateNameTag();
+	}
+
+	private function updateNameTag() : void{
+		$this->setNameTag($this->title . ($this->text !== "" ? "\n$this->text" : ""));
+	}
+
+	public function saveNBT(){
+		parent::saveNBT();
+
+		$this->namedtag->Title = new StringTag("Title", $this->title);
+		$this->namedtag->Text = new StringTag("Text", $this->text);
+	}
+
+	public function onUpdate(int $currentTick) : bool{
+		return false; //Don't ever tick FloatingText
+	}
+
+	public function canCollideWith(Entity $entity) : bool{
+		return false;
+	}
+
+	public function spawnTo(Player $player){
+		$pk = new AddPlayerPacket();
+		$pk->uuid = UUID::fromRandom();
+		$pk->username = "";
+		$pk->entityRuntimeId = $this->id;
+		$pk->position = $this->asVector3(); //TODO: check offset
+		$pk->item = ItemFactory::get(ItemItem::AIR, 0, 0);
+		$pk->metadata = $this->dataProperties;
+
+		$player->dataPacket($pk);
+
+		parent::spawnTo($player);
+	}
+}

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -29,6 +29,7 @@ namespace pocketmine\level;
 use pocketmine\block\Block;
 use pocketmine\block\BlockFactory;
 use pocketmine\entity\Entity;
+use pocketmine\entity\FloatingText;
 use pocketmine\entity\Item as DroppedItem;
 use pocketmine\entity\object\ExperienceOrb;
 use pocketmine\entity\projectile\Arrow;
@@ -1665,6 +1666,26 @@ class Level implements ChunkManager, Metadatable{
 		}
 
 		return $orbs;
+	}
+
+	/**
+	 * @param Vector3 $pos
+	 * @param string  $text
+	 * @param string  $title
+	 *
+	 * @return null|Entity
+	 */
+	public function addFloatingText(Vector3 $pos, string $text, string $title = ""){
+		$entity = Entity::createEntity("FloatingText", $this, Entity::createBaseNBT($pos));
+		assert($entity !== null);
+
+		if($entity instanceof FloatingText){
+			$entity->setTitle($title);
+			$entity->setText($text);
+		}
+
+		$entity->spawnToAll();
+		return $entity;
 	}
 
 	/**

--- a/src/pocketmine/level/particle/FloatingTextParticle.php
+++ b/src/pocketmine/level/particle/FloatingTextParticle.php
@@ -33,6 +33,9 @@ use pocketmine\network\mcpe\protocol\PlayerSkinPacket;
 use pocketmine\network\mcpe\protocol\RemoveEntityPacket;
 use pocketmine\utils\UUID;
 
+/**
+ * @deprecated Use {@link Level#addFloatingText} instead of this, this implementation has issues which cannot be resolved.
+ */
 class FloatingTextParticle extends Particle{
 	//TODO: HACK!
 


### PR DESCRIPTION
This offers several major advantages over the original implementation:
- it will be automatically spawned to players when they join or get within viewing distance
- it will be automatically (de)spawned to players when changing levels
- it will be saved to disk with the world, so no need to recreate it

## Changes
### API changes
- Added `FloatingText` entity
- Added `Level->addFloatingText(Vector3, string, string)`
- Deprecated `FloatingTextParticle`

## Backwards compatibility
- Currently backwards compatible, but I don't intend to maintain the old implementation. When it breaks next time, get ready to move to the new version.

## Tests
TBD
