### PR TITLE
Leaves: Replace a big mess of code with something nice and simple

### DIFF
--- a/src/pocketmine/block/Leaves.php
+++ b/src/pocketmine/block/Leaves.php
@@ -81,50 +81,15 @@ class Leaves extends Transparent{
 			if($down === $this->woodType){
 				return true;
 			}
-			if($fromSide === null){
-				for($side = 2; $side <= 5; ++$side){
-					if($this->findLog($pos->getSide($side), $visited, $distance + 1, $side)){
-						return true;
-					}
-				}
-			}else{ //No more loops
-				switch($fromSide){
-					case 2:
-						if($this->findLog($pos->getSide(Facing::NORTH), $visited, $distance + 1, $fromSide)){
-							return true;
-						}elseif($this->findLog($pos->getSide(Facing::WEST), $visited, $distance + 1, $fromSide)){
-							return true;
-						}elseif($this->findLog($pos->getSide(Facing::EAST), $visited, $distance + 1, $fromSide)){
-							return true;
-						}
-						break;
-					case 3:
-						if($this->findLog($pos->getSide(Facing::SOUTH), $visited, $distance + 1, $fromSide)){
-							return true;
-						}elseif($this->findLog($pos->getSide(Facing::WEST), $visited, $distance + 1, $fromSide)){
-							return true;
-						}elseif($this->findLog($pos->getSide(Facing::EAST), $visited, $distance + 1, $fromSide)){
-							return true;
-						}
-						break;
-					case 4:
-						if($this->findLog($pos->getSide(Facing::NORTH), $visited, $distance + 1, $fromSide)){
-							return true;
-						}elseif($this->findLog($pos->getSide(Facing::SOUTH), $visited, $distance + 1, $fromSide)){
-							return true;
-						}elseif($this->findLog($pos->getSide(Facing::WEST), $visited, $distance + 1, $fromSide)){
-							return true;
-						}
-						break;
-					case 5:
-						if($this->findLog($pos->getSide(Facing::NORTH), $visited, $distance + 1, $fromSide)){
-							return true;
-						}elseif($this->findLog($pos->getSide(Facing::SOUTH), $visited, $distance + 1, $fromSide)){
-							return true;
-						}elseif($this->findLog($pos->getSide(Facing::EAST), $visited, $distance + 1, $fromSide)){
-							return true;
-						}
-						break;
+
+			foreach([
+				Facing::NORTH,
+				Facing::SOUTH,
+				Facing::WEST,
+				Facing::EAST
+			] as $side){
+				if($side !== $fromSide and $this->findLog($pos->getSide($side), $visited, $distance + 1, Facing::opposite($side))){
+					return true;
 				}
 			}
 		}


### PR DESCRIPTION
## Introduction
As I was traversing some code today, I found this mess which is inexplicably complicated and decided to replace it.

This logic should match the original behaviour, but with less code. `$fromSide` now receives the _opposite_ of the side travelled to to reach the current node, such that it is the side of the current node as opposed to the side of the original node, which makes the code easier to understand.

## Changes
### Behavioural changes
Hopefully none.

## Tests
TBD