### PR TITLE
PacketPool: Fixed empty packet handling

### DIFF
--- a/src/pocketmine/network/mcpe/protocol/PacketPool.php
+++ b/src/pocketmine/network/mcpe/protocol/PacketPool.php
@@ -168,11 +168,11 @@ class PacketPool{
 	public static function getPacket(string $buffer) : DataPacket{
 		$offset = 0;
 		if(strlen($buffer) > 0){
-        	$pid = Binary::readUnsignedVarInt($buffer, $offset);
-        }else{
-        	$pid = -1;
-        }
-        $pk = static::getPacketById($pid);
+			$pid = Binary::readUnsignedVarInt($buffer, $offset);
+		}else{
+			$pid = -1;
+		}
+		$pk = static::getPacketById($pid);
 		$pk->setBuffer($buffer, $offset);
 
 		return $pk;

--- a/src/pocketmine/network/mcpe/protocol/PacketPool.php
+++ b/src/pocketmine/network/mcpe/protocol/PacketPool.php
@@ -167,7 +167,12 @@ class PacketPool{
 	 */
 	public static function getPacket(string $buffer) : DataPacket{
 		$offset = 0;
-		$pk = static::getPacketById(Binary::readUnsignedVarInt($buffer, $offset));
+		if(strlen($buffer) > 0){
+        	$pid = Binary::readUnsignedVarInt($buffer, $offset);
+        }else{
+        	$pid = -1;
+        }
+        $pk = static::getPacketById($pid);
 		$pk->setBuffer($buffer, $offset);
 
 		return $pk;


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Fixed empty packet handling

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
None

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
None
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
Error fix

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Fixed empty packet handling:
Crashdump:
```
2018-08-19 [11:08:49] [Server thread/CRITICAL]: ErrorException: "Uninitialized string offset: 0" (EXCEPTION) in "vendor/pocketmine/binaryutils/src/Binary" at line 448
2018-08-19 [11:08:49] [Server thread/DEBUG]: #0 vendor/pocketmine/binaryutils/src/Binary(448): pocketmine\utils\Utils::errorExceptionHandler(integer 8, string Uninitialized string offset: 0, string phar:///root/PocketMine-MP.phar/vendor/pocketmine/binaryutils/src/Binary.php, integer 448, array Array())
2018-08-19 [11:08:49] [Server thread/DEBUG]: #1 src/pocketmine/network/mcpe/protocol/PacketPool(170): pocketmine\utils\Binary::readUnsignedVarInt(string , integer 1)
2018-08-19 [11:08:49] [Server thread/DEBUG]: #2 src/pocketmine/network/mcpe/NetworkSession(186): pocketmine\network\mcpe\protocol\PacketPool::getPacket(string )
2018-08-19 [11:08:49] [Server thread/DEBUG]: #3 src/pocketmine/network/mcpe/RakLibInterface(135): pocketmine\network\mcpe\NetworkSession->handleEncoded(string x.c.f`.....N...}I..)
2018-08-19 [11:08:49] [Server thread/DEBUG]: #4 vendor/pocketmine/raklib/src/server/ServerHandler(98): pocketmine\network\mcpe\RakLibInterface->handleEncapsulated(string 88.230.227.203 2104, raklib\protocol\EncapsulatedPacket object, integer 0)
2018-08-19 [11:08:49] [Server thread/DEBUG]: #5 src/pocketmine/network/mcpe/RakLibInterface(75): raklib\server\ServerHandler->handlePacket()
2018-08-19 [11:08:49] [Server thread/DEBUG]: #6 vendor/pocketmine/snooze/src/SleeperHandler(120): pocketmine\network\mcpe\RakLibInterface->pocketmine\network\mcpe{closure}()
2018-08-19 [11:08:49] [Server thread/DEBUG]: #7 vendor/pocketmine/snooze/src/SleeperHandler(82): pocketmine\snooze\SleeperHandler->processNotifications()
2018-08-19 [11:08:49] [Server thread/DEBUG]: #8 src/pocketmine/Server(2510): pocketmine\snooze\SleeperHandler->sleepUntil(double 1534666129.5162)
2018-08-19 [11:08:49] [Server thread/DEBUG]: #9 src/pocketmine/Server(2379): pocketmine\Server->tickProcessor()
2018-08-19 [11:08:49] [Server thread/DEBUG]: #10 src/pocketmine/Server(1888): pocketmine\Server->start()
2018-08-19 [11:08:49] [Server thread/DEBUG]: #11 src/pocketmine/PocketMine(246): pocketmine\Server->__construct(BaseClassLoader object, pocketmine\utils\MainLogger object, string /root/, string /root/plugins/)
2018-08-19 [11:08:49] [Server thread/DEBUG]: #12 /root/PocketMine-MP.phar(1): require_once(string phar:///root/PocketMine-MP.phar/src/pocketmine/PocketMine.php)
2018-08-19 [11:08:49] [RakLibServer thread/NOTICE]: Blocked 88.230.227.203 for 5 seconds
```

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--
None

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Tested.
