### PR TITLE
Fix having nested onSubmit returning Forms not working

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3393,12 +3393,13 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 				$this->sendFormRequestPacket($form);
 				return true;
 			}
-		}catch(\Throwable $e){
-			$this->server->getLogger()->logException($e);
-			return true;
-		}finally{
 			$this->sentFormId = null;
 			$this->sentForm = null;
+		}catch(\Throwable $e){
+			$this->server->getLogger()->logException($e);
+			$this->sentFormId = null;
+			$this->sentForm = null;
+			return true;
 		}
 
 		if(count($this->formQueue) > 0){


### PR DESCRIPTION
## Introduction
It was impossible to have multiple forms nested in themselves. (For long multiple step forms.)
See the test plugin below for an example, because it's hard to express what the problem was.
Basically after the next Form has been sent the formID has been nullified and the response of that form couldn't be handled anymore.

### Relevant issues
none created, but a thread at https://forums.pmmp.io/threads/problems-with-forms.4500/

## Changes
### API changes
no API changes, just a fix

### Behavioural changes
none

## Backwards compatibility
no BC breaks

## Follow-up
none

## Tests
Here's a plugin that fails at the 2nd form before this and works with this perfectly all the way through:
https://github.com/ScandiePlay/TestForms