### PR TITLE
Player: fix respawning after rage-quit on death

### DIFF
--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -929,6 +929,7 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 
 		if($amount <= 0){
 			if($this->isAlive()){
+				$this->health = 0;
 				$this->kill();
 			}
 		}elseif($amount <= $this->getMaxHealth() or $amount < $this->health){


### PR DESCRIPTION
## Introduction
This fixes exploits related to #1567 by calling respawn logic on join when the player has zero health.

This is a shitty fix and doesn't solve the actual issues described in #1567 (lots of things are still done on respawn that should be done on death), but it's a simple solution for the exploits related to it (respawn logic loophole due to rejoining).

### Relevant issues
This does not resolve (get lost github) #1567, but it resolves the exploits which people have complained about due to this loophole.

## Tests
This has been tested with normal punching respawn and also with a ragequit respawn. Both now work as expected.
