### PR TITLE
Fixed wrong execution PlayerPreLoginEvent close #1831

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1827,7 +1827,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		}
 
 		$this->setSkin($skin);
-		
+
 		$this->server->getPluginManager()->callEvent($ev = new PlayerPreLoginEvent($this, "Plugin reason"));
 		if($ev->isCancelled()){
 			$this->close("", $ev->getKickMessage());

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1827,6 +1827,13 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		}
 
 		$this->setSkin($skin);
+		
+		$this->server->getPluginManager()->callEvent($ev = new PlayerPreLoginEvent($this, "Plugin reason"));
+		if($ev->isCancelled()){
+			$this->close("", $ev->getKickMessage());
+
+			return true;
+		}
 
 		if(!$this->server->isWhitelisted($this->iusername) and $this->kick("Server is white-listed", false)){
 			return true;
@@ -1836,13 +1843,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 			($this->isBanned() or $this->server->getIPBans()->isBanned($this->getAddress())) and
 			$this->kick("You are banned", false)
 		){
-			return true;
-		}
-
-		$this->server->getPluginManager()->callEvent($ev = new PlayerPreLoginEvent($this, "Plugin reason"));
-		if($ev->isCancelled()){
-			$this->close("", $ev->getKickMessage());
-
 			return true;
 		}
 


### PR DESCRIPTION
## Introduction
See https://github.com/pmmp/PocketMine-MP/issues/1831

## Changes
### API changes
`PlayerPreLoginEvent` will be called before check `BanList` and `WhiteList`

## Backward compatibility
This PR should preserve 100% backward-compatibility

## Tests
```
	public function onPlayerPreLoginEvent(PlayerPreLoginEvent $event)
	{
		$player = $event->getPlayer();
		if ($player->isBanned() && $player->hasPermission("ban.exempt")) {
			$player->setBanned(false);
		}
	}
```