### PR TITLE
fix #1551 Slowness Effect levels >= 7 do not reset FOV when removed

### DIFF
--- a/src/pocketmine/entity/Effect.php
+++ b/src/pocketmine/entity/Effect.php
@@ -358,7 +358,7 @@ class Effect{
 				break;
 			case Effect::SLOWNESS:
 				$attr = $entity->getAttributeMap()->getAttribute(Attribute::MOVEMENT_SPEED);
-				$attr->setValue($attr->getValue() / (1 - 0.15 * $instance->getEffectLevel()));
+				$attr->setValue(max($attr->getMinValue(),$attr->getValue() / (1 - 0.15 * $instance->getEffectLevel())));
 				break;
 			case Effect::HEALTH_BOOST:
 				$entity->setMaxHealth($entity->getMaxHealth() - 4 * $instance->getEffectLevel());

--- a/src/pocketmine/entity/Effect.php
+++ b/src/pocketmine/entity/Effect.php
@@ -325,7 +325,7 @@ class Effect{
 				break;
 			case Effect::SLOWNESS:
 				$attr = $entity->getAttributeMap()->getAttribute(Attribute::MOVEMENT_SPEED);
-				$attr->setValue($attr->getValue() * (1 - 0.15 * $instance->getEffectLevel()), true);
+				$attr->setValue($attr->getDefaultValue() * (1 - 0.15 * $instance->getEffectLevel()), true);
 				break;
 
 			case Effect::HEALTH_BOOST:
@@ -358,7 +358,10 @@ class Effect{
 				break;
 			case Effect::SLOWNESS:
 				$attr = $entity->getAttributeMap()->getAttribute(Attribute::MOVEMENT_SPEED);
-				$attr->setValue(max($attr->getDefaultValue(),$attr->getValue() / (1 - 0.15 * $instance->getEffectLevel())));
+				$attr->setValue($attr->getDefaultValue());
+				if($entity->hasEffect(Effect::SPEED)) {
+					$attr->setValue($entity->getEffect(Effect::SPEED)->getEffectLevel() * (1 + 0.2 * $instance->getEffectLevel()));
+				}
 				break;
 			case Effect::HEALTH_BOOST:
 				$entity->setMaxHealth($entity->getMaxHealth() - 4 * $instance->getEffectLevel());

--- a/src/pocketmine/entity/Effect.php
+++ b/src/pocketmine/entity/Effect.php
@@ -360,7 +360,7 @@ class Effect{
 				$attr = $entity->getAttributeMap()->getAttribute(Attribute::MOVEMENT_SPEED);
 				$attr->setValue($attr->getDefaultValue());
 				if($entity->hasEffect(Effect::SPEED)) {
-					$attr->setValue($entity->getEffect(Effect::SPEED)->getEffectLevel() * (1 + 0.2 * $instance->getEffectLevel()));
+					$attr->setValue($attr->getValue() * (1 + 0.2 * $entity->getEffect(Effect::SPEED)->getEffectLevel()));
 				}
 				break;
 			case Effect::HEALTH_BOOST:

--- a/src/pocketmine/entity/Effect.php
+++ b/src/pocketmine/entity/Effect.php
@@ -358,7 +358,7 @@ class Effect{
 				break;
 			case Effect::SLOWNESS:
 				$attr = $entity->getAttributeMap()->getAttribute(Attribute::MOVEMENT_SPEED);
-				$attr->setValue(max($attr->getMinValue(),$attr->getValue() / (1 - 0.15 * $instance->getEffectLevel())));
+				$attr->setValue(max($attr->getDefaultValue(),$attr->getValue() / (1 - 0.15 * $instance->getEffectLevel())));
 				break;
 			case Effect::HEALTH_BOOST:
 				$entity->setMaxHealth($entity->getMaxHealth() - 4 * $instance->getEffectLevel());


### PR DESCRIPTION
slowness always has higher priority than speed

tested