### PR TITLE
Inventory: Split up armor and player inventory

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -74,7 +74,6 @@ use pocketmine\inventory\BigCraftingGrid;
 use pocketmine\inventory\CraftingGrid;
 use pocketmine\inventory\Inventory;
 use pocketmine\inventory\PlayerCursorInventory;
-use pocketmine\inventory\PlayerInventory;
 use pocketmine\inventory\transaction\action\InventoryAction;
 use pocketmine\inventory\transaction\CraftingTransaction;
 use pocketmine\inventory\transaction\InventoryTransaction;
@@ -2077,7 +2076,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		$this->sendData($this);
 
 		$this->inventory->sendContents($this);
-		$this->inventory->sendArmorContents($this);
+		$this->armorInventory->sendContents($this);
 		$this->inventory->sendCreativeContents();
 		$this->inventory->sendHeldItem($this);
 
@@ -2669,7 +2668,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 				$this->sendSettings();
 				$this->inventory->sendContents($this);
-				$this->inventory->sendArmorContents($this);
+				$this->armorInventory->sendContents($this);
 
 				$this->spawnToAll();
 				$this->scheduleUpdate();
@@ -3567,15 +3566,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		return false; //never flag players for despawn
 	}
 
-	public function getArmorPoints() : int{
-		$total = 0;
-		foreach($this->inventory->getArmorContents() as $item){
-			$total += $item->getDefensePoints();
-		}
-
-		return $total;
-	}
-
 	protected function applyPostDamageEffects(EntityDamageEvent $source) : void{
 		parent::applyPostDamageEffects($source);
 
@@ -3674,6 +3664,8 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 	protected function addDefaultWindows(){
 		$this->addWindow($this->getInventory(), ContainerIds::INVENTORY, true);
+
+		$this->addWindow($this->getArmorInventory(), ContainerIds::ARMOR, true);
 
 		$this->cursorInventory = new PlayerCursorInventory($this);
 		$this->addWindow($this->cursorInventory, ContainerIds::CURSOR, true);
@@ -3811,9 +3803,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	protected function sendAllInventories(){
 		foreach($this->windowIndex as $id => $inventory){
 			$inventory->sendContents($this);
-			if($inventory instanceof PlayerInventory){
-				$inventory->sendArmorContents($this);
-			}
 		}
 	}
 

--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -32,7 +32,6 @@ use pocketmine\inventory\EnderChestInventory;
 use pocketmine\inventory\InventoryHolder;
 use pocketmine\inventory\PlayerInventory;
 use pocketmine\item\Consumable;
-use pocketmine\item\enchantment\Enchantment;
 use pocketmine\item\FoodSource;
 use pocketmine\item\Item as ItemItem;
 use pocketmine\level\Level;
@@ -494,6 +493,7 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 	}
 
 	protected function initEntity(){
+		parent::initEntity();
 
 		$this->setPlayerFlag(self::DATA_PLAYER_FLAG_SLEEP, false);
 		$this->propertyManager->setBlockPos(self::DATA_PLAYER_BED_POSITION, null);
@@ -511,7 +511,7 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 					//Old hotbar saving stuff, remove it (useless now)
 					unset($inventoryTag[$i]);
 				}elseif($slot >= 100 and $slot < 104){ //Armor
-					$this->inventory->setItem($this->inventory->getSize() + $slot - 100, ItemItem::nbtDeserialize($item));
+					$this->armorInventory->setItem($slot - 100, ItemItem::nbtDeserialize($item));
 				}else{
 					$this->inventory->setItem($slot - 9, ItemItem::nbtDeserialize($item));
 				}
@@ -528,7 +528,6 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 
 		$this->inventory->setHeldItemIndex($this->namedtag->getInt("SelectedInventorySlot", 0), false);
 
-		parent::initEntity();
 
 		$this->setFood((float) $this->namedtag->getInt("foodLevel", (int) $this->getFood(), true));
 		$this->setExhaustion($this->namedtag->getFloat("foodExhaustionLevel", $this->getExhaustion(), true));
@@ -609,14 +608,6 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 		}
 	}
 
-	protected function doAirSupplyTick(int $tickDiff){
-		//TODO: allow this to apply to other mobs
-		if(($respirationLevel = $this->inventory->getHelmet()->getEnchantmentLevel(Enchantment::RESPIRATION)) <= 0 or
-			lcg_value() <= (1 / ($respirationLevel + 1))){
-			parent::doAirSupplyTick($tickDiff);
-		}
-	}
-
 	public function getName() : string{
 		return $this->getNameTag();
 	}
