### PR TITLE
Added PermissibleTrait

### DIFF
--- a/src/pocketmine/command/ConsoleCommandSender.php
+++ b/src/pocketmine/command/ConsoleCommandSender.php
@@ -24,72 +24,17 @@ declare(strict_types=1);
 namespace pocketmine\command;
 
 use pocketmine\lang\TextContainer;
-use pocketmine\permission\PermissibleBase;
-use pocketmine\permission\Permission;
-use pocketmine\permission\PermissionAttachment;
-use pocketmine\permission\PermissionAttachmentInfo;
-use pocketmine\plugin\Plugin;
+use pocketmine\permission\PermissibleTrait;
 use pocketmine\Server;
 use pocketmine\utils\MainLogger;
 
 class ConsoleCommandSender implements CommandSender{
-
-	private $perm;
+	use PermissibleTrait;
 
 	/** @var int|null */
 	protected $lineHeight = null;
 
 	public function __construct(){
-		$this->perm = new PermissibleBase($this);
-	}
-
-	/**
-	 * @param Permission|string $name
-	 *
-	 * @return bool
-	 */
-	public function isPermissionSet($name) : bool{
-		return $this->perm->isPermissionSet($name);
-	}
-
-	/**
-	 * @param Permission|string $name
-	 *
-	 * @return bool
-	 */
-	public function hasPermission($name) : bool{
-		return $this->perm->hasPermission($name);
-	}
-
-	/**
-	 * @param Plugin $plugin
-	 * @param string $name
-	 * @param bool   $value
-	 *
-	 * @return PermissionAttachment
-	 */
-	public function addAttachment(Plugin $plugin, string $name = null, bool $value = null) : PermissionAttachment{
-		return $this->perm->addAttachment($plugin, $name, $value);
-	}
-
-	/**
-	 * @param PermissionAttachment $attachment
-	 *
-	 * @return void
-	 */
-	public function removeAttachment(PermissionAttachment $attachment){
-		$this->perm->removeAttachment($attachment);
-	}
-
-	public function recalculatePermissions(){
-		$this->perm->recalculatePermissions();
-	}
-
-	/**
-	 * @return PermissionAttachmentInfo[]
-	 */
-	public function getEffectivePermissions() : array{
-		return $this->perm->getEffectivePermissions();
 	}
 
 	/**

--- a/src/pocketmine/command/ConsoleCommandSender.php
+++ b/src/pocketmine/command/ConsoleCommandSender.php
@@ -35,6 +35,7 @@ class ConsoleCommandSender implements CommandSender{
 	protected $lineHeight = null;
 
 	public function __construct(){
+		$this->initPermissible();
 	}
 
 	/**

--- a/src/pocketmine/permission/PermissibleTrait.php
+++ b/src/pocketmine/permission/PermissibleTrait.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\permission;
+
+use pocketmine\plugin\Plugin;
+
+trait PermissibleTrait{
+	/** @var PermissibleBase */
+	private $perm;
+
+	protected function initPermissible() : void{
+		assert($this instanceof Permissible);
+		$this->perm = new PermissibleBase($this);
+	}
+
+	protected function destroyPermissible() : void{
+		$this->perm->clearPermissions();
+		$this->perm = null;
+	}
+
+	public function isPermissionSet($name) : bool{
+		return $this->perm->isPermissionSet($name);
+	}
+
+	public function hasPermission($name) : bool{
+		return $this->perm->hasPermission($name);
+	}
+
+	public function addAttachment(Plugin $plugin, string $name = null, bool $value = null) : PermissionAttachment{
+		return $this->perm->addAttachment($plugin, $name, $value);
+	}
+
+	public function removeAttachment(PermissionAttachment $attachment) : void{
+		$this->perm->removeAttachment($attachment);
+	}
+
+	public function recalculatePermissions() : void{
+		$this->perm->recalculatePermissions();
+	}
+
+	public function getEffectivePermissions() : array{
+		return $this->perm->getEffectivePermissions();
+	}
+
+	public function isOp() : bool{
+		return $this->perm->isOp();
+	}
+
+	public function setOp(bool $value) : void{
+		$this->perm->setOp($value);
+	}
+}


### PR DESCRIPTION
## Introduction
Implementing Permissible is based on PermissibleBase, but redirecting the method calls produces a lot of boilerplate code. This PR adds a trait to copy-paste this boilerplate.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
- Added PermissibleTrait

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
none

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
None.
(Plugins that extend Player and set `$player->closed` incorrectly might lead to memory leaks, but "incorrect" is not something to consider for BC)


## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Not yet tested