### PR TITLE
Cancel PlayerInteractEvent automatically on left-click block when spa…

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2626,7 +2626,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 				$target = $this->level->getBlock($pos);
 				$ev = new PlayerInteractEvent($this, $this->inventory->getItemInHand(), $target, $packet->face, $target->getId() === 0 ? PlayerInteractEvent::LEFT_CLICK_AIR : PlayerInteractEvent::LEFT_CLICK_BLOCK);
-				if(!$this->level->checkSpawnProtection($this, $target)){
+				if($this->level->checkSpawnProtection($this, $target)){
 					$ev->setCancelled();
 				}
 

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2623,13 +2623,19 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 				if($this->lastBreak !== PHP_INT_MAX or $pos->distanceSquared($this) > 10000){
 					break;
 				}
+
 				$target = $this->level->getBlock($pos);
 				$ev = new PlayerInteractEvent($this, $this->inventory->getItemInHand(), $target, $packet->face, $target->getId() === 0 ? PlayerInteractEvent::LEFT_CLICK_AIR : PlayerInteractEvent::LEFT_CLICK_BLOCK);
+				if(!$this->level->checkSpawnProtection($this, $target)){
+					$ev->setCancelled();
+				}
+
 				$this->getServer()->getPluginManager()->callEvent($ev);
 				if($ev->isCancelled()){
 					$this->inventory->sendHeldItem($this);
 					break;
 				}
+
 				$block = $target->getSide($packet->face);
 				if($block->getId() === Block::FIRE){
 					$this->level->setBlock($block, BlockFactory::get(Block::AIR));

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1585,7 +1585,7 @@ class Level implements ChunkManager, Metadatable{
 	 *
 	 * @return bool false if spawn protection cancelled the action, true if not.
 	 */
-	protected function checkSpawnProtection(Player $player, Vector3 $vector) : bool{
+	public function checkSpawnProtection(Player $player, Vector3 $vector) : bool{
 		if(!$player->hasPermission("pocketmine.spawnprotect.bypass") and ($distance = $this->server->getSpawnRadius()) > -1){
 			$t = new Vector2($vector->x, $vector->z);
 			$s = new Vector2($this->getSpawnLocation()->x, $this->getSpawnLocation()->z);


### PR DESCRIPTION
…wn protection is triggered

## Introduction
Currently spawn protection doesn't prevent deletion of fire, and broadcasts block-break animations when the player will not actually be able to break blocks in the zone anyway. This PR automatically sets PlayerInteractEvent to cancelled on left-click if spawn protection is triggered, before calling the event.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
- Block-break animations will no longer be seen in spawn protection radius if the player can't break the block.
- Fire can't be deleted anymore inside the spawn protection radius.

## Backwards compatibility
This might affect existing plugins which change things to do with spawn protection using events.

## Tests
TBD
<!-- Attach scripts or actions to test this pull request, as well as the result -->
