### PR TITLE
Arrow class: No need to import Item class with other name

### DIFF
--- a/src/pocketmine/entity/projectile/Arrow.php
+++ b/src/pocketmine/entity/projectile/Arrow.php
@@ -26,7 +26,7 @@ namespace pocketmine\entity\projectile;
 use pocketmine\entity\Entity;
 use pocketmine\event\inventory\InventoryPickupArrowEvent;
 use pocketmine\item\ItemFactory;
-use pocketmine\item\Item as ItemItem;
+use pocketmine\item\Item;
 use pocketmine\level\Level;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\network\mcpe\protocol\TakeItemEntityPacket;
@@ -89,7 +89,7 @@ class Arrow extends Projectile{
 			return;
 		}
 
-		$item = ItemFactory::get(ItemItem::ARROW, 0, 1);
+		$item = ItemFactory::get(Item::ARROW, 0, 1);
 
 		$playerInventory = $player->getInventory();
 		if($player->isSurvival() and !$playerInventory->canAddItem($item)){

--- a/src/pocketmine/entity/projectile/Arrow.php
+++ b/src/pocketmine/entity/projectile/Arrow.php
@@ -25,8 +25,8 @@ namespace pocketmine\entity\projectile;
 
 use pocketmine\entity\Entity;
 use pocketmine\event\inventory\InventoryPickupArrowEvent;
-use pocketmine\item\ItemFactory;
 use pocketmine\item\Item;
+use pocketmine\item\ItemFactory;
 use pocketmine\level\Level;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\network\mcpe\protocol\TakeItemEntityPacket;


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
There's no Item class in this namespace anymore, after sorting projectile entities into separate folder.
### Relevant issues
<!-- List relevant issues here -->
No issues, just code clean.
## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
There must be tests for this simple change?