### PR TITLE
PluginManager: Allow @ignoreCancelled annotation on event handlers to…

### DIFF
--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -794,7 +794,21 @@ class PluginManager{
 				}catch(\InvalidArgumentException $e){
 					throw new PluginException("Event handler " . get_class($listener) . "->" . $method->getName() . "() declares invalid/unknown priority \"" . $tags["priority"] . "\"");
 				}
-				$ignoreCancelled = isset($tags["ignoreCancelled"]) && strtolower($tags["ignoreCancelled"]) === "true";
+
+				$ignoreCancelled = false;
+				if(isset($tags["ignoreCancelled"])){
+					switch(strtolower($tags["ignoreCancelled"])){
+						case "true":
+						case "":
+							$ignoreCancelled = true;
+							break;
+						case "false":
+							$ignoreCancelled = false;
+							break;
+						default:
+							throw new PluginException("Event handler " . get_class($listener) . "->" . $method->getName() . "() declares invalid @ignoreCancelled value \"" . $tags["ignoreCancelled"] . "\"");
+					}
+				}
 
 				$parameters = $method->getParameters();
 				try{


### PR DESCRIPTION
… not have parameters

## Introduction
Currently it is necessary to declare a value for the `@ignoreCancelled` annotation on event handlers, for example `@ignoreCancelled true`.

This seems superfluous, so this PR allows `@ignoreCancelled` without a value to behave as if the value was `true`.

## Changes
### API changes
- Event handlers can now declare `@ignoreCancelled` without specifying the `true` parameter.
- An exception will now be thrown if a value is given which is not `true` or `false` (case insensitive).


## Backwards compatibility
This does not pose any backwards compatibility breaks for correctly-working code. Code that silently doesn't work on 3.0 might crash on 3.1 (for example `@ignoreCancelled treu` - typo intended - would now cause an exception to be thrown when registering the listener).

## Tests
The following `Listener` has been used to test this:
```php
	/**
	 * @param PlayerJoinEvent $event
	 * @priority HIGHEST
	 * @ignoreCancelled
	 */
	public function onPlayerJoi3n(PlayerJoinEvent $event){
		$event->getPlayer()->kick("test plugin hi", true, "u left the gam");
	}
```

## Notes
- This may require https://github.com/pmmp/PocketMine-MP/commit/b01b477a2a8923558954c0bc62d3595db5505254 or later in order to properly deal with the `@ignoreCancelled` annotation (bug still present in latest release).