### PR TITLE
add UUID ban/unban

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -331,7 +331,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	public function isBanned() : bool{
-		return $this->server->getNameBans()->isBanned($this->iusername);
+		return $this->server->getNameBans()->isBanned($this->iusername) or $this->server->getUUIDBans()->isBanned($this->uuid->toString());
 	}
 
 	public function setBanned(bool $value){
@@ -340,6 +340,16 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 			$this->kick("You have been banned");
 		}else{
 			$this->server->getNameBans()->remove($this->getName());
+		}
+	}
+
+	// Does nothing if the player is not authenticated
+	public function setUUIDBanned(bool $value){
+		if($value === true){
+			$this->server->getUUIDBans()->addBan($this->getUniqueId(), null, null, null);
+			$this->kick("You have been banned");
+		}else{
+			$this->server->getUUIDBans()->remove($this->getUniqueId());
 		}
 	}
 
@@ -1834,7 +1844,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		}
 
 		if(
-			($this->server->getNameBans()->isBanned($this->iusername) or $this->server->getIPBans()->isBanned($this->getAddress())) and
+			($this->server->getNameBans()->isBanned($this->iusername) or $this->server->getUUIDBans()->isBanned($this->uuid->toString()) or $this->server->getIPBans()->isBanned($this->getAddress())) and
 			$this->kick("You are banned", false)
 		){
 			return true;

--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -130,6 +130,9 @@ class Server{
 	/** @var BanList */
 	private $banByIP = null;
 
+	/** @var BanList */
+	private $banByUUID = null;
+
 	/** @var Config */
 	private $operators = null;
 
@@ -1307,6 +1310,13 @@ class Server{
 	}
 
 	/**
+	 * @return BanList
+	 */
+	public function getUUIDBans(){
+		return $this->banByUUID;
+	}
+
+	/**
 	 * @param string $name
 	 */
 	public function addOp(string $name){
@@ -1576,6 +1586,9 @@ class Server{
 			@touch($this->dataPath . "banned-ips.txt");
 			$this->banByIP = new BanList($this->dataPath . "banned-ips.txt");
 			$this->banByIP->load();
+			@touch($this->dataPath . "banned-uuids.txt");
+			$this->banByUUID = new BanList($this->dataPath . "banned-uuids.txt");
+			$this->banByUUID->load();
 
 			$this->maxPlayers = $this->getConfigInt("max-players", 20);
 			$this->setAutoSave($this->getConfigBool("auto-save", true));
@@ -2006,8 +2019,9 @@ class Server{
 			$this->setConfigInt("difficulty", Level::DIFFICULTY_HARD);
 		}
 
-		$this->banByIP->load();
 		$this->banByName->load();
+		$this->banByIP->load();
+		$this->banByUUID->load();
 		$this->reloadWhitelist();
 		$this->operators->reload();
 

--- a/src/pocketmine/command/defaults/BanCommand.php
+++ b/src/pocketmine/command/defaults/BanCommand.php
@@ -28,6 +28,7 @@ use pocketmine\command\CommandSender;
 use pocketmine\command\utils\InvalidCommandSyntaxException;
 use pocketmine\event\TranslationContainer;
 use pocketmine\Player;
+use pocketmine\utils\UUID;
 
 class BanCommand extends VanillaCommand{
 
@@ -56,6 +57,19 @@ class BanCommand extends VanillaCommand{
 
 		if(($player = $sender->getServer()->getPlayerExact($name)) instanceof Player){
 			$player->kick($reason !== "" ? "Banned by admin. Reason: " . $reason : "Banned by admin.");
+
+			$sender->getServer()->getUUIDBans()->addBan($player->getUniqueId()->toString(), $reason, null, $sender->getName());
+
+			$mapFilePath = $sender->getServer()->getDataPath() . "banned-player-uuid-map.yml";
+
+			$mapFileData = [];
+
+			if (file_exists($mapFilePath)) {
+				$mapFileData = yaml_parse_file($mapFilePath);
+			}
+
+			$mapFileData[strtolower($name)] = $player->getUniqueId()->toString();
+			yaml_emit_file($mapFilePath, $mapFileData);
 		}
 
 		Command::broadcastCommandMessage($sender, new TranslationContainer("%commands.ban.success", [$player !== null ? $player->getName() : $name]));

--- a/src/pocketmine/command/defaults/PardonCommand.php
+++ b/src/pocketmine/command/defaults/PardonCommand.php
@@ -27,6 +27,7 @@ use pocketmine\command\Command;
 use pocketmine\command\CommandSender;
 use pocketmine\command\utils\InvalidCommandSyntaxException;
 use pocketmine\event\TranslationContainer;
+use pocketmine\utils\UUID;
 
 class PardonCommand extends VanillaCommand{
 
@@ -40,15 +41,33 @@ class PardonCommand extends VanillaCommand{
 	}
 
 	public function execute(CommandSender $sender, string $commandLabel, array $args){
-		if(!$this->testPermission($sender)){
+		if(!$this->testPermission($sender))
 			return true;
-		}
 
-		if(count($args) !== 1){
+		if(count($args) !== 1)
 			throw new InvalidCommandSyntaxException();
-		}
 
 		$sender->getServer()->getNameBans()->remove($args[0]);
+
+		$mapFilePath = $sender->getServer()->getDataPath() . "banned-player-uuid-map.yml";
+
+		if (file_exists($mapFilePath)){
+			$mapFileData = yaml_parse_file($mapFilePath);
+
+			if (isset($mapFileData[strtolower($args[0])])){
+				try {
+					$uuid = UUID::fromString($mapFileData[strtolower($args[0])]);
+
+					$sender->getServer()->getUUIDBans()->remove($uuid->toString());
+				}catch(\Exception $exception){
+					$sender->getServer()->getLogger()->debug("UUID for pardoned player found, but invalid");
+				}
+
+				unset($mapFileData[$args[0]]);
+			}
+
+			yaml_emit_file($mapFilePath, $mapFileData);
+		}
 
 		Command::broadcastCommandMessage($sender, new TranslationContainer("commands.unban.success", [$args[0]]));
 


### PR DESCRIPTION
UUIDs are a far more reliable method to uniquely
identify players.

## Introduction
This allows server admins to ban a player based on UUID, using either the player's UUID directly, or the player's name. It also lets them unban an UUID.

## Changes
### API changes
getUUIDBans is now a function on the Server instance.

### Behavioural changes
N/A

## Backwards compatibility
N/A

## Tests
I've tested all the commands, and they work correctly (in English, at least), and players cannot log in when their UUID is banned.