### PR TITLE
Automatically create plugin data directories

### DIFF
--- a/src/pocketmine/plugin/PluginBase.php
+++ b/src/pocketmine/plugin/PluginBase.php
@@ -256,9 +256,7 @@ abstract class PluginBase implements Plugin{
 	}
 
 	public function reloadConfig(){
-		if(!$this->saveDefaultConfig()){
-			@mkdir($this->dataFolder);
-		}
+		$this->saveDefaultConfig();
 		$this->config = new Config($this->configFile);
 		if(($configStream = $this->getResource("config.yml")) !== null){
 			$this->config->setDefaults(yaml_parse(Config::fixYAMLIndexes(stream_get_contents($configStream))));

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -181,6 +181,9 @@ class PluginManager{
 						$this->server->getLogger()->error("Projected dataFolder '" . $dataFolder . "' for " . $description->getName() . " exists and is not a directory");
 						return null;
 					}
+					if(!file_exists($dataFolder)){
+						mkdir($dataFolder, 0777, true);
+					}
 
 					$prefixed = $loader->getAccessProtocol() . $path;
 					$loader->loadPlugin($prefixed);


### PR DESCRIPTION
## Introduction
This issue is described in #2248.

#### Advantages
- No more boilerplate code for every plugin developer to write

#### Disadvantages
- Every plugin now has a data directory created for it, no matter whether it wants to use it or not. However, this is consistent with other platforms that I care to look at (such as Android) so this isn't something I consider to be an issue.

### Relevant issues
Fixes #2248

## Changes
### Behavioural changes
- Plugins now don't need to create their data directories themselves, since it's now automatic.

## Backwards compatibility
This does not pose any backwards compatibility issues since plugins should check if their data directory exists before trying to create it anyway.

## Tests
Has been tested with a small range of plugins I have on my development server. This is a fairly trivial change.
