### PR TITLE
Added PluginCommandSender

### DIFF
--- a/src/pocketmine/command/PluginCommandSender.php
+++ b/src/pocketmine/command/PluginCommandSender.php
@@ -24,14 +24,18 @@ declare(strict_types=1);
 namespace pocketmine\command;
 
 use pocketmine\lang\TextContainer;
-use pocketmine\utils\MainLogger;
+use pocketmine\plugin\Plugin;
 
-class ConsoleCommandSender extends SuperCommandSender{
+class PluginCommandSender extends SuperCommandSender{
+	/** @var Plugin */
+	private $plugin;
+	/** @var int */
+	private $lineHeight = PHP_INT_MAX;
 
-	private $perm;
-
-	/** @var int|null */
-	protected $lineHeight = null;
+	public function __construct(Plugin $plugin){
+		parent::__construct();
+		$this->plugin = $plugin;
+	}
 
 	/**
 	 * @param TextContainer|string $message
@@ -44,7 +48,7 @@ class ConsoleCommandSender extends SuperCommandSender{
 		}
 
 		foreach(explode("\n", trim($message)) as $line){
-			MainLogger::getLogger()->info($line);
+			$this->plugin->getLogger()->info($line);
 		}
 	}
 
@@ -52,17 +56,14 @@ class ConsoleCommandSender extends SuperCommandSender{
 	 * @return string
 	 */
 	public function getName() : string{
-		return "CONSOLE";
+		return $this->plugin->getName();
 	}
 
 	public function getScreenLineHeight() : int{
-		return $this->lineHeight ?? PHP_INT_MAX;
+		return $this->lineHeight;
 	}
 
-	public function setScreenLineHeight(int $height = null){
-		if($height !== null and $height < 1){
-			throw new \InvalidArgumentException("Line height must be at least 1");
-		}
-		$this->lineHeight = $height;
+	public function setScreenLineHeight(int $height = null) : void{
+		$this->lineHeight = $height ?? PHP_INT_MAX;
 	}
 }

--- a/src/pocketmine/command/SuperCommandSender.php
+++ b/src/pocketmine/command/SuperCommandSender.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\command;
+
+use pocketmine\permission\PermissibleBase;
+use pocketmine\permission\Permission;
+use pocketmine\permission\PermissionAttachment;
+use pocketmine\permission\PermissionAttachmentInfo;
+use pocketmine\plugin\Plugin;
+use pocketmine\Server;
+
+abstract class SuperCommandSender implements CommandSender{
+
+	/** @var PermissibleBase */
+	private $perm;
+
+	public function __construct(){
+		$this->perm = new PermissibleBase($this);
+	}
+
+	/**
+	 * @param Permission|string $name
+	 *
+	 * @return bool
+	 */
+	public function isPermissionSet($name) : bool{
+		return $this->perm->isPermissionSet($name);
+	}
+
+	/**
+	 * @param Permission|string $name
+	 *
+	 * @return bool
+	 */
+	public function hasPermission($name) : bool{
+		return $this->perm->hasPermission($name);
+	}
+
+	/**
+	 * @param Plugin $plugin
+	 * @param string $name
+	 * @param bool   $value
+	 *
+	 * @return PermissionAttachment
+	 */
+	public function addAttachment(Plugin $plugin, string $name = null, bool $value = null) : PermissionAttachment{
+		return $this->perm->addAttachment($plugin, $name, $value);
+	}
+
+	/**
+	 * @param PermissionAttachment $attachment
+	 *
+	 * @return void
+	 */
+	public function removeAttachment(PermissionAttachment $attachment) : void{
+		$this->perm->removeAttachment($attachment);
+	}
+
+	public function recalculatePermissions() : void{
+		$this->perm->recalculatePermissions();
+	}
+
+	/**
+	 * @return PermissionAttachmentInfo[]
+	 */
+	public function getEffectivePermissions() : array{
+		return $this->perm->getEffectivePermissions();
+	}
+
+	/**
+	 * @return Server
+	 */
+	public function getServer() : Server{
+		return Server::getInstance();
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function isOp() : bool{
+		return true;
+	}
+
+	/**
+	 * @param bool $value
+	 */
+	public function setOp(bool $value) : void{
+		// invalid operation
+	}
+}

--- a/src/pocketmine/plugin/Plugin.php
+++ b/src/pocketmine/plugin/Plugin.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 namespace pocketmine\plugin;
 
 use pocketmine\command\CommandExecutor;
+use pocketmine\command\PluginCommandSender;
 use pocketmine\scheduler\TaskScheduler;
 use pocketmine\Server;
 
@@ -84,6 +85,11 @@ interface Plugin extends CommandExecutor{
 	 * @return PluginLoader
 	 */
 	public function getPluginLoader();
+
+	/**
+	 * @return PluginCommandSender
+	 */
+	public function getCommandSender() : PluginCommandSender;
 
 	/**
 	 * @return TaskScheduler

--- a/src/pocketmine/plugin/PluginBase.php
+++ b/src/pocketmine/plugin/PluginBase.php
@@ -25,6 +25,7 @@ namespace pocketmine\plugin;
 
 use pocketmine\command\Command;
 use pocketmine\command\CommandSender;
+use pocketmine\command\PluginCommandSender;
 use pocketmine\command\PluginIdentifiableCommand;
 use pocketmine\scheduler\TaskScheduler;
 use pocketmine\Server;
@@ -55,7 +56,8 @@ abstract class PluginBase implements Plugin{
 
 	/** @var PluginLogger */
 	private $logger;
-
+	/** @var PluginCommandSender */
+	private $commandSender;
 	/** @var TaskScheduler */
 	private $scheduler;
 
@@ -67,6 +69,7 @@ abstract class PluginBase implements Plugin{
 		$this->file = rtrim($file, "\\/") . "/";
 		$this->configFile = $this->dataFolder . "config.yml";
 		$this->logger = new PluginLogger($this);
+		$this->commandSender = new PluginCommandSender($this);
 		$this->scheduler = new TaskScheduler($this->logger, $this->getFullName());
 
 		$this->onLoad();
@@ -195,7 +198,7 @@ abstract class PluginBase implements Plugin{
 	 * Saves an embedded resource to its relative location in the data folder
 	 *
 	 * @param string $filename
-	 * @param bool $replace
+	 * @param bool   $replace
 	 *
 	 * @return bool
 	 */
@@ -302,6 +305,10 @@ abstract class PluginBase implements Plugin{
 	 */
 	public function getPluginLoader(){
 		return $this->loader;
+	}
+
+	public function getCommandSender() : PluginCommandSender{
+		return $this->commandSender;
 	}
 
 	/**


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
While plugin are not encouraged to dispatch commands on behalf of console (rather than using the actual API methods), there are indeed cases where this is needed, such as in the TimeCommander plugin where the plugin executes some operations with super privileges. Developers usually do this by instantiating a new instance of ConsoleCommandSender. However, this could lead to side effects, such as:
- Commands not typed by console are thought to be typed by console
- Plugins might think console is awake (the server owner is on console), while it is just automated
- Permission changes on console will affect these automated command dispatches
  - idk why someone would want to change permissions on console, but @shoghicp made console permissible, so #BlameShoghi

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
- Added the `PluginCommandSender` clsas
- Added the `getCommandSender() : PluginCommandSender` method in the `Plugin` interface and implemented it in `PluginBase`

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
Any changes due to PluginCommandSender will be documented by plugins using it, so I am not documenting it here.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Non-PluginBase implementations of `Plugin` will be affected.

There has never been the rule that "a command sender is either console/Rcon or player", so this is not considered a backward incompatibility.

If plugins use PluginCommandSender instead of ConsoleCommandSender, this will be the incompatibility of the plugins, not of PocketMine. In addition, since they have almost the same permission semantics and display configuration, it should usually work in the same way (as long as plugins don't hardcode "instanceof ConsoleCommandSender`). The only difference is that they are different CommandSender instances and have separate permission set and screen-height storages.

For reference, [here](https://poggit.pmmp.io/grepPlugins/2018-09-17-62f94a941b671ab3.html) is a report of `instanceof ConsoleCommandSender` usages found in plugins built by Poggit-CI.

## Tests
Not available yet. Should be conducted with an actual plugin that used to use ConsoleCommandSender.