### PR TITLE
Fix projectiles throwing errors on launching, fix #1942

### DIFF
--- a/src/pocketmine/entity/projectile/Projectile.php
+++ b/src/pocketmine/entity/projectile/Projectile.php
@@ -43,10 +43,10 @@ abstract class Projectile extends Entity{
 	public $hadCollision = false;
 
 	public function __construct(Level $level, CompoundTag $nbt, Entity $shootingEntity = null){
-		if($shootingEntity !== null){
-			$this->setOwningEntity($shootingEntity);
-		}
 		parent::__construct($level, $nbt);
+                if($shootingEntity !== null){
+                        $this->setOwningEntity($shootingEntity);
+                }
 	}
 
 	public function attack(EntityDamageEvent $source){

--- a/src/pocketmine/entity/projectile/Projectile.php
+++ b/src/pocketmine/entity/projectile/Projectile.php
@@ -44,9 +44,9 @@ abstract class Projectile extends Entity{
 
 	public function __construct(Level $level, CompoundTag $nbt, Entity $shootingEntity = null){
 		parent::__construct($level, $nbt);
-                if($shootingEntity !== null){
-                        $this->setOwningEntity($shootingEntity);
-                }
+		if($shootingEntity !== null){
+			$this->setOwningEntity($shootingEntity);
+		}
 	}
 
 	public function attack(EntityDamageEvent $source){


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This PR fixes an issue with `Projectile::setOwningEntity()` being called before `Entity::$propertyManager` gets declared.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
* Fixes #1942 

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Previously, launching projectiles with $shootingEntity (param3) declared would result in an error due to `Entity::$propertyManager` not yet being declared. This can been tested by launching a snowball before and after this code shifting.