### PR TITLE
Prepend parent name to permissions starting with a dot

### DIFF
--- a/src/pocketmine/permission/Permission.php
+++ b/src/pocketmine/permission/Permission.php
@@ -92,16 +92,24 @@ class Permission{
 	}
 
 	/**
-	 * @param string $name
-	 * @param array  $data
-	 * @param string $default
-	 * @param array  $output
-	 *
+	 * @param string      $name
+	 * @param array       $data
+	 * @param string      $default
+	 * @param array       $output
+	 * @param null|string $parentName
 	 * @return Permission
 	 *
 	 * @throws \Exception
 	 */
-	public static function loadPermission(string $name, array $data, string $default = self::DEFAULT_OP, array &$output = []) : Permission{
+	public static function loadPermission(string $name, array $data, string $default = self::DEFAULT_OP, array &$output = [], ?string $parentName = null) : Permission{
+		if($name{0} === "."){
+			if($parentName === null){
+				throw new \InvalidStateException("Permission names must not start with a dot");
+			}
+
+			$name = $parentName . $name;
+		}
+
 		$desc = null;
 		$children = [];
 		if(isset($data["default"])){
@@ -117,7 +125,7 @@ class Permission{
 			if(is_array($data["children"])){
 				foreach($data["children"] as $k => $v){
 					if(is_array($v)){
-						if(($perm = self::loadPermission($k, $v, $default, $output)) !== null){
+						if(($perm = self::loadPermission($k, $v, $default, $output, $name)) !== null){
 							$output[] = $perm;
 						}
 					}


### PR DESCRIPTION
## Introduction
Conventionally <sup>[citation needed]</sup>, permission names are constructed according to the permission inheritance. For example, if a permission is a child of the permission `example.permission`, the child permission name should be `example.permission.` plus its own part of the name. This pull request eases declaring permissions by allowing plugins to skip the parent permission name.

### Targeted version
This pull request is targeted at API 4.0.0 as it contains potential backward-incompatible changes.

## Changes
### API changes
Permissions declared in plugin.yml can no longer use names starting with `.`. Using `.` in a root permission will trigger an InvalidStateException. Using `.` in a child permission will mean prepending with the parent permission.

### Behavioural changes
nil

## Backwards compatibility
The pull request is backwards-incompatible, as it changes the behaviour of plugins with permissions starting with `.`.

However, none of the latest build of 2377 plugins built on Poggit-CI (1220 of which declares permissions) uses permissions starting with `.`. Therefore, I consider this change to be *marginally* backward-compatible.

## Tests
Tests will be written for this change after reviews have been given on the idea.