### PR TITLE
Added a pocketmine.yml kill switch for development builds

### DIFF
--- a/src/pocketmine/PocketMine.php
+++ b/src/pocketmine/PocketMine.php
@@ -81,6 +81,7 @@ namespace pocketmine {
 	const NAME = "PocketMine-MP";
 	const VERSION = "1.7dev";
 	const API_VERSION = "3.0.0";
+	const IS_DEVELOPMENT_BUILD = true;
 
 	const MIN_PHP_VERSION = "7.2.0";
 

--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -1452,6 +1452,19 @@ class Server{
 
 			define('pocketmine\DEBUG', (int) $this->getProperty("debug.level", 1));
 
+			$this->forceLanguage = (bool) $this->getProperty("settings.force-language", false);
+			$this->baseLang = new BaseLang($this->getProperty("settings.language", BaseLang::FALLBACK_LANGUAGE));
+			$this->logger->info($this->getLanguage()->translateString("language.selected", [$this->getLanguage()->getName(), $this->getLanguage()->getLang()]));
+
+			if(\pocketmine\IS_DEVELOPMENT_BUILD and !((bool) $this->getProperty("settings.enable-dev-builds", false))){
+				$this->logger->emergency($this->baseLang->translateString("pocketmine.server.devBuild.error1", [\pocketmine\NAME]));
+				$this->logger->emergency($this->baseLang->translateString("pocketmine.server.devBuild.error2"));
+				$this->logger->emergency($this->baseLang->translateString("pocketmine.server.devBuild.error3"));
+				$this->logger->emergency($this->baseLang->translateString("pocketmine.server.devBuild.error4", ["settings.enable-dev-builds"]));
+				$this->forceShutdown();
+				return;
+			}
+
 			if(((int) ini_get('zend.assertions')) > 0 and ((bool) $this->getProperty("debug.assertions.warn-if-enabled", true)) !== false){
 				$this->logger->warning("Debugging assertions are enabled, this may impact on performance. To disable them, set `zend.assertions = -1` in php.ini.");
 			}
@@ -1489,10 +1502,6 @@ class Server{
 				"view-distance" => 8,
 				"xbox-auth" => true
 			]);
-
-			$this->forceLanguage = (bool) $this->getProperty("settings.force-language", false);
-			$this->baseLang = new BaseLang($this->getProperty("settings.language", BaseLang::FALLBACK_LANGUAGE));
-			$this->logger->info($this->getLanguage()->translateString("language.selected", [$this->getLanguage()->getName(), $this->getLanguage()->getLang()]));
 
 			$this->memoryManager = new MemoryManager($this);
 

--- a/src/pocketmine/resources/pocketmine.yml
+++ b/src/pocketmine/resources/pocketmine.yml
@@ -23,6 +23,9 @@ settings:
  #Set this approximately to your number of cores.
  #If set to auto, it'll try to detect the number of cores (or use 2)
  async-workers: auto
+ #Whether to allow running development builds. Dev builds might crash, break your plugins, corrupt your world and more.
+ #It is recommended to avoid using development builds where possible.
+ enable-dev-builds: false
 
 memory:
  #Global soft memory limit in megabytes. Set to 0 to disable

--- a/tests/travis.sh
+++ b/tests/travis.sh
@@ -48,7 +48,7 @@ mkdir "$DATA_DIR"
 mkdir "$PLUGINS_DIR"
 mv DevTools.phar "$PLUGINS_DIR"
 cp -r tests/plugins/PocketMine-TesterPlugin "$PLUGINS_DIR"
-echo -e "stop\n" | "$PHP_BINARY" PocketMine-MP.phar --no-wizard --disable-ansi --disable-readline --debug.level=2 --data="$DATA_DIR" --plugins="$PLUGINS_DIR" --anonymous-statistics.enabled=0 --settings.async-workers="$PM_WORKERS"
+echo -e "stop\n" | "$PHP_BINARY" PocketMine-MP.phar --no-wizard --disable-ansi --disable-readline --debug.level=2 --data="$DATA_DIR" --plugins="$PLUGINS_DIR" --anonymous-statistics.enabled=0 --settings.async-workers="$PM_WORKERS" --settings.enable-dev-builds=1
 
 output=$(grep '\[TesterPlugin\]' "$DATA_DIR/server.log")
 if [ "$output" == "" ]; then


### PR DESCRIPTION
## Introduction
It's very tiresome to keep seeing new users and noobs keep using dev builds when we keep telling them not to for the safety of their data, their plugins and their gameplay. Then they come to us asking why X plugin doesn't work or why the server crashes or whatever.

This pull requests prevents development builds from running out of the box, adding an obstacle to running development builds which should hopefully reduce the amount of turbulence new confused users get hit with when wanting to set up a new server.

Beyond a doubt, those who think they are smart to run dev builds in production today will simply disable this and continue to be morons, but for new users it needs to be made apparent at first use that they are using something unsafe which may have undesirable effects on their server. This is hoped to discourage new users from running unsafe development builds.

### Relevant issues
Too many to count, but not github issues.

## Changes
### API changes
- A new constant, `\pocketmine\IS_DEVELOPMENT_BUILD` has been added. If this constant is true, then the suicide rules apply. This constant should be set to false prior to tagging a release, and then reverted once the release has been created.

### Behavioural changes
- Development builds will now commit suicide unless the `settings.enable-dev-builds` directive is enabled in pocketmine.yml (or through command-line overrides).


## Follow-up
- Translation of the new strings into other languages (which should take place on Crowdin).
- Jenkins configuration needs to be updated to make sure that it can still build development builds.

## Tests
Tested under the following circumstances:
- Switch on, off and not present in pocketmine.yml
- Command-line override using `--settings.enable-dev-builds=1`