### PR TITLE
Add /daylock and /alwaysday

### DIFF
--- a/src/pocketmine/command/SimpleCommandMap.php
+++ b/src/pocketmine/command/SimpleCommandMap.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\command;
 
+use pocketmine\command\defaults\DayLockCommand;
 use pocketmine\command\defaults\BanCommand;
 use pocketmine\command\defaults\BanIpCommand;
 use pocketmine\command\defaults\BanListCommand;
@@ -89,6 +90,8 @@ class SimpleCommandMap implements CommandMap{
 			new BanCommand("ban"),
 			new BanIpCommand("ban-ip"),
 			new BanListCommand("banlist"),
+			new DayLockCommand("alwaysday"),
+		  new DayLockCommand("daylock"),
 			new DefaultGamemodeCommand("defaultgamemode"),
 			new DeopCommand("deop"),
 			new DifficultyCommand("difficulty"),

--- a/src/pocketmine/command/SimpleCommandMap.php
+++ b/src/pocketmine/command/SimpleCommandMap.php
@@ -90,7 +90,6 @@ class SimpleCommandMap implements CommandMap{
 			new BanCommand("ban"),
 			new BanIpCommand("ban-ip"),
 			new BanListCommand("banlist"),
-			new DayLockCommand("alwaysday"),
 			new DayLockCommand("daylock"),
 			new DefaultGamemodeCommand("defaultgamemode"),
 			new DeopCommand("deop"),

--- a/src/pocketmine/command/SimpleCommandMap.php
+++ b/src/pocketmine/command/SimpleCommandMap.php
@@ -91,7 +91,7 @@ class SimpleCommandMap implements CommandMap{
 			new BanIpCommand("ban-ip"),
 			new BanListCommand("banlist"),
 			new DayLockCommand("alwaysday"),
-		  new DayLockCommand("daylock"),
+			new DayLockCommand("daylock"),
 			new DefaultGamemodeCommand("defaultgamemode"),
 			new DeopCommand("deop"),
 			new DifficultyCommand("difficulty"),

--- a/src/pocketmine/command/defaults/DayLockCommand.php
+++ b/src/pocketmine/command/defaults/DayLockCommand.php
@@ -38,7 +38,7 @@ class DayLockCommand extends VanillaCommand{
 			"%pocketmine.command.daylock.description",
 			"%commands.daylock.usage",
 		);
-		$this->setPermission("pocketmine.command.daylock;pocketmine.commands.alwaysday;");
+		$this->setPermission("pocketmine.command.daylock;pocketmine.command.alwaysday");
 	}
 
 	public function execute(CommandSender $sender, string $commandLabel, array $args){

--- a/src/pocketmine/command/defaults/DayLockCommand.php
+++ b/src/pocketmine/command/defaults/DayLockCommand.php
@@ -37,9 +37,8 @@ class DayLockCommand extends VanillaCommand{
 			$name,
 			"%pocketmine.command.daylock.description",
 			"%commands.daylock.usage",
-      ["alwaysday"]
 		);
-		$this->setPermission("pocketmine.command.daylock");
+		$this->setPermission("pocketmine.command.daylock;pocketmine.commands.alwaysday;");
 	}
 
 	public function execute(CommandSender $sender, string $commandLabel, array $args){
@@ -47,29 +46,29 @@ class DayLockCommand extends VanillaCommand{
 			return true;
 		}
 
-    if(count($args) > 1){
-      throw new InvalidCommandSyntaxException();
-    }
+		if(count($args) > 1){
+			throw new InvalidCommandSyntaxException();
+		}
 
-    if(count($args) < 1 or $args[0] === "true"){
-      foreach($sender->getServer()->getLevels() as $level){
-        $level->checkTime();
-        $level->stopTime();
-        $level->checkTime();
-      }
-      $sender->sendMessage(new TranslationContainer("commands.always.day.locked"));
-      Command::broadcastCommandMessage($sender, "Stopped the time.");
-    }elseif($args[0] === "false"){
-      foreach($sender->getServer()->getLevels() as $level){
-        $level->checkTime();
-        $level->startTime();
-        $level->checkTime();
-      }
-      $sender->sendMessage(new TranslationContainer("commands.always.day.unlocked"));
-      Command::broadcastCommandMessage($sender, "Started the time.");
-    }else{
-      throw new InvalidCommandSyntaxException();
-    }
+		if(count($args) < 1 or $args[0] === "true"){
+			foreach($sender->getServer()->getLevels() as $level){
+				$level->checkTime();
+				$level->stopTime();
+				$level->checkTime();
+			}
+
+			Command::broadcastCommandMessage($sender, new TranslationContainer("commands.always.day.locked"));
+		}elseif($args[0] === "false"){
+			foreach($sender->getServer()->getLevels() as $level){
+				$level->checkTime();
+				$level->startTime();
+				$level->checkTime();
+			}
+
+			Command::broadcastCommandMessage($sender, new TranslationContainer("commands.always.day.unlocked"));
+		}else{
+			throw new InvalidCommandSyntaxException();
+		}
 
 		return true;
 	}

--- a/src/pocketmine/command/defaults/DayLockCommand.php
+++ b/src/pocketmine/command/defaults/DayLockCommand.php
@@ -36,9 +36,9 @@ class DayLockCommand extends VanillaCommand{
 		parent::__construct(
 			$name,
 			"%pocketmine.command.daylock.description",
-			"%commands.daylock.usage",
+			"%commands.daylock.usage"
 		);
-		$this->setPermission("pocketmine.command.daylock;pocketmine.command.alwaysday");
+		$this->setPermission("pocketmine.command.daylock");
 	}
 
 	public function execute(CommandSender $sender, string $commandLabel, array $args){

--- a/src/pocketmine/command/defaults/DayLockCommand.php
+++ b/src/pocketmine/command/defaults/DayLockCommand.php
@@ -53,6 +53,7 @@ class DayLockCommand extends VanillaCommand{
 		if(count($args) < 1 or $args[0] === "true"){
 			foreach($sender->getServer()->getLevels() as $level){
 				$level->checkTime();
+				$level->setTime(5000);
 				$level->stopTime();
 				$level->checkTime();
 			}

--- a/src/pocketmine/command/defaults/DayLockCommand.php
+++ b/src/pocketmine/command/defaults/DayLockCommand.php
@@ -52,18 +52,14 @@ class DayLockCommand extends VanillaCommand{
 
 		if(count($args) < 1 or $args[0] === "true"){
 			foreach($sender->getServer()->getLevels() as $level){
-				$level->checkTime();
 				$level->setTime(5000);
 				$level->stopTime();
-				$level->checkTime();
 			}
 
 			Command::broadcastCommandMessage($sender, new TranslationContainer("commands.always.day.locked"));
 		}elseif($args[0] === "false"){
 			foreach($sender->getServer()->getLevels() as $level){
-				$level->checkTime();
 				$level->startTime();
-				$level->checkTime();
 			}
 
 			Command::broadcastCommandMessage($sender, new TranslationContainer("commands.always.day.unlocked"));

--- a/src/pocketmine/command/defaults/DayLockCommand.php
+++ b/src/pocketmine/command/defaults/DayLockCommand.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\command\defaults;
+
+use pocketmine\command\Command;
+use pocketmine\command\CommandSender;
+use pocketmine\command\utils\InvalidCommandSyntaxException;
+use pocketmine\lang\TranslationContainer;
+use pocketmine\level\Level;
+use pocketmine\Player;
+
+class DayLockCommand extends VanillaCommand{
+
+	public function __construct(string $name){
+		parent::__construct(
+			$name,
+			"%pocketmine.command.daylock.description",
+			"%commands.daylock.usage",
+      ["alwaysday"]
+		);
+		$this->setPermission("pocketmine.command.daylock");
+	}
+
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
+		if(!$this->testPermission($sender)){
+			return true;
+		}
+
+    if(count($args) > 1){
+      throw new InvalidCommandSyntaxException();
+    }
+
+    if(count($args) < 1 or $args[0] === "true"){
+      foreach($sender->getServer()->getLevels() as $level){
+        $level->checkTime();
+        $level->stopTime();
+        $level->checkTime();
+      }
+      $sender->sendMessage(new TranslationContainer("commands.always.day.locked"));
+      Command::broadcastCommandMessage($sender, "Stopped the time.");
+    }elseif($args[0] === "false"){
+      foreach($sender->getServer()->getLevels() as $level){
+        $level->checkTime();
+        $level->startTime();
+        $level->checkTime();
+      }
+      $sender->sendMessage(new TranslationContainer("commands.always.day.unlocked"));
+      Command::broadcastCommandMessage($sender, "Started the time.");
+    }else{
+      throw new InvalidCommandSyntaxException();
+    }
+
+		return true;
+	}
+}

--- a/src/pocketmine/command/defaults/DayLockCommand.php
+++ b/src/pocketmine/command/defaults/DayLockCommand.php
@@ -36,7 +36,8 @@ class DayLockCommand extends VanillaCommand{
 		parent::__construct(
 			$name,
 			"%pocketmine.command.daylock.description",
-			"%commands.daylock.usage"
+			"%commands.daylock.usage",
+			["alwaysday"]
 		);
 		$this->setPermission("pocketmine.command.daylock");
 	}

--- a/src/pocketmine/command/defaults/TimeCommand.php
+++ b/src/pocketmine/command/defaults/TimeCommand.php
@@ -47,33 +47,7 @@ class TimeCommand extends VanillaCommand{
 			throw new InvalidCommandSyntaxException();
 		}
 
-		if($args[0] === "start"){
-			if(!$sender->hasPermission("pocketmine.command.time.start")){
-				$sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.permission"));
-
-				return true;
-			}
-			foreach($sender->getServer()->getLevels() as $level){
-				$level->checkTime();
-				$level->startTime();
-				$level->checkTime();
-			}
-			Command::broadcastCommandMessage($sender, "Restarted the time");
-			return true;
-		}elseif($args[0] === "stop"){
-			if(!$sender->hasPermission("pocketmine.command.time.stop")){
-				$sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.permission"));
-
-				return true;
-			}
-			foreach($sender->getServer()->getLevels() as $level){
-				$level->checkTime();
-				$level->stopTime();
-				$level->checkTime();
-			}
-			Command::broadcastCommandMessage($sender, "Stopped the time");
-			return true;
-		}elseif($args[0] === "query"){
+		if($args[0] === "query"){
 			if(!$sender->hasPermission("pocketmine.command.time.query")){
 				$sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.permission"));
 
@@ -101,7 +75,7 @@ class TimeCommand extends VanillaCommand{
 			}
 
 			if($args[1] === "day"){
-				$value = 0;
+				$value = Level::TIME_DAY;
 			}elseif($args[1] === "night"){
 				$value = Level::TIME_NIGHT;
 			}else{

--- a/src/pocketmine/permission/DefaultPermissions.php
+++ b/src/pocketmine/permission/DefaultPermissions.php
@@ -124,7 +124,8 @@ abstract class DefaultPermissions{
 		self::registerPermission(new Permission(self::ROOT . ".command.spawnpoint", "Allows the user to change player's spawnpoint", Permission::DEFAULT_OP), $commands);
 		self::registerPermission(new Permission(self::ROOT . ".command.setworldspawn", "Allows the user to change the world spawn", Permission::DEFAULT_OP), $commands);
 		self::registerPermission(new Permission(self::ROOT . ".command.transferserver", "Allows the user to transfer self to another server", Permission::DEFAULT_OP), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.title", "Allows the user to send a title to the specified player", Permission::DEFAULT_OP), $commands);
+		self::registerPermission(new Permission(self::ROOT . ".command.title", "Allows the user to send a title to the specified player", Permission::DEFAULT_OP), $commands);ds
+		self::registerPermission(new Permission(self::ROOT . ".command.alwaysday", "Allows the user to lock the time", Permission::DEFAULT_OP), $commands);
 		self::registerPermission(new Permission(self::ROOT . ".command.daylock", "Allows the user to lock the time", Permission::DEFAULT_OP), $commands);
 
 		$commands->recalculatePermissibles();

--- a/src/pocketmine/permission/DefaultPermissions.php
+++ b/src/pocketmine/permission/DefaultPermissions.php
@@ -124,8 +124,7 @@ abstract class DefaultPermissions{
 		self::registerPermission(new Permission(self::ROOT . ".command.spawnpoint", "Allows the user to change player's spawnpoint", Permission::DEFAULT_OP), $commands);
 		self::registerPermission(new Permission(self::ROOT . ".command.setworldspawn", "Allows the user to change the world spawn", Permission::DEFAULT_OP), $commands);
 		self::registerPermission(new Permission(self::ROOT . ".command.transferserver", "Allows the user to transfer self to another server", Permission::DEFAULT_OP), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.title", "Allows the user to send a title to the specified player", Permission::DEFAULT_OP), $commands);ds
-		self::registerPermission(new Permission(self::ROOT . ".command.alwaysday", "Allows the user to lock the time", Permission::DEFAULT_OP), $commands);
+		self::registerPermission(new Permission(self::ROOT . ".command.title", "Allows the user to send a title to the specified player", Permission::DEFAULT_OP), $commands);
 		self::registerPermission(new Permission(self::ROOT . ".command.daylock", "Allows the user to lock the time", Permission::DEFAULT_OP), $commands);
 
 		$commands->recalculatePermissibles();

--- a/src/pocketmine/permission/DefaultPermissions.php
+++ b/src/pocketmine/permission/DefaultPermissions.php
@@ -91,8 +91,6 @@ abstract class DefaultPermissions{
 		$time = self::registerPermission(new Permission(self::ROOT . ".command.time", "Allows the user to alter the time", Permission::DEFAULT_OP), $commands);
 		self::registerPermission(new Permission(self::ROOT . ".command.time.add", "Allows the user to fast-forward time"), $time);
 		self::registerPermission(new Permission(self::ROOT . ".command.time.set", "Allows the user to change the time"), $time);
-		self::registerPermission(new Permission(self::ROOT . ".command.time.start", "Allows the user to restart the time"), $time);
-		self::registerPermission(new Permission(self::ROOT . ".command.time.stop", "Allows the user to stop the time"), $time);
 		self::registerPermission(new Permission(self::ROOT . ".command.time.query", "Allows the user query the time"), $time);
 		$time->recalculatePermissibles();
 
@@ -127,6 +125,7 @@ abstract class DefaultPermissions{
 		self::registerPermission(new Permission(self::ROOT . ".command.setworldspawn", "Allows the user to change the world spawn", Permission::DEFAULT_OP), $commands);
 		self::registerPermission(new Permission(self::ROOT . ".command.transferserver", "Allows the user to transfer self to another server", Permission::DEFAULT_OP), $commands);
 		self::registerPermission(new Permission(self::ROOT . ".command.title", "Allows the user to send a title to the specified player", Permission::DEFAULT_OP), $commands);
+		self::registerPermission(new Permission(self::ROOT . ".command.daylock", "Allows the user to lock the time", Permission::DEFAULT_OP), $commands);
 
 		$commands->recalculatePermissibles();
 


### PR DESCRIPTION
## Introduction
This PR implements the `/alwaysday` command and `/daylock` command. It also removes `/time start` and `/time stop`.

Since both commands act *exactly* the same, i have implemented the logic in the daylock command and just registered the class for both "daylock" and "alwaysday". Please tell me if this will have unexpected issues, but i didnt see the point in duplicating code or adding it as an alias since it should show up as a seperate command like in vanilla.

When locking the time, it initially sets it to 5000 (like vanilla) where it will stay until you change it (and then obviously it will stay there).

### Relevant issues
None that i can find.

## Changes
### API changes
* Removed permission `pocketmine.command.time.start`
* Removed permission `pocketmine.command.time.stop`
* Added permission `pocketmine.command.daylock`

### Behavioural changes
None.

## Backwards compatibility
This will (probably) have no effect on plugins, unless they stopped the time using `Server->dispatchCommand` (which they shouldn't be doing anyway).

## Follow-up
Translations required, however the command success messages should display when executed from the client.

The start/stop text will need to be removed from the `/time` command usage string.

## Tests
Join a server and test the following commands:

* /daylock
* /alwaysday
* /daylock true
* /daylock false

It all works perfectly.