### PR TITLE
Player: changeSkin() remove unnecessary parameters.

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -782,12 +782,10 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	 * Plugin developers should not use this, use setSkin() and sendSkin() instead.
 	 *
 	 * @param Skin   $skin
-	 * @param string $newSkinName
-	 * @param string $oldSkinName
 	 *
 	 * @return bool
 	 */
-	public function changeSkin(Skin $skin, string $newSkinName, string $oldSkinName) : bool{
+	public function changeSkin(Skin $skin) : bool{
 		if(!$skin->isValid()){
 			return false;
 		}

--- a/src/pocketmine/network/mcpe/PlayerNetworkSessionAdapter.php
+++ b/src/pocketmine/network/mcpe/PlayerNetworkSessionAdapter.php
@@ -231,7 +231,7 @@ class PlayerNetworkSessionAdapter extends NetworkSession{
 	}
 
 	public function handlePlayerSkin(PlayerSkinPacket $packet) : bool{
-		return $this->player->changeSkin($packet->skin, $packet->newSkinName, $packet->oldSkinName);
+		return $this->player->changeSkin($packet->skin);
 	}
 
 	public function handleBookEdit(BookEditPacket $packet) : bool{


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Since changeSkin() is never used `$newSkinName` and `$oldSkinName` in it's method and Skin class already handled everything for it.

### Relevant issues
* Those parameters are make developers confused and actually mean nothing.
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
Important changes:
Player: changeSkin(Skin $skin, string $newSkinName, string $oldSkinName) to changeSkin(Skin $skin).
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
There is no effect with server behaves.
<!-- Any change in how the server behaves, or its performance? -->
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
Already tested with change skin in-game with any types of skin.
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
