### PR TITLE
Remove implicit chunk autoloading

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -998,7 +998,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 			++$count;
 
 			$this->usedChunks[$index] = false;
-			$this->level->registerChunkLoader($this, $X, $Z, false);
+			$this->level->registerChunkLoader($this, $X, $Z, true);
 
 			if(!$this->level->populateChunk($X, $Z)){
 				continue;

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -520,10 +520,7 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 		$this->boundingBox = new AxisAlignedBB(0, 0, 0, 0, 0, 0);
 		$this->recalculateBoundingBox();
 
-		$this->chunk = $this->level->getChunk($this->getFloorX() >> 4, $this->getFloorZ() >> 4, false);
-		if($this->chunk === null){
-			throw new \InvalidStateException("Cannot create entities in unloaded chunks");
-		}
+		$this->chunk = $level->getLoadedChunk(((int) floor($pos[0])) >> 4, ((int) floor($pos[2])) >> 4);
 
 		if($this->namedtag->hasTag("Motion", ListTag::class)){
 			/** @var float[] $motion */
@@ -1792,11 +1789,12 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 	protected function checkChunks(){
 		$chunkX = $this->getFloorX() >> 4;
 		$chunkZ = $this->getFloorZ() >> 4;
+
 		if($this->chunk === null or ($this->chunk->getX() !== $chunkX or $this->chunk->getZ() !== $chunkZ)){
 			if($this->chunk !== null){
 				$this->chunk->removeEntity($this);
 			}
-			$this->chunk = $this->level->getChunk($chunkX, $chunkZ, true);
+			$this->chunk = $this->level->getChunk($chunkX, $chunkZ);
 
 			if(!$this->justCreated){
 				$newChunk = $this->level->getChunkPlayers($chunkX, $chunkZ);

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -776,7 +776,7 @@ class Level implements ChunkManager, Metadatable{
 					unset($this->chunkCache[$index]);
 					Level::getXZ($index, $chunkX, $chunkZ);
 					if(count($blocks) > 512){
-						$chunk = $this->getChunk($chunkX, $chunkZ);
+						$chunk = $this->getLoadedChunk($chunkX, $chunkZ);
 						foreach($this->getChunkPlayers($chunkX, $chunkZ) as $p){
 							$p->onChunkChanged($chunk);
 						}
@@ -1006,6 +1006,7 @@ class Level implements ChunkManager, Metadatable{
 				unset($this->chunkTickList[$index]);
 			}
 
+			$chunk = $this->chunks[$index];
 			foreach($chunk->getEntities() as $entity){
 				$entity->scheduleUpdate();
 			}
@@ -1312,7 +1313,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @return int bitmap, (id << 4) | data
 	 */
 	public function getFullBlock(int $x, int $y, int $z) : int{
-		return $this->getChunk($x >> 4, $z >> 4, false)->getFullBlock($x & 0x0f, $y, $z & 0x0f);
+		return $this->getLoadedChunk($x >> 4, $z >> 4)->getFullBlock($x & 0x0f, $y, $z & 0x0f);
 	}
 
 	public function isInWorld(int $x, int $y, int $z) : bool{
@@ -1422,7 +1423,7 @@ class Level implements ChunkManager, Metadatable{
 		$yPlusOne = $y + 1;
 
 		if($yPlusOne === $oldHeightMap){ //Block changed directly beneath the heightmap. Check if a block was removed or changed to a different light-filter.
-			$newHeightMap = $this->getChunk($x >> 4, $z >> 4)->recalculateHeightMapColumn($x & 0x0f, $z & 0x0f);
+			$newHeightMap = $this->getLoadedChunk($x >> 4, $z >> 4)->recalculateHeightMapColumn($x & 0x0f, $z & 0x0f);
 		}elseif($yPlusOne > $oldHeightMap){ //Block changed above the heightmap.
 			if(BlockFactory::$lightFilter[$sourceId] > 1 or BlockFactory::$diffusesSkyLight[$sourceId]){
 				$this->setHeightMap($x, $z, $yPlusOne);
@@ -1507,13 +1508,13 @@ class Level implements ChunkManager, Metadatable{
 	 */
 	public function setBlock(Vector3 $pos, Block $block, bool $direct = false, bool $update = true) : bool{
 		$pos = $pos->floor();
-		if(!$this->isInWorld($pos->x, $pos->y, $pos->z)){
+		if(!$this->isInWorld($pos->x, $pos->y, $pos->z) or !$this->isChunkLoaded($pos->x >> 4, $pos->z >> 4)){
 			return false;
 		}
 
 		$this->timings->setBlock->startTiming();
 
-		if($this->getChunk($pos->x >> 4, $pos->z >> 4, true)->setBlock($pos->x & 0x0f, $pos->y, $pos->z & 0x0f, $block->getId(), $block->getDamage())){
+		if($this->getLoadedChunk($pos->x >> 4, $pos->z >> 4)->setBlock($pos->x & 0x0f, $pos->y, $pos->z & 0x0f, $block->getId(), $block->getDamage())){
 			if(!($pos instanceof Position)){
 				$pos = $this->temporalPosition->setComponents($pos->x, $pos->y, $pos->z);
 			}
@@ -2069,7 +2070,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @return Tile|null
 	 */
 	public function getTileAt(int $x, int $y, int $z) : ?Tile{
-		$chunk = $this->getChunk($x >> 4, $z >> 4);
+		$chunk = $this->getLoadedChunk($x >> 4, $z >> 4);
 
 		if($chunk !== null){
 			return $chunk->getTile($x & 0x0f, $y, $z & 0x0f);
@@ -2112,7 +2113,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @return int 0-255
 	 */
 	public function getBlockIdAt(int $x, int $y, int $z) : int{
-		return $this->getChunk($x >> 4, $z >> 4, true)->getBlockId($x & 0x0f, $y, $z & 0x0f);
+		return $this->getLoadedChunk($x >> 4, $z >> 4)->getBlockId($x & 0x0f, $y, $z & 0x0f);
 	}
 
 	/**
@@ -2125,7 +2126,7 @@ class Level implements ChunkManager, Metadatable{
 	 */
 	public function setBlockIdAt(int $x, int $y, int $z, int $id){
 		unset($this->blockCache[$chunkHash = Level::chunkHash($x >> 4, $z >> 4)][$blockHash = Level::blockHash($x, $y, $z)]);
-		$this->getChunk($x >> 4, $z >> 4, true)->setBlockId($x & 0x0f, $y, $z & 0x0f, $id & 0xff);
+		$this->getLoadedChunk($x >> 4, $z >> 4)->setBlockId($x & 0x0f, $y, $z & 0x0f, $id & 0xff);
 
 		if(!isset($this->changedBlocks[$chunkHash])){
 			$this->changedBlocks[$chunkHash] = [];
@@ -2148,7 +2149,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @return int 16-bit
 	 */
 	public function getBlockExtraDataAt(int $x, int $y, int $z) : int{
-		return $this->getChunk($x >> 4, $z >> 4, true)->getBlockExtraData($x & 0x0f, $y, $z & 0x0f);
+		return $this->getLoadedChunk($x >> 4, $z >> 4)->getBlockExtraData($x & 0x0f, $y, $z & 0x0f);
 	}
 
 	/**
@@ -2162,7 +2163,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $data
 	 */
 	public function setBlockExtraDataAt(int $x, int $y, int $z, int $id, int $data){
-		$this->getChunk($x >> 4, $z >> 4, true)->setBlockExtraData($x & 0x0f, $y, $z & 0x0f, ($data << 8) | $id);
+		$this->getLoadedChunk($x >> 4, $z >> 4)->setBlockExtraData($x & 0x0f, $y, $z & 0x0f, ($data << 8) | $id);
 
 		$this->sendBlockExtraData($x, $y, $z, $id, $data);
 	}
@@ -2177,7 +2178,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @return int 0-15
 	 */
 	public function getBlockDataAt(int $x, int $y, int $z) : int{
-		return $this->getChunk($x >> 4, $z >> 4, true)->getBlockData($x & 0x0f, $y, $z & 0x0f);
+		return $this->getLoadedChunk($x >> 4, $z >> 4)->getBlockData($x & 0x0f, $y, $z & 0x0f);
 	}
 
 	/**
@@ -2191,7 +2192,7 @@ class Level implements ChunkManager, Metadatable{
 	public function setBlockDataAt(int $x, int $y, int $z, int $data){
 		unset($this->blockCache[$chunkHash = Level::chunkHash($x >> 4, $z >> 4)][$blockHash = Level::blockHash($x, $y, $z)]);
 
-		$this->getChunk($x >> 4, $z >> 4, true)->setBlockData($x & 0x0f, $y, $z & 0x0f, $data & 0x0f);
+		$this->getLoadedChunk($x >> 4, $z >> 4)->setBlockData($x & 0x0f, $y, $z & 0x0f, $data & 0x0f);
 
 		if(!isset($this->changedBlocks[$chunkHash])){
 			$this->changedBlocks[$chunkHash] = [];
@@ -2212,7 +2213,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @return int 0-15
 	 */
 	public function getBlockSkyLightAt(int $x, int $y, int $z) : int{
-		return $this->getChunk($x >> 4, $z >> 4, true)->getBlockSkyLight($x & 0x0f, $y, $z & 0x0f);
+		return $this->getLoadedChunk($x >> 4, $z >> 4)->getBlockSkyLight($x & 0x0f, $y, $z & 0x0f);
 	}
 
 	/**
@@ -2224,7 +2225,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $level 0-15
 	 */
 	public function setBlockSkyLightAt(int $x, int $y, int $z, int $level){
-		$this->getChunk($x >> 4, $z >> 4, true)->setBlockSkyLight($x & 0x0f, $y, $z & 0x0f, $level & 0x0f);
+		$this->getLoadedChunk($x >> 4, $z >> 4)->setBlockSkyLight($x & 0x0f, $y, $z & 0x0f, $level & 0x0f);
 	}
 
 	/**
@@ -2237,7 +2238,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @return int 0-15
 	 */
 	public function getBlockLightAt(int $x, int $y, int $z) : int{
-		return $this->getChunk($x >> 4, $z >> 4, true)->getBlockLight($x & 0x0f, $y, $z & 0x0f);
+		return $this->getLoadedChunk($x >> 4, $z >> 4)->getBlockLight($x & 0x0f, $y, $z & 0x0f);
 	}
 
 	/**
@@ -2249,7 +2250,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $level 0-15
 	 */
 	public function setBlockLightAt(int $x, int $y, int $z, int $level){
-		$this->getChunk($x >> 4, $z >> 4, true)->setBlockLight($x & 0x0f, $y, $z & 0x0f, $level & 0x0f);
+		$this->getLoadedChunk($x >> 4, $z >> 4)->setBlockLight($x & 0x0f, $y, $z & 0x0f, $level & 0x0f);
 	}
 
 	/**
@@ -2259,7 +2260,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @return int
 	 */
 	public function getBiomeId(int $x, int $z) : int{
-		return $this->getChunk($x >> 4, $z >> 4, true)->getBiomeId($x & 0x0f, $z & 0x0f);
+		return $this->getLoadedChunk($x >> 4, $z >> 4)->getBiomeId($x & 0x0f, $z & 0x0f);
 	}
 
 	/**
@@ -2269,7 +2270,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @return int
 	 */
 	public function getHeightMap(int $x, int $z) : int{
-		return $this->getChunk($x >> 4, $z >> 4, true)->getHeightMap($x & 0x0f, $z & 0x0f);
+		return $this->getLoadedChunk($x >> 4, $z >> 4)->getHeightMap($x & 0x0f, $z & 0x0f);
 	}
 
 	/**
@@ -2278,7 +2279,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $biomeId
 	 */
 	public function setBiomeId(int $x, int $z, int $biomeId){
-		$this->getChunk($x >> 4, $z >> 4, true)->setBiomeId($x & 0x0f, $z & 0x0f, $biomeId);
+		$this->getLoadedChunk($x >> 4, $z >> 4)->setBiomeId($x & 0x0f, $z & 0x0f, $biomeId);
 	}
 
 	/**
@@ -2287,7 +2288,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $value
 	 */
 	public function setHeightMap(int $x, int $z, int $value){
-		$this->getChunk($x >> 4, $z >> 4, true)->setHeightMap($x & 0x0f, $z & 0x0f, $value);
+		$this->getLoadedChunk($x >> 4, $z >> 4)->setHeightMap($x & 0x0f, $z & 0x0f, $value);
 	}
 
 	/**
@@ -2298,23 +2299,32 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * Returns the chunk at the specified X/Z coordinates. If the chunk is not loaded, attempts to (synchronously!!!)
-	 * load it.
+	 * Returns the chunk at the specified X/Z coordinates. Returns null if the chunk is not loaded.
 	 *
-	 * @param int  $x
-	 * @param int  $z
-	 * @param bool $create Whether to create an empty chunk as a placeholder if the chunk does not exist
+	 * @param int $x
+	 * @param int $z
 	 *
 	 * @return Chunk|null
 	 */
-	public function getChunk(int $x, int $z, bool $create = false){
-		if(isset($this->chunks[$index = Level::chunkHash($x, $z)])){
-			return $this->chunks[$index];
-		}elseif($this->loadChunk($x, $z, $create)){
-			return $this->chunks[$index];
+	public function getChunk(int $x, int $z) : ?Chunk{
+		return $this->chunks[Level::chunkHash($x, $z)] ?? null;
+	}
+
+	/**
+	 * Returns the chunk at the specified X/Z coordinates. Throws an exception if it is not loaded.
+	 *
+	 * @param int $chunkX
+	 * @param int $chunkZ
+	 *
+	 * @return Chunk
+	 * @throws \RuntimeException if the chunk is not loaded
+	 */
+	public function getLoadedChunk(int $chunkX, int $chunkZ) : Chunk{
+		if(!isset($this->chunks[$chunkHash = Level::chunkHash($chunkX, $chunkZ)])){
+			throw new \RuntimeException("Chunk $chunkX $chunkZ is not loaded");
 		}
 
-		return null;
+		return $this->chunks[$chunkHash];
 	}
 
 	/**
@@ -2333,7 +2343,7 @@ class Level implements ChunkManager, Metadatable{
 				if($i === 4){
 					continue; //center chunk
 				}
-				$result[$i] = $this->getChunk($x + $xx - 1, $z + $zz - 1, false);
+				$result[$i] = $this->getChunk($x + $xx - 1, $z + $zz - 1);
 			}
 		}
 
@@ -2343,7 +2353,7 @@ class Level implements ChunkManager, Metadatable{
 	public function generateChunkCallback(int $x, int $z, Chunk $chunk){
 		Timings::$generationCallbackTimer->startTiming();
 		if(isset($this->chunkPopulationQueue[$index = Level::chunkHash($x, $z)])){
-			$oldChunk = $this->getChunk($x, $z, false);
+			$oldChunk = $this->getChunk($x, $z);
 			for($xx = -1; $xx <= 1; ++$xx){
 				for($zz = -1; $zz <= 1; ++$zz){
 					unset($this->chunkPopulationLock[Level::chunkHash($x + $xx, $z + $zz)]);
@@ -2351,7 +2361,7 @@ class Level implements ChunkManager, Metadatable{
 			}
 			unset($this->chunkPopulationQueue[$index]);
 			$this->setChunk($x, $z, $chunk, false);
-			$chunk = $this->getChunk($x, $z, false);
+			$chunk = $this->getChunk($x, $z);
 			if($chunk !== null and ($oldChunk === null or !$oldChunk->isPopulated()) and $chunk->isPopulated()){
 				$this->server->getPluginManager()->callEvent(new ChunkPopulateEvent($this, $chunk));
 
@@ -2383,7 +2393,7 @@ class Level implements ChunkManager, Metadatable{
 		$chunk->setZ($chunkZ);
 
 		$chunkHash = Level::chunkHash($chunkX, $chunkZ);
-		$oldChunk = $this->getChunk($chunkX, $chunkZ, false);
+		$oldChunk = $this->getChunk($chunkX, $chunkZ);
 		if($unload and $oldChunk !== null){
 			$this->unloadChunk($chunkX, $chunkZ, false, false);
 		}else{
@@ -2426,7 +2436,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @return int 0-255
 	 */
 	public function getHighestBlockAt(int $x, int $z) : int{
-		return $this->getChunk($x >> 4, $z >> 4, true)->getHighestBlockAt($x & 0x0f, $z & 0x0f);
+		return $this->getLoadedChunk($x >> 4, $z >> 4)->getHighestBlockAt($x & 0x0f, $z & 0x0f);
 	}
 
 	/**
@@ -2822,7 +2832,7 @@ class Level implements ChunkManager, Metadatable{
 		if($spawn instanceof Vector3){
 			$max = $this->worldHeight;
 			$v = $spawn->floor();
-			$chunk = $this->getChunk($v->x >> 4, $v->z >> 4, false);
+			$chunk = $this->getChunk($v->x >> 4, $v->z >> 4);
 			$x = (int) $v->x;
 			$z = (int) $v->z;
 			if($chunk !== null){
@@ -2970,7 +2980,7 @@ class Level implements ChunkManager, Metadatable{
 			return false;
 		}
 
-		$chunk = $this->getChunk($x, $z, true);
+		$chunk = $this->getChunk($x, $z) ?? new Chunk($x, $z);
 		if(!$chunk->isPopulated()){
 			Timings::$populationTimer->startTiming();
 			$populate = true;

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -2330,18 +2330,23 @@ class Level implements ChunkManager, Metadatable{
 	/**
 	 * Returns the chunks adjacent to the specified chunk.
 	 *
-	 * @param int $x
-	 * @param int $z
+	 * @param int  $x
+	 * @param int  $z
+	 *
+	 * @param bool $load
 	 *
 	 * @return Chunk[]
 	 */
-	public function getAdjacentChunks(int $x, int $z) : array{
+	public function getAdjacentChunks(int $x, int $z, bool $load = false) : array{
 		$result = [];
 		for($xx = 0; $xx <= 2; ++$xx){
 			for($zz = 0; $zz <= 2; ++$zz){
 				$i = $zz * 3 + $xx;
 				if($i === 4){
 					continue; //center chunk
+				}
+				if($load){
+					$this->loadChunk($x + $xx - 1, $z + $zz - 1);
 				}
 				$result[$i] = $this->getChunk($x + $xx - 1, $z + $zz - 1);
 			}

--- a/src/pocketmine/level/generator/PopulationTask.php
+++ b/src/pocketmine/level/generator/PopulationTask.php
@@ -50,7 +50,7 @@ class PopulationTask extends AsyncTask{
 		$this->levelId = $level->getId();
 		$this->chunk = $chunk->fastSerialize();
 
-		foreach($level->getAdjacentChunks($chunk->getX(), $chunk->getZ()) as $i => $c){
+		foreach($level->getAdjacentChunks($chunk->getX(), $chunk->getZ(), true) as $i => $c){ //Load chunks to avoid cut trees when overlapping into already-generated but unloaded terrain
 			$this->{"chunk$i"} = $c !== null ? $c->fastSerialize() : null;
 		}
 	}


### PR DESCRIPTION
## Introduction
For a long time it's been problematic that `Level->getChunk()` automatically loads chunks unasked. This has caused a wide range of difficult-to-find bugs, especially since there is no way to get a chunk _without_ loading it, without boilerplate `isChunkLoaded()` checks everywhere.

Issues stemming from this include:
- The good old entity leak of 2016 - if implicit chunk loading didn't exist, it would never have happened, because the server would have crashed instead
- Entities running off the map will load chunks, which is entirely unexpected behaviour and could cause problems with rogue AI in the future.
- Light updates trigger autoloading of chunks, which is the primary blocker for #2107, because they cause CPU and memory leaks.

Another big reason for this change is that it won't be possible to implement asynchronous chunk I/O without it. As we know there's already #1895 open for months, which has stagnated because there are far too many changes in it and has many bugs. This pull request's changes have been separated from #1895 so that they can be integrated separately.

This pull request changes the core to prefer explicit chunk loading **where appropriate** (such as for Players).

## Changes
### API changes
- `Level->getChunk()` DOES NOT load chunks anymore and has had the third parameter removed.
- Added `Level->getLoadedChunk()` which will always either return an existing chunk or throw a `RuntimeException`.
- `Level->get*At()` functions (and their corresponding setters) will not automatically sync-load chunks anymore - instead they will throw exceptions.

It is expected that these changes will _not_ affect plugins for the most part, however some world edit plugins might be affected. It is expected that plugins should utilize the [`ChunkLoader`](https://github.com/pmmp/PocketMine-MP/blob/4f8e4f05220ecd56b038204009fbfdfe4a6359e4/src/pocketmine/level/ChunkLoader.php) to keep chunks loaded that they need to operate on.

For smoothness of upgrading, **please remember that chunk loading will become asynchronous in future**, and plan appropriately.

### Behavioural changes
Implicit chunk autoloading is now removed, fixing lots of bugs.
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
Noted above in the API changes section.

## Tests
Brief tests have been performed, more extensive testing is needed.