### PR TITLE
Implemented Mending enchantment

### DIFF
--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -518,37 +518,32 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 	}
 
 	public function onPickupXp(int $xpValue) : void{
-		//TODO: replace this with a more generic equipment getting/setting interface (this is ugly)
+		static $mainHandIndex = -1;
+
+		//TODO: replace this with a more generic equipment getting/setting interface
 		/** @var Durable[] $equipment */
 		$equipment = [];
 
-		/** @var Durable|null $item */
-		$mainHand = null;
-		/** @var Durable[] $armor */
-		$armor = [];
-
 		if(($item = $this->inventory->getItemInHand()) instanceof Durable and $item->hasEnchantment(Enchantment::MENDING)){
-			$equipment[] = $item;
-			$mainHand = $item;
+			$equipment[$mainHandIndex] = $item;
 		}
 		//TODO: check offhand
 		foreach($this->armorInventory->getContents() as $k => $item){
 			if($item instanceof Durable and $item->hasEnchantment(Enchantment::MENDING)){
-				$equipment[] = $item;
-				$armor[$k] = $item;
+				$equipment[$k] = $item;
 			}
 		}
 
 		if(!empty($equipment)){
-			$repairItem = $equipment[array_rand($equipment)];
+			$repairItem = $equipment[$k = array_rand($equipment)];
 			if($repairItem->getDamage() > 0){
 				$repairAmount = min($repairItem->getDamage(), $xpValue * 2);
 				$repairItem->setDamage($repairItem->getDamage() - $repairAmount);
 				$xpValue -= (int) ceil($repairAmount / 2);
 
-				if($repairItem === $mainHand){
+				if($k === $mainHandIndex){
 					$this->inventory->setItemInHand($repairItem);
-				}elseif(($k = array_search($repairItem, $armor, true)) !== false){
+				}else{
 					$this->armorInventory->setItem($k, $repairItem);
 				}
 			}

--- a/src/pocketmine/entity/object/ExperienceOrb.php
+++ b/src/pocketmine/entity/object/ExperienceOrb.php
@@ -200,10 +200,7 @@ class ExperienceOrb extends Entity{
 			if($currentTarget->canPickupXp() and $this->boundingBox->intersectsWith($currentTarget->getBoundingBox())){
 				$this->flagForDespawn();
 
-				$currentTarget->addXp($this->getXpValue());
-				$currentTarget->resetXpCooldown();
-
-				//TODO: check Mending enchantment
+				$currentTarget->onPickupXp($this->getXpValue());
 			}
 		}
 

--- a/src/pocketmine/item/enchantment/Enchantment.php
+++ b/src/pocketmine/item/enchantment/Enchantment.php
@@ -121,6 +121,8 @@ class Enchantment{
 		self::registerEnchantment(new Enchantment(self::SILK_TOUCH, "%enchantment.untouching", self::RARITY_MYTHIC, self::SLOT_DIG, self::SLOT_SHEARS, 1));
 		self::registerEnchantment(new Enchantment(self::UNBREAKING, "%enchantment.durability", self::RARITY_UNCOMMON, self::SLOT_DIG | self::SLOT_ARMOR | self::SLOT_FISHING_ROD | self::SLOT_BOW, self::SLOT_TOOL | self::SLOT_CARROT_STICK | self::SLOT_ELYTRA, 3));
 
+		self::registerEnchantment(new Enchantment(self::MENDING, "%enchantment.mending", self::RARITY_RARE, self::SLOT_NONE, self::SLOT_ALL, 1));
+
 		self::registerEnchantment(new Enchantment(self::VANISHING, "%enchantment.curse.vanishing", self::RARITY_MYTHIC, self::SLOT_NONE, self::SLOT_ALL, 1));
 	}
 


### PR DESCRIPTION
## Introduction
Implementing Mending enchantment. For those who don't know, this enchantment causes equipped items with the enchantment to become repaired by 2 points for every point of XP collected from an XP orb.

## Changes
### API changes
No API changes made by this PR. There has been 1 new public method added to `Human`, but this is not considered to be API, and does not break API anyway.

### Behavioural changes
Mending enchantment now works.

## Backwards compatibility
None. This is a non-breaking feature addition which should therefore target the next 3.x minor release (3.1).

## Tests
Tested in-game, repairs held items correctly - this has not been thoroughly tested yet, further testing is needed.
