### PR TITLE
Player: Separate disconnection logic into disconnect() API method

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1769,7 +1769,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 		$this->server->getPluginManager()->callEvent($ev = new PlayerPreLoginEvent($this, "Plugin reason"));
 		if($ev->isCancelled()){
-			$this->close("", $ev->getKickMessage());
+			$this->disconnect("", $ev->getKickMessage());
 
 			return true;
 		}
@@ -1804,7 +1804,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		}
 
 		if($error !== null){
-			$this->close("", $this->server->getLanguage()->translateString("pocketmine.disconnect.invalidSession", [$error]));
+			$this->disconnect("", $this->server->getLanguage()->translateString("pocketmine.disconnect.invalidSession", [$error]));
 			return;
 		}
 
@@ -1835,7 +1835,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		foreach($this->server->getLoggedInPlayers() as $p){
 			if($p !== $this and ($p->iusername === $this->iusername or $this->getUniqueId()->equals($p->getUniqueId()))){
 				if(!$p->kick("logged in from another location")){
-					$this->close($this->getLeaveMessage(), "Logged in from another location");
+					$this->disconnect($this->getLeaveMessage(), "Logged in from another location");
 
 					return;
 				}
@@ -1871,7 +1871,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 		$this->server->getPluginManager()->callEvent($ev = new PlayerLoginEvent($this, "Plugin reason"));
 		if($ev->isCancelled()){
-			$this->close($this->getLeaveMessage(), $ev->getKickMessage());
+			$this->disconnect($this->getLeaveMessage(), $ev->getKickMessage());
 
 			return;
 		}
@@ -2718,7 +2718,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 			$pk->address = $ev->getAddress();
 			$pk->port = $ev->getPort();
 			$this->sendDataPacket($pk, true);
-			$this->close("", $ev->getMessage(), false);
+			$this->disconnect("", $ev->getMessage(), false);
 
 			return true;
 		}
@@ -2749,7 +2749,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 					$message = "disconnectionScreen.noReason";
 				}
 			}
-			$this->close($ev->getQuitMessage(), $message);
+			$this->disconnect($ev->getQuitMessage(), $message);
 
 			return true;
 		}
@@ -2924,90 +2924,92 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	 * @param string               $reason Reason showed in console
 	 * @param bool                 $notify
 	 */
