### PR TITLE
PluginManager: Fix patch level check.

### DIFF
--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -413,7 +413,7 @@ class PluginManager{
 					continue;
 				}
 
-				if($pluginNumbers[2] > $serverNumbers[2] and $pluginNumbers[1] >= $serverNumbers[1]){ //If the plugin requires bug fixes in patches, being backwards compatible
+				if($pluginNumbers[2] > $serverNumbers[2] and $pluginNumbers[1] === $serverNumbers[1]){ //If the plugin requires bug fixes in patches, being backwards compatible
 					continue;
 				}
 			}

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -413,7 +413,7 @@ class PluginManager{
 					continue;
 				}
 
-				if($pluginNumbers[2] > $serverNumbers[2]){ //If the plugin requires bug fixes in patches, being backwards compatible
+				if($pluginNumbers[2] > $serverNumbers[2] and $pluginNumbers[1] >= $serverNumbers[1]){ //If the plugin requires bug fixes in patches, being backwards compatible
 					continue;
 				}
 			}

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -413,7 +413,7 @@ class PluginManager{
 					continue;
 				}
 
-				if($pluginNumbers[2] > $serverNumbers[2] and $pluginNumbers[1] === $serverNumbers[1]){ //If the plugin requires bug fixes in patches, being backwards compatible
+				if($pluginNumbers[1] === $serverNumbers[1] and $pluginNumbers[2] > $serverNumbers[2]){ //If the plugin requires bug fixes in patches, being backwards compatible
 					continue;
 				}
 			}


### PR DESCRIPTION
PluginManager: Fix patch level check. to allow loading the plugin when the server's minor level is higher than the plugins declared minor level with matching majors.

## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
The problem relevant to this PR is fully described in #2335 
### Relevant issues
<!-- List relevant issues here -->
* Fixes #2335 

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
None
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
Allows plugins to load predictably when the server major level is the same and minor level is higher than the plugins declared requirements.
## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests

This was tested by changing the plugin API version of a test plugin on a 3.1.2dev instance.  
Results:
Plugin API 3.0.0 loaded
Plugin API 3.0.1 Loaded
Plugin API 3.0.2 Loaded
Plugin API 3.0.3 Loaded
Plugin API 3.0.14 Loaded
Plugin API 3.1.0 Loaded
Plugin API 3.1.1 Loaded
Plugin API 3.1.2 Loaded
Plugin API 3.1.3 Did not Load
Plugin API 3.1.14 Did not load.
Plugin API 3.2.0 Did not Load
Plugin API 3.2.1 Did not Load
Plugin API 3.2.2 Did not Load
Plugin API 3.2.3 Did not Load
Plugin API 3.2.14 Did not Load
