### PR TITLE
Ignore plugin folder name contains (dot) phar

### DIFF
--- a/src/pocketmine/plugin/PharPluginLoader.php
+++ b/src/pocketmine/plugin/PharPluginLoader.php
@@ -81,6 +81,10 @@ class PharPluginLoader implements PluginLoader{
 	 * @return null|PluginDescription
 	 */
 	public function getPluginDescription(string $file){
+		if(is_dir($file)) {
+			return null;
+		}
+
 		$phar = new \Phar($file);
 		if(isset($phar["plugin.yml"])){
 			$pluginYml = $phar["plugin.yml"];


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Fix plugins directory with ".phar" and system detect it as a real phar, but actually its a directory.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
No API changes.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
Nothing affect to main core, its just detect if a $file is directory.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
PharPluginLoader only load Phar files, not directory.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->

<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
`UnexpectedValueException: "Cannot create phar 'C:/Users/KENNAN/Desktop/pmmp/latest/1.2/MinigamesEvent/plugins/PlayerAura_v1.2.phar', file extension (or combination) not recognised or the directory does not exist" (EXCEPTION) in "src/pocketmine/plugin/PharPluginLoader" at line 85`


## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Its just skip directory that contain ".phar".