-	final public function close($message = "", string $reason = "generic reason", bool $notify = true) : void{
-		if($this->isConnected() and !$this->closed){
+	public function disconnect($message = "", string $reason = "generic reason", bool $notify = true) : void{
+		if($this->closed){
+			return;
+		}
+		if(!$this->isConnected()){
+			throw new \InvalidStateException("Player is already disconnected");
+		}
+
+		$ip = $this->networkSession->getIp();
+		$port = $this->networkSession->getPort();
+		$this->networkSession->onPlayerDisconnect($reason, $notify);
+		$this->networkSession = null;
+
+		$this->server->onPlayerDisconnect($this);
+
+		$this->server->getPluginManager()->unsubscribeFromPermission(Server::BROADCAST_CHANNEL_USERS, $this);
+		$this->server->getPluginManager()->unsubscribeFromPermission(Server::BROADCAST_CHANNEL_ADMINISTRATIVE, $this);
+		$this->perm->clearPermissions();
+
+		$this->loggedIn = false;
+		$this->spawned = false;
+
+		if($this->constructed){ //this is messy - TODO: only create the player when login sequence is finished
+			$this->flagForDespawn();
+			$this->despawnFromAll();
+			$this->stopSleep();
+
+			$this->server->getPluginManager()->callEvent($ev = new PlayerQuitEvent($this, $message, $reason));
+			if($ev->getQuitMessage() != ""){
+				$this->server->broadcastMessage($ev->getQuitMessage());
+			}
 
 			try{
-				$ip = $this->networkSession->getIp();
-				$port = $this->networkSession->getPort();
-				$this->networkSession->onPlayerDestroyed($reason, $notify);
-				$this->networkSession = null;
-
-				$this->server->getPluginManager()->unsubscribeFromPermission(Server::BROADCAST_CHANNEL_USERS, $this);
-				$this->server->getPluginManager()->unsubscribeFromPermission(Server::BROADCAST_CHANNEL_ADMINISTRATIVE, $this);
-
-				$this->stopSleep();
-
-				if($this->spawned){
-					$this->server->getPluginManager()->callEvent($ev = new PlayerQuitEvent($this, $message, $reason));
-					if($ev->getQuitMessage() != ""){
-						$this->server->broadcastMessage($ev->getQuitMessage());
-					}
-
-					try{
-						$this->save();
-					}catch(\Throwable $e){
-						$this->server->getLogger()->critical("Failed to save player data for " . $this->getName());
-						$this->server->getLogger()->logException($e);
-					}
-				}
-
-				if($this->isValid()){
-					foreach($this->usedChunks as $index => $d){
-						Level::getXZ($index, $chunkX, $chunkZ);
-						$this->level->unregisterChunkLoader($this, $chunkX, $chunkZ);
-						foreach($this->level->getChunkEntities($chunkX, $chunkZ) as $entity){
-							$entity->despawnFrom($this);
-						}
-						unset($this->usedChunks[$index]);
-					}
-				}
-				$this->usedChunks = [];
-				$this->loadQueue = [];
-
-				if($this->loggedIn){
-					$this->server->onPlayerLogout($this);
-					foreach($this->server->getOnlinePlayers() as $player){
-						if(!$player->canSee($this)){
-							$player->showPlayer($this);
-						}
-					}
-					$this->hiddenPlayers = [];
-				}
-
-				$this->removeAllWindows(true);
-				$this->windows = [];
-				$this->windowIndex = [];
-				$this->cursorInventory = null;
-				$this->craftingGrid = null;
-
-				if($this->constructed){
-					parent::close();
-				}
-				$this->spawned = false;
-
-				if($this->loggedIn){
-					$this->loggedIn = false;
-					$this->server->removeOnlinePlayer($this);
-				}
-
-				$this->server->getLogger()->info($this->getServer()->getLanguage()->translateString("pocketmine.player.logOut", [
-					TextFormat::AQUA . $this->getName() . TextFormat::WHITE,
-					$ip,
-					$port,
-					$this->getServer()->getLanguage()->translateString($reason)
-				]));
-
-				$this->spawnPosition = null;
-
-				if($this->perm !== null){
-					$this->perm->clearPermissions();
-					$this->perm = null;
-				}
+				$this->save();
 			}catch(\Throwable $e){
+				$this->server->getLogger()->critical("Failed to save player data for " . $this->getName());
 				$this->server->getLogger()->logException($e);
-			}finally{
-				$this->server->removePlayer($this);
+			}
+
+			if($this->isValid()){
+				foreach($this->usedChunks as $index => $d){
+					Level::getXZ($index, $chunkX, $chunkZ);
+					$this->level->unregisterChunkLoader($this, $chunkX, $chunkZ);
+					foreach($this->level->getChunkEntities($chunkX, $chunkZ) as $entity){
+						$entity->despawnFrom($this, false);
+					}
+					unset($this->usedChunks[$index]);
+				}
+			}
+			$this->usedChunks = [];
+			$this->loadQueue = [];
+
+			foreach($this->server->getOnlinePlayers() as $player){
+				if(!$player->canSee($this)){
+					$player->showPlayer($this);
+				}
+			}
+			$this->hiddenPlayers = [];
+
+			$this->removeAllWindows(true);
+			$this->windows = [];
+			$this->windowIndex = [];
+		}else{
+			//TODO: HACK! see above comment
+			$this->close();
+		}
+
+		$this->server->getLogger()->info($this->getServer()->getLanguage()->translateString("pocketmine.player.logOut", [
+			TextFormat::AQUA . $this->getName() . TextFormat::WHITE,
+			$ip,
+			$port,
+			$this->getServer()->getLanguage()->translateString($reason)
+		]));
+	}
+
+	public function close() : void{
+		if(!$this->closed){
+			$this->cursorInventory = null;
+			$this->craftingGrid = null;
+			$this->spawnPosition = null;
+			$this->perm = null;
+
+			if($this->constructed){
+				parent::close();
+			}else{
+				$this->closed = true;
 			}
 		}
 	}

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2999,6 +2999,9 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		]));
 	}
 
