### PR TITLE
reorganize and optimize start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -2,8 +2,6 @@
 DIR="$(cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 cd "$DIR"
 
-DO_LOOP="no"
-
 while getopts "p:f:l" OPTION 2> /dev/null; do
 	case ${OPTION} in
 		p)
@@ -47,19 +45,18 @@ fi
 LOOPS=0
 
 set +e
-while [ "$LOOPS" -eq 0 ] || [ "$DO_LOOP" == "yes" ]; do
-	if [ "$DO_LOOP" == "yes" ]; then
-		"$PHP_BINARY" "$POCKETMINE_FILE" $@
-	else
-		exec "$PHP_BINARY" "$POCKETMINE_FILE" $@
-	fi
-	if [ "$DO_LOOP" == "yes" ]; then
+
+if [ "$DO_LOOP" == "yes" ]; then
+	while true; do
 		if [ ${LOOPS} -gt 0 ]; then
 			echo "Restarted $LOOPS times"
 		fi
+		"$PHP_BINARY" "$POCKETMINE_FILE" $@
 		echo "To escape the loop, press CTRL+C now. Otherwise, wait 5 seconds for the server to restart."
 		echo ""
 		sleep 5
 		((LOOPS++))
-	fi
-done
+	done
+else
+	exec "$PHP_BINARY" "$POCKETMINE_FILE" $@
+fi


### PR DESCRIPTION
## Introduction
The code in start.sh was a bit sloppy. Now, it is not. This new version makes use of double brackets, which is a shell built-in, rather than the single brackets which requires an extra process launch, and is thus less performant, and isn't as powerful. The loop logic has been refactored to remove redundant checks, and is now a lot more concise. This change also makes it possible to do `env DO_LOOP="yes" ./start.sh` if you wanted to. The initial `DO_LOOP="no"` is unnecessary, and removing it enables this functionality.

## Changes
### API changes

none.

### Behavioural changes
Equivalent behavior

## Backwards compatibility
Yup.

## Tests
It loops with ./start.sh -l, and doesn't with no arguments. The output is the same as before with the nutty logic. 