### PR TITLE
Added Living::getEntityLookingAt() method

### DIFF
--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -800,24 +800,24 @@ abstract class Living extends Entity implements Damageable{
          * @return null|Entity
          *
          */
-	public function getEntityLookingAt(AxisAlignedBB $distance = null, float $precision = 0.998){
-	        if($distance === null){
-	                $pointA = $this->subtract(100, 100, 100);
-	                $pointB = $this->add(100, 100, 100);
+        public function getTargetEntity2(AxisAlignedBB $distance = null, float $precision = 0.998){
+                if($distance === null){
+                        $pointA = $this->subtract(100, 100, 100);
+                        $pointB = $this->add(100, 100, 100);
 
-	                $distance = new AxisAlignedBB($pointA->x, $pointA->y, $pointA->z, $pointB->x, $pointB->y, $pointB->z);
+                        $distance = new AxisAlignedBB($pointA->x, $pointA->y, $pointA->z, $pointB->x, $pointB->y, $pointB->z);
                 }
 
                 foreach($this->level->getNearbyEntities($distance) as $entity){
-	                if($entity === $this) continue;
+                        if($entity === $this) continue;
 
-	                $toEntity = $this->asVector3()->subtract($entity->asVector3());
-	                $direction = $this->getDirectionVector();
-	                $exact = $toEntity->normalize()->dot($direction);
+                        $toEntity = $entity->asVector3()->subtract($this->asVector3());
+                        $direction = $this->getDirectionVector();
+                        $exact = $toEntity->normalize()->dot($direction);
 
-	                if($exact >= $precision){
+                        if($exact >= $precision){
 
-	                        return $entity;
+                                return $entity;
 
                         }
                 }

--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -800,7 +800,7 @@ abstract class Living extends Entity implements Damageable{
          * @return null|Entity
          *
          */
-        public function getTargetEntity2(AxisAlignedBB $distance = null, float $precision = 0.998){
+        public function getEntityLookingAt(AxisAlignedBB $distance = null, float $precision = 0.998){
                 if($distance === null){
                         $pointA = $this->subtract(100, 100, 100);
                         $pointB = $this->add(100, 100, 100);

--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -37,6 +37,7 @@ use pocketmine\item\Armor;
 use pocketmine\item\Consumable;
 use pocketmine\item\enchantment\Enchantment;
 use pocketmine\item\Item as ItemItem;
+use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Vector3;
 use pocketmine\math\VoxelRayTrace;
 use pocketmine\nbt\tag\ByteTag;
@@ -786,9 +787,43 @@ abstract class Living extends Entity implements Damageable{
 			}
 		}catch(\ArrayOutOfBoundsException $e){
 		}
-
 		return null;
 	}
+
+        /**
+         *
+         * For the exact entity use a precision >= 0.998
+         *
+         * @param AxisAlignedBB|null $distance
+         * @param float              $precision
+         *
+         * @return null|Entity
+         *
+         */
+	public function getEntityLookingAt(AxisAlignedBB $distance = null, float $precision = 0.998){
+	        if($distance === null){
+	                $pointA = $this->subtract(100, 100, 100);
+	                $pointB = $this->add(100, 100, 100);
+
+	                $distance = new AxisAlignedBB($pointA->x, $pointA->y, $pointA->z, $pointB->x, $pointB->y, $pointB->z);
+                }
+
+                foreach($this->level->getNearbyEntities($distance) as $entity){
+	                if($entity === $this) continue;
+
+	                $toEntity = $this->asVector3()->subtract($entity->asVector3());
+	                $direction = $this->getDirectionVector();
+	                $exact = $toEntity->normalize()->dot($direction);
+
+	                if($exact >= $precision){
+
+	                        return $entity;
+
+                        }
+                }
+
+                return null;
+        }
 
 	/**
 	 * Changes the entity's yaw and pitch to make it look at the specified Vector3 position. For mobs, this will cause


### PR DESCRIPTION
## Introduction
Similar to Living::getTargetBlock() this method is used to get the target entity in the view of a living entity.

### Relevant issues

none.

## Changes
### API changes
Living::getEntityLookingAt() has two (2) optional paremeters:

- **distance**: an AlignedAxisBB class to select the distance in which the function searches, the bigger the distance the farther the function can search. If this parameter is null, the function will search in a 100 block radius.
- **precision**: a float that indicates how precise the entity has to be poiting to get the exact target entity. Values >= `0.998` indicate that the entity should be looking exactly at another entity, never use a value >= `1.0`

### Behavioural changes
none.

## Backwards compatibility
none.

## Follow-up
none.

## Requires translations:

none.

## Tests
```Living::getEntityLookingAt()``` was tested by swapping positions with the target entity when the client right clicked. The client was not teleported when not looking directly at an entity.