### PR TITLE
Listener: Add documentation on functionality

### DIFF
--- a/src/pocketmine/event/Listener.php
+++ b/src/pocketmine/event/Listener.php
@@ -23,6 +23,32 @@ declare(strict_types=1);
 
 namespace pocketmine\event;
 
+/**
+ * Classes implementing this interface can be registered to receive called Events when something happens.
+ *
+ * Event handlers do not have to have any particular name - they are detected using reflection.
+ *
+ * A function in a Listener class must meet the following criteria to be registered as an event listener:
+ * - MUST be public
+ * - MUST NOT be static
+ * - MUST accept EXACTLY ONE class parameter which:
+ *   - MUST be a VALID class extending Event
+ *   - MUST NOT be abstract, UNLESS it has an @allowHandle annotation
+ *
+ * Functions which meet the criteria can have the following annotations in their doc comments:
+ *
+ * - `@nonHandler`: Marks a function as NOT being an event handler. Only needed if the function meets the above criteria.
+ * - `@softDepend [PluginName]`: Handler WILL NOT be registered if its event doesn't exist. Useful for soft-depending
+ *     on plugin events. Plugin name is optional.
+ *     Example: `@softDepend SimpleAuth`
+ * - `@ignoreCancelled`: Cancelled events WILL NOT be passed to this handler.
+ * - `@priority <PRIORITY>`: Sets the priority at which this event handler will receive events.
+ *     Example: `@priority HIGHEST`
+ *     @see EventPriority for a list of possible options.
+ *
+ * Event handlers will receive any instanceof the Event class they have chosen to receive. For example, an
+ * EntityDamageEvent handler will also receive any subclass of EntityDamageEvent.
+ */
 interface Listener{
 
 }

--- a/src/pocketmine/event/Listener.php
+++ b/src/pocketmine/event/Listener.php
@@ -30,11 +30,12 @@ use pocketmine\plugin\PluginManager;
  * @see PluginManager::registerEvents()
  *
  * A function in a Listener class must meet the following criteria to be registered as an event handler:
+ *
  * - MUST be public
  * - MUST NOT be static
  * - MUST accept EXACTLY ONE class parameter which:
  *   - MUST be a VALID class extending Event
- *   - MUST NOT be abstract, UNLESS it has an @allowHandle annotation
+ *   - MUST NOT be abstract, UNLESS it has an `@allowHandle` annotation
  *
  * Event handlers do not have to have any particular name - they are detected using reflection.
  * They SHOULD NOT return any values (but this is not currently enforced).

--- a/src/pocketmine/event/Listener.php
+++ b/src/pocketmine/event/Listener.php
@@ -26,7 +26,7 @@ namespace pocketmine\event;
 use pocketmine\plugin\PluginManager;
 
 /**
- * Classes implementing this interface can be registered to receive called Events when something happens.
+ * Classes implementing this interface can be registered to receive called Events.
  * @see PluginManager::registerEvents()
  *
  * A function in a Listener class must meet the following criteria to be registered as an event handler:

--- a/src/pocketmine/event/Listener.php
+++ b/src/pocketmine/event/Listener.php
@@ -31,7 +31,7 @@ use pocketmine\plugin\PluginManager;
  *
  * Event handlers do not have to have any particular name - they are detected using reflection.
  *
- * A function in a Listener class must meet the following criteria to be registered as an event listener:
+ * A function in a Listener class must meet the following criteria to be registered as an event handler:
  * - MUST be public
  * - MUST NOT be static
  * - MUST accept EXACTLY ONE class parameter which:

--- a/src/pocketmine/event/Listener.php
+++ b/src/pocketmine/event/Listener.php
@@ -23,8 +23,11 @@ declare(strict_types=1);
 
 namespace pocketmine\event;
 
+use pocketmine\plugin\PluginManager;
+
 /**
  * Classes implementing this interface can be registered to receive called Events when something happens.
+ * @see PluginManager::registerEvents()
  *
  * Event handlers do not have to have any particular name - they are detected using reflection.
  *

--- a/src/pocketmine/event/Listener.php
+++ b/src/pocketmine/event/Listener.php
@@ -37,7 +37,7 @@ namespace pocketmine\event;
  *
  * Functions which meet the criteria can have the following annotations in their doc comments:
  *
- * - `@nonHandler`: Marks a function as NOT being an event handler. Only needed if the function meets the above criteria.
+ * - `@notHandler`: Marks a function as NOT being an event handler. Only needed if the function meets the above criteria.
  * - `@softDepend [PluginName]`: Handler WILL NOT be registered if its event doesn't exist. Useful for soft-depending
  *     on plugin events. Plugin name is optional.
  *     Example: `@softDepend SimpleAuth`

--- a/src/pocketmine/event/Listener.php
+++ b/src/pocketmine/event/Listener.php
@@ -29,14 +29,15 @@ use pocketmine\plugin\PluginManager;
  * Classes implementing this interface can be registered to receive called Events when something happens.
  * @see PluginManager::registerEvents()
  *
- * Event handlers do not have to have any particular name - they are detected using reflection.
- *
  * A function in a Listener class must meet the following criteria to be registered as an event handler:
  * - MUST be public
  * - MUST NOT be static
  * - MUST accept EXACTLY ONE class parameter which:
  *   - MUST be a VALID class extending Event
  *   - MUST NOT be abstract, UNLESS it has an @allowHandle annotation
+ *
+ * Event handlers do not have to have any particular name - they are detected using reflection.
+ * They SHOULD NOT return any values (but this is not currently enforced).
  *
  * Functions which meet the criteria can have the following annotations in their doc comments:
  *


### PR DESCRIPTION
## Introduction
The `Listener` interface is one of the most magical parts of PocketMine-MP, and before this pull request it didn't have a single bit of documentation.

### Background
There is a recurring theme I've seen with plugin developers. Developers who previously worked with the Bukkit API (which PocketMine-MP's API is mostly derived from) usually don't have too much difficulty getting to grips with PM because a lot of the concepts are shared. This also means that in a lot of cases Bukkit plugin documentation can also sort-of apply to PM.

This generally results in a gap of understanding. Developers directly introduced to PocketMine-MP have very little documentation to work with, and no idea that they could look to Bukkit for clues. Meanwhile, developers who worked with Bukkit and its vastly superior documentation have a significant advantage. This often results in lower quality code because fresh developers have little to no idea what they are doing and are forced to look at the core code itself to find out how to do things, or to look at how other plugin developers did things.

As PM diverges more and more away from the Bukkit API, it is going to be necessary to develop our own comprehensive documentation to ease the entry of new plugin developers into the space.

## Changes
### API changes
This is merely addition of documentation and does not affect any API or behaviour.

## Follow-up
Document more things which are sorely lacking in documentation.