### PR TITLE
Fix for explosions not removing tiles

### DIFF
--- a/src/pocketmine/level/Explosion.php
+++ b/src/pocketmine/level/Explosion.php
@@ -40,6 +40,8 @@ use pocketmine\math\Math;
 use pocketmine\math\Vector3;
 use pocketmine\network\mcpe\protocol\ExplodePacket;
 use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\tile\Chest;
+use pocketmine\tile\Container;
 use pocketmine\tile\Tile;
 
 class Explosion{
@@ -197,9 +199,11 @@ class Explosion{
 		$air = ItemFactory::get(Item::AIR);
 
 		foreach($this->affectedBlocks as $block){
+			$yieldDrops = false;
+
 			if($block instanceof TNT){
 				$block->ignite(mt_rand(10, 30));
-			}elseif(mt_rand(0, 100) < $yield){
+			}elseif($yieldDrops = (mt_rand(0, 100) < $yield)){
 				foreach($block->getDrops($air) as $drop){
 					$this->level->dropItem($block->add(0.5, 0.5, 0.5), $drop);
 				}
@@ -209,7 +213,20 @@ class Explosion{
 
 			$t = $this->level->getTile($block);
 			if($t instanceof Tile){
-				$this->level->removeTile($t);
+				if($yieldDrops and $t instanceof Container) {
+					if($t instanceof Chest){
+						$t->unpair();
+					}
+
+					$dropPos = $t->asVector3()->add(0.5, 0.5, 0.5);
+					foreach($t->getInventory()->getContents() as $drop) {
+						if(!$drop->isNull()){
+							$this->level->dropItem($dropPos, $drop);
+						}
+					}
+				}
+
+				$t->close();
 			}
 
 			$pos = new Vector3($block->x, $block->y, $block->z);

--- a/src/pocketmine/level/Explosion.php
+++ b/src/pocketmine/level/Explosion.php
@@ -40,6 +40,7 @@ use pocketmine\math\Math;
 use pocketmine\math\Vector3;
 use pocketmine\network\mcpe\protocol\ExplodePacket;
 use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\tile\Tile;
 
 class Explosion{
 
@@ -205,6 +206,11 @@ class Explosion{
 			}
 
 			$this->level->setBlockIdAt($block->x, $block->y, $block->z, 0);
+
+			$t = $this->level->getTile($block);
+			if($t instanceof Tile){
+				$this->level->removeTile($t);
+			}
 
 			$pos = new Vector3($block->x, $block->y, $block->z);
 

--- a/src/pocketmine/level/Explosion.php
+++ b/src/pocketmine/level/Explosion.php
@@ -213,13 +213,13 @@ class Explosion{
 
 			$t = $this->level->getTile($block);
 			if($t instanceof Tile){
-				if($yieldDrops and $t instanceof Container) {
+				if($yieldDrops and $t instanceof Container){
 					if($t instanceof Chest){
 						$t->unpair();
 					}
 
 					$dropPos = $t->asVector3()->add(0.5, 0.5, 0.5);
-					foreach($t->getInventory()->getContents() as $drop) {
+					foreach($t->getInventory()->getContents() as $drop){
 						if(!$drop->isNull()){
 							$this->level->dropItem($dropPos, $drop);
 						}


### PR DESCRIPTION
## Introduction
Prior to the commit below, blocks would be removed but any tiles attached to the block would remain (#1450).

### Relevant issues

* Fixes #1450

## Follow-up
Disclaimer: This does not fix tiles that have not been removed by previous explosions, you should use a plugin to achieve this.

## Tests
None – it's a pretty straightforward solution.
