### PR TITLE
Allow command description and usage to depend on sender and time

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -674,7 +674,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 			$data = new CommandData();
 			$data->commandName = $command->getName();
-			$data->commandDescription = $this->server->getLanguage()->translateString($command->getDescription());
+			$data->commandDescription = $this->server->getLanguage()->translateString($command->getDescriptionFor($this));
 			$data->flags = 0;
 			$data->permission = 0;
 

--- a/src/pocketmine/command/Command.php
+++ b/src/pocketmine/command/Command.php
@@ -239,6 +239,8 @@ abstract class Command{
 	}
 
 	/**
+	 * Returns the generic description message of this command.
+	 *
 	 * @return string
 	 */
 	public function getDescription() : string{
@@ -246,10 +248,32 @@ abstract class Command{
 	}
 
 	/**
+	 * Returns the specific description message of this command for the CommandSender at this moment.
+	 *
+	 * @param CommandSender $sender
+	 * @return string
+	 */
+	public function getDescriptionFor(CommandSender $sender) : string{
+		return $this->getDescription();
+	}
+
+	/**
+	 * Returns the generic usage message of this command.
+	 *
 	 * @return string
 	 */
 	public function getUsage() : string{
 		return $this->usageMessage;
+	}
+
+	/**
+	 * Returns the specific usage message of this command for the CommandSender at this moment.
+	 *
+	 * @param CommandSender $sender
+	 * @return string
+	 */
+	public function getUsageFor(CommandSender $sender) : string{
+		return $this->getUsage();
 	}
 
 	/**

--- a/src/pocketmine/command/SimpleCommandMap.php
+++ b/src/pocketmine/command/SimpleCommandMap.php
@@ -257,7 +257,7 @@ class SimpleCommandMap implements CommandMap{
 		try{
 			$target->execute($sender, $sentCommandLabel, $args);
 		}catch(InvalidCommandSyntaxException $e){
-			$sender->sendMessage($this->server->getLanguage()->translateString("commands.generic.usage", [$target->getUsage()]));
+			$sender->sendMessage($this->server->getLanguage()->translateString("commands.generic.usage", [$target->getUsageFor($sender)]));
 		}catch(\Throwable $e){
 			$sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.exception"));
 			$this->server->getLogger()->critical($this->server->getLanguage()->translateString("pocketmine.command.exception", [$commandLine, (string) $target, $e->getMessage()]));

--- a/src/pocketmine/command/defaults/HelpCommand.php
+++ b/src/pocketmine/command/defaults/HelpCommand.php
@@ -78,7 +78,7 @@ class HelpCommand extends VanillaCommand{
 			$sender->sendMessage(new TranslationContainer("commands.help.header", [$pageNumber, count($commands)]));
 			if(isset($commands[$pageNumber - 1])){
 				foreach($commands[$pageNumber - 1] as $command){
-					$sender->sendMessage(TextFormat::DARK_GREEN . "/" . $command->getName() . ": " . TextFormat::WHITE . $command->getDescription());
+					$sender->sendMessage(TextFormat::DARK_GREEN . "/" . $command->getName() . ": " . TextFormat::WHITE . $command->getDescriptionFor($sender));
 				}
 			}
 
@@ -87,8 +87,8 @@ class HelpCommand extends VanillaCommand{
 			if(($cmd = $sender->getServer()->getCommandMap()->getCommand(strtolower($command))) instanceof Command){
 				if($cmd->testPermissionSilent($sender)){
 					$message = TextFormat::YELLOW . "--------- " . TextFormat::WHITE . " Help: /" . $cmd->getName() . TextFormat::YELLOW . " ---------\n";
-					$message .= TextFormat::GOLD . "Description: " . TextFormat::WHITE . $cmd->getDescription() . "\n";
-					$message .= TextFormat::GOLD . "Usage: " . TextFormat::WHITE . implode("\n" . TextFormat::WHITE, explode("\n", $cmd->getUsage())) . "\n";
+					$message .= TextFormat::GOLD . "Description: " . TextFormat::WHITE . $cmd->getDescriptionFor($sender) . "\n";
+					$message .= TextFormat::GOLD . "Usage: " . TextFormat::WHITE . implode("\n" . TextFormat::WHITE, explode("\n", $cmd->getUsageFor($sender))) . "\n";
 					$sender->sendMessage($message);
 
 					return true;


### PR DESCRIPTION
## Introduction
Commands may want to have dynamic description and usage due to many reasons:
- Localization (although this can be better solved with a better Translations API)
- Sender type-dependent usage (e.g. console must provide a player argument for /tp, optional for players)
- Certain permission-dependent features (including disabling certain subcommands)

**Important note:** The usage will become obsolete in the future, as it shall be replaced by arg info, and it is possible to change the description by using a resource pack, but I feel that this is too heavy for a simple problem.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
- Added `Command::getDescriptionFor(CommandSender)` and `Command::getUsageFor(CommandSender)`, which redirect to `Command::getDescription()` and `Command::getUsage()` respectively in their implementation.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
- `/help` uses description and usage from the new methods
- Throwing `InvalidCommandSyntaxException` will show a message from the `getUsageFor` instead of `getUsage`
- In the client, the command description message will be the one generated from `Command::getDescriptionFor` **when the player logins, just after PlayerLoginEvent** and when the player's permissions are recalculated.
  - This will not change when the client changes its language in-game (although really rare).

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Almost fully backwards-comptaible, unless a Command subclass defines getDescriptionFor()/getUsageFor(), which is highly unlikely.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
There are some follow-ups we can do, but they will surely all be rejected because of the never-coming command argss API 😶 

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Tested with a plugin overriding getDescriptionFor() in a command class and running `/help` on console.