### PR TITLE
Add ability to unregister a command completely

### DIFF
--- a/src/pocketmine/command/SimpleCommandMap.php
+++ b/src/pocketmine/command/SimpleCommandMap.php
@@ -180,10 +180,8 @@ class SimpleCommandMap implements CommandMap{
 	 * @return bool
 	 */
 	public function unregister(Command $command) : bool{
-		$label = $command->getLabel();
-
 		foreach($this->knownCommands as $lbl => $cmd) {
-			if($cmd->getLabel() === $label) {
+			if($cmd === $command) {
 				unset($this->knownCommands[$lbl]);
 			}
 		}

--- a/src/pocketmine/command/SimpleCommandMap.php
+++ b/src/pocketmine/command/SimpleCommandMap.php
@@ -176,6 +176,25 @@ class SimpleCommandMap implements CommandMap{
 
 	/**
 	 * @param Command $command
+	 *
+	 * @return bool
+	 */
+	public function unregister(Command $command) : bool{
+		$label = $command->getLabel();
+
+		foreach($this->knownCommands as $lbl => $cmd) {
+			if($cmd->getLabel() === $label) {
+				unset($this->knownCommands[$lbl]);
+			}
+		}
+
+		$command->unregister($this);
+
+		return true;
+	}
+
+	/**
+	 * @param Command $command
 	 * @param bool $isAlias
 	 * @param string $fallbackPrefix
 	 * @param string $label

--- a/src/pocketmine/command/SimpleCommandMap.php
+++ b/src/pocketmine/command/SimpleCommandMap.php
@@ -180,8 +180,8 @@ class SimpleCommandMap implements CommandMap{
 	 * @return bool
 	 */
 	public function unregister(Command $command) : bool{
-		foreach($this->knownCommands as $lbl => $cmd) {
-			if($cmd === $command) {
+		foreach($this->knownCommands as $lbl => $cmd){
+			if($cmd === $command){
 				unset($this->knownCommands[$lbl]);
 			}
 		}


### PR DESCRIPTION
## Introduction
Adds the ability to completely unregister a command (label and aliases).

### Relevant issues

* Addresses #1229

## Changes
### API changes
Add `SimpleCommandMap::unregister()` method

## Tests
~~No testing has been done thus far, the code is relatively straightforward so any issues should be easy to spot.~~
[See comment](https://github.com/pmmp/PocketMine-MP/pull/1464#issuecomment-336378950)