### PR TITLE
Permissions management cleanup

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -640,8 +640,9 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	public function recalculatePermissions(){
-		PermissionManager::getInstance()->unsubscribeFromPermission(Server::BROADCAST_CHANNEL_USERS, $this);
-		PermissionManager::getInstance()->unsubscribeFromPermission(Server::BROADCAST_CHANNEL_ADMINISTRATIVE, $this);
+		$permManager = PermissionManager::getInstance();
+		$permManager->unsubscribeFromPermission(Server::BROADCAST_CHANNEL_USERS, $this);
+		$permManager->unsubscribeFromPermission(Server::BROADCAST_CHANNEL_ADMINISTRATIVE, $this);
 
 		if($this->perm === null){
 			return;
@@ -650,10 +651,10 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		$this->perm->recalculatePermissions();
 
 		if($this->hasPermission(Server::BROADCAST_CHANNEL_USERS)){
-			PermissionManager::getInstance()->subscribeToPermission(Server::BROADCAST_CHANNEL_USERS, $this);
+			$permManager->subscribeToPermission(Server::BROADCAST_CHANNEL_USERS, $this);
 		}
 		if($this->hasPermission(Server::BROADCAST_CHANNEL_ADMINISTRATIVE)){
-			PermissionManager::getInstance()->subscribeToPermission(Server::BROADCAST_CHANNEL_ADMINISTRATIVE, $this);
+			$permManager->subscribeToPermission(Server::BROADCAST_CHANNEL_ADMINISTRATIVE, $this);
 		}
 
 		if($this->spawned){

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -148,6 +148,7 @@ use pocketmine\network\SourceInterface;
 use pocketmine\permission\PermissibleBase;
 use pocketmine\permission\PermissionAttachment;
 use pocketmine\permission\PermissionAttachmentInfo;
+use pocketmine\permission\PermissionManager;
 use pocketmine\plugin\Plugin;
 use pocketmine\resourcepacks\ResourcePack;
 use pocketmine\tile\ItemFrame;
@@ -639,8 +640,8 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	public function recalculatePermissions(){
-		$this->server->getPluginManager()->unsubscribeFromPermission(Server::BROADCAST_CHANNEL_USERS, $this);
-		$this->server->getPluginManager()->unsubscribeFromPermission(Server::BROADCAST_CHANNEL_ADMINISTRATIVE, $this);
+		PermissionManager::getInstance()->unsubscribeFromPermission(Server::BROADCAST_CHANNEL_USERS, $this);
+		PermissionManager::getInstance()->unsubscribeFromPermission(Server::BROADCAST_CHANNEL_ADMINISTRATIVE, $this);
 
 		if($this->perm === null){
 			return;
@@ -649,10 +650,10 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		$this->perm->recalculatePermissions();
 
 		if($this->hasPermission(Server::BROADCAST_CHANNEL_USERS)){
-			$this->server->getPluginManager()->subscribeToPermission(Server::BROADCAST_CHANNEL_USERS, $this);
+			PermissionManager::getInstance()->subscribeToPermission(Server::BROADCAST_CHANNEL_USERS, $this);
 		}
 		if($this->hasPermission(Server::BROADCAST_CHANNEL_ADMINISTRATIVE)){
-			$this->server->getPluginManager()->subscribeToPermission(Server::BROADCAST_CHANNEL_ADMINISTRATIVE, $this);
+			PermissionManager::getInstance()->subscribeToPermission(Server::BROADCAST_CHANNEL_ADMINISTRATIVE, $this);
 		}
 
 		if($this->spawned){
@@ -1020,10 +1021,10 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		$this->sendPlayStatus(PlayStatusPacket::PLAYER_SPAWN);
 
 		if($this->hasPermission(Server::BROADCAST_CHANNEL_USERS)){
-			$this->server->getPluginManager()->subscribeToPermission(Server::BROADCAST_CHANNEL_USERS, $this);
+			PermissionManager::getInstance()->subscribeToPermission(Server::BROADCAST_CHANNEL_USERS, $this);
 		}
 		if($this->hasPermission(Server::BROADCAST_CHANNEL_ADMINISTRATIVE)){
-			$this->server->getPluginManager()->subscribeToPermission(Server::BROADCAST_CHANNEL_ADMINISTRATIVE, $this);
+			PermissionManager::getInstance()->subscribeToPermission(Server::BROADCAST_CHANNEL_ADMINISTRATIVE, $this);
 		}
 
 		$this->server->getPluginManager()->callEvent($ev = new PlayerJoinEvent($this,
@@ -3373,8 +3374,8 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 				$this->interface->close($this, $notify ? $reason : "");
 				$this->sessionAdapter = null;
 
-				$this->server->getPluginManager()->unsubscribeFromPermission(Server::BROADCAST_CHANNEL_USERS, $this);
-				$this->server->getPluginManager()->unsubscribeFromPermission(Server::BROADCAST_CHANNEL_ADMINISTRATIVE, $this);
+				PermissionManager::getInstance()->unsubscribeFromPermission(Server::BROADCAST_CHANNEL_USERS, $this);
+				PermissionManager::getInstance()->unsubscribeFromPermission(Server::BROADCAST_CHANNEL_ADMINISTRATIVE, $this);
 
 				$this->stopSleep();
 

--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -82,6 +82,7 @@ use pocketmine\network\rcon\RCON;
 use pocketmine\network\upnp\UPnP;
 use pocketmine\permission\BanList;
 use pocketmine\permission\DefaultPermissions;
+use pocketmine\permission\PermissionManager;
 use pocketmine\plugin\PharPluginLoader;
 use pocketmine\plugin\Plugin;
 use pocketmine\plugin\PluginLoadOrder;
@@ -1624,7 +1625,7 @@ class Server{
 			$this->resourceManager = new ResourcePackManager($this->getDataPath() . "resource_packs" . DIRECTORY_SEPARATOR, $this->logger);
 
 			$this->pluginManager = new PluginManager($this, $this->commandMap, ((bool) $this->getProperty("plugins.legacy-data-dir", true)) ? null : $this->getDataPath() . "plugin_data" . DIRECTORY_SEPARATOR);
-			$this->pluginManager->subscribeToPermission(Server::BROADCAST_CHANNEL_ADMINISTRATIVE, $this->consoleSender);
+			PermissionManager::getInstance()->subscribeToPermission(Server::BROADCAST_CHANNEL_ADMINISTRATIVE, $this->consoleSender);
 			$this->profilingTickRate = (float) $this->getProperty("settings.profile-report-trigger", 20);
 			$this->pluginManager->registerInterface(new PharPluginLoader($this->autoloader));
 			$this->pluginManager->registerInterface(new ScriptPluginLoader());
@@ -1733,7 +1734,7 @@ class Server{
 		if(!is_array($recipients)){
 			/** @var Player[] $recipients */
 			$recipients = [];
-			foreach($this->pluginManager->getPermissionSubscriptions(self::BROADCAST_CHANNEL_USERS) as $permissible){
+			foreach(PermissionManager::getInstance()->getPermissionSubscriptions(self::BROADCAST_CHANNEL_USERS) as $permissible){
 				if($permissible instanceof Player and $permissible->hasPermission(self::BROADCAST_CHANNEL_USERS)){
 					$recipients[spl_object_hash($permissible)] = $permissible; // do not send messages directly, or some might be repeated
 				}
@@ -1759,7 +1760,7 @@ class Server{
 			/** @var Player[] $recipients */
 			$recipients = [];
 
-			foreach($this->pluginManager->getPermissionSubscriptions(self::BROADCAST_CHANNEL_USERS) as $permissible){
+			foreach(PermissionManager::getInstance()->getPermissionSubscriptions(self::BROADCAST_CHANNEL_USERS) as $permissible){
 				if($permissible instanceof Player and $permissible->hasPermission(self::BROADCAST_CHANNEL_USERS)){
 					$recipients[spl_object_hash($permissible)] = $permissible; // do not send messages directly, or some might be repeated
 				}
@@ -1789,7 +1790,7 @@ class Server{
 			/** @var Player[] $recipients */
 			$recipients = [];
 
-			foreach($this->pluginManager->getPermissionSubscriptions(self::BROADCAST_CHANNEL_USERS) as $permissible){
+			foreach(PermissionManager::getInstance()->getPermissionSubscriptions(self::BROADCAST_CHANNEL_USERS) as $permissible){
 				if($permissible instanceof Player and $permissible->hasPermission(self::BROADCAST_CHANNEL_USERS)){
 					$recipients[spl_object_hash($permissible)] = $permissible; // do not send messages directly, or some might be repeated
 				}
@@ -1814,7 +1815,7 @@ class Server{
 		/** @var CommandSender[] $recipients */
 		$recipients = [];
 		foreach(explode(";", $permissions) as $permission){
-			foreach($this->pluginManager->getPermissionSubscriptions($permission) as $permissible){
+			foreach(PermissionManager::getInstance()->getPermissionSubscriptions($permission) as $permissible){
 				if($permissible instanceof CommandSender and $permissible->hasPermission($permission)){
 					$recipients[spl_object_hash($permissible)] = $permissible; // do not send messages directly, or some might be repeated
 				}

--- a/src/pocketmine/command/Command.php
+++ b/src/pocketmine/command/Command.php
@@ -28,6 +28,7 @@ namespace pocketmine\command;
 
 use pocketmine\lang\TextContainer;
 use pocketmine\lang\TranslationContainer;
+use pocketmine\permission\PermissionManager;
 use pocketmine\Server;
 use pocketmine\timings\TimingsHandler;
 use pocketmine\utils\TextFormat;
@@ -293,7 +294,7 @@ abstract class Command{
 			$m = clone $message;
 			$result = "[" . $source->getName() . ": " . ($source->getServer()->getLanguage()->get($m->getText()) !== $m->getText() ? "%" : "") . $m->getText() . "]";
 
-			$users = $source->getServer()->getPluginManager()->getPermissionSubscriptions(Server::BROADCAST_CHANNEL_ADMINISTRATIVE);
+			$users = PermissionManager::getInstance()->getPermissionSubscriptions(Server::BROADCAST_CHANNEL_ADMINISTRATIVE);
 			$colored = TextFormat::GRAY . TextFormat::ITALIC . $result;
 
 			$m->setText($result);
@@ -301,7 +302,7 @@ abstract class Command{
 			$m->setText($colored);
 			$colored = clone $m;
 		}else{
-			$users = $source->getServer()->getPluginManager()->getPermissionSubscriptions(Server::BROADCAST_CHANNEL_ADMINISTRATIVE);
+			$users = PermissionManager::getInstance()->getPermissionSubscriptions(Server::BROADCAST_CHANNEL_ADMINISTRATIVE);
 			$result = new TranslationContainer("chat.type.admin", [$source->getName(), $message]);
 			$colored = new TranslationContainer(TextFormat::GRAY . TextFormat::ITALIC . "%chat.type.admin", [$source->getName(), $message]);
 		}

--- a/src/pocketmine/event/player/PlayerChatEvent.php
+++ b/src/pocketmine/event/player/PlayerChatEvent.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace pocketmine\event\player;
 
 use pocketmine\event\Cancellable;
+use pocketmine\permission\PermissionManager;
 use pocketmine\Player;
 use pocketmine\Server;
 
@@ -55,7 +56,7 @@ class PlayerChatEvent extends PlayerEvent implements Cancellable{
 		$this->format = $format;
 
 		if($recipients === null){
-			$this->recipients = Server::getInstance()->getPluginManager()->getPermissionSubscriptions(Server::BROADCAST_CHANNEL_USERS);
+			$this->recipients = PermissionManager::getInstance()->getPermissionSubscriptions(Server::BROADCAST_CHANNEL_USERS);
 		}else{
 			$this->recipients = $recipients;
 		}

--- a/src/pocketmine/permission/DefaultPermissions.php
+++ b/src/pocketmine/permission/DefaultPermissions.php
@@ -23,8 +23,6 @@ declare(strict_types=1);
 
 namespace pocketmine\permission;
 
-use pocketmine\Server;
-
 abstract class DefaultPermissions{
 	public const ROOT = "pocketmine";
 
@@ -40,9 +38,9 @@ abstract class DefaultPermissions{
 
 			return self::registerPermission($perm);
 		}
-		Server::getInstance()->getPluginManager()->addPermission($perm);
+		PermissionManager::getInstance()->addPermission($perm);
 
-		return Server::getInstance()->getPluginManager()->getPermission($perm->getName());
+		return PermissionManager::getInstance()->getPermission($perm->getName());
 	}
 
 	public static function registerCorePermissions(){

--- a/src/pocketmine/permission/PermissibleBase.php
+++ b/src/pocketmine/permission/PermissibleBase.php
@@ -25,7 +25,6 @@ namespace pocketmine\permission;
 
 use pocketmine\plugin\Plugin;
 use pocketmine\plugin\PluginException;
-use pocketmine\Server;
 use pocketmine\timings\Timings;
 
 class PermissibleBase implements Permissible{
@@ -92,7 +91,7 @@ class PermissibleBase implements Permissible{
 			return $this->permissions[$name]->getValue();
 		}
 
-		if(($perm = Server::getInstance()->getPluginManager()->getPermission($name)) !== null){
+		if(($perm = PermissionManager::getInstance()->getPermission($name)) !== null){
 			$perm = $perm->getDefault();
 
 			return $perm === Permission::DEFAULT_TRUE or ($this->isOp() and $perm === Permission::DEFAULT_OP) or (!$this->isOp() and $perm === Permission::DEFAULT_NOT_OP);
@@ -147,13 +146,13 @@ class PermissibleBase implements Permissible{
 		Timings::$permissibleCalculationTimer->startTiming();
 
 		$this->clearPermissions();
-		$defaults = Server::getInstance()->getPluginManager()->getDefaultPermissions($this->isOp());
-		Server::getInstance()->getPluginManager()->subscribeToDefaultPerms($this->isOp(), $this->parent ?? $this);
+		$defaults = PermissionManager::getInstance()->getDefaultPermissions($this->isOp());
+		PermissionManager::getInstance()->subscribeToDefaultPerms($this->isOp(), $this->parent ?? $this);
 
 		foreach($defaults as $perm){
 			$name = $perm->getName();
 			$this->permissions[$name] = new PermissionAttachmentInfo($this->parent ?? $this, $name, null, true);
-			Server::getInstance()->getPluginManager()->subscribeToPermission($name, $this->parent ?? $this);
+			PermissionManager::getInstance()->subscribeToPermission($name, $this->parent ?? $this);
 			$this->calculateChildPermissions($perm->getChildren(), false, null);
 		}
 
@@ -165,13 +164,13 @@ class PermissibleBase implements Permissible{
 	}
 
 	public function clearPermissions(){
-		$pluginManager = Server::getInstance()->getPluginManager();
+		$permManager = PermissionManager::getInstance();
 		foreach(array_keys($this->permissions) as $name){
-			$pluginManager->unsubscribeFromPermission($name, $this->parent ?? $this);
+			$permManager->unsubscribeFromPermission($name, $this->parent ?? $this);
 		}
 
-		$pluginManager->unsubscribeFromDefaultPerms(false, $this->parent ?? $this);
-		$pluginManager->unsubscribeFromDefaultPerms(true, $this->parent ?? $this);
+		$permManager->unsubscribeFromDefaultPerms(false, $this->parent ?? $this);
+		$permManager->unsubscribeFromDefaultPerms(true, $this->parent ?? $this);
 
 		$this->permissions = [];
 	}
@@ -183,10 +182,10 @@ class PermissibleBase implements Permissible{
 	 */
 	private function calculateChildPermissions(array $children, bool $invert, ?PermissionAttachment $attachment){
 		foreach($children as $name => $v){
-			$perm = Server::getInstance()->getPluginManager()->getPermission($name);
+			$perm = PermissionManager::getInstance()->getPermission($name);
 			$value = ($v xor $invert);
 			$this->permissions[$name] = new PermissionAttachmentInfo($this->parent ?? $this, $name, $attachment, $value);
-			Server::getInstance()->getPluginManager()->subscribeToPermission($name, $this->parent ?? $this);
+			PermissionManager::getInstance()->subscribeToPermission($name, $this->parent ?? $this);
 
 			if($perm instanceof Permission){
 				$this->calculateChildPermissions($perm->getChildren(), !$value, $attachment);

--- a/src/pocketmine/permission/PermissibleBase.php
+++ b/src/pocketmine/permission/PermissibleBase.php
@@ -146,13 +146,14 @@ class PermissibleBase implements Permissible{
 		Timings::$permissibleCalculationTimer->startTiming();
 
 		$this->clearPermissions();
-		$defaults = PermissionManager::getInstance()->getDefaultPermissions($this->isOp());
-		PermissionManager::getInstance()->subscribeToDefaultPerms($this->isOp(), $this->parent ?? $this);
+		$permManager = PermissionManager::getInstance();
+		$defaults = $permManager->getDefaultPermissions($this->isOp());
+		$permManager->subscribeToDefaultPerms($this->isOp(), $this->parent ?? $this);
 
 		foreach($defaults as $perm){
 			$name = $perm->getName();
 			$this->permissions[$name] = new PermissionAttachmentInfo($this->parent ?? $this, $name, null, true);
-			PermissionManager::getInstance()->subscribeToPermission($name, $this->parent ?? $this);
+			$permManager->subscribeToPermission($name, $this->parent ?? $this);
 			$this->calculateChildPermissions($perm->getChildren(), false, null);
 		}
 
@@ -181,11 +182,12 @@ class PermissibleBase implements Permissible{
 	 * @param PermissionAttachment|null $attachment
 	 */
 	private function calculateChildPermissions(array $children, bool $invert, ?PermissionAttachment $attachment){
+		$permManager = PermissionManager::getInstance();
 		foreach($children as $name => $v){
-			$perm = PermissionManager::getInstance()->getPermission($name);
+			$perm = $permManager->getPermission($name);
 			$value = ($v xor $invert);
 			$this->permissions[$name] = new PermissionAttachmentInfo($this->parent ?? $this, $name, $attachment, $value);
-			PermissionManager::getInstance()->subscribeToPermission($name, $this->parent ?? $this);
+			$permManager->subscribeToPermission($name, $this->parent ?? $this);
 
 			if($perm instanceof Permission){
 				$this->calculateChildPermissions($perm->getChildren(), !$value, $attachment);

--- a/src/pocketmine/permission/Permission.php
+++ b/src/pocketmine/permission/Permission.php
@@ -27,8 +27,6 @@ declare(strict_types=1);
 
 namespace pocketmine\permission;
 
-use pocketmine\Server;
-
 /**
  * Represents a permission
  */
@@ -217,13 +215,13 @@ class Permission{
 	 * @return Permissible[]
 	 */
 	public function getPermissibles() : array{
-		return Server::getInstance()->getPluginManager()->getPermissionSubscriptions($this->name);
+		return PermissionManager::getInstance()->getPermissionSubscriptions($this->name);
 	}
 
 	public function recalculatePermissibles(){
 		$perms = $this->getPermissibles();
 
-		Server::getInstance()->getPluginManager()->recalculatePermissionDefaults($this);
+		PermissionManager::getInstance()->recalculatePermissionDefaults($this);
 
 		foreach($perms as $p){
 			$p->recalculatePermissions();
@@ -243,10 +241,10 @@ class Permission{
 			$name->recalculatePermissibles();
 			return null;
 		}else{
-			$perm = Server::getInstance()->getPluginManager()->getPermission($name);
+			$perm = PermissionManager::getInstance()->getPermission($name);
 			if($perm === null){
 				$perm = new Permission($name);
-				Server::getInstance()->getPluginManager()->addPermission($perm);
+				PermissionManager::getInstance()->addPermission($perm);
 			}
 
 			$this->addParent($perm, $value);

--- a/src/pocketmine/permission/PermissionManager.php
+++ b/src/pocketmine/permission/PermissionManager.php
@@ -1,0 +1,215 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\permission;
+
+use pocketmine\timings\Timings;
+
+class PermissionManager{
+	/** @var PermissionManager|null */
+	private static $instance = null;
+
+	public static function getInstance() : PermissionManager{
+		if(self::$instance === null){
+			self::$instance = new self;
+		}
+
+		return self::$instance;
+	}
+
+	/** @var Permission[] */
+	protected $permissions = [];
+	/** @var Permission[] */
+	protected $defaultPerms = [];
+	/** @var Permission[] */
+	protected $defaultPermsOp = [];
+	/** @var Permissible[][] */
+	protected $permSubs = [];
+	/** @var Permissible[] */
+	protected $defSubs = [];
+	/** @var Permissible[] */
+	protected $defSubsOp = [];
+
+	/**
+	 * @param string $name
+	 *
+	 * @return null|Permission
+	 */
+	public function getPermission(string $name){
+		return $this->permissions[$name] ?? null;
+	}
+
+	/**
+	 * @param Permission $permission
+	 *
+	 * @return bool
+	 */
+	public function addPermission(Permission $permission) : bool{
+		if(!isset($this->permissions[$permission->getName()])){
+			$this->permissions[$permission->getName()] = $permission;
+			$this->calculatePermissionDefault($permission);
+
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * @param string|Permission $permission
+	 */
+	public function removePermission($permission){
+		if($permission instanceof Permission){
+			unset($this->permissions[$permission->getName()]);
+		}else{
+			unset($this->permissions[$permission]);
+		}
+	}
+
+	/**
+	 * @param bool $op
+	 *
+	 * @return Permission[]
+	 */
+	public function getDefaultPermissions(bool $op) : array{
+		if($op){
+			return $this->defaultPermsOp;
+		}else{
+			return $this->defaultPerms;
+		}
+	}
+
+	/**
+	 * @param Permission $permission
+	 */
+	public function recalculatePermissionDefaults(Permission $permission){
+		if(isset($this->permissions[$permission->getName()])){
+			unset($this->defaultPermsOp[$permission->getName()]);
+			unset($this->defaultPerms[$permission->getName()]);
+			$this->calculatePermissionDefault($permission);
+		}
+	}
+
+	/**
+	 * @param Permission $permission
+	 */
+	private function calculatePermissionDefault(Permission $permission){
+		Timings::$permissionDefaultTimer->startTiming();
+		if($permission->getDefault() === Permission::DEFAULT_OP or $permission->getDefault() === Permission::DEFAULT_TRUE){
+			$this->defaultPermsOp[$permission->getName()] = $permission;
+			$this->dirtyPermissibles(true);
+		}
+
+		if($permission->getDefault() === Permission::DEFAULT_NOT_OP or $permission->getDefault() === Permission::DEFAULT_TRUE){
+			$this->defaultPerms[$permission->getName()] = $permission;
+			$this->dirtyPermissibles(false);
+		}
+		Timings::$permissionDefaultTimer->startTiming();
+	}
+
+	/**
+	 * @param bool $op
+	 */
+	private function dirtyPermissibles(bool $op){
+		foreach($this->getDefaultPermSubscriptions($op) as $p){
+			$p->recalculatePermissions();
+		}
+	}
+
+	/**
+	 * @param string      $permission
+	 * @param Permissible $permissible
+	 */
+	public function subscribeToPermission(string $permission, Permissible $permissible){
+		if(!isset($this->permSubs[$permission])){
+			$this->permSubs[$permission] = [];
+		}
+		$this->permSubs[$permission][spl_object_hash($permissible)] = $permissible;
+	}
+
+	/**
+	 * @param string      $permission
+	 * @param Permissible $permissible
+	 */
+	public function unsubscribeFromPermission(string $permission, Permissible $permissible){
+		if(isset($this->permSubs[$permission])){
+			unset($this->permSubs[$permission][spl_object_hash($permissible)]);
+			if(count($this->permSubs[$permission]) === 0){
+				unset($this->permSubs[$permission]);
+			}
+		}
+	}
+
+	/**
+	 * @param string $permission
+	 *
+	 * @return array|Permissible[]
+	 */
+	public function getPermissionSubscriptions(string $permission) : array{
+		return $this->permSubs[$permission] ?? [];
+	}
+
+	/**
+	 * @param bool        $op
+	 * @param Permissible $permissible
+	 */
+	public function subscribeToDefaultPerms(bool $op, Permissible $permissible){
+		if($op){
+			$this->defSubsOp[spl_object_hash($permissible)] = $permissible;
+		}else{
+			$this->defSubs[spl_object_hash($permissible)] = $permissible;
+		}
+	}
+
+	/**
+	 * @param bool        $op
+	 * @param Permissible $permissible
+	 */
+	public function unsubscribeFromDefaultPerms(bool $op, Permissible $permissible){
+		if($op){
+			unset($this->defSubsOp[spl_object_hash($permissible)]);
+		}else{
+			unset($this->defSubs[spl_object_hash($permissible)]);
+		}
+	}
+
+	/**
+	 * @param bool $op
+	 *
+	 * @return Permissible[]
+	 */
+	public function getDefaultPermSubscriptions(bool $op) : array{
+		if($op){
+			return $this->defSubsOp;
+		}
+
+		return $this->defSubs;
+	}
+
+	/**
+	 * @return Permission[]
+	 */
+	public function getPermissions() : array{
+		return $this->permissions;
+	}
+}

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -34,8 +34,8 @@ use pocketmine\event\plugin\PluginEnableEvent;
 use pocketmine\network\mcpe\protocol\ProtocolInfo;
 use pocketmine\permission\Permissible;
 use pocketmine\permission\Permission;
+use pocketmine\permission\PermissionManager;
 use pocketmine\Server;
-use pocketmine\timings\Timings;
 use pocketmine\timings\TimingsHandler;
 use pocketmine\utils\Utils;
 
@@ -60,36 +60,6 @@ class PluginManager{
 	 * @var Plugin[]
 	 */
 	protected $enabledPlugins = [];
-
-	/**
-	 * @var Permission[]
-	 */
-	protected $permissions = [];
-
-	/**
-	 * @var Permission[]
-	 */
-	protected $defaultPerms = [];
-
-	/**
-	 * @var Permission[]
-	 */
-	protected $defaultPermsOp = [];
-
-	/**
-	 * @var Permissible[][]
-	 */
-	protected $permSubs = [];
-
-	/**
-	 * @var Permissible[]
-	 */
-	protected $defSubs = [];
-
-	/**
-	 * @var Permissible[]
-	 */
-	protected $defSubsOp = [];
 
 	/**
 	 * @var PluginLoader[]
@@ -431,166 +401,137 @@ class PluginManager{
 	}
 
 	/**
+	 * @deprecated
+	 * @see PermissionManager::getPermission()
+	 *
 	 * @param string $name
 	 *
 	 * @return null|Permission
 	 */
 	public function getPermission(string $name){
-		return $this->permissions[$name] ?? null;
+		return PermissionManager::getInstance()->getPermission($name);
 	}
 
 	/**
+	 * @deprecated
+	 * @see PermissionManager::addPermission()
+	 *
 	 * @param Permission $permission
 	 *
 	 * @return bool
 	 */
 	public function addPermission(Permission $permission) : bool{
-		if(!isset($this->permissions[$permission->getName()])){
-			$this->permissions[$permission->getName()] = $permission;
-			$this->calculatePermissionDefault($permission);
-
-			return true;
-		}
-
-		return false;
+		return PermissionManager::getInstance()->addPermission($permission);
 	}
 
 	/**
+	 * @deprecated
+	 * @see PermissionManager::removePermission()
+	 *
 	 * @param string|Permission $permission
 	 */
 	public function removePermission($permission){
-		if($permission instanceof Permission){
-			unset($this->permissions[$permission->getName()]);
-		}else{
-			unset($this->permissions[$permission]);
-		}
+		PermissionManager::getInstance()->removePermission($permission);
 	}
 
 	/**
+	 * @deprecated
+	 * @see PermissionManager::getDefaultPermissions()
+	 *
 	 * @param bool $op
 	 *
 	 * @return Permission[]
 	 */
 	public function getDefaultPermissions(bool $op) : array{
-		if($op){
-			return $this->defaultPermsOp;
-		}else{
-			return $this->defaultPerms;
-		}
+		return PermissionManager::getInstance()->getDefaultPermissions($op);
 	}
 
 	/**
+	 * @deprecated
+	 * @see PermissionManager::recalculatePermissionDefaults()
+	 *
 	 * @param Permission $permission
 	 */
 	public function recalculatePermissionDefaults(Permission $permission){
-		if(isset($this->permissions[$permission->getName()])){
-			unset($this->defaultPermsOp[$permission->getName()]);
-			unset($this->defaultPerms[$permission->getName()]);
-			$this->calculatePermissionDefault($permission);
-		}
+		PermissionManager::getInstance()->recalculatePermissionDefaults($permission);
 	}
 
 	/**
-	 * @param Permission $permission
-	 */
-	private function calculatePermissionDefault(Permission $permission){
-		Timings::$permissionDefaultTimer->startTiming();
-		if($permission->getDefault() === Permission::DEFAULT_OP or $permission->getDefault() === Permission::DEFAULT_TRUE){
-			$this->defaultPermsOp[$permission->getName()] = $permission;
-			$this->dirtyPermissibles(true);
-		}
-
-		if($permission->getDefault() === Permission::DEFAULT_NOT_OP or $permission->getDefault() === Permission::DEFAULT_TRUE){
-			$this->defaultPerms[$permission->getName()] = $permission;
-			$this->dirtyPermissibles(false);
-		}
-		Timings::$permissionDefaultTimer->startTiming();
-	}
-
-	/**
-	 * @param bool $op
-	 */
-	private function dirtyPermissibles(bool $op){
-		foreach($this->getDefaultPermSubscriptions($op) as $p){
-			$p->recalculatePermissions();
-		}
-	}
-
-	/**
+	 * @deprecated
+	 * @see PermissionManager::subscribeToPermission()
+	 *
 	 * @param string      $permission
 	 * @param Permissible $permissible
 	 */
 	public function subscribeToPermission(string $permission, Permissible $permissible){
-		if(!isset($this->permSubs[$permission])){
-			$this->permSubs[$permission] = [];
-		}
-		$this->permSubs[$permission][spl_object_hash($permissible)] = $permissible;
+		PermissionManager::getInstance()->subscribeToPermission($permission, $permissible);
 	}
 
 	/**
+	 * @deprecated
+	 * @see PermissionManager::unsubscribeFromPermission()
+	 *
 	 * @param string      $permission
 	 * @param Permissible $permissible
 	 */
 	public function unsubscribeFromPermission(string $permission, Permissible $permissible){
-		if(isset($this->permSubs[$permission])){
-			unset($this->permSubs[$permission][spl_object_hash($permissible)]);
-			if(count($this->permSubs[$permission]) === 0){
-				unset($this->permSubs[$permission]);
-			}
-		}
+		PermissionManager::getInstance()->unsubscribeFromPermission($permission, $permissible);
 	}
 
 	/**
+	 * @deprecated
+	 * @see PermissionManager::getPermissionSubscriptions()
+	 *
 	 * @param string $permission
 	 *
 	 * @return array|Permissible[]
 	 */
 	public function getPermissionSubscriptions(string $permission) : array{
-		return $this->permSubs[$permission] ?? [];
+		return PermissionManager::getInstance()->getPermissionSubscriptions($permission);
 	}
 
 	/**
+	 * @deprecated
+	 * @see PermissionManager::subscribeToDefaultPerms()
+	 *
 	 * @param bool        $op
 	 * @param Permissible $permissible
 	 */
 	public function subscribeToDefaultPerms(bool $op, Permissible $permissible){
-		if($op){
-			$this->defSubsOp[spl_object_hash($permissible)] = $permissible;
-		}else{
-			$this->defSubs[spl_object_hash($permissible)] = $permissible;
-		}
+		PermissionManager::getInstance()->subscribeToDefaultPerms($op, $permissible);
 	}
 
 	/**
+	 * @deprecated
+	 * @see PermissionManager::unsubscribeFromDefaultPerms()
+	 *
 	 * @param bool        $op
 	 * @param Permissible $permissible
 	 */
 	public function unsubscribeFromDefaultPerms(bool $op, Permissible $permissible){
-		if($op){
-			unset($this->defSubsOp[spl_object_hash($permissible)]);
-		}else{
-			unset($this->defSubs[spl_object_hash($permissible)]);
-		}
+		PermissionManager::getInstance()->unsubscribeFromDefaultPerms($op, $permissible);
 	}
 
 	/**
+	 * @deprecated
+	 * @see PermissionManager::getDefaultPermSubscriptions()
+	 *
 	 * @param bool $op
 	 *
 	 * @return Permissible[]
 	 */
 	public function getDefaultPermSubscriptions(bool $op) : array{
-		if($op){
-			return $this->defSubsOp;
-		}
-
-		return $this->defSubs;
+		return PermissionManager::getInstance()->getDefaultPermSubscriptions($op);
 	}
 
 	/**
+	 * @deprecated
+	 * @see PermissionManager::getPermissions()
+	 *
 	 * @return Permission[]
 	 */
 	public function getPermissions() : array{
-		return $this->permissions;
+		return PermissionManager::getInstance()->getPermissions();
 	}
 
 	/**
@@ -610,8 +551,9 @@ class PluginManager{
 			try{
 				$this->server->getLogger()->info($this->server->getLanguage()->translateString("pocketmine.plugin.enable", [$plugin->getDescription()->getFullName()]));
 
+				$permManager = PermissionManager::getInstance();
 				foreach($plugin->getDescription()->getPermissions() as $perm){
-					$this->addPermission($perm);
+					$permManager->addPermission($perm);
 				}
 				$plugin->getScheduler()->setEnabled(true);
 				$plugin->setEnabled(true);
@@ -706,8 +648,9 @@ class PluginManager{
 			}
 			$plugin->getScheduler()->shutdown();
 			HandlerList::unregisterAll($plugin);
+			$permManager = PermissionManager::getInstance();
 			foreach($plugin->getDescription()->getPermissions() as $perm){
-				$this->removePermission($perm);
+				$permManager->removePermission($perm);
 			}
 		}
 	}

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -40,7 +40,7 @@ use pocketmine\timings\TimingsHandler;
 use pocketmine\utils\Utils;
 
 /**
- * Manages all the plugins, Permissions and Permissibles
+ * Manages all the plugins
  */
 class PluginManager{
 	private const MAX_EVENT_CALL_DEPTH = 50;


### PR DESCRIPTION
## Introduction
Aside from all the other ridiculous design problems with the permission system, the biggest problems are its API. This is, once again, a result of poor API design copied from Bukkit.

This pull request removes all permission-related functionality from `PluginManager` and moves it to the `pocketmine\permission\PermissionManager` class.

As can be observed from the removed code in the diff, the permissions system was previously entirely dependent on the Server, because it needed to get the PluginManager for registering permissions. This is utterly ridiculous. This refactor isolates _most_ permission-related functionality within the `permission` namespace.

As mentioned above, this stupid API is a direct result of copying from Bukkit. If you look at the API documentation for Bukkit for `PluginManager` you will see that the methods I'm deprecating here are also in there.

## Changes
### API changes
- Added a new `PermissionManager` class. This can be accessed via its singleton `getInstance()` static method.
- Deprecated the following `PluginManager` methods - these will be removed no later than 4.0.0:
  - `getPermission()`
  - `addPermission()`
  - `removePermission()`
  - `getDefaultPermissions()`
  - `recalculatePermissionDefaults()`
  - `subscribeToPermission()`
  - `unsubscribeFromPermission()`
  - `getPermissionSubscriptions()`
  - `subscribeToDefaultPerms()`
  - `unsubscribeFromDefaultPerms()`
  - `getDefaultPermSubscriptions()`
  - `getPermissions()`

### Behavioural changes
None.

## Backwards compatibility
Deprecations have been made as described above.

## Follow-up
Apply similar treatment to Events API, which is very circularly dependent on the `plugin` namespace.

## Tests
has not been thoroughly tested yet. The server runs, Travis is green... further tests are needed.