### PR TITLE
Skip method if Listener declares method with undefined argument type

### DIFF
--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -752,7 +752,16 @@ class PluginManager{
 				$ignoreCancelled = isset($tags["ignoreCancelled"]) && strtolower($tags["ignoreCancelled"]) === "true";
 
 				$parameters = $method->getParameters();
-				if(count($parameters) === 1 and $parameters[0]->getClass() instanceof \ReflectionClass and is_subclass_of($parameters[0]->getClass()->getName(), Event::class)){
+				try{
+					$isHandler = count($parameters) === 1 && $parameters[0]->getClass() instanceof \ReflectionClass && is_subclass_of($parameters[0]->getClass()->getName(), Event::class);
+				}catch(\ReflectionException $e){
+					if(isset($tags["softDepend"])){
+						continue;
+					}
+
+					throw new \ClassNotFoundException($e->getMessage(), 0, $e);
+				}
+				if($isHandler){
 					$class = $parameters[0]->getClass()->getName();
 					$this->registerEvent($class, $listener, $priority, new MethodEventExecutor($method->getName()), $plugin, $ignoreCancelled);
 				}

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -758,7 +758,7 @@ class PluginManager{
 					$isHandler = count($parameters) === 1 && $parameters[0]->getClass() instanceof \ReflectionClass && is_subclass_of($parameters[0]->getClass()->getName(), Event::class);
 				}catch(\ReflectionException $e){
 					if(isset($tags["softDepend"]) && !isset($this->plugins[$tags["softDepend"]])){
-						MainLogger::getLogger()->debug("Not registering @softDepend listener " . get_class($listener) . "::{$method->getName()}({$parameters[0]->getType()->getName()})");
+						MainLogger::getLogger()->debug("Not registering @softDepend listener " . get_class($listener) . "::" . $method->getName() . "(" . $parameters[0]->getType()->getName() . ")");
 						continue;
 					}
 

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -35,6 +35,8 @@ use pocketmine\permission\Permission;
 use pocketmine\Server;
 use pocketmine\timings\Timings;
 use pocketmine\timings\TimingsHandler;
+use pocketmine\utils\MainLogger;
+use pocketmine\utils\TextFormat;
 
 /**
  * Manages all the plugins, Permissions and Permissibles
@@ -755,11 +757,12 @@ class PluginManager{
 				try{
 					$isHandler = count($parameters) === 1 && $parameters[0]->getClass() instanceof \ReflectionClass && is_subclass_of($parameters[0]->getClass()->getName(), Event::class);
 				}catch(\ReflectionException $e){
-					if(isset($tags["softDepend"])){
+					if(isset($tags["softDepend"]) && !isset($this->plugins[$tags["softDepend"]])){
+						MainLogger::getLogger()->debug("Not registering @softDepend listener " . get_class($listener) . "::{$method->getName()}({$parameters[0]->getType()->getName()})");
 						continue;
 					}
 
-					throw new \ClassNotFoundException($e->getMessage(), 0, $e);
+					throw $e;
 				}
 				if($isHandler){
 					$class = $parameters[0]->getClass()->getName();

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -758,7 +758,7 @@ class PluginManager{
 					$isHandler = count($parameters) === 1 && $parameters[0]->getClass() instanceof \ReflectionClass && is_subclass_of($parameters[0]->getClass()->getName(), Event::class);
 				}catch(\ReflectionException $e){
 					if(isset($tags["softDepend"]) && !isset($this->plugins[$tags["softDepend"]])){
-						MainLogger::getLogger()->debug("Not registering @softDepend listener " . get_class($listener) . "::" . $method->getName() . "(" . $parameters[0]->getType()->getName() . ")");
+						MainLogger::getLogger()->debug("Not registering @softDepend listener " . get_class($listener) . "::" . $method->getName() . "(" . $parameters[0]->getType()->getName() . ") because plugin \"" . $tags["softDepend"] . "\" not found");
 						continue;
 					}
 


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Some plugins may declare a soft dependency to other plugins, i.e. the plugin can still load without the other plugin. These plugins may want to listen to events from these other plugins if they exist, or just ignore the event if they don't exist.

Currently, plugins have to call `PluginManager->registerEvent()` directly, or separate the Listener class, in order not to trigger the error of trying to listen to a non-existent event:

```
[20:31:57] [Server thread/CRITICAL]: ReflectionException: "Class no\such\event does not exist" (EXCEPTION) in "src/pocketmine/plugin/PluginManager" at line 755
```

This pull request allows a Listener class to declare methods requiring parameters of non-existent class types by declaring `@softDepend` in its doccomment. This makes listening events from plugins pssively more convenient.

This is mainly useful for listening to optional events that may exist or not exist. This should not be relied on, say, to execute something when a player is authenticated by a certain auth plugin, because if multiple auth plugins are loaded (for no proper reason though), the upon-auth execution will execute multiple times.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Added the `@softDepend` tag to skip Listener methods with undefined class parameters.

The methods should only be skipped when the soft-depend plugin is not loaded; if it is loaded, but the event is still not found, this is most likely a typo in the event class, or an API change in the dependent plugin. In this case, we still want to display the error message, so `@softDepend` can accept a parameter, the plugin name, which will be made sure not to be loaded.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Fully backward-compatible, as `@softDepend` is not a standard doc comment expected to be found in event listener methods.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Tested with a Listener with an undefined parameter, both with and without `@softDepend`, both working as expected.