### PR TITLE
Added ItemDamageEvent

### DIFF
--- a/src/pocketmine/event/item/ItemDamageEvent.php
+++ b/src/pocketmine/event/item/ItemDamageEvent.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\event\item;
+
+use pocketmine\event\Cancellable;
+use pocketmine\item\Item;
+use pocketmine\Player;
+
+/**
+ * Called when an item gets damaged.
+ */
+class ItemDamageEvent extends ItemEvent implements Cancellable{
+
+    /** @var Item */
+    protected $item;
+    /** @var int */
+    protected $damage;
+
+    public function __construct(Item $item, int $damage){
+        parent::__construct($item);
+        $this->item = $item;
+        $this->damage = $damage;
+    }
+
+    /**
+     * Returns the item damage is applied to.
+     *
+     * @return Item
+     */
+    public function getItem() : Item{
+        return $this->item;
+    }
+
+    /**
+     * Returns the amount of damage applied to the item.
+     *
+     * @return int
+     */
+    public function getDamage() : int{
+        return $this->damage;
+    }
+
+    /**
+     * Sets the amount of damaged applied to the item.
+     *
+     * @param int $damage
+     */
+    public function setDamage(int $damage) : void{
+        $this->damage = $damage;
+    }
+}

--- a/src/pocketmine/event/item/ItemDamageEvent.php
+++ b/src/pocketmine/event/item/ItemDamageEvent.php
@@ -57,7 +57,7 @@ class ItemDamageEvent extends ItemEvent implements Cancellable{
      *
      * @return int
      */
-    public function getDamage() : int{
+    public function getAppliedDamage() : int{
         return $this->damage;
     }
 
@@ -66,7 +66,7 @@ class ItemDamageEvent extends ItemEvent implements Cancellable{
      *
      * @param int $damage
      */
-    public function setDamage(int $damage) : void{
+    public function setAppliedDamage(int $damage) : void{
         $this->damage = $damage;
     }
 }

--- a/src/pocketmine/event/item/ItemEvent.php
+++ b/src/pocketmine/event/item/ItemEvent.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+/**
+* Item related events
+*/
+namespace pocketmine\event\item;
+
+use pocketmine\event\Event;
+use pocketmine\item\Item;
+
+abstract class ItemEvent extends Event{
+
+    /** @var Item */
+    protected $item;
+
+    public function __construct(Item $item){
+        $this->item = $item;
+    }
+
+    /**
+     * @return Item
+     */
+    public function getItem() : Item{
+        return $this->item;
+    }
+}

--- a/src/pocketmine/item/Durable.php
+++ b/src/pocketmine/item/Durable.php
@@ -23,8 +23,10 @@ declare(strict_types=1);
 
 namespace pocketmine\item;
 
+use pocketmine\event\item\ItemDamageEvent;
 use pocketmine\item\enchantment\Enchantment;
 use pocketmine\nbt\tag\ByteTag;
+use pocketmine\Server;
 
 abstract class Durable extends Item{
 
@@ -57,10 +59,14 @@ abstract class Durable extends Item{
 
 		$amount -= $this->getUnbreakingDamageReduction($amount);
 
-		$this->meta = min($this->meta + $amount, $this->getMaxDurability());
-		if($this->isBroken()){
-			$this->onBroken();
-		}
+        Server::getInstance()->getPluginManager()->callEvent($ev = new ItemDamageEvent($this, $amount));
+
+        if(!$ev->isCancelled()){
+            $this->meta = min($this->meta + $ev->getDamage(), $this->getMaxDurability());
+            if($this->isBroken()){
+                $this->onBroken();
+            }
+        }
 
 		return true;
 	}


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Earlier today i was wondering how to disable items taking damage, and instead of doing it in multiple events i thought one event for it all would be better.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Added event\item
Added ItemDamageEvent

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
script:
```php
public function onItemDamage(ItemDamageEvent $event) : void{
    var_dump($event->getDamage());
    $event->setDamage($event->getDamage() + 2);
    var_dump($event->getDamage());
}
```
output:
```php
int(1)
int(3)
```
(tested breaking a block)
