### PR TITLE
Fixed beds drop in creative when the bottom is broken

### DIFF
--- a/src/pocketmine/block/Bed.php
+++ b/src/pocketmine/block/Bed.php
@@ -27,6 +27,7 @@ use pocketmine\event\TranslationContainer;
 use pocketmine\item\Item;
 use pocketmine\item\ItemFactory;
 use pocketmine\level\Level;
+use pocketmine\level\particle\DestroyBlockParticle;
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Vector3;
 use pocketmine\Player;
@@ -193,7 +194,14 @@ class Bed extends Transparent{
 	public function onBreak(Item $item, Player $player = null) : bool{
 		$this->getLevel()->setBlock($this, BlockFactory::get(Block::AIR), true, true);
 		if(($other = $this->getOtherHalf()) !== null){
-			$this->getLevel()->useBreakOn($other, $item, null, $player !== null); //make sure tiles get removed
+			if($player !== null){
+				$other->getLevel()->addParticle(new DestroyBlockParticle($other->add(0.5, 0.5, 0.5), $other));
+			}
+			$tile = $other->getLevel()->getTile($other);
+			if($tile !== null){
+				$tile->close();
+			}
+			$other->getLevel()->setBlock($other, BlockFactory::get(Block::AIR), true, true);
 		}
 
 		return true;


### PR DESCRIPTION
## Introduction
bed should not drop when it is broken in creative

### Relevant issues
fixed #1525

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
Bug check is done, I think this will work correctly.