### PR TITLE
Fix #145, take 2 (slab placement in half gaps doesn't work)

### DIFF
--- a/src/pocketmine/block/Block.php
+++ b/src/pocketmine/block/Block.php
@@ -160,6 +160,10 @@ class Block extends Position implements BlockIds, Metadatable{
 		return false;
 	}
 
+	public function canBePlacedAt(Block $blockReplace, Vector3 $clickVector) : bool{
+		return $blockReplace->canBeReplaced();
+	}
+
 	/**
 	 * Places the Block, using block space and block target, and side. Returns if the block has been placed.
 	 *

--- a/src/pocketmine/block/WoodenSlab.php
+++ b/src/pocketmine/block/WoodenSlab.php
@@ -78,6 +78,18 @@ class WoodenSlab extends Transparent{
 		}
 	}
 
+	public function canBePlacedAt(Block $blockReplace, Vector3 $clickVector) : bool{
+		return parent::canBePlacedAt($blockReplace, $clickVector) or
+			(
+				$blockReplace->getId() === $this->getId() and
+				$blockReplace->getVariant() === $this->getVariant() and
+				(
+					(($blockReplace->getDamage() & 0x08) !== 0 and ($clickVector->y <= 0.5 or $clickVector->y === 1.0)) or //top slab, fill bottom half
+					(($blockReplace->getDamage() & 0x08) === 0 and ($clickVector->y >= 0.5 or $clickVector->y === 0.0)) //bottom slab, fill top half
+				)
+			);
+	}
+
 	public function place(Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $facePos, Player $player = null) : bool{
 		$this->meta &= 0x07;
 		if($face === Vector3::SIDE_DOWN){

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1774,14 +1774,11 @@ class Level implements ChunkManager, Metadatable{
 			return false;
 		}
 
-		if(!($blockReplace->canBeReplaced() === true or ($hand->getId() === Item::WOODEN_SLAB and $blockReplace->getId() === Item::WOODEN_SLAB) or ($hand->getId() === Item::STONE_SLAB and $blockReplace->getId() === Item::STONE_SLAB))){
-			return false;
-		}
-
-		if($blockClicked->canBeReplaced() === true){
+		if($hand->canBePlacedAt($blockClicked, $facePos)){
 			$blockReplace = $blockClicked;
 			$hand->position($blockReplace);
-			//$face = -1;
+		}elseif(!$hand->canBePlacedAt($blockReplace, $facePos)){
+			return false;
 		}
 
 		if($hand->isSolid() === true and $hand->getBoundingBox() !== null){


### PR DESCRIPTION
## Introduction
Since I screwed up the fix for this the first time, being more careful this time.

### Relevant issues
fixes #145

## Changes
### API changes
- added method `Block->canBePlacedAt(Block, Vector3)`

### Behavioural changes
- placing slabs in half-gaps now works as expected

## Tests
confirmed that this fixes #145, and does not recreate #1314 , but this required more code to fix than anticipated, so there might be other issues that I haven't spotted. Please test and review.
