### PR TITLE
Fix a grammar error in Player

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1955,7 +1955,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 				return;
 			}
 
-			$this->server->getLogger()->debug($this->getName() . " is NOT logged into to Xbox Live");
+			$this->server->getLogger()->debug($this->getName() . " is NOT logged into Xbox Live");
 		}else{
 			$this->server->getLogger()->debug($this->getName() . " is logged into Xbox Live");
 			$this->xuid = $xuid;


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
There is a [grammar error](https://github.com/pmmp/PocketMine-MP/blob/f4a26ddfd99f1b56c39a19bb15d73e529e61171a/src/pocketmine/Player.php#L1958) in the Player class.
This pr fixes it.