### PR TITLE
Allow entities to override createBaseNBT 

### DIFF
--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -356,6 +356,25 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 	}
 
 	/**
+	 * Creates the base NBT for the specified type of entity.
+	 *
+	 * @param int|string   $type
+	 * @param Vector3      $pos
+	 * @param null|Vector3 $motion
+	 * @param float        $yaw
+	 * @param float        $pitch
+	 * @return Entity|null
+	 */
+	public static function createBaseNBTForEntity($type, Vector3 $pos, ?Vector3 $motion = null , float $yaw = 0.0, float $pitch = 0.0) : ?CompoundTag{
+		if(isset(self::$knownEntities[$type])){
+			$class = self::$knownEntities[$type];
+			return $class::createBaseNBT($pos, $motion, $yaw, $pitch);
+		}
+
+		return null;
+	}
+
+	/**
 	 * @var Player[]
 	 */
 	protected $hasSpawned = [];

--- a/src/pocketmine/item/SpawnEgg.php
+++ b/src/pocketmine/item/SpawnEgg.php
@@ -34,18 +34,20 @@ class SpawnEgg extends Item{
 	}
 
 	public function onActivate(Player $player, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector) : bool{
-		$nbt = Entity::createBaseNBT($blockReplace->add(0.5, 0, 0.5), null, lcg_value() * 360, 0);
+		$nbt = Entity::createBaseNBTForEntity($this->meta, $blockReplace->add(0.5, 0, 0.5), null, lcg_value() * 360, 0);
 
-		if($this->hasCustomName()){
-			$nbt->setString("CustomName", $this->getCustomName());
-		}
+		if($nbt !== null){
+			if($this->hasCustomName()){
+				$nbt->setString("CustomName", $this->getCustomName());
+			}
 
-		$entity = Entity::createEntity($this->meta, $player->getLevel(), $nbt);
+			$entity = Entity::createEntity($this->meta, $player->getLevel(), $nbt);
 
-		if($entity instanceof Entity){
-			--$this->count;
-			$entity->spawnToAll();
-			return true;
+			if($entity instanceof Entity){
+				--$this->count;
+				$entity->spawnToAll();
+				return true;
+			}
 		}
 
 		return false;


### PR DESCRIPTION
## Introduction
This PR allows entities to override createBaseNBT in order to add additional NBT for entity spawning.
For example Sheep can override createBaseNBT in order to add color randomness.

### Relevant issues
/

-->

## Changes
### API changes
Added Entity::createBaseNBTForEntity

### Behavioural changes
/

## Backwards compatibility
No backwards incompatible changes.

## Follow-up
/

## Tests
/
