### PR TITLE
Fixed misuse of kill() and close() when deleting entities

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1421,7 +1421,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 				$this->server->broadcastPacket($entity->getViewers(), $pk);
 
 				$this->inventory->addItem(clone $item);
-				$entity->kill();
+				$entity->flagForDespawn();
 			}elseif($entity instanceof DroppedItem){
 				if($entity->getPickupDelay() <= 0){
 					$item = $entity->getItem();
@@ -1451,7 +1451,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 						$this->server->broadcastPacket($entity->getViewers(), $pk);
 
 						$this->inventory->addItem(clone $item);
-						$entity->kill();
+						$entity->flagForDespawn();
 					}
 				}
 			}

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -472,6 +472,8 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 
 	/** @var bool */
 	protected $closed = false;
+	/** @var bool */
+	private $needsDespawn = false;
 
 	/** @var TimingsHandler */
 	protected $timings;
@@ -1281,15 +1283,20 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 
 		$this->lastUpdate = $currentTick;
 
+		if($this->needsDespawn){
+			$this->close();
+			return false;
+		}
+
 		if(!$this->isAlive()){
 			$this->deadTicks += $tickDiff;
 			if($this->deadTicks >= $this->maxDeadTicks){
 				$this->despawnFromAll();
 				if(!$this->isPlayer){
-					$this->close();
+					$this->flagForDespawn();
 				}
 			}
-			return $this->deadTicks < $this->maxDeadTicks;
+			return true;
 		}
 
 
@@ -1929,6 +1936,13 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 		foreach($this->hasSpawned as $player){
 			$this->despawnFrom($player);
 		}
+	}
+
+	/**
+	 * Flags the entity to be removed from the world on the next tick.
+	 */
+	public function flagForDespawn() : void{
+		$this->needsDespawn = true;
 	}
 
 	/**

--- a/src/pocketmine/entity/FallingSand.php
+++ b/src/pocketmine/entity/FallingSand.php
@@ -103,7 +103,7 @@ class FallingSand extends Entity{
 			}
 
 			if($this->onGround or $blockTarget !== null){
-				$this->kill();
+				$this->flagForDespawn();
 
 				$block = $this->level->getBlock($pos);
 				if($block->getId() > 0 and $block->isTransparent() and !$block->canBeReplaced()){

--- a/src/pocketmine/entity/Item.php
+++ b/src/pocketmine/entity/Item.php
@@ -117,7 +117,7 @@ class Item extends Entity{
 				if($ev->isCancelled()){
 					$this->age = 0;
 				}else{
-					$this->kill();
+					$this->flagForDespawn();
 					$hasUpdate = true;
 				}
 			}

--- a/src/pocketmine/entity/PrimedTNT.php
+++ b/src/pocketmine/entity/PrimedTNT.php
@@ -91,7 +91,7 @@ class PrimedTNT extends Entity implements Explosive{
 			$this->fuse -= $tickDiff;
 
 			if($this->fuse <= 0){
-				$this->kill();
+				$this->flagForDespawn();
 				$this->explode();
 			}
 		}

--- a/src/pocketmine/entity/projectile/Arrow.php
+++ b/src/pocketmine/entity/projectile/Arrow.php
@@ -72,7 +72,7 @@ class Arrow extends Projectile{
 		}
 
 		if($this->age > 1200){
-			$this->close();
+			$this->flagForDespawn();
 			$hasUpdate = true;
 		}
 

--- a/src/pocketmine/entity/projectile/Projectile.php
+++ b/src/pocketmine/entity/projectile/Projectile.php
@@ -102,7 +102,7 @@ abstract class Projectile extends Entity{
 			}
 		}
 
-		$this->close();
+		$this->flagForDespawn();
 	}
 
 	public function saveNBT(){

--- a/src/pocketmine/entity/projectile/Throwable.php
+++ b/src/pocketmine/entity/projectile/Throwable.php
@@ -40,7 +40,7 @@ abstract class Throwable extends Projectile{
 
 		if($this->age > 1200 or $this->isCollided){
 			//TODO: hit particles
-			$this->kill();
+			$this->flagForDespawn();
 			$hasUpdate = true;
 		}
 

--- a/src/pocketmine/item/Bow.php
+++ b/src/pocketmine/item/Bow.php
@@ -75,7 +75,7 @@ class Bow extends Tool{
 			$entity = $ev->getProjectile(); //This might have been changed by plugins
 
 			if($ev->isCancelled()){
-				$entity->kill();
+				$entity->flagForDespawn();
 				$player->getInventory()->sendContents($player);
 			}else{
 				$entity->setMotion($entity->getMotion()->multiply($ev->getForce()));
@@ -87,7 +87,7 @@ class Bow extends Tool{
 				if($entity instanceof Projectile){
 					$player->getServer()->getPluginManager()->callEvent($projectileEv = new ProjectileLaunchEvent($entity));
 					if($projectileEv->isCancelled()){
-						$ev->getProjectile()->kill();
+						$ev->getProjectile()->flagForDespawn();
 					}else{
 						$ev->getProjectile()->spawnToAll();
 						$player->level->addSound(new LaunchSound($player), $player->getViewers());

--- a/src/pocketmine/item/ProjectileItem.php
+++ b/src/pocketmine/item/ProjectileItem.php
@@ -49,7 +49,7 @@ abstract class ProjectileItem extends Item{
 		if($projectile instanceof Projectile){
 			$player->getServer()->getPluginManager()->callEvent($projectileEv = new ProjectileLaunchEvent($projectile));
 			if($projectileEv->isCancelled()){
-				$projectile->kill();
+				$projectile->flagForDespawn();
 			}else{
 				$projectile->spawnToAll();
 				$player->getLevel()->addSound(new LaunchSound($player), $player->getViewers());


### PR DESCRIPTION
## Introduction
Historically, there was a memory leak which occurred on chunk unload, due to entities creating drops when kill()ed, which happened when their chunks were unloaded. This made clear that an alternative way to delete entities was needed, which gave rise to usages of close() instead of kill().

The problem with this is that close() is nuclear, and calling it midway through an Entity's tick update would cause following code (none the wiser that the entity was closed) to try to access things like the entity's Level and cause an exception to be thrown.

This PR adds a new method `Entity->flagForDespawn()`, which flags an entity as needing to be deleted on the next tick. This allows entities to be scheduled for deletion without the problem of death animations or dropping items, and without the concern of nuking things.

<!-- Explain existing problems or why this pull request is necessary -->

### Relevant issues
fixes #443 

## Changes
### API changes
- Added `Entity->flagForDespawn()`

## Follow-up
The more pressing problem here is of course the problem of `Player->close()`, which causes many issues when plugins kick/close players during events. A follow-up would be to separate the network functionality of `Player->close()` into its own method (perhaps `Player->disconnect()` would be better) so that `Player->close()` functionality can be isolated just to its network parts.

Even better, the functionality of network on Player should be entirely detached from the Player entity. There is currently a problem that Player does not call its Entity parent constructor until the network login sequence is completed, which causes all kinds of odd behaviour and crashes.