### PR TITLE
Peaceful difficulty allows PvP

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2485,7 +2485,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 							}elseif($target instanceof Player){
 								if(($target->getGamemode() & 0x01) > 0){
 									return true;
-								}elseif($this->server->getConfigBoolean("pvp") !== true or $this->level->getDifficulty() === Level::DIFFICULTY_PEACEFUL){
+								}elseif($this->server->getConfigBoolean("pvp") !== true){
 									$cancelled = true;
 								}
 


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Worlds with peaceful difficulty not allows players to hit themself. 

## Changes
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
Now peaceful difficulty allows PvP.