### PR TITLE
Add CompoundTag support to Entity::DATA_TYPE_SLOT

### DIFF
--- a/src/pocketmine/network/mcpe/protocol/DataPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/DataPacket.php
@@ -186,6 +186,7 @@ abstract class DataPacket extends BinaryStream{
 					$value[0] = $item->getId();
 					$value[1] = $item->getCount();
 					$value[2] = $item->getDamage();
+					$value[3] = $item->getCompoundTag();
 					break;
 				case Entity::DATA_TYPE_POS:
 					$value = [0, 0, 0];
@@ -239,7 +240,7 @@ abstract class DataPacket extends BinaryStream{
 					break;
 				case Entity::DATA_TYPE_SLOT:
 					//TODO: change this implementation (use objects)
-					$this->putSlot(ItemFactory::get($d[1][0], $d[1][2], $d[1][1])); //ID, damage, count
+					$this->putSlot(ItemFactory::get($d[1][0], $d[1][2], $d[1][1], $d[1][3])); //ID, damage, count, compoundtag
 					break;
 				case Entity::DATA_TYPE_POS:
 					//TODO: change this implementation (use objects)


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This adds support for written CompoundTag for Items like firework rockets.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
A 4rd parameter for Entity::DATA_TYPE_SLOT now can be specifed which is written CompoundTag
