### PR TITLE
Added Event->finallyCancelled

### DIFF
--- a/src/pocketmine/event/Event.php
+++ b/src/pocketmine/event/Event.php
@@ -79,7 +79,7 @@ abstract class Event{
 	 * @param bool $value
 	 */
 	public function setFinallyCancelled(bool $value = true) : void{
-		if(!$this->isCancellable()){
+		if(!($this instanceof Cancellable)){
 			throw new \BadMethodCallException("Event is not Cancellable");
 		}
 
@@ -90,7 +90,7 @@ abstract class Event{
 	 * @return bool
 	 */
 	public function isFinallyCancelled() : bool{
-		if(!$this->isCancellable()){
+		if(!($this instanceof Cancellable)){
 			throw new \BadMethodCallException("Event is not Cancellable");
 		}
 

--- a/src/pocketmine/event/Event.php
+++ b/src/pocketmine/event/Event.php
@@ -32,6 +32,8 @@ abstract class Event{
 	protected $eventName = null;
 	/** @var bool */
 	private $isCancelled = false;
+	/** @var bool */
+	private $isFinallyCancelled = false;
 
 	/**
 	 * @return string
@@ -66,5 +68,32 @@ abstract class Event{
 
 		/** @var Event $this */
 		$this->isCancelled = $value;
+	}
+
+	/**
+	 * If an event is set to finally-cancelled, the event will not be cancelled immediately, but will be cancelled just
+	 * before the flow returns to {@link PluginManager::callEvent()}'s caller.
+	 *
+	 * In other words, passing true to this function makes sure the event ends up cancelled, but this is not visible to other plugins from {@link Event::isCancelled()}.
+	 *
+	 * @param bool $value
+	 */
+	public function setFinallyCancelled(bool $value = true) : void{
+		if(!$this->isCancellable()){
+			throw new \BadMethodCallException("Event is not Cancellable");
+		}
+
+		$this->isFinallyCancelled = $value;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function isFinallyCancelled() : bool{
+		if(!$this->isCancellable()){
+			throw new \BadMethodCallException("Event is not Cancellable");
+		}
+
+		return $this->isFinallyCancelled;
 	}
 }

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -25,6 +25,7 @@ namespace pocketmine\plugin;
 
 use pocketmine\command\PluginCommand;
 use pocketmine\command\SimpleCommandMap;
+use pocketmine\event\Cancellable;
 use pocketmine\event\Event;
 use pocketmine\event\EventPriority;
 use pocketmine\event\HandlerList;
@@ -712,6 +713,11 @@ class PluginManager{
 				$currentList = $currentList->getParent();
 			}
 		}
+
+		if($event instanceof Cancellable && !$event->isCancelled() && $event->isFinallyCancelled()){
+			$event->setCancelled();
+		}
+
 		--$this->eventCallDepth;
 	}
 


### PR DESCRIPTION
## Introduction
Quoting the scenario "DiscordMirror + HologramChat" from #1798:

> Suppose we have these two plugins:
> * DiscordMirror: it mirrors all chat messages to a Discord channel
> * HologramChat: it shows chat messages as holograms (FloatingText) rather than using the traditional Player->sendMessage().
> 
> The DiscordMirror plugin should listen to PlayerChatEvent at the MONITOR priority. It should ignore cancelled events, e.g. anti-spam plugins and plugins that override chat for other input (e.g. auth plugins may use it for receiving passwords).
> 
> What about the HologramChat plugin? It should override the default behaviour by cancelling the event and spawning the FloatingText in its handler. But if it cancels the event at LOWEST to HIGHEST, it will stop DiscordMirror from working. At the MONITOR event, since the order is undefined, it may or may not affect DiscordMirror.

This pull request is an alternative to #1798. Instead of allowing plugins to execute things at the EXECUTE priority, where multiple handlers may end up cancelling each other, HologramChat should handle the event at MONITOR priority, but using setFinallyCancelled() instead of setCancelled() to stop the default execution. This will prevent DiscordMirror from wrongly seeing the event is cancelled whilst it is, effectively, not cancelled.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Added the getter and setter for `Event->isFinallyCancelled`. If an event is not cancellable, calling such methods will result in an exception, just as the getter and setter for `Event->isCancelled`.

Quoting the documentation for `Event->setFinallyCancelled` in this PR:
> If an event is set to finally-cancelled, the event will not be cancelled immediately, but will be cancelled just before the flow returns to PluginManager::callEvent()'s caller.
>
> In other words, passing true to this function makes sure the event ends up cancelled, but this is not visible to other plugins from Event::isCancelled().

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
If plugins use the events API correctly, there should not be backward incompatibilities.

The only exception is in "hacky" plugins that assume a non-cancelled event at MONITOR level will result in the event context being executed. Such cases are too specific and cannot be protected by this PR case-by-case.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
As this PR is related to cancelling events, it is written based on the rfc/remove-cancellable branch, considering there is no major objection towards #1794 and that there are conflicts merging #1794 to master. This PR should be merged to rfc/remove-cancellable if #1794 has not been merged at the time this PR is approved.

<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Not tested yet.

The Travis-CI is failing because of submodule problems. It is not related to this PR.

## Relevant issues:
* Closes #1798