### PR TITLE
Added the EXECUTE priority.

### DIFF
--- a/src/pocketmine/event/EventPriority.php
+++ b/src/pocketmine/event/EventPriority.php
@@ -28,38 +28,49 @@ namespace pocketmine\event;
  * List of event priorities
  *
  * Events will be called in this order:
- * LOWEST -> LOW -> NORMAL -> HIGH -> HIGHEST -> MONITOR
+ * LOWEST -> LOW -> NORMAL -> HIGH -> HIGHEST -> MONITOR -> EXECUTE
  *
  * MONITOR events should not change the event outcome or contents
  */
 abstract class EventPriority{
 	/**
 	 * Event call is of very low importance and should be ran first, to allow
-	 * other plugins to further customise the outcome
+	 * changes from other plugins to override the outcome
 	 */
-	public const LOWEST = 5;
+	public const LOWEST = 6;
 	/**
 	 * Event call is of low importance
 	 */
-	public const LOW = 4;
+	public const LOW = 5;
 	/**
 	 * Event call is neither important or unimportant, and may be ran normally
 	 */
-	public const NORMAL = 3;
+	public const NORMAL = 4;
 	/**
 	 * Event call is of high importance
 	 */
-	public const HIGH = 2;
+	public const HIGH = 3;
 	/**
 	 * Event call is critical and must have the final say in what happens
 	 * to the event
 	 */
-	public const HIGHEST = 1;
+	public const HIGHEST = 2;
 	/**
-	 * Event is listened to purely for monitoring the outcome of an event.
+	 * Event is listened to purely for monitoring the outcome of the event.
+	 * For example, event-logging plugins should use this priority.
 	 *
 	 * No modifications to the event should be made under this priority
 	 */
-	public const MONITOR = 0;
+	public const MONITOR = 1;
+	/**
+	 * Event is listened to for overriding the execution of the event by
+	 * cancelling it.
+	 *
+	 * This priority is useful for plugins that do not change how the
+	 * incident occurs, i.e. semantically the incident represented by the
+	 * event still occurs, but it is technically cancelled to prevent the
+	 * event from being executed by the calling context.
+	 */
+	public const EXECUTE = 0;
 
 }

--- a/src/pocketmine/event/HandlerList.php
+++ b/src/pocketmine/event/HandlerList.php
@@ -77,7 +77,8 @@ class HandlerList{
 			EventPriority::NORMAL => [],
 			EventPriority::HIGH => [],
 			EventPriority::HIGHEST => [],
-			EventPriority::MONITOR => []
+			EventPriority::MONITOR => [],
+			EventPriority::EXECUTE => []
 		];
 		self::$allLists[] = $this;
 	}
@@ -88,7 +89,7 @@ class HandlerList{
 	 * @throws \Exception
 	 */
 	public function register(RegisteredListener $listener){
-		if($listener->getPriority() < EventPriority::MONITOR or $listener->getPriority() > EventPriority::LOWEST){
+		if($listener->getPriority() < EventPriority::EXECUTE or $listener->getPriority() > EventPriority::LOWEST){
 			return;
 		}
 		if(isset($this->handlerSlots[$listener->getPriority()][spl_object_hash($listener)])){


### PR DESCRIPTION
## Description
Under this priority, an event is listened to for cancelling it and overriding its execution.

This priority is useful for plugins that do not change how the incident occurs, i.e. semantically the incident represented by the event still occurs, but it is technically cancelled to prevent the event from being executed by the calling context.

## Example: DiscordMirror + HologramChat
Suppose we have these two plugins:
* DiscordMirror: it mirrors all chat messages to a Discord channel
* HologramChat: it shows chat messages as holograms (FloatingText) rather than using the traditional Player->sendMessage().

The DiscordMirror plugin should listen to PlayerChatEvent at the MONITOR priority. It should ignore cancelled events, e.g. anti-spam plugins and plugins that override chat for other input (e.g. auth plugins may use it for receiving passwords).

What about the HologramChat plugin? It should override default behaviour by cancelling the event and spawning the FloatingText in its handler. But if it cancels the event at LOWEST to HIGHEST, it will stop DiscordMirror from working. At the MONITOR event, since the order is undefined, it may or may not affect DiscordMirror.

This PR allows HologramChat to handle the event at the EXECUTE priority, which will not affect plugins that only concern the final semantic outcome of the event (DiscordChat).

## Backward compatibility
This PR should preserve 100% backward-compatibility, because the number of event priorities has not been guaranteed to remain unchanged.