### PR TITLE
Allow Command::getPermissionMessage() to return null

### DIFF
--- a/src/pocketmine/command/Command.php
+++ b/src/pocketmine/command/Command.php
@@ -234,9 +234,9 @@ abstract class Command{
 	}
 
 	/**
-	 * @return string
+	 * @return string|null
 	 */
-	public function getPermissionMessage() : string{
+	public function getPermissionMessage() : ?string{
 		return $this->permissionMessage;
 	}
 


### PR DESCRIPTION
## Introduction
If a plugin didn't define a custom permission message for a command $permissionMessage will be null so if you try to use Command::getPermissionMessage() an error will be given.

### Relevant issues
Fixes the issue explained above

## Tests
Tested and now doesn't give an error anymore when trying to get a null permission message