### PR TITLE
Expose plugin.yml contents to plugins with PluginDescription::getMap()

### DIFF
--- a/src/pocketmine/plugin/PluginDescription.php
+++ b/src/pocketmine/plugin/PluginDescription.php
@@ -26,6 +26,8 @@ namespace pocketmine\plugin;
 use pocketmine\permission\Permission;
 
 class PluginDescription{
+	private $map;
+
 	private $name;
 	private $main;
 	private $api;
@@ -66,6 +68,8 @@ class PluginDescription{
 	 * @throws PluginException
 	 */
 	private function loadMap(array $plugin){
+		$this->map = $plugin;
+
 		$this->name = $plugin["name"];
 		if(preg_match('/^[A-Za-z0-9 _.-]+$/', $this->name) === 0){
 			throw new PluginException("Invalid PluginDescription name");
@@ -286,5 +290,9 @@ class PluginDescription{
 	 */
 	public function getWebsite() : string{
 		return $this->website;
+	}
+
+	public function getMap() : array{
+		return $this->map;
 	}
 }


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
(You can ignore the whole introduction and just look at the code)

Powerful plugins and libraries may want to rely on values defined in plugin.yml to do powerful things, such as declaring components (like `commands`) statically.

Some third-party tools, such as compilers, may also inject their metadata into plugin.yml and allow plugins to parse them in plugin.yml, such as reading the build number. (No such tools so far)

This pull request allows them to retrieve the values from plugin.yml without parsing it again.

Of course, this can be done in another file, but I see no harm allowing them to be read from plugin.yml

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
Nil

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Added API function:

```php
public function PluginDescription::getMap() : array;
```

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
Nil

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Nil. This won't lead to _potential_ backwards incompatibility either, as this PR does not allow modification of the values.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
Nil
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
The server still starts up clean with one plugin.