### PR TITLE
Revamp MetadataStore API

### DIFF
--- a/src/pocketmine/metadata/BlockMetadataStore.php
+++ b/src/pocketmine/metadata/BlockMetadataStore.php
@@ -35,55 +35,26 @@ class BlockMetadataStore extends MetadataStore{
 		$this->owningLevel = $owningLevel;
 	}
 
-	public function disambiguate(Metadatable $block, string $metadataKey) : string{
-		if(!($block instanceof Block)){
-			throw new \InvalidArgumentException("Argument must be a Block instance");
+	private function disambiguate(Block $block, string $metadataKey) : string{
+		if($block->getLevel() !== $this->owningLevel){
+			throw new \InvalidStateException("Block does not belong to world " . $this->owningLevel->getName());
 		}
-
 		return $block->x . ":" . $block->y . ":" . $block->z . ":" . $metadataKey;
 	}
 
-	public function getMetadata(Metadatable $subject, string $metadataKey){
-		if(!($subject instanceof Block)){
-			throw new \InvalidArgumentException("Object must be a Block");
-		}
-		if($subject->getLevel() === $this->owningLevel){
-			return parent::getMetadata($subject, $metadataKey);
-		}else{
-			throw new \InvalidStateException("Block does not belong to world " . $this->owningLevel->getName());
-		}
+	public function getMetadata(Block $subject, string $metadataKey){
+		return $this->getMetadataInternal($this->disambiguate($subject, $metadataKey));
 	}
 
-	public function hasMetadata(Metadatable $subject, string $metadataKey) : bool{
-		if(!($subject instanceof Block)){
-			throw new \InvalidArgumentException("Object must be a Block");
-		}
-		if($subject->getLevel() === $this->owningLevel){
-			return parent::hasMetadata($subject, $metadataKey);
-		}else{
-			throw new \InvalidStateException("Block does not belong to world " . $this->owningLevel->getName());
-		}
+	public function hasMetadata(Block $subject, string $metadataKey) : bool{
+		return $this->hasMetadataInternal($this->disambiguate($subject, $metadataKey));
 	}
 
-	public function removeMetadata(Metadatable $subject, string $metadataKey, Plugin $owningPlugin){
-		if(!($subject instanceof Block)){
-			throw new \InvalidArgumentException("Object must be a Block");
-		}
-		if($subject->getLevel() === $this->owningLevel){
-			parent::removeMetadata($subject, $metadataKey, $owningPlugin);
-		}else{
-			throw new \InvalidStateException("Block does not belong to world " . $this->owningLevel->getName());
-		}
+	public function removeMetadata(Block $subject, string $metadataKey, Plugin $owningPlugin){
+		$this->removeMetadataInternal($this->disambiguate($subject, $metadataKey), $owningPlugin);
 	}
 
-	public function setMetadata(Metadatable $subject, string $metadataKey, MetadataValue $newMetadataValue){
-		if(!($subject instanceof Block)){
-			throw new \InvalidArgumentException("Object must be a Block");
-		}
-		if($subject->getLevel() === $this->owningLevel){
-			parent::setMetadata($subject, $metadataKey, $newMetadataValue);
-		}else{
-			throw new \InvalidStateException("Block does not belong to world " . $this->owningLevel->getName());
-		}
+	public function setMetadata(Block $subject, string $metadataKey, MetadataValue $newMetadataValue){
+		$this->setMetadataInternal($this->disambiguate($subject, $metadataKey), $newMetadataValue);
 	}
 }

--- a/src/pocketmine/metadata/EntityMetadataStore.php
+++ b/src/pocketmine/metadata/EntityMetadataStore.php
@@ -24,14 +24,27 @@ declare(strict_types=1);
 namespace pocketmine\metadata;
 
 use pocketmine\entity\Entity;
+use pocketmine\plugin\Plugin;
 
 class EntityMetadataStore extends MetadataStore{
 
-	public function disambiguate(Metadatable $entity, string $metadataKey) : string{
-		if(!($entity instanceof Entity)){
-			throw new \InvalidArgumentException("Argument must be an Entity instance");
-		}
-
+	private function disambiguate(Entity $entity, string $metadataKey) : string{
 		return $entity->getId() . ":" . $metadataKey;
+	}
+
+	public function getMetadata(Entity $subject, string $metadataKey){
+		return $this->getMetadataInternal($this->disambiguate($subject, $metadataKey));
+	}
+
+	public function hasMetadata(Entity $subject, string $metadataKey) : bool{
+		return $this->hasMetadataInternal($this->disambiguate($subject, $metadataKey));
+	}
+
+	public function removeMetadata(Entity $subject, string $metadataKey, Plugin $owningPlugin){
+		$this->removeMetadataInternal($this->disambiguate($subject, $metadataKey), $owningPlugin);
+	}
+
+	public function setMetadata(Entity $subject, string $metadataKey, MetadataValue $newMetadataValue){
+		$this->setMetadataInternal($this->disambiguate($subject, $metadataKey), $newMetadataValue);
 	}
 }

--- a/src/pocketmine/metadata/LevelMetadataStore.php
+++ b/src/pocketmine/metadata/LevelMetadataStore.php
@@ -24,14 +24,27 @@ declare(strict_types=1);
 namespace pocketmine\metadata;
 
 use pocketmine\level\Level;
+use pocketmine\plugin\Plugin;
 
 class LevelMetadataStore extends MetadataStore{
 
-	public function disambiguate(Metadatable $level, string $metadataKey) : string{
-		if(!($level instanceof Level)){
-			throw new \InvalidArgumentException("Argument must be a Level instance");
-		}
-
+	private function disambiguate(Level $level, string $metadataKey) : string{
 		return strtolower($level->getName()) . ":" . $metadataKey;
+	}
+
+	public function getMetadata(Level $subject, string $metadataKey){
+		return $this->getMetadataInternal($this->disambiguate($subject, $metadataKey));
+	}
+
+	public function hasMetadata(Level $subject, string $metadataKey) : bool{
+		return $this->hasMetadataInternal($this->disambiguate($subject, $metadataKey));
+	}
+
+	public function removeMetadata(Level $subject, string $metadataKey, Plugin $owningPlugin){
+		$this->removeMetadataInternal($this->disambiguate($subject, $metadataKey), $owningPlugin);
+	}
+
+	public function setMetadata(Level $subject, string $metadataKey, MetadataValue $newMetadataValue){
+		$this->setMetadataInternal($this->disambiguate($subject, $metadataKey), $newMetadataValue);
 	}
 }

--- a/src/pocketmine/metadata/MetadataStore.php
+++ b/src/pocketmine/metadata/MetadataStore.php
@@ -27,7 +27,6 @@ declare(strict_types=1);
 namespace pocketmine\metadata;
 
 use pocketmine\plugin\Plugin;
-use pocketmine\plugin\PluginException;
 
 abstract class MetadataStore{
 	/** @var \SplObjectStorage[] */
@@ -36,17 +35,12 @@ abstract class MetadataStore{
 	/**
 	 * Adds a metadata value to an object.
 	 *
-	 * @param Metadatable   $subject
-	 * @param string        $metadataKey
+	 * @param string        $key
 	 * @param MetadataValue $newMetadataValue
 	 */
-	public function setMetadata(Metadatable $subject, string $metadataKey, MetadataValue $newMetadataValue){
+	protected function setMetadataInternal(string $key, MetadataValue $newMetadataValue){
 		$owningPlugin = $newMetadataValue->getOwningPlugin();
-		if($owningPlugin === null){
-			throw new PluginException("Plugin cannot be null");
-		}
 
-		$key = $this->disambiguate($subject, $metadataKey);
 		if(!isset($this->metadataMap[$key])){
 			$entry = new \SplObjectStorage();
 			$this->metadataMap[$key] = $entry;
@@ -60,13 +54,11 @@ abstract class MetadataStore{
 	 * Returns all metadata values attached to an object. If multiple
 	 * have attached metadata, each will value will be included.
 	 *
-	 * @param Metadatable $subject
-	 * @param string      $metadataKey
+	 * @param string $key
 	 *
 	 * @return MetadataValue[]
 	 */
-	public function getMetadata(Metadatable $subject, string $metadataKey){
-		$key = $this->disambiguate($subject, $metadataKey);
+	protected function getMetadataInternal(string $key){
 		if(isset($this->metadataMap[$key])){
 			return $this->metadataMap[$key];
 		}else{
@@ -77,24 +69,21 @@ abstract class MetadataStore{
 	/**
 	 * Tests to see if a metadata attribute has been set on an object.
 	 *
-	 * @param Metadatable $subject
-	 * @param string      $metadataKey
+	 * @param string $key
 	 *
 	 * @return bool
 	 */
-	public function hasMetadata(Metadatable $subject, string $metadataKey) : bool{
-		return isset($this->metadataMap[$this->disambiguate($subject, $metadataKey)]);
+	protected function hasMetadataInternal(string $key) : bool{
+		return isset($this->metadataMap[$key]);
 	}
 
 	/**
 	 * Removes a metadata item owned by a plugin from a subject.
 	 *
-	 * @param Metadatable $subject
-	 * @param string      $metadataKey
-	 * @param Plugin      $owningPlugin
+	 * @param string $key
+	 * @param Plugin $owningPlugin
 	 */
-	public function removeMetadata(Metadatable $subject, string $metadataKey, Plugin $owningPlugin){
-		$key = $this->disambiguate($subject, $metadataKey);
+	protected function removeMetadataInternal(string $key, Plugin $owningPlugin){
 		if(isset($this->metadataMap[$key])){
 			unset($this->metadataMap[$key][$owningPlugin]);
 			if($this->metadataMap[$key]->count() === 0){
@@ -118,17 +107,4 @@ abstract class MetadataStore{
 			}
 		}
 	}
-
-	/**
-	 * Creates a unique name for the object receiving metadata by combining
-	 * unique data from the subject with a metadataKey.
-	 *
-	 * @param Metadatable $subject
-	 * @param string      $metadataKey
-	 *
-	 * @return string
-	 *
-	 * @throws \InvalidArgumentException
-	 */
-	abstract public function disambiguate(Metadatable $subject, string $metadataKey) : string;
 }

--- a/src/pocketmine/metadata/PlayerMetadataStore.php
+++ b/src/pocketmine/metadata/PlayerMetadataStore.php
@@ -24,14 +24,27 @@ declare(strict_types=1);
 namespace pocketmine\metadata;
 
 use pocketmine\IPlayer;
+use pocketmine\plugin\Plugin;
 
 class PlayerMetadataStore extends MetadataStore{
 
-	public function disambiguate(Metadatable $player, string $metadataKey) : string{
-		if(!($player instanceof IPlayer)){
-			throw new \InvalidArgumentException("Argument must be an IPlayer instance");
-		}
-
+	private function disambiguate(IPlayer $player, string $metadataKey) : string{
 		return strtolower($player->getName()) . ":" . $metadataKey;
+	}
+
+	public function getMetadata(IPlayer $subject, string $metadataKey){
+		return $this->getMetadataInternal($this->disambiguate($subject, $metadataKey));
+	}
+
+	public function hasMetadata(IPlayer $subject, string $metadataKey) : bool{
+		return $this->hasMetadataInternal($this->disambiguate($subject, $metadataKey));
+	}
+
+	public function removeMetadata(IPlayer $subject, string $metadataKey, Plugin $owningPlugin){
+		$this->removeMetadataInternal($this->disambiguate($subject, $metadataKey), $owningPlugin);
+	}
+
+	public function setMetadata(IPlayer $subject, string $metadataKey, MetadataValue $newMetadataValue){
+		$this->setMetadataInternal($this->disambiguate($subject, $metadataKey), $newMetadataValue);
 	}
 }


### PR DESCRIPTION
## Introduction
MetadataStore doesn't do proper polymorphism. `getMetadata()`, `setMetadata()`, `hasMetadata()` and `removeMetadata()` were not able to be appropriately typehinted for their store type.

This pull request removes  `getMetadata()`, `setMetadata()`, `hasMetadata()` and `removeMetadata()` from the public API of `MetadataStore`, and moves it to the individual implementations. This now allows them to be appropriately typehinted based on the type of metadatable that should be accepted.

This would be a lot less messy if we had generics, but no tango.

## Changes
### API changes
See above.

## Backwards compatibility
This is not **technically** a BC-breaking change, although it does change public API. This is because it preserves the functionality of already-working code (things in the core using this will not experience any behavioural changes). However, incorrectly working code may suffer alterations to its behaviour, but I doubt anyone will care for non-working code.