### PR TITLE
Tile: Be explicit about not calling Tile::createNBT()

### DIFF
--- a/src/pocketmine/tile/Tile.php
+++ b/src/pocketmine/tile/Tile.php
@@ -208,6 +208,9 @@ abstract class Tile extends Position{
 	 * @return CompoundTag
 	 */
 	public static function createNBT(Vector3 $pos, ?int $face = null, ?Item $item = null, ?Player $player = null) : CompoundTag{
+		if(static::class === self::class){
+			throw new \BadMethodCallException(__METHOD__ . " must be called from the scope of a child class");
+		}
 		$nbt = new CompoundTag("", [
 			new StringTag(self::TAG_ID, static::getSaveId()),
 			new IntTag(self::TAG_X, (int) $pos->x),


### PR DESCRIPTION
## Introduction
A common pitfall developers fall into with this function is that it has to be called from the scope of the tile class you're creating NBT for, but people commonly do Tile::createNBT() directly, which then results in cryptic "Tile is not registered" errors. This now throws a BadMethodCallException instead to be fully clear about this.

In the future this will be removed completely once NBT is no longer required to create a tile, but for now this is a confusing issue that should be dealt with.

### Relevant issues
No GitHub issues, but many plugin developers have complained about this problem.

## Changes
### API changes
`Tile::createNBT()` now throws a `BadMethodCallException` if called directly and not from the scope of a child class.

## Backwards compatibility
This does not pose backwards compatibility breaks for already-working code.

## Tests
```
		var_dump(Chest::createNBT(new Vector3(0, 0, 0)));
		var_dump(Tile::createNBT(new Vector3(0, 0, 0)));
```