### PR TITLE
Added experimental support for ZOPFLI chunk compression

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -71,6 +71,7 @@ use pocketmine\nbt\tag\LongTag;
 use pocketmine\nbt\tag\ShortTag;
 use pocketmine\nbt\tag\StringTag;
 use pocketmine\network\AdvancedNetworkInterface;
+use pocketmine\network\mcpe\ChunkRequestTask;
 use pocketmine\network\mcpe\CompressBatchedTask;
 use pocketmine\network\mcpe\NetworkCipher;
 use pocketmine\network\mcpe\NetworkCompression;
@@ -1546,6 +1547,15 @@ class Server{
 			}
 			$this->networkCompressionAsync = (bool) $this->getProperty("network.async-compression", true);
 
+			ChunkRequestTask::$ZOPFLI_COMPRESSION = (bool) $this->getProperty("network.zopfli-chunk-compression", false);
+			if(ChunkRequestTask::$ZOPFLI_COMPRESSION){
+				if(!extension_loaded('zopfli')){
+					$this->logger->error("Zopfli chunk compression requires the zopfli extension");
+					ChunkRequestTask::$ZOPFLI_COMPRESSION = false;
+				}else{
+					$this->logger->debug("Zopfli chunk compression enabled");
+				}
+			}
 			NetworkCipher::$ENABLED = (bool) $this->getProperty("network.enable-encryption", true);
 
 			$this->autoTickRate = (bool) $this->getProperty("level-settings.auto-tick-rate", true);

--- a/src/pocketmine/network/mcpe/NetworkCompression.php
+++ b/src/pocketmine/network/mcpe/NetworkCompression.php
@@ -44,4 +44,16 @@ final class NetworkCompression{
 	public static function compress(string $payload, ?int $compressionLevel = null) : string{
 		return zlib_encode($payload, ZLIB_ENCODING_DEFLATE, $compressionLevel ?? self::$LEVEL);
 	}
+
+	/**
+	 * Extremely slow but good ZLIB-compatible compression using ZOPFLI (if available)
+	 *
+	 * @param string $payload
+	 * @param int    $iterations Higher = better compression but more CPU cost
+	 *
+	 * @return string
+	 */
+	public static function zopfliCompress(string $payload, int $iterations = 1) : string{
+		return zopfli_compress($payload, $iterations);
+	}
 }

--- a/src/pocketmine/resources/pocketmine.yml
+++ b/src/pocketmine/resources/pocketmine.yml
@@ -92,6 +92,9 @@ network:
  compression-level: 7
  #Use AsyncTasks for compression. Adds half/one tick delay, less CPU load on main thread
  async-compression: false
+ #Compress chunks using ZOPFLI instead of ZLIB (if available). 10-20% bandwidth savings for significant extra CPU cost.
+ #This works best for static maps which are immutable and get a lot of players (to ensure high cache hit rate)
+ zopfli-chunk-compression: false
  #Experimental, only for Windows. Tries to use UPnP to automatically port forward
  upnp-forwarding: false
  #Maximum size in bytes of packets sent over the network (default 1492 bytes). Packets larger than this will be


### PR DESCRIPTION
## Introduction
This PR introduces support for using ZOPFLI to super-compress chunks.

ZOPFLI can produce outputs 10-20% smaller than ZLIB level 9 does, but at a huge extra CPU cost.
This huge CPU cost (generally a couple of orders of magnitude) may be worth it for big servers which get lots of traffic, whose maps are static (resulting in a very high percentage of cache hits).

If the map is immutable, the tradeoff between CPU cost and bandwidth is massively skewed in favour of saving bandwidth, since the cache can be primed once and then used many times.

Decompression performance is not affected by this, so clients won't experience any performance difference, although they will have less bandwidth used.

## Changes
### API changes
None.

### Behavioural changes
If the `zopfli` extension is present and `network.zopfli-chunk-compression` is `true`, ZOPFLI compression will be used to compress chunks.

Please be aware that this IS NOT intended for most servers. If you do any kind of building or otherwise modify the map (such as on a creative server) this will just cause a huge loss of performance because the cache in such circumstances has to constantly be recreated.

This is expected to be best in lobby server maps where the world cannot be modified, so that the cache can be primed once and used lots of times.

## Tests
Has been tested using a 1.5.0 client.