### PR TITLE
MainLogger: Do output to console on the logger thread itself

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -171,7 +171,7 @@ class Server{
 
 	private $dispatchSignals = false;
 
-	/** @var \AttachableThreadedLogger */
+	/** @var MainLogger */
 	private $logger;
 
 	/** @var MemoryManager */
@@ -2473,14 +2473,14 @@ class Server{
 		$u = Utils::getMemoryUsage(true);
 		$usage = sprintf("%g/%g/%g/%g MB @ %d threads", round(($u[0] / 1024) / 1024, 2), round(($d[0] / 1024) / 1024, 2), round(($u[1] / 1024) / 1024, 2), round(($u[2] / 1024) / 1024, 2), Utils::getThreadCount());
 
-		echo "\x1b]0;" . $this->getName() . " " .
+		$this->logger->pushToOutputBuffer("\x1b]0;" . $this->getName() . " " .
 			$this->getPocketMineVersion() .
 			" | Online " . count($this->players) . "/" . $this->getMaxPlayers() .
 			" | Memory " . $usage .
 			" | U " . round($this->network->getUpload() / 1024, 2) .
 			" D " . round($this->network->getDownload() / 1024, 2) .
 			" kB/s | TPS " . $this->getTicksPerSecondAverage() .
-			" | Load " . $this->getTickUsageAverage() . "%\x07";
+			" | Load " . $this->getTickUsageAverage() . "%\x07");
 
 		Timings::$titleTickTimer->stopTiming();
 	}


### PR DESCRIPTION
This solves a range of issues (existing and potential) with logging, such as:

- echo is like a disk operation (blocking I/O) which may produce main thread slowdown.
- Logging to the console is _not_ currently synchronized - I am not actually sure why console output doesn't become illegible gibberish when multiple threads use the logger at the same time. Maybe something to do with locking when accessing properties of the logger? (implicit synchronization). This change solves that by doing all output to console on a single thread.
- In PowerShell, if the user selects some text in QuickEdit mode, the server will freeze next time it hits an echo call. This is because STDOUT write blocks until the user stops selecting text. This change resolves that problem.
- This also opens a possible solution to #1979 by handling escape code processing on the logger thread itself.

## Changes
### API changes
- Added 2 new API methods - `MainLogger->pushToOutputBuffer()` and `MainLogger->getOutputBufferContents()`

### Behavioural changes
- Logging now echoes output on the logger thread itself instead of the calling thread, avoiding slowdowns and hangs due to console I/O.
- Title ticking output is now done on the logger thread due to visible slowdown it causes on the main thread.

To be clear, we're usually talking fractions of a millisecond. This is primarily intended to **resolve problems** and not to provide performance improvements.

## Backwards compatibility
This breaks tests as seen below - additionally, logger output can no longer be captured for a thread by using the PHP output buffer functions (`ob_*()`).

## Tests
Has been tested and several bugs fixed (bug fixes have since been ported to master since they were not specific to this change). However, Travis is broken because TesterPlugin needs updating.