### PR TITLE
Fix error related server wizard

### DIFF
--- a/src/pocketmine/lang/BaseLang.php
+++ b/src/pocketmine/lang/BaseLang.php
@@ -116,6 +116,8 @@ class BaseLang{
 		foreach($params as $i => $p){
 			$baseText = str_replace("{%$i}", $this->parseTranslation((string) $p), $baseText, $onlyPrefix);
 		}
+		
+		$baseText = str_replace('\n', PHP_EOL, $baseText);
 
 		return str_replace("%0", "", $baseText); //fixes a client bug where %0 in translation will cause freeze
 	}
@@ -131,6 +133,8 @@ class BaseLang{
 		}else{
 			$baseText = $this->parseTranslation($c->getText());
 		}
+		
+		$baseText = str_replace('\n', PHP_EOL, $baseText);
 
 		return $baseText;
 	}

--- a/src/pocketmine/wizard/SetupWizard.php
+++ b/src/pocketmine/wizard/SetupWizard.php
@@ -92,7 +92,7 @@ class SetupWizard{
 	}
 
 	private function showLicense() : bool{
-		$this->message($this->lang->get("welcome_to_pocketmine"));
+		$this->message(str_replace('\n', PHP_EOL, $this->lang->get("welcome_to_pocketmine")));
 		echo <<<LICENSE
 
   This program is free software: you can redistribute it and/or modify

--- a/src/pocketmine/wizard/SetupWizard.php
+++ b/src/pocketmine/wizard/SetupWizard.php
@@ -92,7 +92,7 @@ class SetupWizard{
 	}
 
 	private function showLicense() : bool{
-		$this->message(str_replace('\n', PHP_EOL, $this->lang->get("welcome_to_pocketmine")));
+		$this->message($this->lang->get("welcome_to_pocketmine"));
 		echo <<<LICENSE
 
   This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
## Introduction
When you install server, escape string("\n") doesn't work.
```
[?] Language (eng): eng
[*] English has been correctly selected.
[*] Welcome to PocketMine-MP!\nBefore starting setting up your new server you have to accept the license.\nPocketMine-MP is licensed under the LGPL License,\nthat you can read opening the LICENSE file on this folder.
```
## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
Tested