### PR TITLE
Fixed setMaxAirSupplyTicks()

### DIFF
--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -550,7 +550,7 @@ abstract class Living extends Entity implements Damageable{
 	 * @param int $ticks
 	 */
 	public function setMaxAirSupplyTicks(int $ticks){
-		$this->setDataProperty(self::DATA_AIR, self::DATA_TYPE_SHORT, $ticks);
+		$this->setDataProperty(self::DATA_MAX_AIR, self::DATA_TYPE_SHORT, $ticks);
 	}
 
 	/**


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Before, this function would set the Player's air supply, but not the maximum air supply, which the function is intended to do.
### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

--> Nothing

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Nothing
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
The function now sets the maximum air supply instead of air supply.
## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? --> This is backwards compatible.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
### Before:
```php
$player->setMaxAirSupplyTicks(440);
```
Result: Player gets 1 extra air bubble, but it isn't set as 11 bubbles maxed (each bubble is 2 seconds or 40 ticks), and you will lose the bubble and not gain it back.

### After:
```php
$player->setMaxAirSupplyTicks(440);
```
Result: Player gets 1 extra air bubble and is set as 11 bubbles (each bubble is 2 seconds or 40 ticks) maxed, and you can gain it back after getting out the water and back in. 
