### PR TITLE
Fixed armor not dropping

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3548,6 +3548,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 			if($this->inventory !== null){
 				$this->inventory->setHeldItemIndex(0, false); //This is already handled when sending contents, don't send it twice
 				$this->inventory->clearAll();
+				$this->armorInventory->clearAll();
 			}
 		}
 

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3548,6 +3548,8 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 			if($this->inventory !== null){
 				$this->inventory->setHeldItemIndex(0, false); //This is already handled when sending contents, don't send it twice
 				$this->inventory->clearAll();
+			}
+			if($this->armorInventory !== null){
 				$this->armorInventory->clearAll();
 			}
 		}

--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -613,7 +613,10 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 	}
 
 	public function getDrops() : array{
-		return $this->inventory !== null ? array_values($this->inventory->getContents()) : [];
+		return array_merge(
+			$this->inventory !== null ? array_values($this->inventory->getContents()) : [],
+			$this->armorInventory !== null ? array_values($this->armorInventory->getContents()) : []
+		);
 	}
 
 	public function saveNBT(){


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

Since the armor-playerinventory split-up in https://github.com/pmmp/PocketMine-MP/commit/6543d969102b6ce761717073fdd858467217b876, armor contents weren't dropping. This commit restores back the return values of `Human::getDrops()` to contain armor contents and Player's armor inventory to get cleared on death (if keepInventory is enabled).

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Death while wearing armor results in armor contents being dropped. This can also be tested by dumping `Human::getDrops()` to check whether it contains the contents from ArmorInventory.

Here's a dump of the following:
https://pastebin.com/fG1pvnV7
![1x](https://user-images.githubusercontent.com/15074389/35353820-d6d884e8-0161-11e8-8f69-3c96ca70b972.JPG)
