### PR TITLE
PluginBase::getResources() returns associative array

### DIFF
--- a/src/pocketmine/plugin/PluginBase.php
+++ b/src/pocketmine/plugin/PluginBase.php
@@ -230,7 +230,7 @@ abstract class PluginBase implements Plugin{
 		if(is_dir($this->file . "resources/")){
 			foreach(new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($this->file . "resources/")) as $resource){
 				if($resource->isFile()){
-					$resources[] = $resource;
+					$resources[substr((string) $resource, strlen($this->file . "resources/"))] = $resource;
 				}
 			}
 		}

--- a/src/pocketmine/plugin/PluginBase.php
+++ b/src/pocketmine/plugin/PluginBase.php
@@ -221,7 +221,7 @@ abstract class PluginBase implements Plugin{
 	}
 
 	/**
-	 * Returns all the resources packaged with the plugin
+	 * Returns all the resources packaged with the plugin in the form ["path/in/resources" => SplFileInfo]
 	 *
 	 * @return \SplFileInfo[]
 	 */
@@ -230,7 +230,8 @@ abstract class PluginBase implements Plugin{
 		if(is_dir($this->file . "resources/")){
 			foreach(new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($this->file . "resources/")) as $resource){
 				if($resource->isFile()){
-					$resources[substr((string) $resource, strlen($this->file . "resources/"))] = $resource;
+					$path = str_replace(DIRECTORY_SEPARATOR, "/", substr((string) $resource, strlen($this->file . "resources/")));
+					$resources[$path] = $resource;
 				}
 			}
 		}


### PR DESCRIPTION
## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
`PluginBase::getResources()` now returns the result in an associative array of strings.

Previously, it was a plain linear array containing instances of `SplFileInfo`.

Now, it has string keys, which is the path of the resource file relative to the resources folder.

## Backwards compatibility
<!-- Any possible backward incompatible changes? How are they solved, or how can they be solved? -->
May affect plugins that expect getResources() to return numeric arrays. However, the key type has never been clearly documented, so it is not considered an API break.

[A search on Poggit](https://poggit.pmmp.io/grepPlugins/2018-05-20-439be3a5b802b571.html) shows that no plugins are relying on the numeric nature of the keys.

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->Tested.