### PR TITLE
PluginBase: Automatically save default config if it doesn't exist

### DIFF
--- a/src/pocketmine/plugin/PluginBase.php
+++ b/src/pocketmine/plugin/PluginBase.php
@@ -256,7 +256,7 @@ abstract class PluginBase implements Plugin{
 	}
 
 	public function reloadConfig(){
-		@mkdir($this->dataFolder);
+		$this->saveDefaultConfig();
 		$this->config = new Config($this->configFile);
 		if(($configStream = $this->getResource("config.yml")) !== null){
 			$this->config->setDefaults(yaml_parse(Config::fixYAMLIndexes(stream_get_contents($configStream))));

--- a/src/pocketmine/plugin/PluginBase.php
+++ b/src/pocketmine/plugin/PluginBase.php
@@ -256,7 +256,9 @@ abstract class PluginBase implements Plugin{
 	}
 
 	public function reloadConfig(){
-		$this->saveDefaultConfig();
+		if(!$this->saveDefaultConfig()){
+			@mkdir($this->dataFolder);
+		}
 		$this->config = new Config($this->configFile);
 		if(($configStream = $this->getResource("config.yml")) !== null){
 			$this->config->setDefaults(yaml_parse(Config::fixYAMLIndexes(stream_get_contents($configStream))));


### PR DESCRIPTION
## Introduction
I wasn't sure whether this would be considered a bug fix or a feature. Nonetheless, it's a behavioural change, so it belongs in 3.1 if anywhere.

Prior to this, plugins would be required to call `saveDefaultConfig()` before calling `getConfig()` or anything else. Calling `getConfig()` without `saveDefaultConfig()` first would generate an empty configuration file. Instead, it now saves the default config before loading it.

TL;DR: if you're sick of having to write `saveDefaultConfig()` at the top of your `onEnable()` before using a config, then this PR is for you.

### Relevant issues
#2248 again (this was where the original bug was discovered)

## Changes
### Behavioural changes
- Reloading a config when the config doesn't exist on disk will now cause the default config to be saved, if it exists.
- For plugins using configs without a `resources/config.yml` present, the behaviour should remain the same as before.

## Backwards compatibility
This should not pose any BC breaks.

## Follow-up
#2219 

## Tests
Has been lightly tested.