### PR TITLE
Added LOCK_EX flag for async save

### DIFF
--- a/src/pocketmine/utils/Config.php
+++ b/src/pocketmine/utils/Config.php
@@ -217,7 +217,7 @@ class Config{
 				}
 
 				if($async){
-					Server::getInstance()->getAsyncPool()->submitTask(new FileWriteTask($this->file, $content));
+					Server::getInstance()->getAsyncPool()->submitTask(new FileWriteTask($this->file, $content, LOCK_EX));
 				}else{
 					file_put_contents($this->file, $content);
 				}


### PR DESCRIPTION
## Introduction
Supposing that we have economy plugin and we add 10 coins for steve, after save it with parameter `$async = true`. But what if you need to save data for many players? Without this flag, the config can be destroyed. 