### PR TITLE
Make Living::addEffect() return bool

### DIFF
--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -231,9 +231,10 @@ abstract class Living extends Entity implements Damageable{
 	 * Adds an effect to the mob.
 	 * If a weaker effect of the same type is already applied, it will be replaced.
 	 * If a weaker or equal-strength effect is already applied but has a shorter duration, it will be replaced.
-	 * Returns whether the effect has been successfully applied.
 	 *
 	 * @param Effect $effect
+	 *
+ 	 * Returns whether the effect has been successfully applied.
 	 * @return bool
 	 */
 	public function addEffect(Effect $effect) : bool{

--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -234,8 +234,7 @@ abstract class Living extends Entity implements Damageable{
 	 *
 	 * @param Effect $effect
 	 *
- 	 * Returns whether the effect has been successfully applied.
-	 * @return bool
+	 * @return bool whether the effect has been successfully applied.
 	 */
 	public function addEffect(Effect $effect) : bool{
 		if(isset($this->effects[$effect->getId()])){

--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -231,17 +231,19 @@ abstract class Living extends Entity implements Damageable{
 	 * Adds an effect to the mob.
 	 * If a weaker effect of the same type is already applied, it will be replaced.
 	 * If a weaker or equal-strength effect is already applied but has a shorter duration, it will be replaced.
+	 * Returns whether the effect has been successfully applied.
 	 *
 	 * @param Effect $effect
+	 * @return bool
 	 */
-	public function addEffect(Effect $effect){
+	public function addEffect(Effect $effect) : bool{
 		if(isset($this->effects[$effect->getId()])){
 			$oldEffect = $this->effects[$effect->getId()];
 			if(
 				abs($effect->getAmplifier()) < $oldEffect->getAmplifier()
 				or (abs($effect->getAmplifier()) === abs($oldEffect->getAmplifier()) and $effect->getDuration() < $oldEffect->getDuration())
 			){
-				return;
+				return false;
 			}
 			$effect->add($this, $oldEffect);
 		}else{
@@ -251,6 +253,8 @@ abstract class Living extends Entity implements Damageable{
 		$this->effects[$effect->getId()] = $effect;
 
 		$this->recalculateEffectColor();
+
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This will let you know if an effect has been successfully applied or not.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Living::addEffect() returns whether the effect has successfully been applied or not.

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
```php
/** @var Living $living */
$effect = Effect::getEffect(Effect::SPEED)->setDuration(INT32_MAX)->setAmplifier(1);
var_dump($living->addEffect($effect));//bool(true)

$effect->setAmplifier(0);
var_dump($living->addEffect($effect));//bool(false)
```