### PR TITLE
Added CommandEvent, deprecated (Remote)?ServerCommandEvent

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -39,6 +39,7 @@ use pocketmine\event\HandlerList;
 use pocketmine\event\level\LevelInitEvent;
 use pocketmine\event\level\LevelLoadEvent;
 use pocketmine\event\player\PlayerDataSaveEvent;
+use pocketmine\event\server\CommandEvent;
 use pocketmine\event\server\QueryRegenerateEvent;
 use pocketmine\event\server\ServerCommandEvent;
 use pocketmine\inventory\CraftingManager;
@@ -1940,10 +1941,20 @@ class Server{
 	 *
 	 * @param CommandSender $sender
 	 * @param string        $commandLine
+	 * @param bool          $internal
 	 *
 	 * @return bool
 	 */
-	public function dispatchCommand(CommandSender $sender, string $commandLine) : bool{
+	public function dispatchCommand(CommandSender $sender, string $commandLine, bool $internal = false) : bool{
+		if(!$internal){
+			$this->pluginManager->callEvent($ev = new CommandEvent($sender, $commandLine));
+			if($ev->isCancelled()){
+				return false;
+			}
+
+			$commandLine = $ev->getCommand();
+		}
+
 		if($this->commandMap->dispatch($sender, $commandLine)){
 			return true;
 		}

--- a/src/pocketmine/command/FormattedCommandAlias.php
+++ b/src/pocketmine/command/FormattedCommandAlias.php
@@ -59,7 +59,7 @@ class FormattedCommandAlias extends Command{
 		}
 
 		foreach($commands as $command){
-			$result |= Server::getInstance()->dispatchCommand($sender, $command);
+			$result |= Server::getInstance()->dispatchCommand($sender, $command, true);
 		}
 
 		return (bool) $result;

--- a/src/pocketmine/event/server/CommandEvent.php
+++ b/src/pocketmine/event/server/CommandEvent.php
@@ -27,16 +27,14 @@ use pocketmine\command\CommandSender;
 use pocketmine\event\Cancellable;
 
 /**
- * Called when the console runs a command, early in the process
+ * Called when any CommandSender runs a command, early in the process
  *
  * You don't want to use this except for a few cases like logging commands,
  * blocking commands on certain places, or applying modifiers.
  *
  * The message DOES NOT contain a slash at the start
- *
- * @deprecated Use CommandEvent instead.
  */
-class ServerCommandEvent extends ServerEvent implements Cancellable{
+class CommandEvent extends ServerEvent implements Cancellable{
 	/** @var string */
 	protected $command;
 

--- a/src/pocketmine/event/server/RemoteServerCommandEvent.php
+++ b/src/pocketmine/event/server/RemoteServerCommandEvent.php
@@ -27,6 +27,8 @@ use pocketmine\command\CommandSender;
 
 /**
  * This event is called when a command is received over RCON.
+ *
+ * @deprecated Use CommandEvent instead.
  */
 class RemoteServerCommandEvent extends ServerCommandEvent{
 


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Currently, plugins have to handle ServerCommandEvent and PlayerCommandPreprocessEvent separately to catch all commands by players and console/RCON. Not only is this inconvenient, but this also prevents plugins from catching events from other CommandSender types. This pull request provides a generic event `pocketmine\event\server\CommandEvent` that covers all CommandSender types.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
- Added `pocketmine\event\server\CommandEvent`
- Added an optional `$internal` parameter to `pocketmine\Server::dispatchCommand()`, which prevents `CommandEvent` from getting called
- Deprecated `pocketmine\event\server\{ServerCommandEvent, RemoteServerCommandEvent}`

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
_nil_

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Two events have been deprecated. This does not (yet) have any impact on backward compatibility.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
_nil_

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
_nil_