### PR TITLE
Fixed save player data after PlayerQuitEvent

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3378,12 +3378,12 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 						$this->server->broadcastMessage($ev->getQuitMessage());
 					}
 
-                    try{
-                        $this->save();
-                    }catch(\Throwable $e){
-                        $this->server->getLogger()->critical("Failed to save player data for " . $this->getName());
-                        $this->server->getLogger()->logException($e);
-                    }
+					try{
+						$this->save();
+					}catch(\Throwable $e){
+						$this->server->getLogger()->critical("Failed to save player data for " . $this->getName());
+						$this->server->getLogger()->logException($e);
+					}
 				}
 				$this->joined = false;
 

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3373,17 +3373,17 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 				$this->stopSleep();
 
 				if($this->joined){
-					try{
-						$this->save();
-					}catch(\Throwable $e){
-						$this->server->getLogger()->critical("Failed to save player data for " . $this->getName());
-						$this->server->getLogger()->logException($e);
-					}
-
 					$this->server->getPluginManager()->callEvent($ev = new PlayerQuitEvent($this, $message, $reason));
 					if($ev->getQuitMessage() != ""){
 						$this->server->broadcastMessage($ev->getQuitMessage());
 					}
+
+                    try{
+                        $this->save();
+                    }catch(\Throwable $e){
+                        $this->server->getLogger()->critical("Failed to save player data for " . $this->getName());
+                        $this->server->getLogger()->logException($e);
+                    }
 				}
 				$this->joined = false;
 


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Fixed saving of data that did not work before, because the data was saved before the call to PlayerQuitEvent
### Relevant issues
Fixed https://github.com/pmmp/PocketMine-MP/issues/1543
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
Completely tested and everything works fine!