### PR TITLE
Adding Player::getDeviceOS() function

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -166,6 +166,13 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	public const ADVENTURE = 2;
 	public const SPECTATOR = 3;
 	public const VIEW = Player::SPECTATOR;
+	public const OS_ANDROID = 1;
+	public const OS_IOS = 2;
+	public const OS_MAC = 3;
+	public const OS_FIRE = 4;
+	public const OS_GEARVR = 5;
+	public const OS_HOLOLENS = 6;
+	public const OS_WINDOWS = 7;
 
 	/**
 	 * Checks a supplied username and checks it is valid.

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3974,6 +3974,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	public function getDeviceOS() : int{
-	    return $this->deviceOS;
-    }
+		return $this->deviceOS;
+	}
 }

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -234,6 +234,9 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	/** @var string */
 	protected $xuid = "";
 
+	/** @var int */
+	protected $deviceOS;
+
 	protected $windowCnt = 2;
 	/** @var int[] */
 	protected $windows = [];
@@ -1880,6 +1883,8 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 		$this->uuid = UUID::fromString($packet->clientUUID);
 		$this->rawUUID = $this->uuid->toBinary();
+
+		$this->deviceOS = $packet->clientData["DeviceOS"];
 
 		$skin = new Skin(
 			$packet->clientData["SkinId"],
@@ -3960,4 +3965,8 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	public function isLoaderActive() : bool{
 		return $this->isConnected();
 	}
+
+	public function getDeviceOS() : int{
+	    return $this->deviceOS;
+    }
 }


### PR DESCRIPTION
## Introduction
This PR adds a new function to the player class, Player::getDeviceOS().

## Changes
### API changes
 * Adds Player::getDeviceOS()

## Tests
Tested with a clean PMMP server and a test plugin, that sent a message when the player joins with the deviceOS number, to test if the deviceOS function worked.
