### PR TITLE
Remove a whole bunch of crap from the `Plugin` public interface

### DIFF
--- a/src/pocketmine/plugin/Plugin.php
+++ b/src/pocketmine/plugin/Plugin.php
@@ -29,8 +29,6 @@ namespace pocketmine\plugin;
 use pocketmine\command\CommandExecutor;
 use pocketmine\scheduler\TaskScheduler;
 use pocketmine\Server;
-use pocketmine\utils\Config;
-
 
 /**
  * It is recommended to use PluginBase for the actual plugin
@@ -92,20 +90,6 @@ interface Plugin extends CommandExecutor{
 	 * @return \SplFileInfo[]
 	 */
 	public function getResources() : array;
-
-	/**
-	 * @return Config
-	 */
-	public function getConfig() : Config;
-
-	public function saveConfig();
-
-	/**
-	 * @return bool
-	 */
-	public function saveDefaultConfig() : bool;
-
-	public function reloadConfig();
 
 	/**
 	 * @return Server

--- a/src/pocketmine/plugin/Plugin.php
+++ b/src/pocketmine/plugin/Plugin.php
@@ -66,32 +66,6 @@ interface Plugin extends CommandExecutor{
 	public function getDescription() : PluginDescription;
 
 	/**
-	 * Gets an embedded resource in the plugin file.
-	 *
-	 * @param string $filename
-	 *
-	 * @return null|resource Resource data, or null
-	 */
-	public function getResource(string $filename);
-
-	/**
-	 * Saves an embedded resource to its relative location in the data folder
-	 *
-	 * @param string $filename
-	 * @param bool $replace
-	 *
-	 * @return bool
-	 */
-	public function saveResource(string $filename, bool $replace = false) : bool;
-
-	/**
-	 * Returns all the resources packaged with the plugin
-	 *
-	 * @return \SplFileInfo[]
-	 */
-	public function getResources() : array;
-
-	/**
 	 * @return Server
 	 */
 	public function getServer() : Server;

