### PR TITLE
Fixed a bug where CursorInventory was not cleared after death

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -77,6 +77,7 @@ use pocketmine\inventory\transaction\InventoryTransaction;
 use pocketmine\inventory\transaction\TransactionValidationException;
 use pocketmine\item\Consumable;
 use pocketmine\item\Durable;
+use pocketmine\item\enchantment\Enchantment;
 use pocketmine\item\Item;
 use pocketmine\item\WritableBook;
 use pocketmine\item\WrittenBook;

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1472,7 +1472,11 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 	public function getDrops() : array{
 		if(!$this->isCreative()){
-			return parent::getDrops();
+			return array_merge(
+				parent::getDrops(),
+				array_filter(
+					$this->cursorInventory !== null ? array_values($this->cursorInventory->getContents()) : [], 
+					function(Item $item) : bool{ return !$item->hasEnchantment(Enchantment::VANISHING); }));
 		}
 
 		return [];

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3633,6 +3633,9 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 			if($this->armorInventory !== null){
 				$this->armorInventory->clearAll();
 			}
+			if($this->cursorInventory !== null){
+				$this->cursorInventory->clearAll();
+			}
 		}
 
 		if($ev->getDeathMessage() != ""){


### PR DESCRIPTION
## Introduction
This pull request fixes bug with clearing CursorInventory after death. It is strange that it did not before.


## Tests
Tests were conducted before and after fixes the bug. Everything works fine, inventory was cleaned.