### PR TITLE
Network buffering

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -90,6 +90,7 @@ use pocketmine\nbt\tag\ByteTag;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\DoubleTag;
 use pocketmine\nbt\tag\ListTag;
+use pocketmine\network\mcpe\CompressBatchPromise;
 use pocketmine\network\mcpe\NetworkCipher;
 use pocketmine\network\mcpe\NetworkSession;
 use pocketmine\network\mcpe\protocol\AdventureSettingsPacket;
@@ -892,7 +893,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		unset($this->loadQueue[$index]);
 	}
 
-	public function sendChunk(int $x, int $z, string $payload){
+	public function sendChunk(int $x, int $z, CompressBatchPromise $promise){
 		if(!$this->isConnected()){
 			return;
 		}
@@ -900,7 +901,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		$this->usedChunks[Level::chunkHash($x, $z)] = true;
 		$this->chunkLoadCount++;
 
-		$this->networkSession->sendEncoded($payload);
+		$this->networkSession->queueCompressed($promise);
 
 		if($this->spawned){
 			foreach($this->level->getChunkEntities($x, $z) as $entity){

--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -2538,10 +2538,6 @@ class Server{
 
 		++$this->tickCounter;
 
-		Timings::$connectionTimer->startTiming();
-		$this->network->tick();
-		Timings::$connectionTimer->stopTiming();
-
 		Timings::$schedulerTimer->startTiming();
 		$this->pluginManager->tickSchedulers($this->tickCounter);
 		Timings::$schedulerTimer->stopTiming();
@@ -2551,6 +2547,10 @@ class Server{
 		Timings::$schedulerAsyncTimer->stopTiming();
 
 		$this->checkTickUpdates($this->tickCounter);
+
+		Timings::$connectionTimer->startTiming();
+		$this->network->tick();
+		Timings::$connectionTimer->stopTiming();
 
 		if(($this->tickCounter % 20) === 0){
 			if($this->doTitleTick){

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -69,6 +69,7 @@ use pocketmine\metadata\MetadataValue;
 use pocketmine\nbt\tag\ListTag;
 use pocketmine\nbt\tag\StringTag;
 use pocketmine\network\mcpe\ChunkRequestTask;
+use pocketmine\network\mcpe\CompressBatchPromise;
 use pocketmine\network\mcpe\protocol\DataPacket;
 use pocketmine\network\mcpe\protocol\LevelEventPacket;
 use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
@@ -122,7 +123,7 @@ class Level implements ChunkManager, Metadatable{
 	/** @var Block[][] */
 	private $blockCache = [];
 
-	/** @var string[] */
+	/** @var CompressBatchPromise[] */
 	private $chunkCache = [];
 
 	/** @var int */
@@ -2459,7 +2460,7 @@ class Level implements ChunkManager, Metadatable{
 		$this->chunkSendQueue[$index][$player->getLoaderId()] = $player;
 	}
 
-	private function sendChunkFromCache(int $x, int $z){
+	private function sendCachedChunk(int $x, int $z){
 		if(isset($this->chunkSendQueue[$index = Level::chunkHash($x, $z)])){
 			foreach($this->chunkSendQueue[$index] as $player){
 				/** @var Player $player */
@@ -2487,10 +2488,12 @@ class Level implements ChunkManager, Metadatable{
 						continue;
 					}
 				}
+
 				if(isset($this->chunkCache[$index])){
-					$this->sendChunkFromCache($x, $z);
+					$this->sendCachedChunk($x, $z);
 					continue;
 				}
+
 				$this->timings->syncChunkSendPrepareTimer->startTiming();
 
 				$chunk = $this->chunks[$index] ?? null;
@@ -2499,7 +2502,30 @@ class Level implements ChunkManager, Metadatable{
 				}
 				assert($chunk->getX() === $x and $chunk->getZ() === $z, "Chunk coordinate mismatch: expected $x $z, but chunk has coordinates " . $chunk->getX() . " " . $chunk->getZ() . ", did you forget to clone a chunk before setting?");
 
-				$this->server->getAsyncPool()->submitTask($task = new ChunkRequestTask($this, $x, $z, $chunk));
+				/*
+				 * we don't send promises directly to the players here because unresolved promises of chunk sending
+				 * would slow down the sending of other packets, especially if a chunk takes a long time to prepare.
+				 */
+
+				$promise = new CompressBatchPromise();
+				$promise->onResolve(function(CompressBatchPromise $promise) use ($x, $z, $index): void{
+					if(!$this->closed){
+						$this->timings->syncChunkSendTimer->startTiming();
+
+						unset($this->chunkSendTasks[$index]);
+
+						$this->chunkCache[$index] = $promise;
+						$this->sendCachedChunk($x, $z);
+						if(!$this->server->getMemoryManager()->canUseChunkCache()){
+							unset($this->chunkCache[$index]);
+						}
+
+						$this->timings->syncChunkSendTimer->stopTiming();
+					}else{
+						$this->server->getLogger()->debug("Dropped prepared chunk $x $z due to level not loaded");
+					}
+				});
+				$this->server->getAsyncPool()->submitTask($task = new ChunkRequestTask($x, $z, $chunk, $promise));
 				$this->chunkSendTasks[$index] = $task;
 
 				$this->timings->syncChunkSendPrepareTimer->stopTiming();
@@ -2507,21 +2533,6 @@ class Level implements ChunkManager, Metadatable{
 
 			$this->timings->syncChunkSendTimer->stopTiming();
 		}
-	}
-
-	public function chunkRequestCallback(int $x, int $z, string $payload){
-		$this->timings->syncChunkSendTimer->startTiming();
-
-		$index = Level::chunkHash($x, $z);
-		unset($this->chunkSendTasks[$index]);
-
-		$this->chunkCache[$index] = $payload;
-		$this->sendChunkFromCache($x, $z);
-		if(!$this->server->getMemoryManager()->canUseChunkCache()){
-			unset($this->chunkCache[$index]);
-		}
-
-		$this->timings->syncChunkSendTimer->stopTiming();
 	}
 
 	/**

--- a/src/pocketmine/network/mcpe/CompressBatchPromise.php
+++ b/src/pocketmine/network/mcpe/CompressBatchPromise.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\network\mcpe;
+
+class CompressBatchPromise{
+	/** @var callable[] */
+	private $callbacks = [];
+
+	/** @var string|null */
+	private $result = null;
+
+	public function onResolve(callable $callback) : void{
+		if($this->result !== null){
+			$callback($this);
+		}else{
+			$this->callbacks[] = $callback;
+		}
+	}
+
+	public function resolve(string $result) : void{
+		if($this->result !== null){
+			throw new \InvalidStateException("Cannot resolve promise more than once");
+		}
+		$this->result = $result;
+		foreach($this->callbacks as $callback){
+			$callback($this);
+		}
+		$this->callbacks = [];
+	}
+
+	public function getResult() : string{
+		if($this->result === null){
+			throw new \InvalidStateException("Promise has not yet been resolved");
+		}
+		return $this->result;
+	}
+
+	public function hasResult() : bool{
+		return $this->result !== null;
+	}
+}

--- a/src/pocketmine/network/mcpe/CompressBatchTask.php
+++ b/src/pocketmine/network/mcpe/CompressBatchTask.php
@@ -26,20 +26,20 @@ namespace pocketmine\network\mcpe;
 use pocketmine\scheduler\AsyncTask;
 use pocketmine\Server;
 
-class CompressBatchedTask extends AsyncTask{
+class CompressBatchTask extends AsyncTask{
 
 	private $level;
 	private $data;
 
 	/**
-	 * @param PacketStream     $stream
-	 * @param NetworkSession[] $targets
-	 * @param int              $compressionLevel
+	 * @param PacketStream         $stream
+	 * @param int                  $compressionLevel
+	 * @param CompressBatchPromise $promise
 	 */
-	public function __construct(PacketStream $stream, array $targets, int $compressionLevel){
+	public function __construct(PacketStream $stream, int $compressionLevel, CompressBatchPromise $promise){
 		$this->data = $stream->buffer;
 		$this->level = $compressionLevel;
-		$this->storeLocal($targets);
+		$this->storeLocal($promise);
 	}
 
 	public function onRun() : void{
@@ -47,9 +47,8 @@ class CompressBatchedTask extends AsyncTask{
 	}
 
 	public function onCompletion(Server $server) : void{
-		/** @var NetworkSession[] $targets */
-		$targets = $this->fetchLocal();
-
-		$server->broadcastPacketsCallback($this->getResult(), $targets);
+		/** @var CompressBatchPromise $promise */
+		$promise = $this->fetchLocal();
+		$promise->resolve($this->getResult());
 	}
 }

--- a/src/pocketmine/network/mcpe/NetworkSession.php
+++ b/src/pocketmine/network/mcpe/NetworkSession.php
@@ -68,11 +68,19 @@ class NetworkSession{
 	/** @var NetworkCipher */
 	private $cipher;
 
+	/** @var PacketStream|null */
+	private $sendBuffer;
+
+	/** @var \SplQueue|CompressBatchPromise[] */
+	private $compressedQueue;
+
 	public function __construct(Server $server, NetworkInterface $interface, string $ip, int $port){
 		$this->server = $server;
 		$this->interface = $interface;
 		$this->ip = $ip;
 		$this->port = $port;
+
+		$this->compressedQueue = new \SplQueue();
 
 		$this->connectTime = time();
 		$this->server->getNetwork()->scheduleSessionTick($this);
@@ -206,10 +214,10 @@ class NetworkSession{
 				return false;
 			}
 
-			//TODO: implement buffering (this is just a quick fix)
-			$stream = new PacketStream();
-			$stream->putPacket($packet);
-			$this->server->batchPackets([$this], $stream, true, $immediate);
+			$this->addToSendBuffer($packet);
+			if($immediate){
+				$this->flushSendBuffer(true);
+			}
 
 			return true;
 		}finally{
@@ -217,7 +225,59 @@ class NetworkSession{
 		}
 	}
 
-	public function sendEncoded(string $payload, bool $immediate = false) : void{
+	/**
+	 * @internal
+	 * @param DataPacket $packet
+	 */
+	public function addToSendBuffer(DataPacket $packet) : void{
+		$timings = Timings::getSendDataPacketTimings($packet);
+		$timings->startTiming();
+		try{
+			if($this->sendBuffer === null){
+				$this->sendBuffer = new PacketStream();
+			}
+			$this->sendBuffer->putPacket($packet);
+			$this->server->getNetwork()->scheduleSessionTick($this);
+		}finally{
+			$timings->stopTiming();
+		}
+	}
+
+	private function flushSendBuffer(bool $immediate = false) : void{
+		if($this->sendBuffer !== null){
+			$promise = $this->server->prepareBatch($this->sendBuffer, $immediate);
+			$this->sendBuffer = null;
+			$this->queueCompressed($promise, $immediate);
+		}
+	}
+
+	public function queueCompressed(CompressBatchPromise $payload, bool $immediate = false) : void{
+		$this->flushSendBuffer($immediate); //Maintain ordering if possible
+		if($immediate){
+			//Skips all queues
+			$this->sendEncoded($payload->getResult(), true);
+		}else{
+			$this->compressedQueue->enqueue($payload);
+			$payload->onResolve(function(CompressBatchPromise $payload) : void{
+				if($this->connected and $this->compressedQueue->bottom() === $payload){
+					while(!$this->compressedQueue->isEmpty()){
+						/** @var CompressBatchPromise $current */
+						$current = $this->compressedQueue->bottom();
+						if($current->hasResult()){
+							$this->compressedQueue->dequeue();
+
+							$this->sendEncoded($current->getResult());
+						}else{
+							//can't send any more queued until this one is ready
+							break;
+						}
+					}
+				}
+			});
+		}
+	}
+
+	private function sendEncoded(string $payload, bool $immediate = false) : void{
 		if($this->cipher !== null){
 			Timings::$playerNetworkSendEncryptTimer->startTiming();
 			$payload = $this->cipher->encrypt($payload);
@@ -289,6 +349,8 @@ class NetworkSession{
 		$this->handler = null;
 		$this->interface = null;
 		$this->player = null;
+		$this->sendBuffer = null;
+		$this->compressedQueue = null;
 	}
 
 	public function enableEncryption(string $encryptionKey, string $handshakeJwt) : void{
@@ -345,7 +407,10 @@ class NetworkSession{
 			return true; //keep ticking until timeout
 		}
 
-		//TODO: more stuff on tick
+		if($this->sendBuffer !== null){
+			$this->flushSendBuffer();
+		}
+
 		return false;
 	}
 }

--- a/src/pocketmine/network/mcpe/NetworkSession.php
+++ b/src/pocketmine/network/mcpe/NetworkSession.php
@@ -260,6 +260,9 @@ class NetworkSession{
 			$this->compressedQueue->enqueue($payload);
 			$payload->onResolve(function(CompressBatchPromise $payload) : void{
 				if($this->connected and $this->compressedQueue->bottom() === $payload){
+					$this->compressedQueue->dequeue(); //result unused
+					$this->sendEncoded($payload->getResult());
+
 					while(!$this->compressedQueue->isEmpty()){
 						/** @var CompressBatchPromise $current */
 						$current = $this->compressedQueue->bottom();

--- a/src/pocketmine/network/mcpe/handler/PreSpawnSessionHandler.php
+++ b/src/pocketmine/network/mcpe/handler/PreSpawnSessionHandler.php
@@ -87,7 +87,7 @@ class PreSpawnSessionHandler extends SessionHandler{
 		$this->player->sendAllInventories();
 		$this->player->getInventory()->sendCreativeContents();
 		$this->player->getInventory()->sendHeldItem($this->player);
-		$this->session->sendEncoded($this->server->getCraftingManager()->getCraftingDataPacket());
+		$this->session->queueCompressed($this->server->getCraftingManager()->getCraftingDataPacket());
 
 		$this->server->sendFullPlayerListData($this->player);
 	}


### PR DESCRIPTION
## Introduction
This introduces buffering for packet batching.

Prior to these changes, every packet would be compressed by itself and sent over RakNet directly. This is an enormous waste of bytes due to the overhead of sending a packet:
- 2 bytes (zlib header)
- 1 byte (zlib block header)
- 4 bytes (zlib block length)
- 4 bytes (adler32)
- 8 bytes (encryption checksum)
- 10 bytes (RakNet datagram info)
- 10 bytes IF packet has to be split

This means that sending a single packet of 1 byte can incur up to 29 bytes of extra overhead in the current architecture. This is a huge waste.

These changes reduce this wastage by buffering packets per-session until the end of the tick before sending.

These changes also have a performance advantage due to less compression, more batched compressible data, less data to be sent overall, less checksums, etc.

## Changes
### Behavioural changes
- Async compression is now reliable and does not cause race conditions due to queuing.
- Bandwidth usage reductions, especially when sending lots of small packets.
- Performance improvements.

This has been PR'd because of concerns over the latency when mixing buffering types (for example level buffering). This should be addressed before this is merged.

## Tests
Has been tested in-game, but needs more work to reduce sending latency where possible.