### PR TITLE
Fix deprecated event message

### DIFF
--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -774,7 +774,7 @@ class PluginManager{
 
 		$tags = self::parseDocComment((string) (new \ReflectionClass($event))->getDocComment());
 		if(isset($tags["deprecated"]) and $this->server->getProperty("settings.deprecated-verbose", true)){
-			$this->server->getLogger()->warning($this->server->getLanguage()->translateString("pocketmine.plugin.deprecateEvent", [
+			$this->server->getLogger()->warning($this->server->getLanguage()->translateString("pocketmine.plugin.deprecatedEvent", [
 				$plugin->getName(),
 				$event,
 				get_class($listener) . "->" . ($executor instanceof MethodEventExecutor ? $executor->getMethod() : "<unknown>")


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This pull request fixes extremely stupid bug since 49fbbea7bf552574606f67ce0b1e7ffecb76e894.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
Fixes deprecated event message not getting shown properly (shows as its key).

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
No.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
No.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
No.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
No.

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Tested and once again works just fine as it was supposed to.