--- a/src/pocketmine/plugin/Plugin.php
+++ b/src/pocketmine/plugin/Plugin.php
@@ -40,16 +40,6 @@ interface Plugin extends CommandExecutor{
 	public function __construct(PluginLoader $loader, Server $server, PluginDescription $description, string $dataFolder, string $file);
 
 	/**
-	 * Called when the plugin is loaded, before calling onEnable()
-	 */
-	public function onLoad();
-
-	/**
-	 * Called when the plugin is enabled
-	 */
-	public function onEnable();
-
-	/**
 	 * @return bool
 	 */
 	public function isEnabled() : bool;
@@ -58,12 +48,6 @@ interface Plugin extends CommandExecutor{
 	 * @param bool $enabled
 	 */
 	public function setEnabled(bool $enabled = true) : void;
-
-	/**
-	 * Called when the plugin is disabled
-	 * Use this to free open things and finish actions
-	 */
-	public function onDisable();
 
 	/**
 	 * @return bool

--- a/src/pocketmine/plugin/PluginBase.php
+++ b/src/pocketmine/plugin/PluginBase.php
@@ -182,7 +182,7 @@ abstract class PluginBase implements Plugin{
 	 *
 	 * @return null|resource Resource data, or null
 	 */
-	public function getResource(string $filename){
+	protected function getResource(string $filename){
 		$filename = rtrim(str_replace("\\", "/", $filename), "/");
 		if(file_exists($this->file . "resources/" . $filename)){
 			return fopen($this->file . "resources/" . $filename, "rb");
@@ -192,12 +192,14 @@ abstract class PluginBase implements Plugin{
 	}
 
 	/**
+	 * Saves an embedded resource to its relative location in the data folder
+	 *
 	 * @param string $filename
 	 * @param bool $replace
 	 *
 	 * @return bool
 	 */
-	public function saveResource(string $filename, bool $replace = false) : bool{
+	protected function saveResource(string $filename, bool $replace = false) : bool{
 		if(trim($filename) === ""){
 			return false;
 		}
@@ -226,7 +228,7 @@ abstract class PluginBase implements Plugin{
 	 *
 	 * @return \SplFileInfo[]
 	 */
-	public function getResources() : array{
+	protected function getResources() : array{
 		$resources = [];
 		if(is_dir($this->file . "resources/")){
 			foreach(new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($this->file . "resources/")) as $resource){

--- a/src/pocketmine/plugin/PluginBase.php
+++ b/src/pocketmine/plugin/PluginBase.php
@@ -68,20 +68,29 @@ abstract class PluginBase implements Plugin{
 		$this->configFile = $this->dataFolder . "config.yml";
 		$this->logger = new PluginLogger($this);
 		$this->scheduler = new TaskScheduler($this->logger, $this->getFullName());
+
+		$this->onLoad();
 	}
 
 	/**
 	 * Called when the plugin is loaded, before calling onEnable()
 	 */
-	public function onLoad(){
+	protected function onLoad()/* : void /* TODO: uncomment this for next major version */{
 
 	}
 
-	public function onEnable(){
+	/**
+	 * Called when the plugin is enabled
+	 */
+	protected function onEnable()/* : void /* TODO: uncomment this for next major version */{
 
 	}
 
-	public function onDisable(){
+	/**
+	 * Called when the plugin is disabled
+	 * Use this to free open things and finish actions
+	 */
+	protected function onDisable()/* : void /* TODO: uncomment this for next major version */{
 
 	}
 

--- a/src/pocketmine/plugin/PluginBase.php
+++ b/src/pocketmine/plugin/PluginBase.php
@@ -243,7 +243,7 @@ abstract class PluginBase implements Plugin{
 	/**
 	 * @return Config
 	 */
-	public function getConfig() : Config{
+	protected function getConfig() : Config{
 		if($this->config === null){
 			$this->reloadConfig();
 		}
@@ -251,20 +251,20 @@ abstract class PluginBase implements Plugin{
 		return $this->config;
 	}
 
-	public function saveConfig(){
+	protected function saveConfig(){
 		if(!$this->getConfig()->save()){
 			$this->getLogger()->critical("Could not save config to " . $this->configFile);
 		}
 	}
 
-	public function saveDefaultConfig() : bool{
+	protected function saveDefaultConfig() : bool{
 		if(!file_exists($this->configFile)){
 			return $this->saveResource("config.yml", false);
 		}
 		return false;
 	}
 
-	public function reloadConfig(){
+	protected function reloadConfig(){
 		$this->config = new Config($this->configFile);
 		if(($configStream = $this->getResource("config.yml")) !== null){
 			$this->config->setDefaults(yaml_parse(Config::fixYAMLIndexes(stream_get_contents($configStream))));

--- a/src/pocketmine/plugin/PluginBase.php
+++ b/src/pocketmine/plugin/PluginBase.php
@@ -182,7 +182,7 @@ abstract class PluginBase implements Plugin{
 	 *
 	 * @return null|resource Resource data, or null
 	 */
-	protected function getResource(string $filename){
+	public function getResource(string $filename){
 		$filename = rtrim(str_replace("\\", "/", $filename), "/");
 		if(file_exists($this->file . "resources/" . $filename)){
 			return fopen($this->file . "resources/" . $filename, "rb");
@@ -199,7 +199,7 @@ abstract class PluginBase implements Plugin{
 	 *
 	 * @return bool
 	 */
-	protected function saveResource(string $filename, bool $replace = false) : bool{
+	public function saveResource(string $filename, bool $replace = false) : bool{
 		if(trim($filename) === ""){
 			return false;
 		}
@@ -228,7 +228,7 @@ abstract class PluginBase implements Plugin{
 	 *
 	 * @return \SplFileInfo[]
 	 */
-	protected function getResources() : array{
+	public function getResources() : array{
 		$resources = [];
 		if(is_dir($this->file . "resources/")){
 			foreach(new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($this->file . "resources/")) as $resource){
@@ -245,7 +245,7 @@ abstract class PluginBase implements Plugin{
 	/**
 	 * @return Config
 	 */
-	protected function getConfig() : Config{
+	public function getConfig() : Config{
 		if($this->config === null){
 			$this->reloadConfig();
 		}
@@ -253,20 +253,20 @@ abstract class PluginBase implements Plugin{
 		return $this->config;
 	}
 
-	protected function saveConfig(){
+	public function saveConfig(){
 		if(!$this->getConfig()->save()){
 			$this->getLogger()->critical("Could not save config to " . $this->configFile);
 		}
 	}
 
-	protected function saveDefaultConfig() : bool{
+	public function saveDefaultConfig() : bool{
 		if(!file_exists($this->configFile)){
 			return $this->saveResource("config.yml", false);
 		}
 		return false;
 	}
 
-	protected function reloadConfig(){
+	public function reloadConfig(){
 		$this->config = new Config($this->configFile);
 		if(($configStream = $this->getResource("config.yml")) !== null){
 			$this->config->setDefaults(yaml_parse(Config::fixYAMLIndexes(stream_get_contents($configStream))));

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -201,7 +201,6 @@ class PluginManager{
 						 * @see Plugin::__construct()
 						 */
 						$plugin = new $mainClass($loader, $this->server, $description, $dataFolder, $prefixed);
-						$plugin->onLoad();
 						$this->plugins[$plugin->getDescription()->getName()] = $plugin;
 
 						$pluginCommands = $this->parseYamlCommands($plugin);


### PR DESCRIPTION
## Introduction
As discussed in #2249 , there are a whole lot of things declared in the `Plugin` public interface which do not need to be there, because they are only used from within `PluginBase`.

### Relevant issues
#2249 

## Changes
### API changes
- Removed the following from `Plugin` interface: `onLoad()`, `onEnable()`, `onDisable()`, `getResource()`, `saveResource()`, `getResources()`, `getConfig()`, `saveDefaultConfig()`, `saveConfig()`, `reloadConfig()`.
- Changed visibility of the following `PluginBase` methods from `public` to `protected`: `onLoad()`, `onEnable()`, `onDisable()`, `getResource()`, `saveResource()`, `getResources()`, `getConfig()`, `saveDefaultConfig()`, `saveConfig()`, `reloadConfig()`

### Behavioural changes
None. This is purely an API cleanup.

## Backwards compatibility
This does pose _potential_ BC breaks for things using the `Plugin` interface, but in the vast majority of cases, plugins should not be affected by this change.

This now reduces the unnecessary overcomplexity of writing a custom `Plugin` implementation.

## Follow-up
- Consider making `Plugin` not inherit from `CommandExecutor`.

## Tests
This has been tested with DevTools and several other plugins, but not thoroughly. Since these methods are supposed to be internal anyway, it shouldn't break any good code.