### PR TITLE
Allow fire make flame arrows

### DIFF
--- a/src/pocketmine/block/Fire.php
+++ b/src/pocketmine/block/Fire.php
@@ -66,9 +66,6 @@ class Fire extends Flowable{
 		$entity->attack($ev);
 
 		$ev = new EntityCombustByBlockEvent($this, $entity, 8);
-		if($entity instanceof Arrow){
-			$ev->setCancelled();
-		}
 		Server::getInstance()->getPluginManager()->callEvent($ev);
 		if(!$ev->isCancelled()){
 			$entity->setOnFire($ev->getDuration());


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
When firing an arrow through a fire block, the arrow does not become lit.  This is not vanilla behaviour.

### Relevant issues

* Fixes #2467

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
N/A

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
Fire blocks light Arrow entities on fire.
## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Fully compatible

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
None Needed

## Tests
Untested, but the code matches the equivalent in Lava which works correctly.
