### PR TITLE
Door: Prevent placement above height limit.

### DIFF
--- a/src/pocketmine/block/Door.php
+++ b/src/pocketmine/block/Door.php
@@ -154,7 +154,7 @@ abstract class Door extends Transparent{
 		if($face === Facing::UP){
 			$blockUp = $this->getSide(Facing::UP);
 			$blockDown = $this->getSide(Facing::DOWN);
-			if(!$blockUp->canBeReplaced() or $blockDown->isTransparent()){
+			if(!$blockUp->canBeReplaced() or $blockDown->isTransparent() or $blockUp->getLevel()->getWorldHeight() <= $blockUp->getY()){
 				return false;
 			}
 


### PR DESCRIPTION
## Introduction
Check and prevent if the top block of a door would be at or above the max world height once placed.

### Relevant issues
Fixes: Half-doors can be placed at y=255 #2441

## Tests
Placement now works the same as in vanilla.
