### PR TITLE
Level: Bail on trying to unload a level during level tick

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -241,6 +241,9 @@ class Level implements ChunkManager, Metadatable{
 	/** @var int */
 	public $tickRateCounter = 0;
 
+	/** @var bool */
+	private $doingTick = false;
+
 	/** @var string|Generator */
 	private $generator;
 
@@ -528,8 +531,12 @@ class Level implements ChunkManager, Metadatable{
 	 * @param bool $force default false, force unload of default level
 	 *
 	 * @return bool
+	 * @throws \InvalidStateException if trying to unload a level during level tick
 	 */
 	public function unload(bool $force = false) : bool{
+		if($this->doingTick and !$force){
+			throw new \InvalidStateException("Cannot unload a level during level tick");
+		}
 
 		$ev = new LevelUnloadEvent($this);
 
@@ -697,7 +704,16 @@ class Level implements ChunkManager, Metadatable{
 		}
 
 		$this->timings->doTick->startTiming();
+		$this->doingTick = true;
+		try{
+			$this->actuallyDoTick($currentTick);
+		}finally{
+			$this->doingTick = false;
+			$this->timings->doTick->stopTiming();
+		}
+	}
 
+	protected function actuallyDoTick(int $currentTick) : void{
 		$this->checkTime();
 
 		$this->sunAnglePercentage = $this->computeSunAnglePercentage(); //Sun angle depends on the current time
@@ -818,8 +834,6 @@ class Level implements ChunkManager, Metadatable{
 		}
 
 		$this->chunkPackets = [];
-
-		$this->timings->doTick->stopTiming();
 	}
 
 	public function checkSleep(){


### PR DESCRIPTION
## Introduction
For a long time it's been a problem that plugins may unload a level during an event fired during the level's tick. This generally causes instability and crashes due to things having their levels suddenly closed without warning.

This pull request disallows unloading levels during level ticks, and presents clear errors about why this cannot be done.

### Relevant issues
#1527 

## Changes
### API changes
- `Level->unload()` will now throw an `InvalidStateException` if called during a level tick.

## Backwards compatibility
This presents changes of behaviour to plugins unloading levels during events. However, since this would usually crash the server anyway, it's not considered to be a big deal.

## Follow-up
Provide a way to asynchronously unload a level, since it can't always be done immediately.

## Tests
TBD
