### PR TITLE
Implemented Config->removeNested()

### DIFF
--- a/src/pocketmine/utils/Config.php
+++ b/src/pocketmine/utils/Config.php
@@ -376,6 +376,27 @@ class Config{
 		return $this->nestedCache[$key] = $base;
 	}
 
+	public function removeNested(string $key) : void{
+		unset($this->nestedCache[$key]);
+
+		$vars = explode(".", $key);
+
+		$currentNode =& $this->config;
+		while(count($vars) > 0){
+			$nodeName = array_shift($vars);
+			if(isset($currentNode[$nodeName])){
+				if(empty($vars)){ //final node
+					unset($currentNode[$nodeName]);
+					break;
+				}elseif(is_array($currentNode[$nodeName])){
+					$currentNode =& $currentNode[$nodeName];
+				}
+			}else{
+				break;
+			}
+		}
+	}
+
 	/**
 	 * @param       $k
 	 * @param mixed $default

--- a/src/pocketmine/utils/Config.php
+++ b/src/pocketmine/utils/Config.php
@@ -387,7 +387,6 @@ class Config{
 			if(isset($currentNode[$nodeName])){
 				if(empty($vars)){ //final node
 					unset($currentNode[$nodeName]);
-					break;
 				}elseif(is_array($currentNode[$nodeName])){
 					$currentNode =& $currentNode[$nodeName];
 				}

--- a/src/pocketmine/utils/Config.php
+++ b/src/pocketmine/utils/Config.php
@@ -377,7 +377,7 @@ class Config{
 	}
 
 	public function removeNested(string $key) : void{
-		unset($this->nestedCache[$key]);
+		$this->nestedCache = [];
 
 		$vars = explode(".", $key);
 


### PR DESCRIPTION
## Introduction
We have `getNested()`, `setNested()`, but no `removeNested()`.

Sometimes we want to delete data from a nested key in a config. Currently there is no way to do so (`remove()` doesn't deal with this).

## Changes
### API changes
- Added `Config->removeNested(string $key)`

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
```php

		$this->getConfig()->setNested("a.b.c", "wtf"); //set a nested "a.b.c"
		$this->getConfig()->save();
		var_dump($this->getConfig());
		var_dump(file_get_contents($this->getDataFolder() . "config.yml"));

		echo PHP_EOL;
		$this->getConfig()->removeNested("a.b.c"); //removes item "c" from the "a.b" nested key
		$this->getConfig()->save();

		var_dump($this->getConfig());
		var_dump(file_get_contents($this->getDataFolder() . "config.yml"));

		$this->getConfig()->removeNested("a.b"); //removes item "b" from the "a" key
		$this->getConfig()->save();

		var_dump($this->getConfig());
		var_dump(file_get_contents($this->getDataFolder() . "config.yml"));
```

## Follow-up
This change is needed for a change I need to make to #1461 .