### PR TITLE
PluginBase: Do not fill defaults from resources/config.yml

### DIFF
--- a/src/pocketmine/plugin/PluginBase.php
+++ b/src/pocketmine/plugin/PluginBase.php
@@ -258,10 +258,6 @@ abstract class PluginBase implements Plugin{
 	public function reloadConfig(){
 		$this->saveDefaultConfig();
 		$this->config = new Config($this->configFile);
-		if(($configStream = $this->getResource("config.yml")) !== null){
-			$this->config->setDefaults(yaml_parse(Config::fixYAMLIndexes(stream_get_contents($configStream))));
-			fclose($configStream);
-		}
 	}
 
 	/**


### PR DESCRIPTION
## Introduction
described in referenced issue.

### Relevant issues
#2219 

## Changes
### API changes
- `PluginBase->reloadConfig()` will no longer fill in defaults from `resources/config.yml`. Instead, default values for `Config->get()` should be used (is there anyone who _doesn't_ do this???)

## Backwards compatibility
- Potential BC break for plugins whose users have messed up their configs where defaults have not been used.

## Tests
This is a trivial change and does not need substantial testing.