### PR TITLE
Marked some classes final, made their protected fields private

### DIFF
--- a/src/pocketmine/MemoryManager.php
+++ b/src/pocketmine/MemoryManager.php
@@ -29,7 +29,7 @@ use pocketmine\scheduler\GarbageCollectionTask;
 use pocketmine\timings\Timings;
 use pocketmine\utils\Utils;
 
-class MemoryManager{
+final class MemoryManager{
 
 	/** @var Server */
 	private $server;

--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -117,7 +117,7 @@ use pocketmine\utils\UUID;
 /**
  * The class that manages everything
  */
-class Server{
+final class Server{
 	public const BROADCAST_CHANNEL_ADMINISTRATIVE = "pocketmine.broadcast.admin";
 	public const BROADCAST_CHANNEL_USERS = "pocketmine.broadcast.user";
 

--- a/src/pocketmine/command/CommandReader.php
+++ b/src/pocketmine/command/CommandReader.php
@@ -37,7 +37,7 @@ class CommandReader extends Thread{
 	private static $stdin;
 
 	/** @var \Threaded */
-	protected $buffer;
+	private $buffer;
 	private $shutdown = false;
 	private $type = self::TYPE_STREAM;
 

--- a/src/pocketmine/command/SimpleCommandMap.php
+++ b/src/pocketmine/command/SimpleCommandMap.php
@@ -69,12 +69,12 @@ use pocketmine\lang\TranslationContainer;
 use pocketmine\Server;
 use pocketmine\utils\TextFormat;
 
-class SimpleCommandMap implements CommandMap{
+final class SimpleCommandMap implements CommandMap{
 
 	/**
 	 * @var Command[]
 	 */
-	protected $knownCommands = [];
+	private $knownCommands = [];
 
 	/** @var Server */
 	private $server;

--- a/src/pocketmine/inventory/CraftingManager.php
+++ b/src/pocketmine/inventory/CraftingManager.php
@@ -31,13 +31,13 @@ use pocketmine\network\mcpe\PacketStream;
 use pocketmine\network\mcpe\protocol\CraftingDataPacket;
 use pocketmine\timings\Timings;
 
-class CraftingManager{
+final class CraftingManager{
 	/** @var ShapedRecipe[][] */
-	protected $shapedRecipes = [];
+	private $shapedRecipes = [];
 	/** @var ShapelessRecipe[][] */
-	protected $shapelessRecipes = [];
+	private $shapelessRecipes = [];
 	/** @var FurnaceRecipe[] */
-	protected $furnaceRecipes = [];
+	private $furnaceRecipes = [];
 
 	/** @var CompressBatchPromise */
 	private $craftingDataCache;

--- a/src/pocketmine/level/format/io/LevelProviderManager.php
+++ b/src/pocketmine/level/format/io/LevelProviderManager.php
@@ -29,8 +29,8 @@ use pocketmine\level\format\io\region\McRegion;
 use pocketmine\level\format\io\region\PMAnvil;
 use pocketmine\utils\Utils;
 
-abstract class LevelProviderManager{
-	protected static $providers = [];
+final class LevelProviderManager{
+	private static $providers = [];
 
 	/** @var string|LevelProvider */
 	private static $default = PMAnvil::class;

--- a/src/pocketmine/network/Network.php
+++ b/src/pocketmine/network/Network.php
@@ -33,7 +33,7 @@ use pocketmine\network\mcpe\NetworkSession;
 use pocketmine\network\mcpe\protocol\PacketPool;
 use pocketmine\Server;
 
-class Network{
+final class Network{
 	/** @var Server */
 	private $server;
 

--- a/src/pocketmine/network/query/QueryHandler.php
+++ b/src/pocketmine/network/query/QueryHandler.php
@@ -31,7 +31,7 @@ use pocketmine\network\AdvancedNetworkInterface;
 use pocketmine\Server;
 use pocketmine\utils\Binary;
 
-class QueryHandler{
+final class QueryHandler{
 	private $server, $lastToken, $token, $longData, $shortData, $timeout;
 
 	public const HANDSHAKE = 9;

--- a/src/pocketmine/permission/PermissionManager.php
+++ b/src/pocketmine/permission/PermissionManager.php
@@ -25,7 +25,7 @@ namespace pocketmine\permission;
 
 use pocketmine\timings\Timings;
 
-class PermissionManager{
+final class PermissionManager{
 	/** @var PermissionManager|null */
 	private static $instance = null;
 
@@ -38,17 +38,17 @@ class PermissionManager{
 	}
 
 	/** @var Permission[] */
-	protected $permissions = [];
+	private $permissions = [];
 	/** @var Permission[] */
-	protected $defaultPerms = [];
+	private $defaultPerms = [];
 	/** @var Permission[] */
-	protected $defaultPermsOp = [];
+	private $defaultPermsOp = [];
 	/** @var Permissible[][] */
-	protected $permSubs = [];
+	private $permSubs = [];
 	/** @var Permissible[] */
-	protected $defSubs = [];
+	private $defSubs = [];
 	/** @var Permissible[] */
-	protected $defSubsOp = [];
+	private $defSubsOp = [];
 
 	/**
 	 * @param string $name

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -40,7 +40,7 @@ use pocketmine\utils\Utils;
 /**
  * Manages all the plugins
  */
-class PluginManager{
+final class PluginManager{
 
 	/** @var Server */
 	private $server;
@@ -51,17 +51,17 @@ class PluginManager{
 	/**
 	 * @var Plugin[]
 	 */
-	protected $plugins = [];
+	private $plugins = [];
 
 	/**
 	 * @var Plugin[]
 	 */
-	protected $enabledPlugins = [];
+	private $enabledPlugins = [];
 
 	/**
 	 * @var PluginLoader[]
 	 */
-	protected $fileAssociations = [];
+	private $fileAssociations = [];
 
 	/** @var string|null */
 	private $pluginDataDirectory;
@@ -430,7 +430,7 @@ class PluginManager{
 	 *
 	 * @return PluginCommand[]
 	 */
-	protected function parseYamlCommands(Plugin $plugin) : array{
+	private function parseYamlCommands(Plugin $plugin) : array{
 		$pluginCmds = [];
 
 		foreach($plugin->getDescription()->getCommands() as $key => $data){

--- a/src/pocketmine/resourcepacks/ResourcePackManager.php
+++ b/src/pocketmine/resourcepacks/ResourcePackManager.php
@@ -26,7 +26,7 @@ namespace pocketmine\resourcepacks;
 
 use pocketmine\utils\Config;
 
-class ResourcePackManager{
+final class ResourcePackManager{
 
 	/** @var string */
 	private $path;

--- a/src/pocketmine/scheduler/AsyncPool.php
+++ b/src/pocketmine/scheduler/AsyncPool.php
@@ -27,7 +27,7 @@ namespace pocketmine\scheduler;
  * Manages general-purpose worker threads used for processing asynchronous tasks, and the tasks submitted to those
  * workers.
  */
-class AsyncPool{
+final class AsyncPool{
 	private const WORKER_START_OPTIONS = PTHREADS_INHERIT_INI | PTHREADS_INHERIT_CONSTANTS;
 
 	/** @var \ClassLoader */
@@ -35,7 +35,7 @@ class AsyncPool{
 	/** @var \ThreadedLogger */
 	private $logger;
 	/** @var int */
-	protected $size;
+	private $size;
 	/** @var int */
 	private $workerMemoryLimit;
 


### PR DESCRIPTION
## Changes
Singleton classes should be final, because they are not supposed to be extended. Extending classes when it is not designed to be extended is bad in software architecture.

In addition, this pull request changes all protected fields in final classes to private for clarity and consistency.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
As the classes affected are not supposed to be extended, I do not consider this as backward compatibility. However I will still target the changes towards major.next

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
As this does not add or change any behaviour or API, the Travis-CI run should be sufficient.