### PR TITLE
Add API methods: Entity::isInvisible(), Entity::setInvisible()

### DIFF
--- a/src/pocketmine/entity/Effect.php
+++ b/src/pocketmine/entity/Effect.php
@@ -423,7 +423,7 @@ class Effect{
 
 		switch($this->id){
 			case Effect::INVISIBILITY:
-				$entity->setGenericFlag(Entity::DATA_FLAG_INVISIBLE, true);
+				$entity->setInvisible();
 				$entity->setNameTagVisible(false);
 				break;
 			case Effect::SPEED:
@@ -466,7 +466,7 @@ class Effect{
 
 		switch($this->id){
 			case Effect::INVISIBILITY:
-				$entity->setGenericFlag(Entity::DATA_FLAG_INVISIBLE, false);
+				$entity->setInvisible(false);
 				$entity->setNameTagVisible(true);
 				break;
 			case Effect::SPEED:

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -655,13 +655,13 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 		$this->setGenericFlag(self::DATA_FLAG_IMMOBILE, $value);
 	}
 
-        public function isInvisible() : bool{
-                return $this->getGenericFlag(self::DATA_FLAG_INVISIBLE);
-        }
+	public function isInvisible() : bool{
+		return $this->getGenericFlag(self::DATA_FLAG_INVISIBLE);
+	}
 
-        public function setInvisible(bool $value = true){
-                $this->setGenericFlag(self::DATA_FLAG_INVISIBLE, $value);
-        }
+	public function setInvisible(bool $value = true) : void{
+		$this->setGenericFlag(self::DATA_FLAG_INVISIBLE, $value);
+	}
 
 	/**
 	 * Returns whether the entity is able to climb blocks such as ladders or vines.

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -655,6 +655,14 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 		$this->setGenericFlag(self::DATA_FLAG_IMMOBILE, $value);
 	}
 
+        public function isInvisible() : bool{
+                return $this->getGenericFlag(self::DATA_FLAG_INVISIBLE);
+        }
+
+        public function setInvisible(bool $value = true){
+                $this->setGenericFlag(self::DATA_FLAG_INVISIBLE, $value);
+        }
+
 	/**
 	 * Returns whether the entity is able to climb blocks such as ladders or vines.
 	 * @return bool


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Many plugins make use of `Entity::setDataFlag(Entity::DATA_FLAGS, Entity::DATA_FLAG_INVISIBLE, bool)` function. This commit adds a short-hand for the functions, just like some other API functions (`Entity::isSprinting()`, `Entity::setSprinting()`, `Entity::isImmobile()`, `Entity::setImmobile()` etc...).

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Added API methods
`Entity::isInvisible()`: Returns whether entity is invisible.
`Entity::setInvisible()`: Toggle entity's visibility.

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
A simple invisible toggler:
```
/** @var Entity $player */
$isInvis = $player->isInvisible();
$player->setInvisible(!$isInvis);
$player->sendMessage("You are now " . ($player->isInvisible() ? "invisible" : "visible") . ".");
```
![video-1-17-2018-12-38-23-pm](https://user-images.githubusercontent.com/15074389/35033389-ef0f7a5a-fb83-11e7-90ff-bac2932605ac.gif)
