### PR TITLE
Implemented Infinity enchantment

### DIFF
--- a/src/pocketmine/item/Bow.php
+++ b/src/pocketmine/item/Bow.php
@@ -24,9 +24,11 @@ declare(strict_types=1);
 namespace pocketmine\item;
 
 use pocketmine\entity\Entity;
+use pocketmine\entity\projectile\Arrow as ArrowEntity;
 use pocketmine\entity\projectile\Projectile;
 use pocketmine\event\entity\EntityShootBowEvent;
 use pocketmine\event\entity\ProjectileLaunchEvent;
+use pocketmine\item\enchantment\Enchantment;
 use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
 use pocketmine\Player;
 
@@ -64,6 +66,10 @@ class Bow extends Tool{
 
 		$entity = Entity::createEntity("Arrow", $player->getLevel(), $nbt, $player, $force == 2);
 		if($entity instanceof Projectile){
+			$infinity = $this->hasEnchantment(Enchantment::INFINITY);
+			if($infinity and $entity instanceof ArrowEntity){
+				$entity->setPickupMode(ArrowEntity::PICKUP_CREATIVE);
+			}
 			$ev = new EntityShootBowEvent($player, $this, $entity, $force);
 
 			if($force < 0.1 or $diff < 5){
@@ -80,7 +86,9 @@ class Bow extends Tool{
 			}else{
 				$entity->setMotion($entity->getMotion()->multiply($ev->getForce()));
 				if($player->isSurvival()){
-					$player->getInventory()->removeItem(ItemFactory::get(Item::ARROW, 0, 1));
+					if(!$infinity){ //TODO: tipped arrows are still consumed when Infinity is applied
+						$player->getInventory()->removeItem(ItemFactory::get(Item::ARROW, 0, 1));
+					}
 					$this->applyDamage(1);
 				}
 

--- a/src/pocketmine/item/Bow.php
+++ b/src/pocketmine/item/Bow.php
@@ -66,12 +66,10 @@ class Bow extends Tool{
 
 		$entity = Entity::createEntity("Arrow", $player->getLevel(), $nbt, $player, $force == 2);
 		if($entity instanceof Projectile){
-
 			$infinity = $this->hasEnchantment(Enchantment::INFINITY);
 			if($infinity and $entity instanceof ArrowEntity){
 				$entity->setPickupMode(ArrowEntity::PICKUP_CREATIVE);
 			}
-
 			if(($powerLevel = $this->getEnchantmentLevel(Enchantment::POWER)) > 0){
 				$entity->setBaseDamage($entity->getBaseDamage() + (($powerLevel + 1) / 2));
 			}

--- a/src/pocketmine/item/enchantment/Enchantment.php
+++ b/src/pocketmine/item/enchantment/Enchantment.php
@@ -121,6 +121,8 @@ class Enchantment{
 		self::registerEnchantment(new Enchantment(self::SILK_TOUCH, "%enchantment.untouching", self::RARITY_MYTHIC, self::SLOT_DIG, self::SLOT_SHEARS, 1));
 		self::registerEnchantment(new Enchantment(self::UNBREAKING, "%enchantment.durability", self::RARITY_UNCOMMON, self::SLOT_DIG | self::SLOT_ARMOR | self::SLOT_FISHING_ROD | self::SLOT_BOW, self::SLOT_TOOL | self::SLOT_CARROT_STICK | self::SLOT_ELYTRA, 3));
 
+		self::registerEnchantment(new Enchantment(self::INFINITY, "%enchantment.arrowInfinite", self::RARITY_MYTHIC, self::SLOT_BOW, self::SLOT_NONE, 1));
+
 		self::registerEnchantment(new Enchantment(self::VANISHING, "%enchantment.curse.vanishing", self::RARITY_MYTHIC, self::SLOT_NONE, self::SLOT_ALL, 1));
 	}
 


### PR DESCRIPTION
## Introduction
Implements Infinity enchantment, minus the additional behavioural characteristics around tipped/spectral arrows (because those aren't implemented yet).

This enchantment allows players to shoot arrows infinitely as long as they have a single normal arrow in the inventory. These arrows cannot be picked up by survival players (otherwise they would be able to duplicate them).

## Changes
### API changes
- Added new methods `Arrow->getPickupMode()`, `Arrow->setPickupMode()`.
- Added new public constants `Arrow::PICKUP_NONE`, `Arrow::PICKUP_ANY`, `Arrow::PICKUP_CREATIVE`.
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
`Infinity` enchantment now works for normal arrows.

## Tests
Tested with normal arrows in creative and survival.
