### PR TITLE
PluginManager: Altered regex to allow @ignoreCancelled without a value

### DIFF
--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -760,7 +760,7 @@ class PluginManager{
 					if(!isset($matches[1])){
 						$ignoreCancelled = true;
 					}else{
-						$matches[1] = strtolower($matches[1]);
+						$matches[1] = strtolower(trim($matches[1]));
 						if($matches[1] === "false"){
 							$ignoreCancelled = false;
 						}elseif($matches[1] === "true"){

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -756,12 +756,16 @@ class PluginManager{
 						$priority = constant(EventPriority::class . "::" . $matches[1]);
 					}
 				}
-				if(preg_match("/^[\t ]*\\* @ignoreCancelled[\t ]{1,}([a-zA-Z]{1,})/m", (string) $method->getDocComment(), $matches) > 0){
-					$matches[1] = strtolower($matches[1]);
-					if($matches[1] === "false"){
-						$ignoreCancelled = false;
-					}elseif($matches[1] === "true"){
+				if(preg_match("/^[\t ]*\\* @ignoreCancelled([\t ]{1,}([a-zA-Z]{1,}))?/m", (string) $method->getDocComment(), $matches) > 0){
+					if(!isset($matches[1])){
 						$ignoreCancelled = true;
+					}else{
+						$matches[1] = strtolower($matches[1]);
+						if($matches[1] === "false"){
+							$ignoreCancelled = false;
+						}elseif($matches[1] === "true"){
+							$ignoreCancelled = true;
+						}
 					}
 				}
 


### PR DESCRIPTION
## Introduction
This allows specification of `@ignoreCancelled` on event handlers without a `true` or `false` value. If a value is not specified, `true` is used.

## Changes
### API changes
see intro

## Tests
```php
	/**
	 * @param BlockBreakEvent $event
	 * @ignoreCancelled
         */
	public function onBlockBreak(BlockBreakEvent $event){
		var_dump($event->getPlayer()->lastBreak);
		$event->getPlayer()->sendMessage("Time to break: " . ceil((microtime(true) - $event->getPlayer()->lastBreak) * 20) . " ticks");
		$event->getPlayer()->sendMessage("Expected: " . ceil($event->getBlock()->getBreakTime($event->getItem()) * 20) . " ticks");
	}
```
