### PR TITLE
Fixed double chest inventory desync issues, closes #2261

### DIFF
--- a/src/pocketmine/inventory/DoubleChestInventory.php
+++ b/src/pocketmine/inventory/DoubleChestInventory.php
@@ -64,7 +64,12 @@ class DoubleChestInventory extends ChestInventory implements InventoryHolder{
 	}
 
 	public function setItem(int $index, Item $item, bool $send = true) : bool{
-		return $index < $this->left->getSize() ? $this->left->setItem($index, $item, $send) : $this->right->setItem($index - $this->left->getSize(), $item, $send);
+		$old = $this->getItem($index);
+		if($index < $this->left->getSize() ? $this->left->setItem($index, $item, $send) : $this->right->setItem($index - $this->left->getSize(), $item, $send)){
+			$this->onSlotChange($index, $old, $send);
+			return true;
+		}
+		return false;
 	}
 
 	public function getContents(bool $includeEmpty = false) : array{

--- a/src/pocketmine/tile/Chest.php
+++ b/src/pocketmine/tile/Chest.php
@@ -113,10 +113,14 @@ class Chest extends Spawnable implements InventoryHolder, Container, Nameable{
 				$pair->checkPairing();
 			}
 			if($this->doubleInventory === null){
-				if(($pair->x + ($pair->z << 15)) > ($this->x + ($this->z << 15))){ //Order them correctly
-					$this->doubleInventory = new DoubleChestInventory($pair, $this);
+				if($pair->doubleInventory !== null){
+					$this->doubleInventory = $pair->doubleInventory;
 				}else{
-					$this->doubleInventory = new DoubleChestInventory($this, $pair);
+					if(($pair->x + ($pair->z << 15)) > ($this->x + ($this->z << 15))){ //Order them correctly
+						$this->doubleInventory = new DoubleChestInventory($pair, $this);
+					}else{
+						$this->doubleInventory = new DoubleChestInventory($this, $pair);
+					}
 				}
 			}
 		}else{


### PR DESCRIPTION
## Introduction
chest pairing really needs rewriting... this code really sucks

This is hacky but fixes #2261 .

## Changes
### Behavioural changes
- fixed bug described in #2261 
- Paired chest halves now share the same `DoubleChestInventory` instance

## Follow-up
rewrite chest pairing... it really, really sucks

## Tests
has been lightly tested, but I'm wary of merging this directly due to the potential for recursion bugs. @Muqsit would you mind testing this?