### PR TITLE
Remove $handlerList from PlayerExperienceChangeEvent

### DIFF
--- a/src/pocketmine/event/player/PlayerExperienceChangeEvent.php
+++ b/src/pocketmine/event/player/PlayerExperienceChangeEvent.php
@@ -31,7 +31,6 @@ use pocketmine\event\entity\EntityEvent;
  * Called when a player gains or loses XP levels and/or progress.
  */
 class PlayerExperienceChangeEvent extends EntityEvent implements Cancellable{
-	public static $handlerList = null;
 	/** @var Human */
 	protected $entity;
 	/** @var int */


### PR DESCRIPTION
I noticed that PlayerExperienceChangeEvent was the only event class that still declared a `$handlerList` property. It is no longer needed, and the `$handlerList` declaration for every other event class was removed with commit 49fbbea. This PR removes this small inconsistency.

Nothing in the PMMP code uses `PlayerExperienceChangeEvent::$handlerList` anymore, so there will not be any effects on anything.