### PR TITLE
PluginManager: Skip methods not declared by instanceof Listener when registering handlers

### DIFF
--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -783,7 +783,7 @@ class PluginManager{
 
 		$reflection = new \ReflectionClass(get_class($listener));
 		foreach($reflection->getMethods(\ReflectionMethod::IS_PUBLIC) as $method){
-			if(!$method->isStatic()){
+			if(!$method->isStatic() and $method->getDeclaringClass()->implementsInterface(Listener::class)){
 				$tags = Utils::parseDocComment((string) $method->getDocComment());
 				if(isset($tags["notHandler"])){
 					continue;


### PR DESCRIPTION


## Introduction
This is quite an interesting bug. If you have
```php
class A{
    public function onMove(PlayerMoveEvent $event){} //shouldn't be a handler because this class isn't a Listener
}

class B extends A implements Listener{}
```
then
```php
registerEvents(new B, $plugin);
```

then `A::onMove()` will be registered as an event handler even though `A` is not an instanceof `Listener`.

This was observed by noting that plugins which do something like `extends PluginBase implements Listener` causes `registerEvents()` to try and register `PluginBase` methods as event handlers, which could lead to astonishing behaviour.

### Relevant issues
None known.

## Changes
### Behavioural changes
- Methods declared in parent classes of classes implementing `Listener` will not be considered as event handlers unless they themselves implement `Listener`.

## Backwards compatibility
If anyone used this bug to their own purposes, then I'm surprised.

## Tests
```php
declare(strict_types=1);

namespace dktapps\test;

use pocketmine\event\Listener;
use pocketmine\event\player\PlayerMoveEvent;

class ListenerTest{

	public function onPlayerMov(PlayerMoveEvent $event){
		//is not an event handler
var_dump("what");
	}
}

class ListenerChild extends ListenerTest implements Listener{

}
```
In PluginBase::onEnable():

```php
		$this->getServer()->getPluginManager()->registerEvents(new ListenerChild(), $this);
```
will no longer output "what" after this PR.