### PR TITLE
Fix health overflow after calling setMaxHealth()

### DIFF
--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -943,6 +943,9 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 	 */
 	public function setMaxHealth(int $amount){
 		$this->maxHealth = $amount;
+		if($this->health > $amount){
+			$this->health = $amount;
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
While setting an entity's max health, the server does not check whether the entity's health is > than their maxHealth.

## Changes
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
`Entity::setMaxHealth($amount)` will check whether the entity's health is greater than the `$amount` and handle the situation appropriately.

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
Before:
```php
/** @var Entity $entity */
$entity->setMaxHealth(40);
$entity->setHealth(40);
$entity->setMaxHealth(20);
var_dump($entity->getHealth());//float(40)
```
After:
```php
/** @var Entity $entity */
$entity->setMaxHealth(40);
$entity->setHealth(40);
$entity->setMaxHealth(20);
var_dump($entity->getHealth());//float(20)
```