### PR TITLE
Config: Properly prevent keys getting transformed into bools

### DIFF
--- a/src/pocketmine/utils/Config.php
+++ b/src/pocketmine/utils/Config.php
@@ -110,7 +110,7 @@ class Config{
 	 * @return string
 	 */
 	public static function fixYAMLIndexes(string $str) : string{
-		return preg_replace("#^([ ]*)([a-zA-Z_]{1}[ ]*)\\:$#m", "$1\"$2\":", $str);
+		return preg_replace("#^([\t ]*)(y|Y|yes|Yes|YES|n|N|no|No|NO|true|True|TRUE|false|False|FALSE|on|On|ON|off|Off|OFF)([\t ]*)\:#m", "$1\"$2\"$3:", $str);
 	}
 
 	/**


### PR DESCRIPTION
## Introduction
Many plugin developers have fallen into the trap of trying to store coordinates in YAML configs, like this:
```yaml
x: 1
y: 2
z: 3
```
which, when parsed by YAML, results in the following astonishing behaviour:
```
array(3) {
  ["x"]=>
  int(1)
  [1]=>
  int(2)
  ["z"]=>
  int(3)
}
```

Notice that the `y` key has been transformed into a `1`.

Why does this astonishing behaviour occur, you might ask?
The answer lies with the YAML 1.1 specification, as seen here: http://yaml.org/type/bool.html
YAML 1.2 removes this idiocy, but our YAML extension doesn't support the YAML 1.2 specification.

When booleans are used as keys in an array, they are transformed into their integer equivalents, i.e. `0` and `1`.
This bug-like and obscure behaviour is undesirable for plugin developers for obvious reasons. It might be useful for values but certainly not for keys.

The original regex almost completely failed at its objective, because it a) only worked if there was no value for the key, and b) did not prevent all such occurrences getting transformed, while quoting patterns that would not get transformed anyway.

### Relevant issues
None listed, but many plugin devs have hit this issue.

## Changes
### Behavioural changes
YAML with keys `y`, `yes`, `n`, `no`, `true`, `false`, `on`, `off` (and their cased variants) will no longer be transformed into `1` or `0`.

## Backwards compatibility
I doubt any plugin dev made use of this annoying behaviour, but nonetheless it is a behavioural change that could affect plugins, so this is targeting 3.2 (open to discussion/retarget).

## Follow-up
Search for a YAML 1.2 compliant implementation to replace the one we are using now.

## Tests
```yaml
x: 1
y: 2
z: 3
```
now emits
```
array(3) {
  ["x"]=>
  int(1)
  ["y"]=>
  int(2)
  ["z"]=>
  int(3)
}
```
instead of
```
array(3) {
  ["x"]=>
  int(1)
  [1]=>
  int(2)
  ["z"]=>
  int(3)
}
```