### PR TITLE
Added getRandomTickedBlocks() function

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -966,8 +966,8 @@ class Level implements ChunkManager, Metadatable{
 	public function clearChunkCache(int $chunkX, int $chunkZ){
 		unset($this->chunkCache[Level::chunkHash($chunkX, $chunkZ)]);
 	}
-	
-	public function getRandomTickedBlocks(): SplFixedArray{
+
+	public function getRandomTickedBlocks() : SplFixedArray{
 		return $this->randomTickBlocks;
 	}
 

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -966,6 +966,10 @@ class Level implements ChunkManager, Metadatable{
 	public function clearChunkCache(int $chunkX, int $chunkZ){
 		unset($this->chunkCache[Level::chunkHash($chunkX, $chunkZ)]);
 	}
+	
+	public function getRandomTickedBlocks(): SplFixedArray{
+		return $this->randomTickBlocks;
+	}
 
 	public function addRandomTickedBlock(int $id){
 		$this->randomTickBlocks[$id] = BlockFactory::get($id);


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
It would be more convenient to completely disable all possible variations of the blocks.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
`Level::getRandomTickedBlocks()` - Returns array with random ticked blocks

## Tests
It works, tested on my own server

```
foreach ($this->getServer()->getDefaultLevel()->getRandomTickedBlocks() as $id => $block) {
	if ($block === null) {
		continue;
	}
	var_dump($id);
	$this->getServer()->getDefaultLevel()->removeRandomTickedBlock($id);
}
```