### PR TITLE
Added API to allow flagging an entity not to be saved to disk when it…

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3376,6 +3376,14 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		return [];
 	}
 
+	public function canSaveWithChunk() : bool{
+		return false;
+	}
+
+	public function setCanSaveWithChunk(bool $value) : void{
+		throw new \BadMethodCallException("Players can't be saved with chunks");
+	}
+
 	/**
 	 * Handles player data saving
 	 *

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -338,6 +338,9 @@ abstract class Entity extends Location implements Metadatable{
 	protected $isStatic = false;
 
 	/** @var bool */
+	private $savedWithChunk = true;
+
+	/** @var bool */
 	public $isCollided = false;
 	/** @var bool */
 	public $isCollidedHorizontally = false;
@@ -762,6 +765,24 @@ abstract class Entity extends Location implements Metadatable{
 		}
 
 		return false;
+	}
+
+	/**
+	 * Returns whether this entity will be saved when its chunk is unloaded.
+	 * @return bool
+	 */
+	public function canSaveWithChunk() : bool{
+		return $this->savedWithChunk;
+	}
+
+	/**
+	 * Sets whether this entity will be saved when its chunk is unloaded. This can be used to prevent the entity being
+	 * saved to disk.
+	 *
+	 * @param bool $value
+	 */
+	public function setCanSaveWithChunk(bool $value) : void{
+		$this->savedWithChunk = $value;
 	}
 
 	/**

--- a/src/pocketmine/level/format/io/region/Anvil.php
+++ b/src/pocketmine/level/format/io/region/Anvil.php
@@ -71,7 +71,7 @@ class Anvil extends McRegion{
 		$entities = [];
 
 		foreach($chunk->getEntities() as $entity){
-			if(!($entity instanceof Player) and !$entity->isClosed()){
+			if($entity->canSaveWithChunk() and !$entity->isClosed()){
 				$entity->saveNBT();
 				$entities[] = $entity->namedtag;
 			}

--- a/src/pocketmine/level/format/io/region/McRegion.php
+++ b/src/pocketmine/level/format/io/region/McRegion.php
@@ -89,7 +89,7 @@ class McRegion extends BaseLevelProvider{
 		$entities = [];
 
 		foreach($chunk->getEntities() as $entity){
-			if(!($entity instanceof Player) and !$entity->isClosed()){
+			if($entity->canSaveWithChunk() and !$entity->isClosed()){
 				$entity->saveNBT();
 				$entities[] = $entity->namedtag;
 			}

--- a/src/pocketmine/level/format/io/region/PMAnvil.php
+++ b/src/pocketmine/level/format/io/region/PMAnvil.php
@@ -74,7 +74,7 @@ class PMAnvil extends Anvil{
 		$entities = [];
 
 		foreach($chunk->getEntities() as $entity){
-			if(!($entity instanceof Player) and !$entity->isClosed()){
+			if($entity->canSaveWithChunk() and !$entity->isClosed()){
 				$entity->saveNBT();
 				$entities[] = $entity->namedtag;
 			}


### PR DESCRIPTION
…s chunk is saved

## Introduction
Sometimes plugins want to create an entity that only exists for the runtime of the server, and don't want the entity getting saved to disk.

Currently achieving this goal can be pretty challenging because plugins have to hook events to listen for chunk saving, and then remove any entities which they don't want saved. This can be particularly problematic during server shutdown, as plugins are disabled before levels are unloaded.

This PR adds the capability to allow flagging an entity as non-permanent so that it doesn't get saved to disk when the chunk is saved.

## Relevant issues
#1393 

## Changes
### API changes
- Added methods `Entity->canSaveWithChunk()` and `Entity->setCanSaveWithChunk()`
<!-- Any additions to the API that should be documented in release notes? -->

## Backwards compatibility
- No BC breaks here, only API additions.

## Tests
TBD
<!-- Attach scripts or actions to test this pull request, as well as the result -->
