### PR TITLE
Fix DoubleSlab block name

### DIFF
--- a/src/pocketmine/block/DoubleSlab.php
+++ b/src/pocketmine/block/DoubleSlab.php
@@ -35,7 +35,7 @@ abstract class DoubleSlab extends Solid{
 	abstract public function getSlabId() : int;
 
 	public function getName() : string{
-		return "Double " . BlockFactory::get($this->getSlabId(), $this->getVariant())->getName() . " Slab";
+		return "Double " . BlockFactory::get($this->getSlabId(), $this->getVariant())->getName();
 	}
 
 	public function getDropsForCompatibleTool(Item $item) : array{


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
`DoubleSlab::getName()` concatenates the single slab's name. [Slabs already return their name along with the `Slab` suffix](https://github.com/pmmp/PocketMine-MP/blob/4f8e4f05220ecd56b038204009fbfdfe4a6359e4/src/pocketmine/block/StoneSlab.php#L59). `DoubleSlab` class suffixes the `Slab`-suffixed name by adding another `Slab` making `DoubleStoneSlab::getName()` for example, return `Double Stone Slab Slab`.
This PR removes the "Slab" suffix from DoubleSlabs.

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
```php
var_dump(Block::get(Block::DOUBLE_STONE_SLAB)->getName());
//Prior to this PR: string("Double Stone Slab Slab")
//With this PR: string("Double Stone Slab")
```