### PR TITLE
SIGKILL should be a string

### DIFF
--- a/src/pocketmine/PocketMine.php
+++ b/src/pocketmine/PocketMine.php
@@ -371,7 +371,7 @@ namespace pocketmine {
 			case "linux":
 			default:
 				if(function_exists("posix_kill")){
-					posix_kill($pid, SIGKILL);
+					posix_kill($pid, "SIGKILL");
 				}else{
 					exec("kill -9 " . ((int) $pid) . " > /dev/null 2>&1");
 				}


### PR DESCRIPTION
There is no SIGKILL constant. This should be a string.

## Introduction
There is no SIGKILL constant, it should be a string, so now it's a string.

### Relevant issues
PocketMine kills processes improperly

## Changes
### API changes
None

### Behavioural changes
None

## Backwards compatibility
No issues.

## Follow-up
Afterwards, have a beer.

## Tests

Now processes are killed properly.