### PR TITLE
Remove support for source-code installations from start.* scripts

### DIFF
--- a/start.cmd
+++ b/start.cmd
@@ -12,13 +12,9 @@ if exist bin\php\php.exe (
 if exist PocketMine-MP.phar (
 	set POCKETMINE_FILE=PocketMine-MP.phar
 ) else (
-	if exist src\pocketmine\PocketMine.php (
-		set POCKETMINE_FILE=src\pocketmine\PocketMine.php
-	) else (
-		echo Couldn't find a valid PocketMine-MP installation
-		pause
-		exit 1
-	)
+	echo Couldn't find a valid PocketMine-MP installation
+	pause
+	exit 1
 )
 
 if exist bin\mintty.exe (

--- a/start.ps1
+++ b/start.ps1
@@ -18,8 +18,6 @@ if($php -ne ""){
 if($file -eq ""){
 	if(Test-Path "PocketMine-MP.phar"){
 	    $file = "PocketMine-MP.phar"
-	}elseif(Test-Path "src\pocketmine\PocketMine.php"){
-	    $file = "src\pocketmine\PocketMine.php"
 	}else{
 	    echo "Couldn't find a valid PocketMine-MP installation"
 	    pause

--- a/start.sh
+++ b/start.sh
@@ -36,8 +36,6 @@ fi
 if [ "$POCKETMINE_FILE" == "" ]; then
 	if [ -f ./PocketMine-MP.phar ]; then
 		POCKETMINE_FILE="./PocketMine-MP.phar"
-	elif [ -f ./src/pocketmine/PocketMine.php ]; then
-		POCKETMINE_FILE="./src/pocketmine/PocketMine.php"
 	else
 		echo "Couldn't find a valid PocketMine-MP installation"
 		exit 1


### PR DESCRIPTION
## Introduction
This was suggested recently by @TheDeibo. We don't want end users running source-code installations unless they are developers, and developers should know how to boot a source-code installation anyway.

## Changes
### Behavioural changes
`start.sh`, `start.ps1` and `start.cmd` no longer take note of source-code installations.

Note that in the future, support for running from source-code could be removed altogether (for example if a preprocessing step becomes mandatory).