### PR TITLE
Level: Make spawn protection non-dependent on op count

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1627,7 +1627,7 @@ class Level implements ChunkManager, Metadatable{
 
 			$spawnLocation = $this->getSpawnLocation();
 			$s = new Vector2($spawnLocation->x, $spawnLocation->z);
-			if(count($this->server->getOps()->getAll()) > 0 and $t->distance($s) <= $distance){
+			if($t->distance($s) <= $distance){
 				return true;
 			}
 		}


### PR DESCRIPTION
## Introduction
I don't care if this matches PC behaviour or not. bugs.mojang.com is full of bug reports about this. Just search for "minecraft spawn protection not working" and you'll see what I mean.

If you want to disable spawn protection, actually disable it. This behaviour is something that most users are not aware of and find astonishing when they discover it.

### Relevant issues
More than I care to list. Many people have complained about spawn protection inexplicably not working over the years.

## Changes
### Behavioural changes
If enabled, spawn protection will no longer be disabled when there are no operators.

## Follow-up
Consider moving spawn protection to an external plugin.

## Tests
This is a trivial change and shouldn't need extensive testing.
