### PR TITLE
Added an event for handling duplicate logins

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -58,6 +58,7 @@ use pocketmine\event\player\PlayerJoinEvent;
 use pocketmine\event\player\PlayerJumpEvent;
 use pocketmine\event\player\PlayerKickEvent;
 use pocketmine\event\player\PlayerLoginEvent;
+use pocketmine\event\player\PlayerLoginOtherLocationEvent;
 use pocketmine\event\player\PlayerMoveEvent;
 use pocketmine\event\player\PlayerPreLoginEvent;
 use pocketmine\event\player\PlayerQuitEvent;
@@ -1787,11 +1788,13 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 		foreach($this->server->getLoggedInPlayers() as $p){
 			if($p !== $this and ($p->iusername === $this->iusername or $this->getUniqueId()->equals($p->getUniqueId()))){
-				if(!$p->kick("logged in from another location")){
-					$this->close($this->getLeaveMessage(), "Logged in from another location");
-
+				$this->server->getPluginManager()->callEvent($ev = new PlayerLoginOtherLocationEvent($this->networkSession, $p->networkSession));
+				if($ev->isCancelled()){
+					$this->networkSession->disconnect($ev->getDisconnectMessage());
 					return false;
 				}
+
+				$p->networkSession->disconnect($ev->getDisconnectMessage());
 			}
 		}
 

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -58,7 +58,7 @@ use pocketmine\event\player\PlayerJoinEvent;
 use pocketmine\event\player\PlayerJumpEvent;
 use pocketmine\event\player\PlayerKickEvent;
 use pocketmine\event\player\PlayerLoginEvent;
-use pocketmine\event\player\PlayerLoginOtherLocationEvent;
+use pocketmine\event\player\PlayerDuplicateLoginEvent;
 use pocketmine\event\player\PlayerMoveEvent;
 use pocketmine\event\player\PlayerPreLoginEvent;
 use pocketmine\event\player\PlayerQuitEvent;
@@ -1788,7 +1788,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 		foreach($this->server->getLoggedInPlayers() as $p){
 			if($p !== $this and ($p->iusername === $this->iusername or $this->getUniqueId()->equals($p->getUniqueId()))){
-				$this->server->getPluginManager()->callEvent($ev = new PlayerLoginOtherLocationEvent($this->networkSession, $p->networkSession));
+				$this->server->getPluginManager()->callEvent($ev = new PlayerDuplicateLoginEvent($this->networkSession, $p->networkSession));
 				if($ev->isCancelled()){
 					$this->networkSession->disconnect($ev->getDisconnectMessage());
 					return false;

--- a/src/pocketmine/event/player/PlayerDuplicateLoginEvent.php
+++ b/src/pocketmine/event/player/PlayerDuplicateLoginEvent.php
@@ -31,7 +31,7 @@ use pocketmine\network\mcpe\NetworkSession;
  * Called when a player connects with a username or UUID that is already used by another player on the server.
  * If cancelled, the newly connecting session will be disconnected; otherwise, the existing player will be disconnected.
  */
-class PlayerLoginOtherLocationEvent extends Event implements Cancellable{
+class PlayerDuplicateLoginEvent extends Event implements Cancellable{
 
 	/** @var NetworkSession */
 	private $connectingSession;

--- a/src/pocketmine/event/player/PlayerLoginOtherLocationEvent.php
+++ b/src/pocketmine/event/player/PlayerLoginOtherLocationEvent.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\event\player;
+
+use pocketmine\event\Cancellable;
+use pocketmine\event\Event;
+use pocketmine\network\mcpe\NetworkSession;
+
+/**
+ * Called when a player connects with a username or UUID that is already used by another player on the server.
+ * If cancelled, the newly connecting session will be disconnected; otherwise, the existing player will be disconnected.
+ */
+class PlayerLoginOtherLocationEvent extends Event implements Cancellable{
+
+	/** @var NetworkSession */
+	private $connectingSession;
+	/** @var NetworkSession */
+	private $existingSession;
+	/** @var string */
+	private $disconnectMessage = "Logged in from another location";
+
+	public function __construct(NetworkSession $connectingSession, NetworkSession $existingSession){
+		$this->connectingSession = $connectingSession;
+		$this->existingSession = $existingSession;
+	}
+
+	public function getConnectingSession() : NetworkSession{
+		return $this->connectingSession;
+	}
+
+	public function getExistingSession() : NetworkSession{
+		return $this->existingSession;
+	}
+
+	/**
+	 * Returns the message shown to the session which gets disconnected.
+	 *
+	 * @return string
+	 */
+	public function getDisconnectMessage() : string{
+		return $this->disconnectMessage;
+	}
+
+	/**
+	 * @param string $message
+	 */
+	public function setDisconnectMessage(string $message) : void{
+		$this->disconnectMessage = $message;
+	}
+}


### PR DESCRIPTION
## Introduction
By default, when a second player joins with the same UUID or username as an existing player, the first player will be kicked off the server to make room for the new player, with the message `Logged in from another location`.

Many server owners dislike this behaviour and use plugins to control it. However, it is currently inconvenient to do so since this requires handling `PlayerKickEvent` and checking for a hard-coded kick message.

Additionally, this current method poses problems for the separation of Player and NetworkSession which has been underway for several months, because this would be fired at a point where the player has not yet been created in the future. Therefore, this is a necessary change in order to eliminate this barrier.

The intent of this PR is to seek feedback on the event naming, since `PlayerLoginOtherLocationEvent` is rather wordy and not very concise.

## Changes
### API changes
- Duplicate players will no longer cause `PlayerKickEvent` to be fired.
- Added a new `PlayerDuplicateLoginEvent` (naming open to discussion).
  - Cancelling this event will reverse the default behaviour and cause the newly connecting session to be disconnected instead.
  - Network sessions are used instead of Players in this event since in the future this will be fired before the player is created.

## Tests
```php
	public function onPlayerDupe(PlayerDuplicateLoginEvent $event){
		$event->setCancelled();
		$event->setDisconnectMessage("you're already logged in");
	}
```
will cause the connecting player to be kicked from the server with these changes.
