### PR TITLE
API additions to Player::kick() and PlayerKickEvent

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3171,11 +3171,13 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	 *
 	 * @param string $reason
 	 * @param bool   $isAdmin
+	 * @param TextContainer|string $quitMessage
 	 *
 	 * @return bool
 	 */
-	public function kick(string $reason = "", bool $isAdmin = true) : bool{
-		$this->server->getPluginManager()->callEvent($ev = new PlayerKickEvent($this, $reason, $this->getLeaveMessage()));
+	public function kick(string $reason = "", bool $isAdmin = true, $quitMessage = null) : bool{
+		$quitMessage = $quitMessage ?? $this->getLeaveMessage();
+		$this->server->getPluginManager()->callEvent($ev = new PlayerKickEvent($this, $reason, $quitMessage));
 		if(!$ev->isCancelled()){
 			$message = $reason;
 			if($isAdmin){

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3176,8 +3176,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	 * @return bool
 	 */
 	public function kick(string $reason = "", bool $isAdmin = true, $quitMessage = null) : bool{
-		$quitMessage = $quitMessage ?? $this->getLeaveMessage();
-		$this->server->getPluginManager()->callEvent($ev = new PlayerKickEvent($this, $reason, $quitMessage));
+		$this->server->getPluginManager()->callEvent($ev = new PlayerKickEvent($this, $reason, $quitMessage ?? $this->getLeaveMessage()));
 		if(!$ev->isCancelled()){
 			$reason = $ev->getReason();
 			$message = $reason;

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3179,6 +3179,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		$quitMessage = $quitMessage ?? $this->getLeaveMessage();
 		$this->server->getPluginManager()->callEvent($ev = new PlayerKickEvent($this, $reason, $quitMessage));
 		if(!$ev->isCancelled()){
+			$reason = $ev->getReason();
 			$message = $reason;
 			if($isAdmin){
 				if(!$this->isBanned()){

--- a/src/pocketmine/event/player/PlayerKickEvent.php
+++ b/src/pocketmine/event/player/PlayerKickEvent.php
@@ -50,6 +50,13 @@ class PlayerKickEvent extends PlayerEvent implements Cancellable{
 		$this->reason = $reason;
 	}
 
+	/**
+	 * @param string $reason
+	 */
+	public function setReason(string $reason) : void{
+		$this->reason = $reason;
+	}
+
 	public function getReason() : string{
 		return $this->reason;
 	}


### PR DESCRIPTION
## Introduction
This PR fixes the following problems:
- You can't specify the quit message while kicking a player by using Player::kick() method.
- You can't change the kick reason while handling PlayerKickEvent.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
This PR adds to the API:
- A third optional parameter to Player::kick() which defines the quit message.
- The setReason() method to PlayerKickEvent.
### Behavioural changes
There are no behavioural changes.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
These additions are fully backwards compatible.
## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
This PR was tested with this script plugin: https://pastebin.com/Yv9MDRhd


