### PR TITLE
Fix Player DisplayName

### DIFF
--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -756,7 +756,7 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 
 		$pk = new AddPlayerPacket();
 		$pk->uuid = $this->getUniqueId();
-		$pk->username = $this->getName();
+		$pk->username = $this->getDisplayName();
 		$pk->entityRuntimeId = $this->getId();
 		$pk->position = $this->asVector3();
 		$pk->motion = $this->getMotion();


### PR DESCRIPTION
## Introduction
This patch is for fix to display of player display name.

### Relevant issues
none

## Changes
### API changes
No

### Behavioural changes
No

## Backwards compatibility
Yes

## Follow-up
No

## Tests
A&B: spawn.
A: change display name.
A: move to away(B isn't loaded chunk).
B: move to A.