### PR TITLE
Fix TNT#ignite fuse

### DIFF
--- a/src/pocketmine/block/TNT.php
+++ b/src/pocketmine/block/TNT.php
@@ -60,7 +60,7 @@ class TNT extends Solid{
 
 		$mot = (new Random())->nextSignedFloat() * M_PI * 2;
 		$nbt = Entity::createBaseNBT($this->add(0.5, 0, 0.5), new Vector3(-sin($mot) * 0.02, 0.2, -cos($mot) * 0.02));
-		$nbt->setByte("Fuse", $fuse);
+		$nbt->setShort("Fuse", $fuse);
 
 		$tnt = Entity::createEntity("PrimedTNT", $this->getLevel(), $nbt);
 


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
The `fuse` parameter to `TNT#ignite` can never be used. Currently it sets the NBT as a byte, however here:
https://github.com/pmmp/PocketMine-MP/blob/master/src/pocketmine/entity/PrimedTNT.php#L57-L61
it's retrieved as a short, meaning there's no valid tag and it defaults to the 80 tick fuse.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
Not aware of any

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
nuthin'

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
Explosions lighting TNT blocks will explode with a fuse of `mt_rand(10, 30)` instead of 80, which is intended.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
No issues, actually FIXES something lol

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--
nop

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
nah

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Without this TNT chains explode 80 ticks apart from each other, with it's much faster and not regular at all.

lol sorry for this pr to fix one tiny line