+	/**
+	 * @internal
+	 */
 	public function close() : void{
 		if(!$this->closed){
 			$this->cursorInventory = null;

--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -2034,7 +2034,7 @@ class Server{
 			}
 
 			foreach($this->players as $player){
-				$player->close($player->getLeaveMessage(), $this->getProperty("settings.shutdown-message", "Server closed"));
+				$player->disconnect($player->getLeaveMessage(), $this->getProperty("settings.shutdown-message", "Server closed"));
 			}
 
 			$this->getLogger()->debug("Unloading all levels");
@@ -2268,8 +2268,10 @@ class Server{
 		$this->loggedInPlayers[$player->getRawUniqueId()] = $player;
 	}
 
-	public function onPlayerLogout(Player $player){
+	public function onPlayerDisconnect(Player $player) : void{
+		$this->removeOnlinePlayer($player);
 		unset($this->loggedInPlayers[$player->getRawUniqueId()]);
+		$this->removePlayer($player);
 	}
 
 	public function addPlayer(Player $player){
@@ -2341,7 +2343,7 @@ class Server{
 	private function checkTickUpdates(int $currentTick, float $tickTime) : void{
 		foreach($this->players as $p){
 			if(!$p->loggedIn and ($tickTime - $p->creationTime) >= 10){
-				$p->close("", "Login timeout");
+				$p->disconnect("", "Login timeout");
 			}elseif($this->alwaysTickPlayers and $p->spawned){
 				$p->onUpdate($currentTick);
 			}

--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -2269,8 +2269,10 @@ class Server{
 	}
 
 	public function onPlayerDisconnect(Player $player) : void{
-		$this->removeOnlinePlayer($player);
-		unset($this->loggedInPlayers[$player->getRawUniqueId()]);
+		if($player->loggedIn){ //TODO: remove this hack once incomplete players are dealt with
+			$this->removeOnlinePlayer($player);
+			unset($this->loggedInPlayers[$player->getRawUniqueId()]);
+		}
 		$this->removePlayer($player);
 	}
 

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -538,8 +538,11 @@ class Level implements ChunkManager, Metadatable{
 		$this->server->getLogger()->info($this->server->getLanguage()->translateString("pocketmine.level.unloading", [$this->getName()]));
 		$defaultLevel = $this->server->getDefaultLevel();
 		foreach($this->getPlayers() as $player){
-			if($this === $defaultLevel or $defaultLevel === null){
-				$player->close($player->getLeaveMessage(), "Forced default level unload");
+			if(!$player->isConnected()){
+				$player->close(); //this would normally get called on the next tick, but it won't if the level is unloaded
+			}elseif($this === $defaultLevel or $defaultLevel === null){
+				$player->disconnect($player->getLeaveMessage(), "Forced default level unload");
+				$player->close(); //same as above
 			}elseif($defaultLevel instanceof Level){
 				$player->teleport($this->server->getDefaultLevel()->getSafeSpawn());
 			}

--- a/src/pocketmine/network/mcpe/NetworkSession.php
+++ b/src/pocketmine/network/mcpe/NetworkSession.php
@@ -195,7 +195,7 @@ class NetworkSession{
 	public function disconnect(string $reason, bool $notify = true) : void{
 		if($this->connected){
 			$this->connected = false;
-			$this->player->close($this->player->getLeaveMessage(), $reason);
+			$this->player->disconnect($this->player->getLeaveMessage(), $reason);
 			$this->doServerDisconnect($reason, $notify);
 		}
 	}
@@ -206,7 +206,7 @@ class NetworkSession{
 	 * @param string $reason
 	 * @param bool   $notify
 	 */
-	public function onPlayerDestroyed(string $reason, bool $notify = true) : void{
+	public function onPlayerDisconnect(string $reason, bool $notify = true) : void{
 		if($this->connected){
 			$this->connected = false;
 			$this->doServerDisconnect($reason, $notify);
@@ -240,7 +240,7 @@ class NetworkSession{
 	public function onClientDisconnect(string $reason) : void{
 		if($this->connected){
 			$this->connected = false;
-			$this->player->close($this->player->getLeaveMessage(), $reason);
+			$this->player->disconnect($this->player->getLeaveMessage(), $reason);
 			$this->disconnectCleanup();
 		}
 	}


### PR DESCRIPTION
## Introduction
close() should NOT be used by plugins anymore.

disconnect() will do the logic that won't cause things to crash. close() will handle breaking cyclic references and cleanup only.

This fixes a multitude of bugs relating to player kicking and closing during events. This fixes #1239 and a range of other related (but not reported on the issue tracker) bugs.

### Relevant issues
#1239

## Changes
### API changes
- Added new API method `Player->disconnect()`.
- `Player->close()` should now be considered internal, and should not be used.

### Behavioural changes
None known.
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
This breaks backwards compatibility by changing the use and functionality of `Player->close()`. It should perhaps be made private, but this isn't currently possible due to limitations in how entity deletion works.

## Follow-up
- Clean up generic Entity deletion in this fashion.
- Make Player only be constructed when the login sequence is completed, to remove the mess of incomplete players.

## Tests
Transferring, kicking and disconnecting during `PlayerInteractEvent` and `PlayerAnimateEvent` have been tested, amongst other things.