### PR TITLE
Fixed broken logic in EntityEffectEvents

### DIFF
--- a/src/pocketmine/entity/Effect.php
+++ b/src/pocketmine/entity/Effect.php
@@ -24,8 +24,6 @@ declare(strict_types=1);
 namespace pocketmine\entity;
 
 use pocketmine\event\entity\EntityDamageEvent;
-use pocketmine\event\entity\EntityEffectAddEvent;
-use pocketmine\event\entity\EntityEffectRemoveEvent;
 use pocketmine\event\entity\EntityRegainHealthEvent;
 use pocketmine\event\player\PlayerExhaustEvent;
 use pocketmine\network\mcpe\protocol\MobEffectPacket;
@@ -399,10 +397,6 @@ class Effect{
 	 * @param Effect|null $oldEffect
 	 */
 	public function add(Entity $entity, Effect $oldEffect = null){
-		$entity->getLevel()->getServer()->getPluginManager()->callEvent($ev = new EntityEffectAddEvent($entity, $this, $oldEffect));
-		if($ev->isCancelled()){
-			return;
-		}
 		if($entity instanceof Player){
 			$pk = new MobEffectPacket();
 			$pk->entityRuntimeId = $entity->getId();
@@ -457,11 +451,6 @@ class Effect{
 	 * @param bool   $send
 	 */
 	public function remove(Entity $entity, bool $send = true){
-		$entity->getLevel()->getServer()->getPluginManager()->callEvent($ev = new EntityEffectRemoveEvent($entity, $this));
-		if($ev->isCancelled()){
-			return;
-		}
-
 		if($send and $entity instanceof Player){
 			$pk = new MobEffectPacket();
 			$pk->entityRuntimeId = $entity->getId();


### PR DESCRIPTION
## Introduction
When these effects were cancelled, they were still added/removed as active effects server-side. This caused bugs such as #1767 .

### Relevant issues
#141 introduced the defective code.

## Changes
### Behavioural changes
cancelling these events now works as expected (in theory)

## Follow-up
There is a problem with the behaviour when EntityEffectRemoveEvent is cancelled due to the effect duration becoming zero, which would result in the duration consequently becoming negative and causing a crash. This is a relevant issue but a separate bug from the one this PR is targeted at.

## Tests
TBD
