### PR TITLE
Human: Add support for 128x128 skins in isValidSkin()

### DIFF
--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -105,7 +105,7 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 	 * @return bool
 	 */
 	public static function isValidSkin(string $skin) : bool{
-		return strlen($skin) === 64 * 64 * 4 or strlen($skin) === 64 * 32 * 4;
+		return strlen($skin) === 64 * 64 * 4 or strlen($skin) === 64 * 32 * 4 or strlen($skin) === 128 * 128 * 4;
 	}
 
 	/**


### PR DESCRIPTION
## Introduction
The method **isValidSkin()** needs an update to allow skins of 128x128 pixel.

### Relevant issues
* Fixes issues in plugins using this this method (e.g. Slapper) when validating skins of this size.

## Backwards compatibility
I noticed when creating NBT data from skindata (128x128 pixel) you'll need a ByteArrayTag because a StringTag can't hold a length of 128 * 128 * 4 bytes.

## Tests
I've tested this change using the Slapper plugin - result can be seen here 😄 :

![grafik](https://user-images.githubusercontent.com/15960628/38437024-8383895c-39d6-11e8-9d94-7dc1d0be6e07.png)
