### PR TITLE
Some changes to messages

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -1610,7 +1610,7 @@ class Server{
 
 			$this->logger->info($this->getLanguage()->translateString("pocketmine.server.info", [
 				$this->getName(),
-				($version->isDev() ? TextFormat::YELLOW : "") . $version->get(true) . TextFormat::WHITE,
+				($version->isDev() ? TextFormat::YELLOW : "") . $version->get(true) . TextFormat::RESET,
 				$this->getCodename(),
 				$this->getApiVersion()
 			]));

--- a/src/pocketmine/block/Bed.php
+++ b/src/pocketmine/block/Bed.php
@@ -142,7 +142,7 @@ class Bed extends Transparent{
 
 				return true;
 			}elseif($player->distanceSquared($this) > 4 and $player->distanceSquared($other) > 4){
-				//MCPE doesn't have messages for bed too far away
+				$player->sendMessage(new TranslationContainer(TextFormat::GRAY . "%tile.bed.tooFar"));
 				return true;
 			}
 


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This pull request changes some messages.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
Nothing.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Nothing.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
Now you'll be able to see message which says bed is too far away.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
No backwards incompatible changes.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
Bed message works fine, but server sends that message even I'm close to bed. You'll probably want to fix that issue.

Requires translation:

| `tile.bed.tooFar` | `Bed is too far away` |

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
Server startup: Start the server.
Bed: Click bed from far distance.