### PR TITLE
Match Entity::DATA_FLAG_ONFIRE behaviour with vanilla MCPE

### DIFF
--- a/src/pocketmine/entity/Effect.php
+++ b/src/pocketmine/entity/Effect.php
@@ -442,8 +442,8 @@ class Effect{
 				}
 				break;
 			case Effect::FIRE_RESISTANCE:
-				if($entity->getFireTicks() > 2){
-					$entity->setFireTicks(2);
+				if($entity->getFireTicks() > 40){
+					$entity->setFireTicks(40);
 				}
 				break;
 		}

--- a/src/pocketmine/entity/Effect.php
+++ b/src/pocketmine/entity/Effect.php
@@ -441,6 +441,9 @@ class Effect{
 					$entity->setAbsorption($new);
 				}
 				break;
+			case Effect::FIRE_RESISTANCE:
+				$entity->extinguish(2);
+				break;
 		}
 	}
 

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -989,18 +989,35 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 		return $this->fireTicks > 0;
 	}
 
-	public function setOnFire(int $seconds){
+	/**
+	 * Sets the entity on fire.
+	 *
+	 * @param int $seconds
+	 *
+	 * @return bool whether the entity was successfully set on fire.
+	 */
+	public function setOnFire(int $seconds) : bool{
 		$ticks = $seconds * 20;
-		if($ticks > $this->fireTicks){
+
+		$isUpdated = $ticks > $this->fireTicks;
+		if($isUpdated){
 			$this->fireTicks = $ticks;
+			$this->setGenericFlag(self::DATA_FLAG_ONFIRE, true);
 		}
 
-		$this->setGenericFlag(self::DATA_FLAG_ONFIRE, true);
+		return $isUpdated;
 	}
 
-	public function extinguish(){
-		$this->fireTicks = 0;
-		$this->setGenericFlag(self::DATA_FLAG_ONFIRE, false);
+	/**
+	 * Extinguishes the entity if on fire.
+	 *
+	 * @param int $seconds delay in extinguishing the entity.
+	 */
+	public function extinguish(int $seconds = 0) : void{
+		$this->fireTicks = $seconds * 20;
+		if($seconds === 0){
+			$this->setGenericFlag(self::DATA_FLAG_ONFIRE, false);
+		}
 	}
 
 	public function isFireProof() : bool{

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -1023,7 +1023,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 	public function extinguish(){
 		$this->fireTicks = 0;
 		$this->setGenericFlag(self::DATA_FLAG_ONFIRE, false);
-
 	}
 
 	public function isFireProof() : bool{

--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -384,7 +384,7 @@ abstract class Living extends Entity implements Damageable{
 			$e = $source->getDamager();
 			if($source instanceof EntityDamageByChildEntityEvent){
 				$e = $source->getChild();
-				if($e->isOnFire() > 0){
+				if($e !== null and $e->isOnFire() > 0){
 					$this->setOnFire(2 * $this->level->getDifficulty());
 				}
 			}

--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -384,7 +384,7 @@ abstract class Living extends Entity implements Damageable{
 			$e = $source->getDamager();
 			if($source instanceof EntityDamageByChildEntityEvent){
 				$e = $source->getChild();
-				if($e !== null and $e->isOnFire() > 0){
+				if($e !== null and $e->isOnFire()){
 					$this->setOnFire(2 * $this->level->getDifficulty());
 				}
 			}

--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -384,13 +384,12 @@ abstract class Living extends Entity implements Damageable{
 			$e = $source->getDamager();
 			if($source instanceof EntityDamageByChildEntityEvent){
 				$e = $source->getChild();
-			}
-
-			if($e !== null){
 				if($e->isOnFire() > 0){
 					$this->setOnFire(2 * $this->level->getDifficulty());
 				}
+			}
 
+			if($e !== null){
 				$deltaX = $this->x - $e->x;
 				$deltaZ = $this->z - $e->z;
 				$this->knockBack($e, $source->getDamage(), $deltaX, $deltaZ, $source->getKnockBack());
@@ -516,6 +515,10 @@ abstract class Living extends Entity implements Damageable{
 				$effect->setDuration($duration);
 			}
 		}
+	}
+
+	public function setOnFire(int $seconds) : bool{
+		return !$this->hasEffect(Effect::FIRE_RESISTANCE) and parent::setOnFire($seconds);
 	}
 
 	protected function dealFireDamage(){


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This PR fixes non-vanilla behaviours related to `Entity::DATA_FLAG_ONFIRE` and brings changes in certain entity-fire related API functions.

### Relevant issues
* Fixes #1778

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
* `Entity::setOnFire()` now returns `(boolean)` whether `Entity::$fireTicks`'s value was changed. See Tests.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
* `Effect::FIRE_RESISTANCE` behaves the same way it does in vanilla:
  * Entities will not be set on fire while having `Effect::FIRE_RESISTANCE` on them.
  * Entities that were put on fire before having `Effect::FIRE_RESISTANCE` on them will need to wait 2 seconds for the effect to extinguish the fire off them. _[**NOTE:** The wait time of 2 seconds is capped to `Entity::$fireTicks`, meaning that only if `Entity::$fireTicks` > 2 seconds, the entity will be extinguished in 2 seconds)_. During these 2 seconds, the entity will NOT deal any fire damage albeit on fire.
* Living entities won't be set on fire when hurt by another entity that is on fire, unless hurt through `EntityDamageByChildEvent` (called by Projectiles).

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
```php
/** @var Entity $entity */
$entity->extinguish();

var_dump($entity->setOnFire(10));//bool(true)
var_dump($entity->setOnFire(8));//bool(false) #Entity::$fireTicks > 8.
```