### PR TITLE
Implemented @notHandler annotation for event handlers - skip register…

### DIFF
--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -745,6 +745,9 @@ class PluginManager{
 		foreach($reflection->getMethods(\ReflectionMethod::IS_PUBLIC) as $method){
 			if(!$method->isStatic()){
 				$tags = self::parseDocComment((string) $method->getDocComment());
+				if(isset($tags["notHandler"])){
+					continue;
+				}
 
 				try{
 					$priority = isset($tags["priority"]) ? EventPriority::fromString($tags["priority"]) : EventPriority::NORMAL;


### PR DESCRIPTION
…ing any handlers with this annotation

It is somewhat reasonable to have a function in an event handler which accepts an Event parameter, but is not a handler. For example, multiple event handlers can redirect to the same function to process an event, but this function may not want to receive called events.

There are other ways to get around this, such as making the event handler protected/private, or adding a dummy parameter, but this way is cleaner and more explicit.

Relevant old-repo PR: PocketMine/PocketMine-MP#2143