### PR TITLE
Implement Player -> Entity interaction

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2469,12 +2469,12 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 				switch($type){
 					case InventoryTransactionPacket::USE_ITEM_ON_ENTITY_ACTION_INTERACT:
-						$item = $packet->trData->itemInHand;
+						$item = $this->inventory->getItemInHand();
 						$clickPos = $packet->trData->clickPos;
 						$slot = $packet->trData->hotbarSlot;
 
 						$ev = new PlayerEntityInteractEvent($this, $target, $item, $clickPos, $slot);
-						
+
 						if(!$this->canInteract($target, 8)){
 							$ev->setCancelled();
 						}

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -51,6 +51,7 @@ use pocketmine\event\player\PlayerChatEvent;
 use pocketmine\event\player\PlayerCommandPreprocessEvent;
 use pocketmine\event\player\PlayerDeathEvent;
 use pocketmine\event\player\PlayerEditBookEvent;
+use pocketmine\event\player\PlayerEntityInteractEvent;
 use pocketmine\event\player\PlayerExhaustEvent;
 use pocketmine\event\player\PlayerGameModeChangeEvent;
 use pocketmine\event\player\PlayerInteractEvent;
@@ -2468,7 +2469,23 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 				switch($type){
 					case InventoryTransactionPacket::USE_ITEM_ON_ENTITY_ACTION_INTERACT:
-						break; //TODO
+						$item = $packet->trData->itemInHand;
+						$clickPos = $packet->trData->clickPos;
+						$slot = $packet->trData->hotbarSlot;
+
+						$ev = new PlayerEntityInteractEvent($this, $target, $item, $clickPos, $slot);
+						
+						if(!$this->canInteract($target, 8)){
+							$ev->setCancelled();
+						}
+
+						$this->server->getPluginManager()->callEvent($ev);
+
+						if(!$ev->isCancelled()){
+							$target->onInteract($this, $item, $clickPos, $slot);
+						}
+
+						return true;
 					case InventoryTransactionPacket::USE_ITEM_ON_ENTITY_ACTION_ATTACK:
 						if(!$target->isAlive()){
 							return true;

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -990,10 +990,8 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 	 * @param Item    $item
 	 * @param Vector3 $clickPos
 	 * @param int     $slot
-	 * @return void
 	 */
 	public function onInteract(Player $player, Item $item, Vector3 $clickPos, int $slot) : void{
-		return;
 	}
 
 	public function entityBaseTick(int $tickDiff = 1) : bool{

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -992,6 +992,7 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 	 * @param int     $slot
 	 */
 	public function onInteract(Player $player, Item $item, Vector3 $clickPos, int $slot) : void{
+
 	}
 
 	public function entityBaseTick(int $tickDiff = 1) : bool{

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -986,16 +986,16 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 	/**
 	 * Called when interacted or tapped by a Player
 	 *
-	 * @param Player $player
-	 * @param Item $item
+	 * @param Player  $player
+	 * @param Item    $item
 	 * @param Vector3 $clickPos
-	 * @param int $slot
-	 * @return bool
+	 * @param int     $slot
+	 * @return void
 	 */
-	public function onInteract(Player $player, Item $item, Vector3 $clickPos, int $slot) : bool {
-		return true;
+	public function onInteract(Player $player, Item $item, Vector3 $clickPos, int $slot) : void{
+		return;
 	}
-	
+
 	public function entityBaseTick(int $tickDiff = 1) : bool{
 		//TODO: check vehicles
 

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -48,6 +48,7 @@ use pocketmine\event\entity\EntityMotionEvent;
 use pocketmine\event\entity\EntityRegainHealthEvent;
 use pocketmine\event\entity\EntitySpawnEvent;
 use pocketmine\event\entity\EntityTeleportEvent;
+use pocketmine\item\Item;
 use pocketmine\level\format\Chunk;
 use pocketmine\level\Level;
 use pocketmine\level\Location;
@@ -982,6 +983,19 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 		return $this->propertyManager;
 	}
 
+	/**
+	 * Called when interacted or tapped by a Player
+	 *
+	 * @param Player $player
+	 * @param Item $item
+	 * @param Vector3 $clickPos
+	 * @param int $slot
+	 * @return bool
+	 */
+	public function onInteract(Player $player, Item $item, Vector3 $clickPos, int $slot) : bool {
+		return true;
+	}
+	
 	public function entityBaseTick(int $tickDiff = 1) : bool{
 		//TODO: check vehicles
 

--- a/src/pocketmine/event/player/PlayerEntityInteractEvent.php
+++ b/src/pocketmine/event/player/PlayerEntityInteractEvent.php
@@ -82,6 +82,8 @@ class PlayerEntityInteractEvent extends PlayerEvent implements Cancellable{
 	}
 
 	/**
+	 * Returns the hotbar slot number used to tap/click the entity
+	 *
 	 * @return int
 	 */
 	public function getSlot() : int{

--- a/src/pocketmine/event/player/PlayerEntityInteractEvent.php
+++ b/src/pocketmine/event/player/PlayerEntityInteractEvent.php
@@ -84,7 +84,7 @@ class PlayerEntityInteractEvent extends PlayerEvent implements Cancellable{
 	/**
 	 * @return int
 	 */
-	public function geSlot() : int{
+	public function getSlot() : int{
 		return $this->slot;
 	}
 }

--- a/src/pocketmine/event/player/PlayerEntityInteractEvent.php
+++ b/src/pocketmine/event/player/PlayerEntityInteractEvent.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\event\player;
+
+use pocketmine\entity\Entity;
+use pocketmine\event\Cancellable;
+use pocketmine\item\Item;
+use pocketmine\math\Vector3;
+use pocketmine\Player;
+
+/**
+ * Called when a player interacts with an entity
+ */
+class PlayerEntityInteractEvent extends PlayerEvent implements Cancellable{
+	/** @var Entity */
+	protected $entity;
+
+	/** @var Item */
+	protected $item;
+
+	/** @var Vector3 */
+	protected $clickPos;
+
+	/** @var int */
+	protected $slot;
+
+	/**
+	 * @param Player       $player
+	 * @param Entity       $entity
+	 * @param Item         $item
+	 * @param Vector3      $clickPos
+	 * @param int          $slot
+	 */
+	public function __construct(Player $player, Entity $entity, Item $item, Vector3 $clickPos, int $slot){
+		$this->player = $player;
+		$this->entity = $entity;
+		$this->item = $item;
+		$this->clickPos = $clickPos;
+		$this->slot = $slot;
+	}
+
+	/**
+	 * @return Entity
+	 */
+	public function getEntity() : Entity{
+		return $this->entity;
+	}
+
+	/**
+	 * @return Item
+	 */
+	public function getItem() : Item{
+		return $this->item;
+	}
+
+	/**
+	 * @return Vector3
+	 */
+	public function getClickPosition() : Vector3{
+		return $this->clickPos;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function geSlot() : int{
+		return $this->slot;
+	}
+}


### PR DESCRIPTION
## Introduction
This PR implements Player to Entity interaction... Which makes ArmorStands, Villager Trading UIs, Operations on Player interact (like on Mineplex) possible without overusing EntityDamageEvent or using a separate Packet Handler for plugins.

### Relevant issues
Currently, No issues address this but it is a 'TODO' in https://github.com/pmmp/PocketMine-MP/blob/master/src/pocketmine/Player.php#L2471

## Changes
### API changes
This adds Entity::onInteract() and PlayerEntityInteractEvent

### Behavioural changes
None

## Backwards compatibility
Purely API additions, no BC Breaks.

## Follow-up
None

## Tests
This can be tested by registering an entity that uses Entity::onInteract() or by using a plugin and listening for PlayerEntityInteractEvent
