### PR TITLE
Renamed swapPage to swapPages and cleaned up page pushing.

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2978,7 +2978,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 				$modifiedPages[] = $packet->pageNumber;
 				break;
 			case BookEditPacket::TYPE_SWAP_PAGES:
-				$newBook->swapPage($packet->pageNumber, $packet->secondaryPageNumber);
+				$newBook->swapPages($packet->pageNumber, $packet->secondaryPageNumber);
 				$modifiedPages = [$packet->pageNumber, $packet->secondaryPageNumber];
 				break;
 			case BookEditPacket::TYPE_SIGN_BOOK:

--- a/src/pocketmine/item/WritableBook.php
+++ b/src/pocketmine/item/WritableBook.php
@@ -195,7 +195,11 @@ class WritableBook extends Item{
 			if($downwards){
 				unset($namedTag->pages->{$key});
 			}
-			$namedTag->pages->{$key + $type} = clone $page;
+			$namedTag->pages->{$key + $type} = $page;
+		}
+
+		if(!$downwards){
+			unset($namedTag->pages->{$pageId});
 		}
 		return true;
 	}

--- a/src/pocketmine/item/WritableBook.php
+++ b/src/pocketmine/item/WritableBook.php
@@ -156,7 +156,7 @@ class WritableBook extends Item{
 	 *
 	 * @return bool indicating success
 	 */
-	public function swapPage(int $pageId1, int $pageId2) : bool{
+	public function swapPages(int $pageId1, int $pageId2) : bool{
 		if(!$this->pageExists($pageId1) or !$this->pageExists($pageId2)){
 			return false;
 		}
@@ -195,10 +195,7 @@ class WritableBook extends Item{
 			if($downwards){
 				unset($namedTag->pages->{$key});
 			}
-			$namedTag->pages->{$key + $type} = new CompoundTag("", [
-				new StringTag("text", $page->text->getValue()),
-				new StringTag("photoname", "")
-			]);
+			$namedTag->pages->{$key + $type} = clone $page;
 		}
 		return true;
 	}


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Renamed WritableBook->swapPage() to WritableBook->swapPages() and cleaned up page pushing.
Doesn't have any behavioural changes.
