### PR TITLE
Implement XP

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1433,6 +1433,14 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		return [];
 	}
 
+	public function getXpDropAmount() : int{
+		if(!$this->isCreative()){
+			return min(100, $this->getCurrentTotalXp());
+		}
+
+		return 0;
+	}
+
 	protected function checkGroundState(float $movX, float $movY, float $movZ, float $dx, float $dy, float $dz){
 		if(!$this->onGround or $movY != 0){
 			$bb = clone $this->boundingBox;

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1435,7 +1435,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 	public function getXpDropAmount() : int{
 		if(!$this->isCreative()){
-			return min(100, $this->getCurrentTotalXp());
+			return parent::getXpDropAmount();
 		}
 
 		return 0;

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -29,6 +29,7 @@ namespace pocketmine\entity;
 use pocketmine\block\Block;
 use pocketmine\block\BlockFactory;
 use pocketmine\block\Water;
+use pocketmine\entity\object\ExperienceOrb;
 use pocketmine\entity\projectile\Arrow;
 use pocketmine\entity\projectile\Egg;
 use pocketmine\entity\projectile\Snowball;
@@ -227,6 +228,7 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 
 		Entity::registerEntity(Arrow::class, false, ['Arrow', 'minecraft:arrow']);
 		Entity::registerEntity(Egg::class, false, ['Egg', 'minecraft:egg']);
+		Entity::registerEntity(ExperienceOrb::class, false, ['XPOrb', 'minecraft:xp_orb']);
 		Entity::registerEntity(FallingSand::class, false, ['FallingSand', 'minecraft:falling_block']);
 		Entity::registerEntity(Item::class, false, ['Item', 'minecraft:item']);
 		Entity::registerEntity(PrimedTNT::class, false, ['PrimedTnt', 'PrimedTNT', 'minecraft:tnt']);

--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -76,6 +76,7 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 
 	protected $totalXp = 0;
 	protected $xpSeed;
+	protected $xpCooldown = 0;
 
 	protected $baseOffset = 1.62;
 
@@ -410,6 +411,23 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 		$this->totalXp = $amount;
 	}
 
+	/**
+	 * Returns whether the human can pickup XP orbs (checks cooldown time)
+	 * @return bool
+	 */
+	public function canPickupXp() : bool{
+		return $this->xpCooldown === 0;
+	}
+
+	/**
+	 * Sets the duration in ticks until the human can pick up another XP orb.
+	 * @param int $value
+	 */
+	public function resetXpCooldown(int $value = 2){
+		$this->xpCooldown = $value;
+	}
+
+
 	public function getInventory(){
 		return $this->inventory;
 	}
@@ -504,6 +522,10 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 		$hasUpdate = parent::entityBaseTick($tickDiff);
 
 		$this->doFoodTick($tickDiff);
+
+		if($this->xpCooldown > 0){
+			$this->xpCooldown--;
+		}
 
 		return $hasUpdate;
 	}

--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -300,9 +300,10 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 
 	/**
 	 * Sets the player's experience level. This does not affect their total XP or their XP progress.
+	 *
 	 * @param int $level
 	 */
-	public function setXpLevel(int $level){
+	public function setXpLevel(int $level) : void{
 		$this->attributeMap->getAttribute(Attribute::EXPERIENCE_LEVEL)->setValue($level);
 	}
 
@@ -342,9 +343,10 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 
 	/**
 	 * Sets the player's progress through the current level to a value between 0.0 and 1.0.
+	 *
 	 * @param float $progress
 	 */
-	public function setXpProgress(float $progress){
+	public function setXpProgress(float $progress) : void{
 		$this->attributeMap->getAttribute(Attribute::EXPERIENCE)->setValue($progress);
 	}
 
@@ -453,9 +455,10 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 
 	/**
 	 * Sets the duration in ticks until the human can pick up another XP orb.
+	 *
 	 * @param int $value
 	 */
-	public function resetXpCooldown(int $value = 2){
+	public function resetXpCooldown(int $value = 2) : void{
 		$this->xpCooldown = $value;
 	}
 

--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -459,6 +459,9 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 		$this->xpCooldown = $value;
 	}
 
+	public function getXpDropAmount() : int{
+		return (int) min(100, $this->getCurrentTotalXp());
+	}
 
 	public function getInventory(){
 		return $this->inventory;

--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -510,7 +510,9 @@ abstract class Living extends Entity implements Damageable{
 			$this->deadTicks += $tickDiff;
 			if($this->deadTicks >= $this->maxDeadTicks){
 				$this->endDeathAnimation();
-				//TODO: spawn experience orbs here
+
+				//TODO: check death conditions (must have been damaged by player < 5 seconds from death)
+				$this->level->dropExperience($this, $this->getXpDropAmount());
 			}
 		}
 
@@ -658,6 +660,14 @@ abstract class Living extends Entity implements Damageable{
 	 */
 	public function getDrops() : array{
 		return [];
+	}
+
+	/**
+	 * Returns the amount of XP this mob will drop on death.
+	 * @return int
+	 */
+	public function getXpDropAmount() : int{
+		return 0;
 	}
 
 	/**

--- a/src/pocketmine/entity/Zombie.php
+++ b/src/pocketmine/entity/Zombie.php
@@ -57,4 +57,9 @@ class Zombie extends Monster{
 
 		return $drops;
 	}
+
+	public function getXpDropAmount() : int{
+		//TODO: check for equipment and whether it's a baby
+		return 5;
+	}
 }

--- a/src/pocketmine/entity/object/ExperienceOrb.php
+++ b/src/pocketmine/entity/object/ExperienceOrb.php
@@ -41,6 +41,48 @@ class ExperienceOrb extends Entity{
 	 */
 	public const MAX_TARGET_DISTANCE = 8.0;
 
+	/**
+	 * Split sizes used for dropping experience orbs.
+	 */
+	public const ORB_SPLIT_SIZES = [2477, 1237, 617, 307, 149, 73, 37, 17, 7, 3, 1]; //This is indexed biggest to smallest so that we can return as soon as we found the biggest value.
+
+	/**
+	 * Returns the largest size of normal XP orb that will be spawned for the specified amount of XP. Used to split XP
+	 * up into multiple orbs when an amount of XP is dropped.
+	 *
+	 * @param int $amount
+	 *
+	 * @return int
+	 */
+	public static function getMaxOrbSize(int $amount) : int{
+		foreach(self::ORB_SPLIT_SIZES as $split){
+			if($amount >= $split){
+				return $split;
+			}
+		}
+
+		return 1;
+	}
+
+	/**
+	 * Splits the specified amount of XP into an array of acceptable XP orb sizes.
+	 *
+	 * @param int $amount
+	 *
+	 * @return int[]
+	 */
+	public static function splitIntoOrbSizes(int $amount) : array{
+		$result = [];
+
+		while($amount > 0){
+			$size = self::getMaxOrbSize($amount);
+			$result[] = $size;
+			$amount -= $size;
+		}
+
+		return $result;
+	}
+
 	public $height = 0.25;
 	public $width = 0.25;
 

--- a/src/pocketmine/entity/object/ExperienceOrb.php
+++ b/src/pocketmine/entity/object/ExperienceOrb.php
@@ -27,7 +27,6 @@ use pocketmine\entity\Entity;
 use pocketmine\entity\Human;
 use pocketmine\nbt\tag\IntTag;
 use pocketmine\nbt\tag\ShortTag;
-use pocketmine\network\mcpe\protocol\LevelEventPacket;
 use pocketmine\Player;
 
 class ExperienceOrb extends Entity{
@@ -200,7 +199,6 @@ class ExperienceOrb extends Entity{
 				$this->flagForDespawn();
 
 				$currentTarget->addXp($this->getXpValue());
-				$this->level->broadcastLevelEvent($this, LevelEventPacket::EVENT_SOUND_ORB, mt_rand());
 				$currentTarget->resetXpCooldown();
 
 				//TODO: check Mending enchantment

--- a/src/pocketmine/entity/object/ExperienceOrb.php
+++ b/src/pocketmine/entity/object/ExperienceOrb.php
@@ -1,0 +1,170 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\entity\object;
+
+use pocketmine\entity\Entity;
+use pocketmine\entity\Human;
+use pocketmine\nbt\tag\IntTag;
+use pocketmine\nbt\tag\ShortTag;
+use pocketmine\network\mcpe\protocol\LevelEventPacket;
+use pocketmine\Player;
+
+class ExperienceOrb extends Entity{
+	public const NETWORK_ID = self::XP_ORB;
+
+	public const TAG_VALUE_PC = "Value"; //short
+	public const TAG_VALUE_PE = "experience value"; //int (WTF?)
+
+	/**
+	 * Max distance an orb will follow a player across.
+	 */
+	public const MAX_TARGET_DISTANCE = 8.0;
+
+	public $height = 0.25;
+	public $width = 0.25;
+
+	public $gravity = 0.04;
+	public $drag = 0.02;
+
+	/**
+	 * @var int
+	 * Ticker used for determining interval in which to look for new target players.
+	 */
+	protected $lookForTargetTime = 0;
+
+	/**
+	 * @var int|null
+	 * Runtime entity ID of the player this XP orb is targeting.
+	 */
+	protected $targetPlayerRuntimeId = null;
+
+	protected function initEntity(){
+		parent::initEntity();
+
+		$this->age = $this->namedtag->getShort("Age", 0);
+
+		$value = 0;
+		if($this->namedtag->hasTag(self::TAG_VALUE_PC, ShortTag::class)){ //PC
+			$value = $this->namedtag->getShort(self::TAG_VALUE_PC);
+		}elseif($this->namedtag->hasTag(self::TAG_VALUE_PE, IntTag::class)){ //PE save format
+			$value = $this->namedtag->getInt(self::TAG_VALUE_PE);
+		}
+
+		$this->setXpValue($value);
+	}
+
+	public function saveNBT(){
+		parent::saveNBT();
+
+		$this->namedtag->setShort("Age", $this->age);
+
+		$this->namedtag->setShort(self::TAG_VALUE_PC, $this->getXpValue());
+		$this->namedtag->setInt(self::TAG_VALUE_PE, $this->getXpValue());
+	}
+
+	public function getXpValue() : int{
+		return $this->getDataProperty(self::DATA_EXPERIENCE_VALUE) ?? 0;
+	}
+
+	public function setXpValue(int $amount) : void{
+		if($amount <= 0){
+			throw new \InvalidArgumentException("XP amount must be greater than 0, got $amount");
+		}
+		$this->setDataProperty(self::DATA_EXPERIENCE_VALUE, self::DATA_TYPE_INT, $amount);
+	}
+
+	public function hasTargetPlayer() : bool{
+		return $this->targetPlayerRuntimeId !== null;
+	}
+
+	public function getTargetPlayer() : ?Human{
+		if($this->targetPlayerRuntimeId === null){
+			return null;
+		}
+
+		$entity = $this->server->findEntity($this->targetPlayerRuntimeId, $this->level);
+		if($entity instanceof Human){
+			return $entity;
+		}
+
+		return null;
+	}
+
+	public function setTargetPlayer(?Human $player) : void{
+		$this->targetPlayerRuntimeId = $player ? $player->getId() : null;
+	}
+
+	public function entityBaseTick(int $tickDiff = 1) : bool{
+		$hasUpdate = parent::entityBaseTick($tickDiff);
+
+		if($this->age > 6000){
+			$this->flagForDespawn();
+			return true;
+		}
+
+		$currentTarget = $this->getTargetPlayer();
+
+		if($this->lookForTargetTime >= 20){
+			if($currentTarget === null or $currentTarget->distanceSquared($this) > self::MAX_TARGET_DISTANCE ** 2){
+				$this->setTargetPlayer(null);
+
+				$newTarget = $this->level->getNearestEntity($this, self::MAX_TARGET_DISTANCE, Human::class);
+
+				if($newTarget instanceof Human and !($newTarget instanceof Player and $newTarget->isSpectator())){
+					$currentTarget = $newTarget;
+					$this->setTargetPlayer($currentTarget);
+				}
+			}
+
+			$this->lookForTargetTime = 0;
+		}else{
+			$this->lookForTargetTime += $tickDiff;
+		}
+
+		if($currentTarget !== null){
+			$vector = $currentTarget->subtract($this)->add(0, $currentTarget->getEyeHeight() / 2, 0)->divide(self::MAX_TARGET_DISTANCE);
+
+			$distance = $vector->length();
+			$oneMinusDistance = (1 - $distance) ** 2;
+
+			if($oneMinusDistance > 0){
+				$this->motionX += $vector->x / $distance * $oneMinusDistance * 0.2;
+				$this->motionY += $vector->y / $distance * $oneMinusDistance * 0.2;
+				$this->motionZ += $vector->z / $distance * $oneMinusDistance * 0.2;
+			}
+
+			if($currentTarget->canPickupXp() and $this->boundingBox->intersectsWith($currentTarget->getBoundingBox())){
+				$this->flagForDespawn();
+
+				$currentTarget->addXp($this->getXpValue());
+				$this->level->broadcastLevelEvent($this, LevelEventPacket::EVENT_SOUND_ORB, mt_rand());
+				$currentTarget->resetXpCooldown();
+
+				//TODO: check Mending enchantment
+			}
+		}
+
+		return $hasUpdate;
+	}
+}

--- a/src/pocketmine/entity/utils/ExperienceUtils.php
+++ b/src/pocketmine/entity/utils/ExperienceUtils.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\entity\utils;
+
+use pocketmine\math\Math;
+
+abstract class ExperienceUtils{
+
+	/**
+	 * Calculates and returns the amount of XP needed to get from level 0 to level $level
+	 *
+	 * @param int $level
+	 * @return int
+	 */
+	public static function getXpToReachLevel(int $level) : int{
+		if($level <= 16){
+			return $level ** 2 + $level * 6;
+		}elseif($level <= 31){
+			return (int) ($level ** 2 * 2.5 - 40.5 * $level + 360);
+		}
+
+		return (int) ($level ** 2 * 4.5 - 162.5 * $level + 2220);
+	}
+
+	/**
+	 * Returns the amount of XP needed to reach $level + 1.
+	 *
+	 * @param int $level
+	 *
+	 * @return int
+	 */
+	public static function getXpToCompleteLevel(int $level) : int{
+		if($level <= 15){
+			return 2 * $level + 7;
+		}elseif($level <= 30){
+			return 5 * $level - 38;
+		}else{
+			return 9 * $level - 158;
+		}
+	}
+
+	/**
+	 * Calculates and returns the number of XP levels the specified amount of XP points are worth.
+	 * This returns a floating-point number, the decimal part being the progress through the resulting level.
+	 *
+	 * @param int $xp
+	 *
+	 * @return float
+	 */
+	public static function getLevelFromXp(int $xp) : float{
+		if($xp <= self::getXpToReachLevel(16)){
+			$a = 1;
+			$b = 6;
+			$c = 0;
+		}elseif($xp <= self::getXpToReachLevel(31)){
+			$a = 2.5;
+			$b = -40.5;
+			$c = 360;
+		}else{
+			$a = 4.5;
+			$b = -162.5;
+			$c = 2220;
+		}
+
+		$x = Math::solveQuadratic($a, $b, $c - $xp);
+
+		return (float) max($x); //we're only interested in the positive solution
+	}
+}

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -31,6 +31,7 @@ use pocketmine\block\BlockFactory;
 use pocketmine\entity\Effect;
 use pocketmine\entity\Entity;
 use pocketmine\entity\Item as DroppedItem;
+use pocketmine\entity\object\ExperienceOrb;
 use pocketmine\entity\projectile\Arrow;
 use pocketmine\event\block\BlockBreakEvent;
 use pocketmine\event\block\BlockPlaceEvent;
@@ -1697,6 +1698,41 @@ class Level implements ChunkManager, Metadatable{
 			}
 		}
 		return null;
+	}
+
+	/**
+	 * Drops XP orbs into the world for the specified amount, splitting the amount into several orbs if necessary.
+	 *
+	 * @param Vector3 $pos
+	 * @param int     $amount
+	 *
+	 * @return ExperienceOrb[]
+	 */
+	public function dropExperience(Vector3 $pos, int $amount) : array{
+		/** @var ExperienceOrb[] $orbs */
+		$orbs = [];
+
+		foreach(ExperienceOrb::splitIntoOrbSizes($amount) as $split){
+			$nbt = Entity::createBaseNBT(
+				$pos,
+				$this->temporalVector->setComponents((lcg_value() * 0.2 - 0.1) * 2, lcg_value() * 0.4, (lcg_value() * 0.2 - 0.1) * 2),
+				lcg_value() * 360,
+				0
+			);
+			$nbt->setShort(ExperienceOrb::TAG_VALUE_PC, $split);
+
+			$orb = Entity::createEntity("XPOrb", $this, $nbt);
+			if($orb === null){
+				continue;
+			}
+
+			$orb->spawnToAll();
+			if($orb instanceof ExperienceOrb){
+				$orbs[] = $orb;
+			}
+		}
+
+		return $orbs;
 	}
 
 	/**


### PR DESCRIPTION
This pull request provides the base work needed for things to use XP.

Currently nothing in the core actually _uses_ this API, however this functionality will (of course) be needed in the future. The primary goal of this PR is to provide a workable API for plugins to use so that they can use experience for their own purposes.

description to be continued...

### Things that need to be done
- [x] Drop experience on player & mob death.
- [x] add level-up sound

### Possible follow-ups
- [ ] Add `setKeepExperience()` to PlayerDeathEvent
- [ ] Add events for experience change (not required, but nice to have).