### PR TITLE
Fix EntityEat events.

### DIFF
--- a/src/pocketmine/event/entity/EntityEatBlockEvent.php
+++ b/src/pocketmine/event/entity/EntityEatBlockEvent.php
@@ -28,6 +28,8 @@ use pocketmine\entity\Entity;
 use pocketmine\item\FoodSource;
 
 class EntityEatBlockEvent extends EntityEatEvent{
+	public static $handlerList = null;
+
 	public function __construct(Entity $entity, FoodSource $foodSource){
 		if(!($foodSource instanceof Block)){
 			throw new \InvalidArgumentException("Food source must be a block");
@@ -38,7 +40,7 @@ class EntityEatBlockEvent extends EntityEatEvent{
 	/**
 	 * @return Block
 	 */
-	public function getResidue(){
+	public function getResidue() : Block{
 		return parent::getResidue();
 	}
 

--- a/src/pocketmine/event/entity/EntityEatEvent.php
+++ b/src/pocketmine/event/entity/EntityEatEvent.php
@@ -29,7 +29,6 @@ use pocketmine\event\Cancellable;
 use pocketmine\item\FoodSource;
 
 class EntityEatEvent extends EntityEvent implements Cancellable{
-	public static $handlerList = null;
 
 	/** @var FoodSource */
 	private $foodSource;

--- a/src/pocketmine/event/entity/EntityEatItemEvent.php
+++ b/src/pocketmine/event/entity/EntityEatItemEvent.php
@@ -28,6 +28,8 @@ use pocketmine\item\Food;
 use pocketmine\item\Item;
 
 class EntityEatItemEvent extends EntityEatEvent{
+	public static $handlerList = null;
+
 	public function __construct(Entity $entity, Food $foodSource){
 		parent::__construct($entity, $foodSource);
 	}
@@ -35,7 +37,7 @@ class EntityEatItemEvent extends EntityEatEvent{
 	/**
 	 * @return Item
 	 */
-	public function getResidue(){
+	public function getResidue() : Item{
 		return parent::getResidue();
 	}
 


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This PR fixes EntityEat events not being able to be handled through plugins.

Currently, trying to handle EntityEatBlockEvent/EntityEatItemEvent would give you the following error:
`[Server thread/CRITICAL]: pocketmine\plugin\PluginException: "pocketmine\event\entity\EntityEatItemEvent does not have a valid handler list" (EXCEPTION) in "src/pocketmine/plugin/PluginManager" at line 805`
This is due to non-existance of `Event::$handlerList` property in EntityEatBlockEvent and EntityEatItemEvent. For an unknown reason, that property existed in EntityEatEvent instead.

[The server also never fired EntityEatItemEvent.](https://github.com/pmmp/PocketMine-MP/blob/18777a90411c4d8baf1cf484676cd49350375255/src/pocketmine/item/Food.php#L53-#L63)

## Changes
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
* The server now fires EntityEatItemEvent.
* Plugins can now handle EntityEatBlockEvent and EntityEatItemEvent.

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
```php
public function handleEntityEatItem(EntityEatItemEvent $event){
    $event->getResidue();
}

public function handleEntityEatBlockEvent(EntityEatBlockEvent $event){
    $event->getResidue();
}
```