### PR TITLE
MainLogger::logException() now logs inducing exceptions

### DIFF
--- a/src/utils/Utils.php
+++ b/src/utils/Utils.php
@@ -409,10 +409,11 @@ class Utils{
 	/**
 	 * @param array $trace
 	 * @param int   $maxStringLength
+	 * @param int   $depth           each depth level indents all resultant messages by 2 spaces
 	 *
 	 * @return array
 	 */
-	public static function printableTrace(array $trace, int $maxStringLength = 80) : array{
+	public static function printableTrace(array $trace, int $maxStringLength = 80, int $depth = 0) : array{
 		$messages = [];
 		for($i = 0; isset($trace[$i]); ++$i){
 			$params = "";
@@ -436,7 +437,7 @@ class Utils{
 					return gettype($value) . " " . Utils::printable((string) $value);
 				}, $args));
 			}
-			$messages[] = "#$i " . (isset($trace[$i]["file"]) ? Filesystem::cleanPath($trace[$i]["file"]) : "") . "(" . (isset($trace[$i]["line"]) ? $trace[$i]["line"] : "") . "): " . (isset($trace[$i]["class"]) ? $trace[$i]["class"] . (($trace[$i]["type"] === "dynamic" or $trace[$i]["type"] === "->") ? "->" : "::") : "") . $trace[$i]["function"] . "(" . Utils::printable($params) . ")";
+			$messages[] = str_repeat("  ", $depth) . "#$i " . (isset($trace[$i]["file"]) ? Filesystem::cleanPath($trace[$i]["file"]) : "") . "(" . (isset($trace[$i]["line"]) ? $trace[$i]["line"] : "") . "): " . (isset($trace[$i]["class"]) ? $trace[$i]["class"] . (($trace[$i]["type"] === "dynamic" or $trace[$i]["type"] === "->") ? "->" : "::") : "") . $trace[$i]["function"] . "(" . Utils::printable($params) . ")";
 		}
 		return $messages;
 	}


### PR DESCRIPTION
## Introduction
PocketMine implements its own error logging mechanism, which does not log indirect exception causes. This may prevent some errors from being properly displayed.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
nil

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Added a `$depth` function to `Utils::printableTrace`

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
Logged exception causes are now displayed in this manner:

```
$exception
$exception->trace
Caused by:
  $exception->previous
  $exception->previous->trace
  Caused by: $exception->previous->previous
    $exception->previous->previous->trace
...
```

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
MainLogger is not supposed to be extended, so I consider there to be no backward compatibility issues.

## Follow-up
This is not planning to get backported to 3.x due to extensive API changes across majors.
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
See https://github.com/pmmp/PocketMine-MP/pull/2447#issuecomment-565790033