### PR TITLE
Change air tank regeneration to match UA

### DIFF
--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -695,7 +695,7 @@ abstract class Living extends Entity implements Damageable{
 	}
 
 	/**
-	 * Ticks the entity's air supply when it cannot breathe.
+	 * Ticks the entity's air supply, consuming it when underwater and regenerating it when out of water.
 	 *
 	 * @param int $tickDiff
 	 *

--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -665,13 +665,8 @@ abstract class Living extends Entity implements Damageable{
 				$this->attack($ev);
 			}
 
-			if(!$this->canBreathe()){
-				$this->setBreathing(false);
-				$this->doAirSupplyTick($tickDiff);
+			if($this->doAirSupplyTick($tickDiff)){
 				$hasUpdate = true;
-			}elseif(!$this->isBreathing()){
-				$this->setBreathing(true);
-				$this->setAirSupplyTicks($this->getMaxAirSupplyTicks());
 			}
 		}
 
@@ -701,21 +696,41 @@ abstract class Living extends Entity implements Damageable{
 
 	/**
 	 * Ticks the entity's air supply when it cannot breathe.
+	 *
 	 * @param int $tickDiff
+	 *
+	 * @return bool
 	 */
-	protected function doAirSupplyTick(int $tickDiff) : void{
-		if(($respirationLevel = $this->armorInventory->getHelmet()->getEnchantmentLevel(Enchantment::RESPIRATION)) <= 0 or
-			lcg_value() <= (1 / ($respirationLevel + 1))
-		){
-			$ticks = $this->getAirSupplyTicks() - $tickDiff;
+	protected function doAirSupplyTick(int $tickDiff) : bool{
+		$ticks = $this->getAirSupplyTicks();
+		$oldTicks = $ticks;
+		if(!$this->canBreathe()){
+			$this->setBreathing(false);
 
-			if($ticks <= -20){
-				$this->setAirSupplyTicks(0);
-				$this->onAirExpired();
-			}else{
-				$this->setAirSupplyTicks($ticks);
+			if(($respirationLevel = $this->armorInventory->getHelmet()->getEnchantmentLevel(Enchantment::RESPIRATION)) <= 0 or
+				lcg_value() <= (1 / ($respirationLevel + 1))
+			){
+				$ticks -= $tickDiff;
+				if($ticks <= -20){
+					$ticks = 0;
+					$this->onAirExpired();
+				}
+			}
+		}elseif(!$this->isBreathing()){
+			if($ticks < ($max = $this->getMaxAirSupplyTicks())){
+				$ticks += $tickDiff * 5;
+			}
+			if($ticks >= $max){
+				$ticks = $max;
+				$this->setBreathing(true);
 			}
 		}
+
+		if($ticks !== $oldTicks){
+			$this->setAirSupplyTicks($ticks);
+		}
+
+		return $ticks !== $oldTicks;
 	}
 
 	/**


### PR DESCRIPTION
## Introduction
In Update Aquatic, air bubbles now regenerate rapidly when out of water, instead of instantaneously as in previous versions.

## Changes
### Behavioural changes
Player air tank is now regenerated at 5 points per tick, approximating vanilla.

## Tests
Has been tested in-game.