### PR TITLE
Add missing corner checks for Stair BB calculation

### DIFF
--- a/src/pocketmine/block/Stair.php
+++ b/src/pocketmine/block/Stair.php
@@ -79,7 +79,7 @@ abstract class Stair extends Transparent{
 
 	private function getPossibleCornerFacing(bool $oppositeFacing) : ?int{
 		$side = $this->getSide($oppositeFacing ? Facing::opposite($this->facing) : $this->facing);
-		if($side instanceof Stair and (
+		if($side instanceof Stair and $side->upsideDown === $this->upsideDown and (
 			$side->facing === Facing::rotate($this->facing, Facing::AXIS_Y, true) or
 			$side->facing === Facing::rotate($this->facing, Facing::AXIS_Y, false))
 		){


### PR DESCRIPTION
## Introduction
Stair bounding box calculation did not take corners into account prior to this pull request. This can lead to strange effects with arrows (colliding with nothing or passing through seemingly solid parts of the block) and may also cause problems with movement anti-cheat.

## Changes
### Behavioural changes
Stair bounding boxes now take corner wrapping into account. This now makes entities (most noticeably arrows) behave correctly when encountering a corner stair.

This targets master instead of 3.3 due to changes in the code responsible for handling this, so I am not pushing this to 3.3 because I don't want to deal with collisions.

## Tests
A test server is live at dev1.ams.pmmp.io:19132. This has been tested in game using arrows to determine collision points.
![unknown](https://user-images.githubusercontent.com/14214667/45932367-e8571c00-bf72-11e8-8249-3a746d2f74ed.png)