### PR TITLE
Implemented TextFormat::colorize()

### DIFF
--- a/src/pocketmine/utils/TextFormat.php
+++ b/src/pocketmine/utils/TextFormat.php
@@ -81,6 +81,18 @@ abstract class TextFormat{
 	}
 
 	/**
+	 * Replaces placeholders of § with the correct character. Only valid codes (as in the constants of the TextFormat class) will be converted.
+	 *
+	 * @param string $string
+	 * @param string $placeholder default "&"
+	 *
+	 * @return string
+	 */
+	public static function colorize(string $string, string $placeholder = "&") : string{
+		return preg_replace('/' . preg_quote($placeholder) . '([0-9a-fk-or])/u', TextFormat::ESCAPE . '$1', $string);
+	}
+
+	/**
 	 * Returns an JSON-formatted string with colors/markup
 	 *
 	 * @param string|array $string

--- a/src/pocketmine/utils/TextFormat.php
+++ b/src/pocketmine/utils/TextFormat.php
@@ -89,7 +89,7 @@ abstract class TextFormat{
 	 * @return string
 	 */
 	public static function colorize(string $string, string $placeholder = "&") : string{
-		return preg_replace('/' . preg_quote($placeholder) . '([0-9a-fk-or])/u', TextFormat::ESCAPE . '$1', $string);
+		return preg_replace('/' . preg_quote($placeholder, "/") . '([0-9a-fk-or])/u', TextFormat::ESCAPE . '$1', $string);
 	}
 
 	/**


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
See 4c46087ffccc7f26835a1fc5bbf2ac60397884f9 for the initial discussion

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Added TextFormat::colorize().

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
nil

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
No backward incompatibilities noted.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
nil
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
```php
<?php
use pocketmine\utils\TextFormat;
include "vendor/autoload.php";
echo TextFormat::colorize("&a&b&c&d&e&f&g&h&i&j&&o& r&");
```

```
§a§b§c§d§e§f&g&h&i&j&§o& r&
```