### PR TITLE
able to bypass that checks block's Id in Level::useItemOn()

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1768,12 +1768,13 @@ class Level implements ChunkManager, Metadatable{
 			return false;
 		}
 
-		if($blockClicked->getId() === Block::AIR){
-			return false;
-		}
-
 		if($player !== null){
 			$ev = new PlayerInteractEvent($player, $item, $blockClicked, $clickVector, $face, PlayerInteractEvent::RIGHT_CLICK_BLOCK);
+			
+			if($blockClicked->getId() === Block::AIR){
+				$ev->setCancelled(); //set it to cancelled so plugins can bypass this
+			}
+			
 			if($this->checkSpawnProtection($player, $blockClicked)){
 				$ev->setCancelled(); //set it to cancelled so plugins can bypass this
 			}


### PR DESCRIPTION
## Introduction
i was making Hide and Seek minigame
i sent block on each players position(that's fake block used sendBlock)
but i couldn't make player get damaged on hit blocks(without handling packets)

### Relevant issues
able to bypass that checks block's Id in Level::useItemOn()