@@ -652,7 +643,7 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 
 			//Armor
 			for($slot = 100; $slot < 104; ++$slot){
-				$item = $this->inventory->getItem($this->inventory->getSize() + $slot - 100);
+				$item = $this->armorInventory->getItem($slot - 100);
 				if(!$item->isNull()){
 					$inventoryTag[$slot] = $item->nbtSerialize($slot);
 				}
@@ -708,7 +699,7 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 		$pk->metadata = $this->propertyManager->getAll();
 		$player->dataPacket($pk);
 
-		$this->inventory->sendArmorContents($player);
+		$this->armorInventory->sendContents($player);
 
 		if(!($this instanceof Player)){
 			$this->sendSkin([$player]);

--- a/src/pocketmine/inventory/ArmorInventory.php
+++ b/src/pocketmine/inventory/ArmorInventory.php
@@ -1,0 +1,144 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\inventory;
+
+use pocketmine\entity\Living;
+use pocketmine\event\entity\EntityArmorChangeEvent;
+use pocketmine\item\Item;
+use pocketmine\network\mcpe\protocol\InventorySlotPacket;
+use pocketmine\network\mcpe\protocol\MobArmorEquipmentPacket;
+use pocketmine\Player;
+use pocketmine\Server;
+
+class ArmorInventory extends BaseInventory{
+	public const SLOT_HEAD = 0;
+	public const SLOT_CHEST = 1;
+	public const SLOT_LEGS = 2;
+	public const SLOT_FEET = 3;
+
+	/** @var Living */
+	protected $holder;
+
+	public function __construct(Living $holder){
+		$this->holder = $holder;
+		parent::__construct();
+	}
+
+	public function getHolder() : Living{
+		return $this->holder;
+	}
+
+	public function getName() : string{
+		return "Armor";
+	}
+
+	public function getDefaultSize() : int{
+		return 4;
+	}
+
+	public function getHelmet() : Item{
+		return $this->getItem(self::SLOT_HEAD);
+	}
+
+	public function getChestplate() : Item{
+		return $this->getItem(self::SLOT_CHEST);
+	}
+
+	public function getLeggings() : Item{
+		return $this->getItem(self::SLOT_LEGS);
+	}
+
+	public function getBoots() : Item{
+		return $this->getItem(self::SLOT_FEET);
+	}
+
+	public function setHelmet(Item $helmet) : bool{
+		return $this->setItem(self::SLOT_HEAD, $helmet);
+	}
+
+	public function setChestplate(Item $chestplate) : bool{
+		return $this->setItem(self::SLOT_CHEST, $chestplate);
+	}
+
+	public function setLeggings(Item $leggings) : bool{
+		return $this->setItem(self::SLOT_LEGS, $leggings);
+	}
+
+	public function setBoots(Item $boots) : bool{
+		return $this->setItem(self::SLOT_FEET, $boots);
+	}
+
+	protected function doSetItemEvents(int $index, Item $newItem) : ?Item{
+		Server::getInstance()->getPluginManager()->callEvent($ev = new EntityArmorChangeEvent($this->getHolder(), $this->getItem($index), $newItem, $index));
+		if($ev->isCancelled()){
+			return null;
+		}
+
+		return $ev->getNewItem();
+	}
+
+	public function sendSlot(int $index, $target) : void{
+		if($target instanceof Player){
+			$target = [$target];
+		}
+
+		$armor = $this->getContents(true);
+
+		$pk = new MobArmorEquipmentPacket();
+		$pk->entityRuntimeId = $this->getHolder()->getId();
+		$pk->slots = $armor;
+		$pk->encode();
+
+		foreach($target as $player){
+			if($player === $this->getHolder()){
+				/** @var Player $player */
+
+				$pk2 = new InventorySlotPacket();
+				$pk2->windowId = $player->getWindowId($this);
+				$pk2->inventorySlot = $index - $this->getSize();
+				$pk2->item = $this->getItem($index);
+				$player->dataPacket($pk2);
+			}else{
+				$player->dataPacket($pk);
+			}
+		}
+	}
+
+	public function sendContents($target) : void{
+		if($target instanceof Player){
+			$target = [$target];
+		}
+
+		$armor = $this->getContents(true);
+
+		$pk = new MobArmorEquipmentPacket();
+		$pk->entityRuntimeId = $this->getHolder()->getId();
+		$pk->slots = $armor;
+		$pk->encode();
+
+		foreach($target as $player){
+			$player->dataPacket($pk);
+		}
+	}
+}

--- a/src/pocketmine/inventory/ArmorInventory.php
+++ b/src/pocketmine/inventory/ArmorInventory.php
@@ -141,4 +141,11 @@ class ArmorInventory extends BaseInventory{
 			$player->dataPacket($pk);
 		}
 	}
+
+	/**
+	 * @return Player[]
+	 */
+	public function getViewers() : array{
+		return array_merge(parent::getViewers(), $this->holder->getViewers());
+	}
 }

