### PR TITLE
Fix direction checking for player interactions, close #983

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1743,11 +1743,10 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	 *
 	 * @param Vector3 $pos
 	 * @param         $maxDistance
-	 * @param float   $maxDiff default 0.71 (approximately sqrt(2) / 2, half of the diagonal width of a block)
 	 *
 	 * @return bool
 	 */
-	public function canInteract(Vector3 $pos, $maxDistance, float $maxDiff = 0.71) : bool{
+	public function canInteract(Vector3 $pos, $maxDistance) : bool{
 		$eyePos = $this->getPosition()->add(0, $this->getEyeHeight(), 0);
 		if($eyePos->distanceSquared($pos) > $maxDistance ** 2){
 			return false;
@@ -1756,7 +1755,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		$dV = $this->getDirectionVector();
 		$eyeDot = $dV->dot($eyePos);
 		$targetDot = $dV->dot($pos);
-		return ($targetDot - $eyeDot) >= -$maxDiff;
+		return ($targetDot - $eyeDot) >= 0;
 	}
 
 	protected function initHumanData(){

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1753,10 +1753,10 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 			return false;
 		}
 
-		$dV = $this->getDirectionPlane();
-		$dot = $dV->dot(new Vector2($eyePos->x, $eyePos->z));
-		$dot1 = $dV->dot(new Vector2($pos->x, $pos->z));
-		return ($dot1 - $dot) >= -$maxDiff;
+		$dV = $this->getDirectionVector();
+		$eyeDot = $dV->dot($eyePos);
+		$targetDot = $dV->dot($pos);
+		return ($targetDot - $eyeDot) >= -$maxDiff;
 	}
 
 	protected function initHumanData(){


### PR DESCRIPTION
## Introduction
This fixes the interaction bug described in #983 .

Previously this checked to make sure that the player could interact with the specified block based on their current yaw (no more than 90 degrees either side). This works relatively fine when using crosshairs, but presents problems when using mobile touch controls for mining and placing blocks, since they allow touching blocks which are behind the player.

This PR changes the direction check to also take pitch into account when doing direction checks. This means that the range of clickable blocks will now rotate on the Y axis when the player turns their head, which means they can now legally touch blocks "behind" themselves within certain bounds (again, 90 degrees either way).

### Relevant issues
fixes #983 

## Changes
### Behavioural changes
Direction check now works correctly and does not interfere with mobile players' interactions.

## Backwards compatibility
The `maxDiff` parameter (which is now obsolete) has been removed from `Player->canInteract()`. Overloading this will still work fine, but the overloaded arguments will be ignored. Nothing in the core uses this anyway.

## Tests
Tested:
- with a desktop client, crosshairs - works fine
- mobile client, free touch controls - works fine
- mobile client, free touch controls, hacks for placing blocks in the opposite direction to self: triggers anti-cheat.

## Notes
This check could just be removed. However I felt it was more productive to understand it and try to fix it, since it was already there.