### PR TITLE
Clear the title bar when the server shutdown.

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -2077,7 +2077,9 @@ class Server{
 			$this->logger->emergency("Crashed while crashing, killing process");
 			@Utils::kill(getmypid());
 		}
-		echo "\x1b]0; \x07";
+		if($this->doTitleTick){
+				echo "\x1b]0; \x07";
+		}
 	}
 
 	/**

--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -2077,7 +2077,7 @@ class Server{
 			$this->logger->emergency("Crashed while crashing, killing process");
 			@Utils::kill(getmypid());
 		}
-
+		echo "\x1b]0; \x07";
 	}
 
 	/**


### PR DESCRIPTION
## Introduction
It always annoys me how when i stop my server and want to keep my terminal open i still have the title of pocketmine.

### Relevant issues
Not a real issue.

## Changes
Now the title bar gets cleared when the server shutdown.

### API changes
No api changes.

### Behavioural changes
No behavioural changes.

## Backwards compatibility
No backwards compatibility.

## Follow-up
No action required after this pull request.

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

--> No.

## Tests
This will clear the old pocketmine title bar text off the terminal (or cmd) when pocketmine shutdown just as simple as it sounds like.