--- a/src/pocketmine/inventory/BaseInventory.php
+++ b/src/pocketmine/inventory/BaseInventory.php
@@ -426,11 +426,7 @@ abstract class BaseInventory implements Inventory{
 		}
 
 		$pk = new InventoryContentPacket();
-
-		//Using getSize() here allows PlayerInventory to report that it's 4 slots smaller than it actually is (armor hack)
-		for($i = 0, $size = $this->getSize(); $i < $size; ++$i){
-			$pk->items[$i] = $this->getItem($i);
-		}
+		$pk->items = $this->getContents(true);
 
 		foreach($target as $player){
 			if(($id = $player->getWindowId($this)) === ContainerIds::NONE){
@@ -466,6 +462,6 @@ abstract class BaseInventory implements Inventory{
 	}
 
 	public function slotExists(int $slot) : bool{
-		return $slot >= 0 and $slot < $this->slots->getSize(); //use actual slots size to allow PlayerInventory to lie
+		return $slot >= 0 and $slot < $this->slots->getSize();
 	}
 }

--- a/src/pocketmine/inventory/transaction/InventoryTransaction.php
+++ b/src/pocketmine/inventory/transaction/InventoryTransaction.php
@@ -25,7 +25,6 @@ namespace pocketmine\inventory\transaction;
 
 use pocketmine\event\inventory\InventoryTransactionEvent;
 use pocketmine\inventory\Inventory;
-use pocketmine\inventory\PlayerInventory;
 use pocketmine\inventory\transaction\action\InventoryAction;
 use pocketmine\inventory\transaction\action\SlotChangeAction;
 use pocketmine\item\Item;
@@ -239,9 +238,6 @@ class InventoryTransaction{
 	protected function sendInventories() : void{
 		foreach($this->inventories as $inventory){
 			$inventory->sendContents($this->source);
-			if($inventory instanceof PlayerInventory){
-				$inventory->sendArmorContents($this->source);
-			}
 		}
 	}
 

--- a/src/pocketmine/network/mcpe/protocol/types/NetworkInventoryAction.php
+++ b/src/pocketmine/network/mcpe/protocol/types/NetworkInventoryAction.php
@@ -159,12 +159,6 @@ class NetworkInventoryAction{
 	public function createInventoryAction(Player $player){
 		switch($this->sourceType){
 			case self::SOURCE_CONTAINER:
-				if($this->windowId === ContainerIds::ARMOR){
-					//TODO: HACK!
-					$this->inventorySlot += 36;
-					$this->windowId = ContainerIds::INVENTORY;
-				}
-
 				$window = $player->getWindow($this->windowId);
 				if($window !== null){
 					return new SlotChangeAction($window, $this->inventorySlot, $this->oldItem, $this->newItem);


### PR DESCRIPTION
## Introduction
This now allows all Living entities the possibility to wear armour, and allows moving some player-specific armour logic down to Living so that all entities can benefit from them.

This also fixes a bug caused by https://github.com/pmmp/PocketMine-MP/commit/4d2549b50ab245649b40367c4070294251de6419 where armour does not visibly change for viewers (this is a bug in the transaction system which has been worked around in the second commit).

This is dependent on 2fb580db26cb9335d38d38cba99864f54793cbf8 and 1de7c5b114298416ce2a30065fce3a0a92b10963.

## Changes
### API changes
- All Armor-related methods have been removed from PlayerInventory.
- Removed hacks for PlayerInventory size.
- Added API method `Living->getArmorInventory()`

### Other changes
- Removed PlayerInventory redirect hack from NetworkInventoryAction.

### Behavioural changes
Everything should work as it did previously, except for that more things can be done with armour.

## Follow-up
Armor for mobs is not currently saved in their NBT (except for players). This should be done in the future.

## Tests
wear armour and remove it while others are watching
change armour, quit & rejoin (load/save)