### PR TITLE
LevelProviders refactor

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -2406,6 +2406,10 @@ class Level implements ChunkManager, Metadatable{
 		if($chunk === null){
 			return;
 		}
+
+		$chunk->setX($chunkX);
+		$chunk->setZ($chunkZ);
+
 		$chunkHash = Level::chunkHash($chunkX, $chunkZ);
 		$oldChunk = $this->getChunk($chunkX, $chunkZ, false);
 		if($unload and $oldChunk !== null){

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -2780,7 +2780,7 @@ class Level implements ChunkManager, Metadatable{
 				}
 			}
 
-			$chunk->unload();
+			$chunk->onUnload();
 		}catch(\Throwable $e){
 			$logger = $this->server->getLogger();
 			$logger->error($this->server->getLanguage()->translateString("pocketmine.level.chunkUnloadError", [$e->getMessage()]));

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -343,7 +343,7 @@ class Level implements ChunkManager, Metadatable{
 		/** @var LevelProvider $provider */
 
 		if(is_subclass_of($provider, LevelProvider::class, true)){
-			$this->provider = new $provider($this, $path);
+			$this->provider = new $provider($path);
 		}else{
 			throw new LevelException("Provider is not a subclass of LevelProvider");
 		}
@@ -2546,7 +2546,7 @@ class Level implements ChunkManager, Metadatable{
 				}
 				$this->timings->syncChunkSendPrepareTimer->startTiming();
 
-				$chunk = $this->provider->getChunk($x, $z, false);
+				$chunk = $this->provider->getChunk($x, $z);
 				if(!($chunk instanceof Chunk)){
 					throw new ChunkException("Invalid Chunk sent");
 				}
@@ -2686,7 +2686,13 @@ class Level implements ChunkManager, Metadatable{
 
 		$this->cancelUnloadChunkRequest($x, $z);
 
-		$chunk = $this->provider->getChunk($x, $z, $generate);
+		$this->timings->syncChunkLoadDataTimer->startTiming();
+
+		$this->provider->loadChunk($x, $z, $generate);
+		$chunk = $this->provider->getChunk($x, $z);
+
+		$this->timings->syncChunkLoadDataTimer->stopTiming();
+
 		if($chunk === null){
 			if($generate){
 				throw new \InvalidStateException("Could not create new Chunk");

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -2763,12 +2763,11 @@ class Level implements ChunkManager, Metadatable{
 			$this->server->getPluginManager()->callEvent($ev = new ChunkUnloadEvent($this, $chunk));
 			if($ev->isCancelled()){
 				$this->timings->doChunkUnload->stopTiming();
+
 				return false;
 			}
-		}
 
-		try{
-			if($chunk !== null){
+			try{
 				if($trySave and $this->getAutoSave() and $chunk->isGenerated()){
 					if($chunk->hasChanged() or count($chunk->getTiles()) > 0 or count($chunk->getSavableEntities()) > 0){
 						$this->provider->saveChunk($chunk);
@@ -2780,11 +2779,11 @@ class Level implements ChunkManager, Metadatable{
 				}
 
 				$chunk->onUnload();
+			}catch(\Throwable $e){
+				$logger = $this->server->getLogger();
+				$logger->error($this->server->getLanguage()->translateString("pocketmine.level.chunkUnloadError", [$e->getMessage()]));
+				$logger->logException($e);
 			}
-		}catch(\Throwable $e){
-			$logger = $this->server->getLogger();
-			$logger->error($this->server->getLanguage()->translateString("pocketmine.level.chunkUnloadError", [$e->getMessage()]));
-			$logger->logException($e);
 		}
 
 		unset($this->chunks[$chunkHash]);

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -2780,8 +2780,7 @@ class Level implements ChunkManager, Metadatable{
 				}
 			}
 
-			//TODO: not checking return value, but is it needed anyway?
-			$chunk->unload($safe);
+			$chunk->unload();
 		}catch(\Throwable $e){
 			$logger = $this->server->getLogger();
 			$logger->error($this->server->getLanguage()->translateString("pocketmine.level.chunkUnloadError", [$e->getMessage()]));

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -2778,9 +2778,9 @@ class Level implements ChunkManager, Metadatable{
 				foreach($this->getChunkLoaders($x, $z) as $loader){
 					$loader->onChunkUnloaded($chunk);
 				}
-			}
 
-			$chunk->onUnload();
+				$chunk->onUnload();
+			}
 		}catch(\Throwable $e){
 			$logger = $this->server->getLogger();
 			$logger->error($this->server->getLanguage()->translateString("pocketmine.level.chunkUnloadError", [$e->getMessage()]));

--- a/src/pocketmine/level/format/Chunk.php
+++ b/src/pocketmine/level/format/Chunk.php
@@ -691,9 +691,9 @@ class Chunk{
 	}
 
 	/**
-	 * Unloads the chunk, closing entities and tiles.
+	 * Called when the chunk is unloaded, closing entities and tiles.
 	 */
-	public function unload() : void{
+	public function onUnload() : void{
 		foreach($this->getEntities() as $entity){
 			if($entity instanceof Player){
 				continue;

--- a/src/pocketmine/level/format/Chunk.php
+++ b/src/pocketmine/level/format/Chunk.php
@@ -692,20 +692,8 @@ class Chunk{
 
 	/**
 	 * Unloads the chunk, closing entities and tiles.
-	 *
-	 * @param bool $safe Whether to check if there are still players using this chunk
-	 *
-	 * @return bool
 	 */
-	public function unload(bool $safe = true) : bool{
-		if($safe){
-			foreach($this->getEntities() as $entity){
-				if($entity instanceof Player){
-					return false;
-				}
-			}
-		}
-
+	public function unload() : void{
 		foreach($this->getEntities() as $entity){
 			if($entity instanceof Player){
 				continue;
@@ -716,8 +704,6 @@ class Chunk{
 		foreach($this->getTiles() as $tile){
 			$tile->close();
 		}
-
-		return true;
 	}
 
 	/**

--- a/src/pocketmine/level/format/io/BaseLevelProvider.php
+++ b/src/pocketmine/level/format/io/BaseLevelProvider.php
@@ -37,8 +37,6 @@ abstract class BaseLevelProvider implements LevelProvider{
 	protected $path;
 	/** @var CompoundTag */
 	protected $levelData;
-	/** @var Chunk[] */
-	protected $chunks = [];
 
 	public function __construct(string $path){
 		$this->path = $path;
@@ -117,84 +115,20 @@ abstract class BaseLevelProvider implements LevelProvider{
 		file_put_contents($this->getPath() . "level.dat", $buffer);
 	}
 
-	public function getChunk(int $chunkX, int $chunkZ){
-		return $this->chunks[Level::chunkHash($chunkX, $chunkZ)] ?? null;
-	}
-
-	public function isChunkLoaded(int $chunkX, int $chunkZ) : bool{
-		return isset($this->chunks[Level::chunkHash($chunkX, $chunkZ)]);
-	}
-
-	public function getLoadedChunks() : array{
-		return $this->chunks;
-	}
-
-	public function loadChunk(int $chunkX, int $chunkZ, bool $create = false) : bool{
-		$index = Level::chunkHash($chunkX, $chunkZ);
-		if(isset($this->chunks[$index])){
-			return true;
-		}
-
+	public function loadChunk(int $chunkX, int $chunkZ, bool $create = false) : ?Chunk{
 		$chunk = $this->readChunk($chunkX, $chunkZ);
 		if($chunk === null and $create){
 			$chunk = new Chunk($chunkX, $chunkZ);
 		}
 
-		if($chunk !== null){
-			$this->chunks[$index] = $chunk;
-
-			return true;
-		}else{
-			return false;
-		}
+		return $chunk;
 	}
 
-	public function setChunk(int $chunkX, int $chunkZ, Chunk $chunk){
-		$chunk->setX($chunkX);
-		$chunk->setZ($chunkZ);
-
-		if(isset($this->chunks[$index = Level::chunkHash($chunkX, $chunkZ)]) and $this->chunks[$index] !== $chunk){
-			$this->unloadChunk($chunkX, $chunkZ, false);
+	public function saveChunk(Chunk $chunk) : void{
+		if(!$chunk->isGenerated()){
+			throw new \InvalidStateException("Cannot save un-generated chunk");
 		}
-
-		$this->chunks[$index] = $chunk;
-	}
-
-	public function saveChunks(){
-		foreach($this->chunks as $chunk){
-			$this->saveChunk($chunk->getX(), $chunk->getZ());
-		}
-	}
-
-	public function saveChunk(int $chunkX, int $chunkZ) : bool{
-		if($this->isChunkLoaded($chunkX, $chunkZ)){
-			$chunk = $this->getChunk($chunkX, $chunkZ);
-			if(!$chunk->isGenerated()){
-				throw new \InvalidStateException("Cannot save un-generated chunk");
-			}
-			$this->writeChunk($chunk);
-
-			return true;
-		}
-
-		return false;
-	}
-
-	public function unloadChunk(int $chunkX, int $chunkZ, bool $safe = true) : bool{
-		$chunk = $this->chunks[$index = Level::chunkHash($chunkX, $chunkZ)] ?? null;
-		if($chunk instanceof Chunk and $chunk->unload($safe)){
-			unset($this->chunks[$index]);
-			return true;
-		}
-
-		return false;
-	}
-
-	public function unloadChunks(){
-		foreach($this->chunks as $chunk){
-			$this->unloadChunk($chunk->getX(), $chunk->getZ(), false);
-		}
-		$this->chunks = [];
+		$this->writeChunk($chunk);
 	}
 
 	abstract protected function readChunk(int $chunkX, int $chunkZ) : ?Chunk;

--- a/src/pocketmine/level/format/io/BaseLevelProvider.php
+++ b/src/pocketmine/level/format/io/BaseLevelProvider.php
@@ -70,14 +70,6 @@ abstract class BaseLevelProvider implements LevelProvider{
 		return $this->path;
 	}
 
-	public function getServer(){
-		return $this->level->getServer();
-	}
-
-	public function getLevel() : Level{
-		return $this->level;
-	}
-
 	public function getName() : string{
 		return $this->levelData->getString("LevelName");
 	}
@@ -215,15 +207,6 @@ abstract class BaseLevelProvider implements LevelProvider{
 			$this->unloadChunk($chunk->getX(), $chunk->getZ(), false);
 		}
 		$this->chunks = [];
-	}
-
-	public function isChunkPopulated(int $chunkX, int $chunkZ) : bool{
-		$chunk = $this->getChunk($chunkX, $chunkZ);
-		if($chunk !== null){
-			return $chunk->isPopulated();
-		}else{
-			return false;
-		}
 	}
 
 	abstract protected function readChunk(int $chunkX, int $chunkZ) : ?Chunk;

--- a/src/pocketmine/level/format/io/BaseLevelProvider.php
+++ b/src/pocketmine/level/format/io/BaseLevelProvider.php
@@ -33,8 +33,6 @@ use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\StringTag;
 
 abstract class BaseLevelProvider implements LevelProvider{
-	/** @var Level */
-	protected $level;
 	/** @var string */
 	protected $path;
 	/** @var CompoundTag */
@@ -42,8 +40,7 @@ abstract class BaseLevelProvider implements LevelProvider{
 	/** @var Chunk[] */
 	protected $chunks = [];
 
-	public function __construct(Level $level, string $path){
-		$this->level = $level;
+	public function __construct(string $path){
 		$this->path = $path;
 		if(!file_exists($this->path)){
 			mkdir($this->path, 0777, true);
@@ -120,15 +117,8 @@ abstract class BaseLevelProvider implements LevelProvider{
 		file_put_contents($this->getPath() . "level.dat", $buffer);
 	}
 
-	public function getChunk(int $chunkX, int $chunkZ, bool $create = false){
-		$index = Level::chunkHash($chunkX, $chunkZ);
-		if(isset($this->chunks[$index])){
-			return $this->chunks[$index];
-		}else{
-			$this->loadChunk($chunkX, $chunkZ, $create);
-
-			return $this->chunks[$index] ?? null;
-		}
+	public function getChunk(int $chunkX, int $chunkZ){
+		return $this->chunks[Level::chunkHash($chunkX, $chunkZ)] ?? null;
 	}
 
 	public function isChunkLoaded(int $chunkX, int $chunkZ) : bool{
@@ -145,12 +135,10 @@ abstract class BaseLevelProvider implements LevelProvider{
 			return true;
 		}
 
-		$this->level->timings->syncChunkLoadDataTimer->startTiming();
 		$chunk = $this->readChunk($chunkX, $chunkZ);
 		if($chunk === null and $create){
 			$chunk = new Chunk($chunkX, $chunkZ);
 		}
-		$this->level->timings->syncChunkLoadDataTimer->stopTiming();
 
 		if($chunk !== null){
 			$this->chunks[$index] = $chunk;

--- a/src/pocketmine/level/format/io/LevelProvider.php
+++ b/src/pocketmine/level/format/io/LevelProvider.php
@@ -145,22 +145,6 @@ interface LevelProvider{
 	public function isChunkLoaded(int $chunkX, int $chunkZ) : bool;
 
 	/**
-	 * @param int $chunkX
-	 * @param int $chunkZ
-	 *
-	 * @return bool
-	 */
-	public function isChunkGenerated(int $chunkX, int $chunkZ) : bool;
-
-	/**
-	 * @param int $chunkX
-	 * @param int $chunkZ
-	 *
-	 * @return bool
-	 */
-	public function isChunkPopulated(int $chunkX, int $chunkZ) : bool;
-
-	/**
 	 * @return string
 	 */
 	public function getName() : string;
@@ -213,11 +197,6 @@ interface LevelProvider{
 	public function getLoadedChunks() : array;
 
 	public function doGarbageCollection();
-
-	/**
-	 * @return Level
-	 */
-	public function getLevel() : Level;
 
 	public function close();
 

--- a/src/pocketmine/level/format/io/LevelProvider.php
+++ b/src/pocketmine/level/format/io/LevelProvider.php
@@ -151,8 +151,14 @@ interface LevelProvider{
 	 */
 	public function setDifficulty(int $difficulty);
 
+	/**
+	 * Performs garbage collection in the level provider, such as cleaning up regions in Region-based worlds.
+	 */
 	public function doGarbageCollection();
 
+	/**
+	 * Performs cleanups necessary when the level provider is closed and no longer needed.
+	 */
 	public function close();
 
 }

--- a/src/pocketmine/level/format/io/LevelProvider.php
+++ b/src/pocketmine/level/format/io/LevelProvider.php
@@ -24,16 +24,14 @@ declare(strict_types=1);
 namespace pocketmine\level\format\io;
 
 use pocketmine\level\format\Chunk;
-use pocketmine\level\Level;
 use pocketmine\math\Vector3;
 
 interface LevelProvider{
 
 	/**
-	 * @param Level  $level
 	 * @param string $path
 	 */
-	public function __construct(Level $level, string $path);
+	public function __construct(string $path);
 
 	/**
 	 * Returns the full provider name, like "anvil" or "mcregion", will be used to find the correct format.
@@ -91,13 +89,12 @@ interface LevelProvider{
 	 * Gets the Chunk object
 	 * This method must be implemented by all the level formats.
 	 *
-	 * @param int  $chunkX
-	 * @param int  $chunkZ
-	 * @param bool $create
+	 * @param int $chunkX
+	 * @param int $chunkZ
 	 *
 	 * @return Chunk|null
 	 */
-	public function getChunk(int $chunkX, int $chunkZ, bool $create = false);
+	public function getChunk(int $chunkX, int $chunkZ);
 
 	/**
 	 * @param int   $chunkX

--- a/src/pocketmine/level/format/io/LevelProvider.php
+++ b/src/pocketmine/level/format/io/LevelProvider.php
@@ -86,60 +86,20 @@ interface LevelProvider{
 	public function getGeneratorOptions() : array;
 
 	/**
-	 * Gets the Chunk object
-	 * This method must be implemented by all the level formats.
-	 *
-	 * @param int $chunkX
-	 * @param int $chunkZ
-	 *
-	 * @return Chunk|null
-	 */
-	public function getChunk(int $chunkX, int $chunkZ);
-
-	/**
-	 * @param int   $chunkX
-	 * @param int   $chunkZ
 	 * @param Chunk $chunk
-	 */
-	public function setChunk(int $chunkX, int $chunkZ, Chunk $chunk);
-
-	/**
-	 * @param int $chunkX
-	 * @param int $chunkZ
 	 *
-	 * @return bool
+	 * @return void
 	 */
-	public function saveChunk(int $chunkX, int $chunkZ) : bool;
-
-	public function saveChunks();
+	public function saveChunk(Chunk $chunk) : void;
 
 	/**
 	 * @param int  $chunkX
 	 * @param int  $chunkZ
 	 * @param bool $create
 	 *
-	 * @return bool
+	 * @return null|Chunk
 	 */
-	public function loadChunk(int $chunkX, int $chunkZ, bool $create = false) : bool;
-
-	/**
-	 * @param int  $chunkX
-	 * @param int  $chunkZ
-	 * @param bool $safe
-	 *
-	 * @return bool
-	 */
-	public function unloadChunk(int $chunkX, int $chunkZ, bool $safe = true) : bool;
-
-	public function unloadChunks();
-
-	/**
-	 * @param int $chunkX
-	 * @param int $chunkZ
-	 *
-	 * @return bool
-	 */
-	public function isChunkLoaded(int $chunkX, int $chunkZ) : bool;
+	public function loadChunk(int $chunkX, int $chunkZ, bool $create = false) : ?Chunk;
 
 	/**
 	 * @return string
@@ -187,11 +147,6 @@ interface LevelProvider{
 	 * @param int $difficulty
 	 */
 	public function setDifficulty(int $difficulty);
-
-	/**
-	 * @return Chunk[]
-	 */
-	public function getLoadedChunks() : array;
 
 	public function doGarbageCollection();
 

--- a/src/pocketmine/level/format/io/LevelProvider.php
+++ b/src/pocketmine/level/format/io/LevelProvider.php
@@ -86,13 +86,16 @@ interface LevelProvider{
 	public function getGeneratorOptions() : array;
 
 	/**
-	 * @param Chunk $chunk
+	 * Saves a chunk (usually to disk).
 	 *
-	 * @return void
+	 * @param Chunk $chunk
 	 */
 	public function saveChunk(Chunk $chunk) : void;
 
 	/**
+	 * Loads a chunk (usually from disk storage) and returns it. If the chunk does not exist, null is returned, or an
+	 * empty Chunk if $create is specified.
+	 *
 	 * @param int  $chunkX
 	 * @param int  $chunkZ
 	 * @param bool $create

--- a/src/pocketmine/level/format/io/leveldb/LevelDB.php
+++ b/src/pocketmine/level/format/io/leveldb/LevelDB.php
@@ -527,7 +527,6 @@ class LevelDB extends BaseLevelProvider{
 	}
 
 	public function close(){
-		$this->unloadChunks();
 		$this->db->close();
 	}
 }

--- a/src/pocketmine/level/format/io/leveldb/LevelDB.php
+++ b/src/pocketmine/level/format/io/leveldb/LevelDB.php
@@ -527,10 +527,6 @@ class LevelDB extends BaseLevelProvider{
 		return $this->db->get(LevelDB::chunkIndex($chunkX, $chunkZ) . self::TAG_VERSION) !== false;
 	}
 
-	public function isChunkGenerated(int $chunkX, int $chunkZ) : bool{
-		return $this->chunkExists($chunkX, $chunkZ) and ($chunk = $this->getChunk($chunkX, $chunkZ, false)) !== null;
-	}
-
 	public function close(){
 		$this->unloadChunks();
 		$this->db->close();

--- a/src/pocketmine/level/format/io/leveldb/LevelDB.php
+++ b/src/pocketmine/level/format/io/leveldb/LevelDB.php
@@ -87,10 +87,9 @@ class LevelDB extends BaseLevelProvider{
 		}
 	}
 
-	public function __construct(Level $level, string $path){
+	public function __construct(string $path){
 		self::checkForLevelDBExtension();
 
-		$this->level = $level;
 		$this->path = $path;
 		if(!file_exists($this->path)){
 			mkdir($this->path, 0777, true);
@@ -530,6 +529,5 @@ class LevelDB extends BaseLevelProvider{
 	public function close(){
 		$this->unloadChunks();
 		$this->db->close();
-		$this->level = null;
 	}
 }

--- a/src/pocketmine/level/format/io/leveldb/LevelDB.php
+++ b/src/pocketmine/level/format/io/leveldb/LevelDB.php
@@ -74,9 +74,6 @@ class LevelDB extends BaseLevelProvider{
 	public const CURRENT_LEVEL_CHUNK_VERSION = 7;
 	public const CURRENT_LEVEL_SUBCHUNK_VERSION = 0;
 
-	/** @var Chunk[] */
-	protected $chunks = [];
-
 	/** @var \LevelDB */
 	protected $db;
 
@@ -249,13 +246,6 @@ class LevelDB extends BaseLevelProvider{
 		file_put_contents($this->getPath() . "level.dat", Binary::writeLInt(self::CURRENT_STORAGE_VERSION) . Binary::writeLInt(strlen($buffer)) . $buffer);
 	}
 
-	public function unloadChunks(){
-		foreach($this->chunks as $chunk){
-			$this->unloadChunk($chunk->getX(), $chunk->getZ(), false);
-		}
-		$this->chunks = [];
-	}
-
 	public function getGenerator() : string{
 		return (string) $this->levelData["generatorName"];
 	}
@@ -272,48 +262,13 @@ class LevelDB extends BaseLevelProvider{
 		$this->levelData->setInt("Difficulty", $difficulty); //yes, this is intended! (in PE: int, PC: byte)
 	}
 
-	public function getLoadedChunks() : array{
-		return $this->chunks;
-	}
-
-	public function isChunkLoaded(int $x, int $z) : bool{
-		return isset($this->chunks[Level::chunkHash($x, $z)]);
-	}
-
-	public function saveChunks(){
-		foreach($this->chunks as $chunk){
-			$this->saveChunk($chunk->getX(), $chunk->getZ());
-		}
-	}
-
-	public function loadChunk(int $chunkX, int $chunkZ, bool $create = false) : bool{
-		if(isset($this->chunks[$index = Level::chunkHash($chunkX, $chunkZ)])){
-			return true;
-		}
-
-		$this->level->timings->syncChunkLoadDataTimer->startTiming();
-		$chunk = $this->readChunk($chunkX, $chunkZ);
-		if($chunk === null and $create){
-			$chunk = new Chunk($chunkX, $chunkZ);
-		}
-		$this->level->timings->syncChunkLoadDataTimer->stopTiming();
-
-		if($chunk !== null){
-			$this->chunks[$index] = $chunk;
-
-			return true;
-		}else{
-			return false;
-		}
-	}
-
 	/**
 	 * @param int $chunkX
 	 * @param int $chunkZ
 	 *
 	 * @return Chunk|null
 	 */
-	private function readChunk($chunkX, $chunkZ){
+	protected function readChunk(int $chunkX, int $chunkZ) : ?Chunk{
 		$index = LevelDB::chunkIndex($chunkX, $chunkZ);
 
 		if(!$this->chunkExists($chunkX, $chunkZ)){
@@ -484,7 +439,7 @@ class LevelDB extends BaseLevelProvider{
 		}
 	}
 
-	private function writeChunk(Chunk $chunk){
+	protected function writeChunk(Chunk $chunk) : void{
 		$index = LevelDB::chunkIndex($chunk->getX(), $chunk->getZ());
 		$this->db->put($index . self::TAG_VERSION, chr(self::CURRENT_LEVEL_CHUNK_VERSION));
 
@@ -557,65 +512,11 @@ class LevelDB extends BaseLevelProvider{
 		}
 	}
 
-	public function unloadChunk(int $x, int $z, bool $safe = true) : bool{
-		$chunk = $this->chunks[$index = Level::chunkHash($x, $z)] ?? null;
-		if($chunk instanceof Chunk and $chunk->unload($safe)){
-			unset($this->chunks[$index]);
-
-			return true;
-		}
-
-		return false;
-	}
-
-	public function saveChunk(int $chunkX, int $chunkZ) : bool{
-		if($this->isChunkLoaded($chunkX, $chunkZ)){
-			$chunk = $this->getChunk($chunkX, $chunkZ);
-			if(!$chunk->isGenerated()){
-				throw new \InvalidStateException("Cannot save un-generated chunk");
-			}
-			$this->writeChunk($chunk);
-
-			return true;
-		}
-
-		return false;
-	}
-
-	/**
-	 * @param int $chunkX
-	 * @param int $chunkZ
-	 * @param bool $create
-	 *
-	 * @return Chunk|null
-	 */
-	public function getChunk(int $chunkX, int $chunkZ, bool $create = false){
-		$index = Level::chunkHash($chunkX, $chunkZ);
-		if(isset($this->chunks[$index])){
-			return $this->chunks[$index];
-		}else{
-			$this->loadChunk($chunkX, $chunkZ, $create);
-
-			return $this->chunks[$index] ?? null;
-		}
-	}
-
 	/**
 	 * @return \LevelDB
 	 */
 	public function getDatabase() : \LevelDB{
 		return $this->db;
-	}
-
-	public function setChunk(int $chunkX, int $chunkZ, Chunk $chunk){
-		$chunk->setX($chunkX);
-		$chunk->setZ($chunkZ);
-
-		if(isset($this->chunks[$index = Level::chunkHash($chunkX, $chunkZ)]) and $this->chunks[$index] !== $chunk){
-			$this->unloadChunk($chunkX, $chunkZ, false);
-		}
-
-		$this->chunks[$index] = $chunk;
 	}
 
 	public static function chunkIndex(int $chunkX, int $chunkZ) : string{
@@ -628,15 +529,6 @@ class LevelDB extends BaseLevelProvider{
 
 	public function isChunkGenerated(int $chunkX, int $chunkZ) : bool{
 		return $this->chunkExists($chunkX, $chunkZ) and ($chunk = $this->getChunk($chunkX, $chunkZ, false)) !== null;
-	}
-
-	public function isChunkPopulated(int $chunkX, int $chunkZ) : bool{
-		$chunk = $this->getChunk($chunkX, $chunkZ);
-		if($chunk instanceof Chunk){
-			return $chunk->isPopulated();
-		}else{
-			return false;
-		}
 	}
 
 	public function close(){

--- a/src/pocketmine/level/format/io/region/McRegion.php
+++ b/src/pocketmine/level/format/io/region/McRegion.php
@@ -350,7 +350,6 @@ class McRegion extends BaseLevelProvider{
 	}
 
 	public function close(){
-		$this->unloadChunks();
 		foreach($this->regions as $index => $region){
 			$region->close();
 			unset($this->regions[$index]);

--- a/src/pocketmine/level/format/io/region/McRegion.php
+++ b/src/pocketmine/level/format/io/region/McRegion.php
@@ -355,7 +355,6 @@ class McRegion extends BaseLevelProvider{
 			$region->close();
 			unset($this->regions[$index]);
 		}
-		$this->level = null;
 	}
 
 	protected function readChunk(int $chunkX, int $chunkZ) : ?Chunk{

--- a/src/pocketmine/level/format/io/region/McRegion.php
+++ b/src/pocketmine/level/format/io/region/McRegion.php
@@ -280,14 +280,6 @@ class McRegion extends BaseLevelProvider{
 		$this->levelData->setByte("Difficulty", $difficulty);
 	}
 
-	public function isChunkGenerated(int $chunkX, int $chunkZ) : bool{
-		if(($region = $this->getRegion($chunkX >> 5, $chunkZ >> 5)) !== null){
-			return $region->chunkExists($chunkX & 0x1f, $chunkZ & 0x1f) and $this->getChunk($chunkX & 0x1f, $chunkZ & 0x1f, true)->isGenerated();
-		}
-
-		return false;
-	}
-
 	public function doGarbageCollection(){
 		$limit = time() - 300;
 		foreach($this->regions as $index => $region){

--- a/src/pocketmine/level/format/io/region/McRegion.php
+++ b/src/pocketmine/level/format/io/region/McRegion.php
@@ -44,9 +44,6 @@ class McRegion extends BaseLevelProvider{
 	/** @var RegionLoader[] */
 	protected $regions = [];
 
-	/** @var Chunk[] */
-	protected $chunks = [];
-
 	/**
 	 * @param Chunk $chunk
 	 *
@@ -283,124 +280,12 @@ class McRegion extends BaseLevelProvider{
 		$this->levelData->setByte("Difficulty", $difficulty);
 	}
 
-	public function getChunk(int $chunkX, int $chunkZ, bool $create = false){
-		$index = Level::chunkHash($chunkX, $chunkZ);
-		if(isset($this->chunks[$index])){
-			return $this->chunks[$index];
-		}else{
-			$this->loadChunk($chunkX, $chunkZ, $create);
-
-			return $this->chunks[$index] ?? null;
-		}
-	}
-
-	public function setChunk(int $chunkX, int $chunkZ, Chunk $chunk){
-		self::getRegionIndex($chunkX, $chunkZ, $regionX, $regionZ);
-		$this->loadRegion($regionX, $regionZ);
-
-		$chunk->setX($chunkX);
-		$chunk->setZ($chunkZ);
-
-
-		if(isset($this->chunks[$index = Level::chunkHash($chunkX, $chunkZ)]) and $this->chunks[$index] !== $chunk){
-			$this->unloadChunk($chunkX, $chunkZ, false);
-		}
-
-		$this->chunks[$index] = $chunk;
-	}
-
-	public function saveChunk(int $chunkX, int $chunkZ) : bool{
-		if($this->isChunkLoaded($chunkX, $chunkZ)){
-			$chunk = $this->getChunk($chunkX, $chunkZ);
-			if(!$chunk->isGenerated()){
-				throw new \InvalidStateException("Cannot save un-generated chunk");
-			}
-			$this->getRegion($chunkX >> 5, $chunkZ >> 5)->writeChunk($chunkX & 0x1f, $chunkZ & 0x1f, $this->nbtSerialize($chunk));
-
-			return true;
-		}
-
-		return false;
-	}
-
-	public function saveChunks(){
-		foreach($this->chunks as $chunk){
-			$this->saveChunk($chunk->getX(), $chunk->getZ());
-		}
-	}
-
-	public function loadChunk(int $chunkX, int $chunkZ, bool $create = false) : bool{
-		$index = Level::chunkHash($chunkX, $chunkZ);
-		if(isset($this->chunks[$index])){
-			return true;
-		}
-		$regionX = $regionZ = null;
-		self::getRegionIndex($chunkX, $chunkZ, $regionX, $regionZ);
-		assert(is_int($regionX) and is_int($regionZ));
-
-		$this->loadRegion($regionX, $regionZ);
-		$this->level->timings->syncChunkLoadDataTimer->startTiming();
-
-		$chunk = null;
-
-		$chunkData = $this->getRegion($regionX, $regionZ)->readChunk($chunkX & 0x1f, $chunkZ & 0x1f);
-		if($chunkData !== null){
-			$chunk = $this->nbtDeserialize($chunkData);
-		}
-
-		if($chunk === null and $create){
-			$chunk = new Chunk($chunkX, $chunkZ);
-		}
-		$this->level->timings->syncChunkLoadDataTimer->stopTiming();
-
-		if($chunk !== null){
-			$this->chunks[$index] = $chunk;
-			return true;
-		}else{
-			return false;
-		}
-	}
-
-	public function unloadChunk(int $chunkX, int $chunkZ, bool $safe = true) : bool{
-		$chunk = $this->chunks[$index = Level::chunkHash($chunkX, $chunkZ)] ?? null;
-		if($chunk instanceof Chunk and $chunk->unload($safe)){
-			unset($this->chunks[$index]);
-			return true;
-		}
-
-		return false;
-	}
-
-	public function unloadChunks(){
-		foreach($this->chunks as $chunk){
-			$this->unloadChunk($chunk->getX(), $chunk->getZ(), false);
-		}
-		$this->chunks = [];
-	}
-
-	public function isChunkLoaded(int $chunkX, int $chunkZ) : bool{
-		return isset($this->chunks[Level::chunkHash($chunkX, $chunkZ)]);
-	}
-
 	public function isChunkGenerated(int $chunkX, int $chunkZ) : bool{
 		if(($region = $this->getRegion($chunkX >> 5, $chunkZ >> 5)) !== null){
 			return $region->chunkExists($chunkX & 0x1f, $chunkZ & 0x1f) and $this->getChunk($chunkX & 0x1f, $chunkZ & 0x1f, true)->isGenerated();
 		}
 
 		return false;
-	}
-
-	public function isChunkPopulated(int $chunkX, int $chunkZ) : bool{
-		$chunk = $this->getChunk($chunkX, $chunkZ);
-		if($chunk !== null){
-			return $chunk->isPopulated();
-		}else{
-			return false;
-		}
-	}
-
-	public function getLoadedChunks() : array{
-		return $this->chunks;
 	}
 
 	public function doGarbageCollection(){
@@ -479,5 +364,30 @@ class McRegion extends BaseLevelProvider{
 			unset($this->regions[$index]);
 		}
 		$this->level = null;
+	}
+
+	protected function readChunk(int $chunkX, int $chunkZ) : ?Chunk{
+		$regionX = $regionZ = null;
+		self::getRegionIndex($chunkX, $chunkZ, $regionX, $regionZ);
+		assert(is_int($regionX) and is_int($regionZ));
+
+		$this->loadRegion($regionX, $regionZ);
+
+		$chunkData = $this->getRegion($regionX, $regionZ)->readChunk($chunkX & 0x1f, $chunkZ & 0x1f);
+		if($chunkData !== null){
+			return $this->nbtDeserialize($chunkData);
+		}
+
+		return null;
+	}
+
+	protected function writeChunk(Chunk $chunk) : void{
+		$chunkX = $chunk->getX();
+		$chunkZ = $chunk->getZ();
+
+		self::getRegionIndex($chunkX, $chunkZ, $regionX, $regionZ);
+		$this->loadRegion($regionX, $regionZ);
+
+		$this->getRegion($regionX, $regionZ)->writeChunk($chunkX & 0x1f, $chunkZ & 0x1f, $this->nbtSerialize($chunk));
 	}
 }


### PR DESCRIPTION
## Introduction
Level providers are currently extremely confusing and overcomplicated. This pull request delivers a major refactor to level providers, which drastically simplifies their implementation, makes them independent of Levels, and lots of other cool bonuses.

This is a follow-up to the changes made resulting in the 3.0.0-ALPHA4 API bump (disentanglement of chunks from their level providers to allow them to exist independently).

## Changes
### API changes
- `LevelProvider`s are no longer dependent on Levels. This is a significant change because it makes it possible to construct `LevelProvider`s on threads without a `Level`, which opens up **future possibilities** to do many cool things:
    - Super-simple world format conversion
    - Asynchronous chunk I/O
    **(DISCLAIMER: These things are NOT implemented yet, but are examples of things that COULD be done.)**
- The `LevelProvider` interface has undergone significant changes. Unused or redundant methods have been stripped out, and the remaining methods have significant changes:
    - `loadChunk()` now directly returns a `Chunk` object read from disk.
    - `saveChunk()` now directly accepts a `Chunk` object instead of coordinates.
    - `__construct()` now **only** accepts a `string $path`, the `Level` parameter has been removed.
    - The following methods have been obsoleted, and therefore removed:
        - `getChunk()`
        - `setChunk()`
        - `saveChunks()`
        - `unloadChunk()`
        - `unloadChunks()`
        - `isChunkLoaded()`
        - `getLoadedChunks()`
        - `isChunkGenerated()`
        - `isChunkPopulated()`
        - `getLevel()`
- `getServer()` method has been removed from `BaseLevelProvider`.

### Behavioural changes
- `LevelProvider`s no longer keep records of loaded chunks. They are now simplified down to an I/O interface. This was changed because `Level`s already keep records of loaded chunks, so the records in the providers were entirely unnecessary, except for excessive overcomplications.
- `LevelProvider`s are no longer circularly dependent on their `Level`s.

Functionally, everything should work the same as it did before to the end user.

## Backwards compatibility
This poses backwards compatibility breaks for reasons described above.

## Follow-up
This will be followed by further changes, including:
- Split level providers into chunk I/O and level-data components
- Making chunk I/O asynchronous.

## Tests
This has been lightly tested with all world formats. However, everything should work fine.