### PR TITLE
Forms API, part 2: Implementation

### DIFF
--- a/src/pocketmine/form/BaseForm.php
+++ b/src/pocketmine/form/BaseForm.php
@@ -26,8 +26,6 @@ declare(strict_types=1);
  */
 namespace pocketmine\form;
 
-use pocketmine\Player;
-
 /**
  * Base class for a custom form. Forms are serialized to JSON data to be sent to clients.
  */
@@ -47,18 +45,6 @@ abstract class BaseForm implements Form{
 	public function getTitle() : string{
 		return $this->title;
 	}
-
-	/**
-	 * @inheritdoc
-	 * Plugins should not override this method. Override the appropriate onSubmit for each form implementation instead.
-	 *
-	 * @param Player $player
-	 * @param mixed  $data
-	 *
-	 * @return Form|null a form which will be opened immediately (before queued forms) as a response to this form, or null if not applicable.
-	 * @throws FormValidationException
-	 */
-	abstract public function handleResponse(Player $player, $data) : ?Form;
 
 	/**
 	 * Serializes the form to JSON for sending to clients.

--- a/src/pocketmine/form/BaseForm.php
+++ b/src/pocketmine/form/BaseForm.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+/**
+ * API for Minecraft: Bedrock custom UI (forms)
+ */
+namespace pocketmine\form;
+
+use pocketmine\Player;
+
+/**
+ * Base class for a custom form. Forms are serialized to JSON data to be sent to clients.
+ */
+abstract class BaseForm implements Form{
+
+	/** @var string */
+	protected $title;
+
+	public function __construct(string $title){
+		$this->title = $title;
+	}
+
+	/**
+	 * Returns the text shown on the form title-bar.
+	 * @return string
+	 */
+	public function getTitle() : string{
+		return $this->title;
+	}
+
+	/**
+	 * @inheritdoc
+	 * Plugins should not override this method. Override the appropriate onSubmit for each form implementation instead.
+	 *
+	 * @param Player $player
+	 * @param mixed  $data
+	 *
+	 * @return Form|null a form which will be opened immediately (before queued forms) as a response to this form, or null if not applicable.
+	 * @throws FormValidationException
+	 */
+	abstract public function handleResponse(Player $player, $data) : ?Form;
+
+	/**
+	 * Serializes the form to JSON for sending to clients.
+	 *
+	 * @return array
+	 */
+	final public function jsonSerialize() : array{
+		$ret = $this->serializeFormData();
+		$ret["type"] = $this->getType();
+		$ret["title"] = $this->getTitle();
+
+		return $ret;
+	}
+
+	/**
+	 * Returns the type used to show this form to clients
+	 * @return string
+	 */
+	abstract protected function getType() : string;
+
+	/**
+	 * Serializes additional data needed to show this form to clients.
+	 * @return array
+	 */
+	abstract protected function serializeFormData() : array;
+
+}

--- a/src/pocketmine/form/CustomForm.php
+++ b/src/pocketmine/form/CustomForm.php
@@ -97,7 +97,7 @@ abstract class CustomForm extends BaseForm{
 		return null;
 	}
 
-	public function handleResponse(Player $player, $data) : ?Form{
+	final public function handleResponse(Player $player, $data) : ?Form{
 		if($data === null){
 			return $this->onClose($player);
 		}

--- a/src/pocketmine/form/CustomForm.php
+++ b/src/pocketmine/form/CustomForm.php
@@ -79,30 +79,24 @@ abstract class CustomForm extends BaseForm{
 	/**
 	 * @param Player             $player
 	 * @param CustomFormResponse $data
-	 *
-	 * @return null|Form
 	 */
-	public function onSubmit(Player $player, CustomFormResponse $data) : ?Form{
-		return null;
+	public function onSubmit(Player $player, CustomFormResponse $data) : void{
+
 	}
 
 	/**
 	 * Called when a player closes the form without submitting it.
 	 *
 	 * @param Player $player
-	 *
-	 * @return Form|null a form which will be opened immediately (before queued forms) as a response to this form, or null if not applicable.
 	 */
-	public function onClose(Player $player) : ?Form{
-		return null;
+	public function onClose(Player $player) : void{
+
 	}
 
-	final public function handleResponse(Player $player, $data) : ?Form{
+	final public function handleResponse(Player $player, $data) : void{
 		if($data === null){
-			return $this->onClose($player);
-		}
-
-		if(is_array($data)){
+			$this->onClose($player);
+		}elseif(is_array($data)){
 			if(($actual = count($data)) !== ($expected = count($this->elements))){
 				throw new FormValidationException("Expected $expected result data, got $actual");
 			}
@@ -123,10 +117,10 @@ abstract class CustomForm extends BaseForm{
 				$values[$element->getName()] = $value;
 			}
 
-			return $this->onSubmit($player, new CustomFormResponse($values));
+			$this->onSubmit($player, new CustomFormResponse($values));
+		}else{
+			throw new FormValidationException("Expected array or null, got " . gettype($data));
 		}
-
-		throw new FormValidationException("Expected array or null, got " . gettype($data));
 	}
 
 	/**

--- a/src/pocketmine/form/CustomForm.php
+++ b/src/pocketmine/form/CustomForm.php
@@ -1,0 +1,144 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\form;
+
+use pocketmine\form\element\CustomFormElement;
+use pocketmine\Player;
+use pocketmine\utils\Utils;
+
+abstract class CustomForm extends BaseForm{
+
+	/** @var CustomFormElement[] */
+	private $elements;
+	/** @var CustomFormElement[] */
+	private $elementMap = [];
+
+	/**
+	 * @param string              $title
+	 * @param CustomFormElement[] $elements
+	 */
+	public function __construct(string $title, array $elements){
+		assert(Utils::validateObjectArray($elements, CustomFormElement::class));
+
+		parent::__construct($title);
+		$this->elements = array_values($elements);
+		foreach($this->elements as $element){
+			if(isset($this->elements[$element->getName()])){
+				throw new \InvalidArgumentException("Multiple elements cannot have the same name, found \"" . $element->getName() . "\" more than once");
+			}
+			$this->elementMap[$element->getName()] = $element;
+		}
+	}
+
+	/**
+	 * @param int $index
+	 *
+	 * @return CustomFormElement|null
+	 */
+	public function getElement(int $index) : ?CustomFormElement{
+		return $this->elements[$index] ?? null;
+	}
+
+	/**
+	 * @param string $name
+	 *
+	 * @return null|CustomFormElement
+	 */
+	public function getElementByName(string $name) : ?CustomFormElement{
+		return $this->elementMap[$name] ?? null;
+	}
+
+	/**
+	 * @return CustomFormElement[]
+	 */
+	public function getAllElements() : array{
+		return $this->elements;
+	}
+
+	/**
+	 * @param Player             $player
+	 * @param CustomFormResponse $data
+	 *
+	 * @return null|Form
+	 */
+	public function onSubmit(Player $player, CustomFormResponse $data) : ?Form{
+		return null;
+	}
+
+	/**
+	 * Called when a player closes the form without submitting it.
+	 *
+	 * @param Player $player
+	 *
+	 * @return Form|null a form which will be opened immediately (before queued forms) as a response to this form, or null if not applicable.
+	 */
+	public function onClose(Player $player) : ?Form{
+		return null;
+	}
+
+	public function handleResponse(Player $player, $data) : ?Form{
+		if($data === null){
+			return $this->onClose($player);
+		}
+
+		if(is_array($data)){
+			if(($actual = count($data)) !== ($expected = count($this->elements))){
+				throw new FormValidationException("Expected $expected result data, got $actual");
+			}
+
+			$values = [];
+
+			/** @var array $data */
+			foreach($data as $index => $value){
+				if(!isset($this->elements[$index])){
+					throw new FormValidationException("Element at offset $index does not exist");
+				}
+				$element = $this->elements[$index];
+				try{
+					$element->validateValue($value);
+				}catch(FormValidationException $e){
+					throw new FormValidationException("Validation failed for element \"" . $element->getName() . "\": " . $e->getMessage(), 0, $e);
+				}
+				$values[$element->getName()] = $value;
+			}
+
+			return $this->onSubmit($player, new CustomFormResponse($values));
+		}
+
+		throw new FormValidationException("Expected array or null, got " . gettype($data));
+	}
+
+	/**
+	 * @return string
+	 */
+	protected function getType() : string{
+		return "custom_form";
+	}
+
+	protected function serializeFormData() : array{
+		return [
+			"content" => $this->elements
+		];
+	}
+}

--- a/src/pocketmine/form/CustomFormResponse.php
+++ b/src/pocketmine/form/CustomFormResponse.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\form;
+
+class CustomFormResponse{
+	/** @var array */
+	private $data;
+
+	public function __construct(array $data){
+		$this->data = $data;
+	}
+
+	public function getInt(string $name) : int{
+		$this->checkExists($name);
+		return $this->data[$name];
+	}
+
+	public function getString(string $name) : string{
+		$this->checkExists($name);
+		return $this->data[$name];
+	}
+
+	public function getFloat(string $name) : float{
+		$this->checkExists($name);
+		return $this->data[$name];
+	}
+
+	public function getBool(string $name) : bool{
+		$this->checkExists($name);
+		return $this->data[$name];
+	}
+
+	public function getAll() : array{
+		return $this->data;
+	}
+
+	private function checkExists(string $name) : void{
+		if(!isset($this->data[$name])){
+			throw new \InvalidArgumentException("Value \"$name\" not found");
+		}
+	}
+}

--- a/src/pocketmine/form/FormIcon.php
+++ b/src/pocketmine/form/FormIcon.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\form;
+
+/**
+ * Represents an icon which can be placed next to options on menus, or as the icon for the server-settings form type.
+ */
+class FormIcon implements \JsonSerializable{
+	public const IMAGE_TYPE_URL = "url";
+	public const IMAGE_TYPE_PATH = "path";
+
+	/**
+	 * @var string
+	 */
+	private $type;
+	/**
+	 * @var string
+	 */
+	private $data;
+
+	/**
+	 * @param string $data URL or path depending on the type chosen.
+	 * @param string $type Can be one of the constants at the top of the file, but only "url" is known to work.
+	 */
+	public function __construct(string $data, string $type = self::IMAGE_TYPE_URL){
+		$this->type = $type;
+		$this->data = $data;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getType() : string{
+		return $this->type;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getData() : string{
+		return $this->data;
+	}
+
+	public function jsonSerialize(){
+		return [
+			"type" => $this->type,
+			"data" => $this->data
+		];
+	}
+}

--- a/src/pocketmine/form/MenuForm.php
+++ b/src/pocketmine/form/MenuForm.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\form;
+
+use pocketmine\Player;
+use pocketmine\utils\Utils;
+
+/**
+ * This form type presents a menu to the user with a list of options on it. The user may select an option or close the
+ * form by clicking the X in the top left corner.
+ */
+abstract class MenuForm extends BaseForm{
+
+	/** @var string */
+	protected $content;
+	/** @var MenuOption[] */
+	private $options;
+
+	/**
+	 * @param string       $title
+	 * @param string       $text
+	 * @param MenuOption[] $options
+	 */
+	public function __construct(string $title, string $text, array $options){
+		assert(Utils::validateObjectArray($options, MenuOption::class));
+
+		parent::__construct($title);
+		$this->content = $text;
+		$this->options = array_values($options);
+	}
+
+	public function getOption(int $position) : ?MenuOption{
+		return $this->options[$position] ?? null;
+	}
+
+	/**
+	 * @param Player $player Player submitting this form.
+	 * @param int    $selectedOption Selected option, can be used with getOption().
+	 *
+	 * @return null|Form A form to show to the player after this one, or null.
+	 */
+	public function onSubmit(Player $player, int $selectedOption) : ?Form{
+		return null;
+	}
+
+	/**
+	 * Called when a player clicks the close button on this form without selecting an option.
+	 *
+	 * @param Player $player
+	 *
+	 * @return Form|null a form which will be opened immediately (before queued forms) as a response to this form, or null if not applicable.
+	 */
+	public function onClose(Player $player) : ?Form{
+		return null;
+	}
+
+	final public function handleResponse(Player $player, $data) : ?Form{
+		if($data === null){
+			return $this->onClose($player);
+		}
+
+		if(is_int($data)){
+			if(!isset($this->options[$data])){
+				throw new FormValidationException("Option $data does not exist");
+			}
+			return $this->onSubmit($player, $data);
+		}
+
+		throw new FormValidationException("Expected int or null, got " . gettype($data));
+	}
+
+	protected function getType() : string{
+		return "form";
+	}
+
+	protected function serializeFormData() : array{
+		return [
+			"content" => $this->content,
+			"buttons" => $this->options //yes, this is intended (MCPE calls them buttons)
+		];
+	}
+}

--- a/src/pocketmine/form/MenuForm.php
+++ b/src/pocketmine/form/MenuForm.php
@@ -57,37 +57,31 @@ abstract class MenuForm extends BaseForm{
 	/**
 	 * @param Player $player Player submitting this form.
 	 * @param int    $selectedOption Selected option, can be used with getOption().
-	 *
-	 * @return null|Form A form to show to the player after this one, or null.
 	 */
-	public function onSubmit(Player $player, int $selectedOption) : ?Form{
-		return null;
+	public function onSubmit(Player $player, int $selectedOption) : void{
+
 	}
 
 	/**
 	 * Called when a player clicks the close button on this form without selecting an option.
 	 *
 	 * @param Player $player
-	 *
-	 * @return Form|null a form which will be opened immediately (before queued forms) as a response to this form, or null if not applicable.
 	 */
-	public function onClose(Player $player) : ?Form{
-		return null;
+	public function onClose(Player $player) : void{
+
 	}
 
-	final public function handleResponse(Player $player, $data) : ?Form{
+	final public function handleResponse(Player $player, $data) : void{
 		if($data === null){
-			return $this->onClose($player);
-		}
-
-		if(is_int($data)){
+			$this->onClose($player);
+		}elseif(is_int($data)){
 			if(!isset($this->options[$data])){
 				throw new FormValidationException("Option $data does not exist");
 			}
-			return $this->onSubmit($player, $data);
+			$this->onSubmit($player, $data);
+		}else{
+			throw new FormValidationException("Expected int or null, got " . gettype($data));
 		}
-
-		throw new FormValidationException("Expected int or null, got " . gettype($data));
 	}
 
 	protected function getType() : string{

--- a/src/pocketmine/form/MenuOption.php
+++ b/src/pocketmine/form/MenuOption.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\form;
+
+/**
+ * Represents an option on a MenuForm. The option is shown as a button and may optionally have an image next to it.
+ */
+class MenuOption implements \JsonSerializable{
+
+	/**
+	 * @var string
+	 */
+	private $text;
+	/**
+	 * @var FormIcon|null
+	 */
+	private $image;
+
+	public function __construct(string $text, ?FormIcon $image = null){
+		$this->text = $text;
+		$this->image = $image;
+	}
+
+	public function getText() : string{
+		return $this->text;
+	}
+
+	public function hasImage() : bool{
+		return $this->image !== null;
+	}
+
+	public function getImage() : ?FormIcon{
+		return $this->image;
+	}
+
+	public function jsonSerialize(){
+		$json = [
+			"text" => $this->text
+		];
+
+		if($this->hasImage()){
+			$json["image"] = $this->image;
+		}
+
+		return $json;
+	}
+}

--- a/src/pocketmine/form/ModalForm.php
+++ b/src/pocketmine/form/ModalForm.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\form;
+
+use pocketmine\Player;
+
+/**
+ * This form type presents a simple "yes/no" dialog with two buttons.
+ */
+abstract class ModalForm extends BaseForm{
+
+	/** @var string */
+	private $content;
+	/** @var string */
+	private $button1;
+	/** @var string */
+	private $button2;
+
+	/**
+	 * @param string $title Text to put on the title of the dialog.
+	 * @param string $text Text to put in the body.
+	 * @param string $yesButtonText Text to show on the "Yes" button. Defaults to client-translated "Yes" string.
+	 * @param string $noButtonText Text to show on the "No" button. Defaults to client-translated "No" string.
+	 */
+	public function __construct(string $title, string $text, string $yesButtonText = "gui.yes", string $noButtonText = "gui.no"){
+		parent::__construct($title);
+		$this->content = $text;
+		$this->button1 = $yesButtonText;
+		$this->button2 = $noButtonText;
+	}
+
+	public function getYesButtonText() : string{
+		return $this->button1;
+	}
+
+	public function getNoButtonText() : string{
+		return $this->button2;
+	}
+
+	/**
+	 * @param Player $player Player submitting this form
+	 * @param bool   $choice Selected option. True for yes button, false for no button.
+	 *
+	 * @return null|Form A form to show to the player after this one, or null.
+	 */
+	public function onSubmit(Player $player, bool $choice) : ?Form{
+		return null;
+	}
+
+	final public function handleResponse(Player $player, $data) : ?Form{
+		if(!is_bool($data)){
+			throw new FormValidationException("Expected bool, got " . gettype($data));
+		}
+
+		return $this->onSubmit($player, $data);
+	}
+
+	protected function getType() : string{
+		return "modal";
+	}
+
+	protected function serializeFormData() : array{
+		return [
+			"content" => $this->content,
+			"button1" => $this->button1,
+			"button2" => $this->button2
+		];
+	}
+}

--- a/src/pocketmine/form/ModalForm.php
+++ b/src/pocketmine/form/ModalForm.php
@@ -61,19 +61,17 @@ abstract class ModalForm extends BaseForm{
 	/**
 	 * @param Player $player Player submitting this form
 	 * @param bool   $choice Selected option. True for yes button, false for no button.
-	 *
-	 * @return null|Form A form to show to the player after this one, or null.
 	 */
-	public function onSubmit(Player $player, bool $choice) : ?Form{
-		return null;
+	public function onSubmit(Player $player, bool $choice) : void{
+
 	}
 
-	final public function handleResponse(Player $player, $data) : ?Form{
+	final public function handleResponse(Player $player, $data) : void{
 		if(!is_bool($data)){
 			throw new FormValidationException("Expected bool, got " . gettype($data));
 		}
 
-		return $this->onSubmit($player, $data);
+		$this->onSubmit($player, $data);
 	}
 
 	protected function getType() : string{

--- a/src/pocketmine/form/ServerSettingsForm.php
+++ b/src/pocketmine/form/ServerSettingsForm.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\form;
+
+/**
+ * Represents a custom form which can be shown in the Settings menu on the client. This is exactly the same as a regular
+ * CustomForm, except that this type can also have an icon which can be shown on the settings section button.
+ *
+ * Passing this form to {@link Player::sendForm()} will not show a form with an icon nor set this form as the server
+ * settings.
+ */
+abstract class ServerSettingsForm extends CustomForm{
+	/**
+	 * @var FormIcon|null
+	 */
+	private $icon;
+
+	public function __construct(string $title, array $elements, ?FormIcon $icon = null){
+		parent::__construct($title, $elements);
+		$this->icon = $icon;
+	}
+
+	public function hasIcon() : bool{
+		return $this->icon !== null;
+	}
+
+	public function getIcon() : ?FormIcon{
+		return $this->icon;
+	}
+
+	protected function serializeFormData() : array{
+		$data = parent::serializeFormData();
+
+		if($this->hasIcon()){
+			$data["icon"] = $this->icon;
+		}
+
+		return $data;
+	}
+}

--- a/src/pocketmine/form/element/BaseSelector.php
+++ b/src/pocketmine/form/element/BaseSelector.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\form\element;
+
+use pocketmine\form\FormValidationException;
+
+abstract class BaseSelector extends CustomFormElement{
+	/** @var int */
+	protected $defaultOptionIndex;
+	/** @var string[] */
+	protected $options;
+
+	/**
+	 * @param string   $name
+	 * @param string   $text
+	 * @param string[] $options
+	 * @param int      $defaultOptionIndex
+	 */
+	public function __construct(string $name, string $text, array $options, int $defaultOptionIndex = 0){
+		parent::__construct($name, $text);
+		$this->options = array_values($options);
+
+		if(!isset($this->options[$defaultOptionIndex])){
+			throw new \InvalidArgumentException("No option at index $defaultOptionIndex, cannot set as default");
+		}
+		$this->defaultOptionIndex = $defaultOptionIndex;
+	}
+
+	/**
+	 * @param int $value
+	 *
+	 * @throws FormValidationException
+	 */
+	public function validateValue($value) : void{
+		if(!is_int($value)){
+			throw new FormValidationException("Expected int, got " . gettype($value));
+		}
+		if(!isset($this->options[$value])){
+			throw new FormValidationException("Option $value does not exist");
+		}
+	}
+
+	/**
+	 * Returns the text of the option at the specified index, or null if it doesn't exist.
+	 *
+	 * @param int $index
+	 *
+	 * @return string|null
+	 */
+	public function getOption(int $index) : ?string{
+		return $this->options[$index] ?? null;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getDefaultOptionIndex() : int{
+		return $this->defaultOptionIndex;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getDefaultOption() : string{
+		return $this->options[$this->defaultOptionIndex];
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function getOptions() : array{
+		return $this->options;
+	}
+}

--- a/src/pocketmine/form/element/CustomFormElement.php
+++ b/src/pocketmine/form/element/CustomFormElement.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\form\element;
+
+use pocketmine\form\FormValidationException;
+
+/**
+ * Base class for UI elements which can be placed on custom forms.
+ */
+abstract class CustomFormElement implements \JsonSerializable{
+	/** @var string */
+	private $name;
+	/** @var string */
+	private $text;
+
+	public function __construct(string $name, string $text){
+		$this->name = $name;
+		$this->text = $text;
+	}
+
+	/**
+	 * Returns the type of element.
+	 * @return string
+	 */
+	abstract public function getType() : string;
+
+	/**
+	 * Returns the element's name. This is used to identify the element in code.
+	 * @return string
+	 */
+	public function getName() : string{
+		return $this->name;
+	}
+
+	/**
+	 * Returns the element's label. Usually this is used to explain to the user what a control does.
+	 * @return string
+	 */
+	public function getText() : string{
+		return $this->text;
+	}
+
+	/**
+	 * Validates that the given value is of the correct type and fits the constraints for the component. This function
+	 * should do appropriate type checking and throw whatever errors necessary if the value is not valid.
+	 *
+	 * @param mixed $value
+	 * @throws FormValidationException
+	 */
+	abstract public function validateValue($value) : void;
+
+	/**
+	 * Returns an array of properties which can be serialized to JSON for sending.
+	 *
+	 * @return array
+	 */
+	final public function jsonSerialize() : array{
+		$ret = $this->serializeElementData();
+		$ret["type"] = $this->getType();
+		$ret["text"] = $this->getText();
+
+		return $ret;
+	}
+
+	/**
+	 * Returns an array of extra data needed to serialize this element to JSON for showing to a player on a form.
+	 * @return array
+	 */
+	abstract protected function serializeElementData() : array;
+}

--- a/src/pocketmine/form/element/Dropdown.php
+++ b/src/pocketmine/form/element/Dropdown.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\form\element;
+
+class Dropdown extends BaseSelector{
+
+	public function getType() : string{
+		return "dropdown";
+	}
+
+	protected function serializeElementData() : array{
+		return [
+			"options" => $this->options,
+			"default" => $this->defaultOptionIndex
+		];
+	}
+}

--- a/src/pocketmine/form/element/Input.php
+++ b/src/pocketmine/form/element/Input.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\form\element;
+
+use pocketmine\form\FormValidationException;
+
+/**
+ * Element which accepts text input. The text-box can have a default value, and may also have a text hint when there is
+ * no text in the box.
+ */
+class Input extends CustomFormElement{
+
+	/** @var string */
+	private $hint;
+	/** @var string */
+	private $default;
+
+	/**
+	 * @param string $name
+	 * @param string $text
+	 * @param string $hintText
+	 * @param string $defaultText
+	 */
+	public function __construct(string $name, string $text, string $hintText = "", string $defaultText = ""){
+		parent::__construct($name, $text);
+		$this->hint = $hintText;
+		$this->default = $defaultText;
+	}
+
+	public function getType() : string{
+		return "input";
+	}
+
+	/**
+	 * @param string $value
+	 *
+	 * @throws FormValidationException
+	 */
+	public function validateValue($value) : void{
+		if(!is_string($value)){
+			throw new FormValidationException("Expected string, got " . gettype($value));
+		}
+	}
+
+	/**
+	 * Returns the text shown in the text-box when the box is not focused and there is no text in it.
+	 * @return string
+	 */
+	public function getHintText() : string{
+		return $this->hint;
+	}
+
+	/**
+	 * Returns the text which will be in the text-box by default.
+	 * @return string
+	 */
+	public function getDefaultText() : string{
+		return $this->default;
+	}
+
+	protected function serializeElementData() : array{
+		return [
+			"placeholder" => $this->hint,
+			"default" => $this->default
+		];
+	}
+}

--- a/src/pocketmine/form/element/Label.php
+++ b/src/pocketmine/form/element/Label.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\form\element;
+
+/**
+ * Element which displays some text on a form.
+ */
+class Label extends CustomFormElement{
+
+	public function getType() : string{
+		return "label";
+	}
+
+	public function validateValue($value) : void{
+		assert($value === null);
+	}
+
+	protected function serializeElementData() : array{
+		return [];
+	}
+}

--- a/src/pocketmine/form/element/Slider.php
+++ b/src/pocketmine/form/element/Slider.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\form\element;
+
+use pocketmine\form\FormValidationException;
+
+class Slider extends CustomFormElement{
+
+	/** @var float */
+	private $min;
+	/** @var float */
+	private $max;
+	/** @var float */
+	private $step;
+	/** @var float */
+	private $default;
+
+	public function __construct(string $name, string $text, float $min, float $max, float $step = 1.0, ?float $default = null){
+		parent::__construct($name, $text);
+
+		if($this->min > $this->max){
+			throw new \InvalidArgumentException("Slider min value should be less than max value");
+		}
+		$this->min = $min;
+		$this->max = $max;
+
+		if($default !== null){
+			if($default > $this->max or $default < $this->min){
+				throw new \InvalidArgumentException("Default must be in range $this->min ... $this->max");
+			}
+			$this->default = $default;
+		}else{
+			$this->default = $this->min;
+		}
+
+		if($step <= 0){
+			throw new \InvalidArgumentException("Step must be greater than zero");
+		}
+		$this->step = $step;
+	}
+
+	public function getType() : string{
+		return "slider";
+	}
+
+	/**
+	 * @param float $value
+	 *
+	 * @throws FormValidationException
+	 */
+	public function validateValue($value) : void{
+		if(!is_float($value) and !is_int($value)){
+			throw new FormValidationException("Expected float, got " . gettype($value));
+		}
+		if($value < $this->min or $value > $this->max){
+			throw new FormValidationException("Value $value is out of bounds (min $this->min, max $this->max)");
+		}
+	}
+
+	/**
+	 * @return float
+	 */
+	public function getMin() : float{
+		return $this->min;
+	}
+
+	/**
+	 * @return float
+	 */
+	public function getMax() : float{
+		return $this->max;
+	}
+
+	/**
+	 * @return float
+	 */
+	public function getStep() : float{
+		return $this->step;
+	}
+
+	/**
+	 * @return float
+	 */
+	public function getDefault() : float{
+		return $this->default;
+	}
+
+	protected function serializeElementData() : array{
+		return [
+			"min" => $this->min,
+			"max" => $this->max,
+			"default" => $this->default,
+			"step" => $this->step
+		];
+	}
+}

--- a/src/pocketmine/form/element/StepSlider.php
+++ b/src/pocketmine/form/element/StepSlider.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\form\element;
+
+class StepSlider extends BaseSelector{
+
+	public function getType() : string{
+		return "step_slider";
+	}
+
+	protected function serializeElementData() : array{
+		return [
+			"steps" => $this->options,
+			"default" => $this->defaultOptionIndex
+		];
+	}
+}

--- a/src/pocketmine/form/element/Toggle.php
+++ b/src/pocketmine/form/element/Toggle.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\form\element;
+
+use pocketmine\form\FormValidationException;
+
+/**
+ * Represents a UI on/off switch. The switch may have a default value.
+ */
+class Toggle extends CustomFormElement{
+	/** @var bool */
+	private $default;
+
+	public function __construct(string $name, string $text, bool $defaultValue = false){
+		parent::__construct($name, $text);
+		$this->default = $defaultValue;
+	}
+
+	public function getType() : string{
+		return "toggle";
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function getDefaultValue() : bool{
+		return $this->default;
+	}
+
+	/**
+	 * @param bool $value
+	 *
+	 * @throws FormValidationException
+	 */
+	public function validateValue($value) : void{
+		if(!is_bool($value)){
+			throw new FormValidationException("Expected bool, got " . gettype($value));
+		}
+	}
+
+	protected function serializeElementData() : array{
+		return [
+			"default" => $this->default
+		];
+	}
+}

--- a/src/pocketmine/utils/Utils.php
+++ b/src/pocketmine/utils/Utils.php
@@ -547,4 +547,13 @@ class Utils{
 
 		return true; //stfu operator
 	}
+
+	public static function validateObjectArray(array $array, string $class) : bool{
+		foreach($array as $key => $item){
+			if(!($item instanceof $class)){
+				throw new \TypeError("Element \"$key\" is not an instance of $class");
+			}
+		}
+		return true;
+	}
 }


### PR DESCRIPTION
## Introduction
This is a revision of #1476 , which was abandoned due to me getting sick of messing about with it and it being full of bugs.

This primarily differs from #1476 due to a large simplification in how form data is handled. Previously form response data would be stored in the form itself, which added a lot of extra complexity to form handling, made them impossible to duplicate, reuse, etc etc. In this revision, forms and their subcomponents do not have any responsibility for storing response data - instead it's passed to `onSubmit()`.

This is not yet complete and will probably see further changes before it is done.

## Changes
### API changes
- Added new classes under the `pocketmine\form` namespace
- Added API method `Player->sendForm()`.

### Behavioural changes
This is a pure API addition and should not affect any existing behaviour, apart from possibly breaking external form API plugins.

## Backwards compatibility
see Behavioural changes

## Tests
has been briefly tested, test scripts will come.