### PR TITLE
Fix coloured message

### DIFF
--- a/src/pocketmine/Achievement.php
+++ b/src/pocketmine/Achievement.php
@@ -115,7 +115,7 @@ abstract class Achievement{
 	 */
 	public static function broadcast(Player $player, string $achievementId) : bool{
 		if(isset(Achievement::$list[$achievementId])){
-			$translation = new TranslationContainer("chat.type.achievement", [$player->getDisplayName(), TextFormat::GREEN . Achievement::$list[$achievementId]["name"] . TextFormat::RESET]);
+			$translation = new TranslationContainer("chat.type.achievement", [$player->getDisplayName(), TextFormat::GREEN . Achievement::$list[$achievementId]["name"] . TextFormat::WHITE]);
 			if(Server::getInstance()->getConfigBoolean("announce-player-achievements", true) === true){
 				Server::getInstance()->broadcastMessage($translation);
 			}else{

--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -1497,7 +1497,7 @@ class Server{
 
 			$this->memoryManager = new MemoryManager($this);
 
-			$this->logger->info($this->getLanguage()->translateString("pocketmine.server.start", [TextFormat::AQUA . $this->getVersion() . TextFormat::RESET]));
+			$this->logger->info($this->getLanguage()->translateString("pocketmine.server.start", [TextFormat::AQUA . $this->getVersion() . TextFormat::WHITE]));
 
 			if(($poolSize = $this->getProperty("settings.async-workers", "auto")) === "auto"){
 				$poolSize = ServerScheduler::$WORKERS;


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
I thought I fixed it on #910, but I didn't think about if TextFormat::RESET is used on console, it'll change to gray, not white like in client. (Haven't tested it on second part (when I changed it from white to reset) because I thought it has no problem, sorry)

~~Blame @Muqsit!! feat. dktapps - BlameShoghicp Records~~

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
Nothing.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Nothing.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
Now these two messages are shown as expected.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Nothing.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
Probably also fix stuffs like server reload command message.

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
Works fine. Tested on local.
