### PR TITLE
Enable ANSI support for git bash

### DIFF
--- a/src/pocketmine/utils/Terminal.php
+++ b/src/pocketmine/utils/Terminal.php
@@ -64,7 +64,7 @@ abstract class Terminal{
 						getenv('TERM') !== false or //Console says it supports colours
 						(function_exists('sapi_windows_vt100_support') and sapi_windows_vt100_support($stdout)) //we're on windows and have vt100 support
 					)
-				));
+				) or getenv('MSYSTEM') !== false);
 				fclose($stdout);
 			}
 


### PR DESCRIPTION
## Introduction
Before:
![default](https://user-images.githubusercontent.com/13465245/44392044-ee07af00-a539-11e8-9aac-69c8d833f588.png)
After:
![default](https://user-images.githubusercontent.com/13465245/44391981-ce708680-a539-11e8-9dcd-5d2f48a5e04b.png)

## Tests
Tested on git bash and Debian 9.
