### PR TITLE
Asynchronous events: Phase I

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -2518,6 +2518,8 @@ class Server{
 		$this->network->processInterfaces();
 		Timings::$connectionTimer->stopTiming();
 
+		$this->pluginManager->checkEvents($this->tickCounter);
+
 		Timings::$schedulerTimer->startTiming();
 		$this->pluginManager->tickSchedulers($this->tickCounter);
 		Timings::$schedulerTimer->stopTiming();

--- a/src/pocketmine/event/Event.php
+++ b/src/pocketmine/event/Event.php
@@ -26,12 +26,31 @@ declare(strict_types=1);
  */
 namespace pocketmine\event;
 
+use pocketmine\plugin\RegisteredListener;
+use pocketmine\Server;
+use pocketmine\utils\MainLogger;
+
 abstract class Event{
+	public const MAX_PAUSE_TICKS = 6000;
 
 	/** @var string|null */
 	protected $eventName = null;
 	/** @var bool */
 	private $isCancelled = false;
+
+	/** @var bool */
+	private $async = false;
+	/** @var RegisteredListener[]|null */
+	private $asyncQueue = null;
+	/** @var bool */
+	private $asyncComplete = false;
+	/** @var callable|null */
+	private $asyncCompleteFunc = null;
+
+	/** @var int|null */
+	private $pauseTimeout = null;
+	/** @var callable|null */
+	private $pauseTimeoutFunc = null;
 
 	/**
 	 * @return string
@@ -66,5 +85,148 @@ abstract class Event{
 
 		/** @var Event $this */
 		$this->isCancelled = $value;
+	}
+
+	/**
+	 * @internal Only to be called from PluginManager->callAsyncEvent
+	 *
+	 * @param RegisteredListener[] $asyncQueue
+	 * @param callable             $onCompletion
+	 */
+	final public function setAsyncQueue(array $asyncQueue, callable $onCompletion) : void{
+		$this->async = true;
+		$this->asyncQueue = $asyncQueue;
+		$this->asyncCompleteFunc = $onCompletion;
+	}
+
+	final public function isAsync() : bool{
+		return $this->async;
+	}
+
+	/**
+	 * @internal Only to be called from PluginManager->callAsyncEvent
+	 *
+	 * @param int $currentTick
+	 */
+	final public function startAsyncQueue(int $currentTick) : void{
+		if(!$this->async){
+			throw new \InvalidStateException("Could not start async queue on a non-async event");
+		}
+		if(reset($this->asyncQueue) === false){
+			$this->asyncComplete = true;
+			return;
+		}
+
+		$this->doAsyncLoop();
+		if($this->asyncComplete){
+			$this->onComplete();
+		}
+	}
+
+	final public function asyncCheck(int $currentTick) : bool{
+		if(!$this->asyncComplete){
+			if($this->pauseTimeout !== null and $this->pauseTimeout < $currentTick){
+				// paused but timed out
+				($this->pauseTimeoutFunc)($this);
+				$this->pauseTimeout = $this->pauseTimeoutFunc = null;
+			}
+
+			if($this->pauseTimeout === null){
+				// continue() or pauseTimeoutFunc has been called,
+				next($this->asyncQueue);
+				$this->doAsyncLoop();
+			}
+		}
+
+		if($this->asyncComplete){
+			$this->onComplete();
+			return true;
+		}
+		return false;
+	}
+
+	private function doAsyncLoop() : void{
+		/** @var RegisteredListener $listener */
+		while(($listener = current($this->asyncQueue)) !== false){
+			// while has more listener and not paused
+			if($listener->getPlugin()->isEnabled()){
+				try{
+					$listener->callEvent($this);
+				}catch(\Throwable $e){
+					MainLogger::getLogger()->critical(
+						Server::getInstance()->getLanguage()->translateString("pocketmine.plugin.eventError", [
+							$this->getEventName(),
+							$listener->getPlugin()->getDescription()->getFullName(),
+							$e->getMessage(),
+							get_class($listener->getListener())
+						]));
+					MainLogger::getLogger()->logException($e);
+				}
+			}
+			if($this->pauseTimeout !== null){ // paused
+				break;
+			}
+			next($this->asyncQueue);
+		}
+		$this->asyncComplete = current($this->asyncQueue) === false;
+	}
+
+	private function onComplete() : void{
+		// $this->asyncComplete is true here. Do not try to callAsyncEvent() immediately.
+		($this->asyncCompleteFunc)($this);
+
+		$this->async = false;
+		$this->asyncComplete = false;
+		$this->asyncQueue = null;
+		$this->pauseTimeout = null;
+		$this->pauseTimeoutFunc = null;
+	}
+
+	public function pause(int $ticks = 200, ?callable $onTimeout = null) : void{
+		if(!$this->async){
+			throw new \InvalidStateException("Could not pause non-async event; only events called with PluginManager->callAsyncEvent() can be paused");
+		}
+		if($ticks > Event::MAX_PAUSE_TICKS){
+			throw new \OutOfRangeException("Events must not be paused for more than " . Event::MAX_PAUSE_TICKS . " ticks");
+		}
+		if($this->pauseTimeout !== null){
+			throw new \InvalidStateException("Event has already been paused");
+		}
+
+		$this->pauseTimeout = Server::getInstance()->getTick() + $ticks;
+		$this->pauseTimeoutFunc = $onTimeout ?? [$this, "onTimeout"];
+	}
+
+	final public function continue() : void{
+		if($this->pauseTimeout === null){
+			throw new \InvalidStateException("Cannot continue a non-paused event");
+		}
+		$this->pauseTimeout = $this->pauseTimeoutFunc = null;
+		// do not execute anything directly after this, to prevent recursion stack overflow or concurrency due to the plugin executing something after this call
+	}
+
+	public function onTimeout() : void{
+		MainLogger::getLogger()->error(
+			Server::getInstance()->getLanguage()->translateString("pocketmine.plugin.eventTimeout", [
+				$this->getEventName(),
+				current($this->asyncQueue)->getPlugin()->getDescription()->getFullName(),
+				get_class(current($this->asyncQueue)->getListener())
+			]));
+	}
+
+	/**
+	 * @return bool
+	 */
+	final public function isAsyncComplete() : bool{
+		return $this->asyncComplete;
+	}
+
+
+	public function __debugInfo(){
+		$array = (array) $this;
+		unset($array["\0" . Event::class . "\0asyncQueue"],
+			$array["\0" . Event::class . "\0asyncCompleteFunc"],
+			$array["\0" . Event::class . "\0pauseTimeoutFunc"]);
+		return $array;
 	}
 }


### PR DESCRIPTION
## Introduction
Event handlers can now return asynchronously. By asynchronously, I mean that event listeners can delay the execution of the next event handler, hence the execution of the event calling context.

This is very useful for plugins that wish to set useful values in event handlers, instead of using hacks. For example, a plugin that uses an online agent to check whether an event is cancelled can cancel the event after the online agent returns a value, instead of redoing/undoing the event a few ticks later, causing undesired side effects.

### Relevant issues
* Proposed in #1881
* Based on #1792 
* #1798 is no longer necessary due to this PR
* #1961 is no longer necessary due to this PR

## Changes
### API changes
#### Added API methods
##### pocketmine\event\Event
```php
public final function pause(int $ticks = 200, ?callable $onTimeout = null) : void;
public final function continue() : void;
```

##### pocketmine\plugin\PluginManager
```php
public function callAsyncEvent(Event $event, callable $onCompletion) : void;
```

### Behavioural changes
This is a pure API addition. There shall be no behaviour changes unless a plugin is using the new API.

## Backward compatibility
This is a pure API addition. All backward incompatibility shall be attributed to plugins, not the core.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
The core should use features in this PR. Details are described in #1881.
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
https://gist.github.com/SOF3/a02c48c5ed6f9c69cddc6229bbb68ae3
