### PR TITLE
 Changed PermissibleBase to trait to remove boilerplate

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -123,7 +123,7 @@ use pocketmine\network\mcpe\protocol\types\ContainerIds;
 use pocketmine\network\mcpe\protocol\types\PlayerPermissions;
 use pocketmine\network\mcpe\protocol\UpdateAttributesPacket;
 use pocketmine\network\mcpe\ProcessLoginTask;
-use pocketmine\permission\PermissibleBase;
+use pocketmine\permission\PermissibleTrait;
 use pocketmine\permission\PermissionManager;
 use pocketmine\plugin\Plugin;
 use pocketmine\tile\ItemFrame;
@@ -138,7 +138,7 @@ use pocketmine\utils\UUID;
  * Main class that handles networking, recovery, and packet sending to the server part
  */
 class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
-	use PermissibleBase {
+	use PermissibleTrait {
 		hasPermission as private _hasPermission;
 		recalculatePermissions as private _recalculatePermissions;
 	}

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2854,7 +2854,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 				$this->spawnPosition = null;
 
-				$this->clearPermissions();
+				$this->destroyPermissible();
 			}catch(\Throwable $e){
 				$this->server->getLogger()->logException($e);
 			}finally{

--- a/src/pocketmine/command/ConsoleCommandSender.php
+++ b/src/pocketmine/command/ConsoleCommandSender.php
@@ -25,71 +25,17 @@ namespace pocketmine\command;
 
 use pocketmine\lang\TextContainer;
 use pocketmine\permission\PermissibleBase;
-use pocketmine\permission\Permission;
-use pocketmine\permission\PermissionAttachment;
-use pocketmine\permission\PermissionAttachmentInfo;
-use pocketmine\plugin\Plugin;
 use pocketmine\Server;
 use pocketmine\utils\MainLogger;
 
 class ConsoleCommandSender implements CommandSender{
-
-	private $perm;
+	use PermissibleBase;
 
 	/** @var int|null */
 	protected $lineHeight = null;
 
 	public function __construct(){
-		$this->perm = new PermissibleBase($this);
-	}
-
-	/**
-	 * @param Permission|string $name
-	 *
-	 * @return bool
-	 */
-	public function isPermissionSet($name) : bool{
-		return $this->perm->isPermissionSet($name);
-	}
-
-	/**
-	 * @param Permission|string $name
-	 *
-	 * @return bool
-	 */
-	public function hasPermission($name) : bool{
-		return $this->perm->hasPermission($name);
-	}
-
-	/**
-	 * @param Plugin $plugin
-	 * @param string $name
-	 * @param bool   $value
-	 *
-	 * @return PermissionAttachment
-	 */
-	public function addAttachment(Plugin $plugin, string $name = null, bool $value = null) : PermissionAttachment{
-		return $this->perm->addAttachment($plugin, $name, $value);
-	}
-
-	/**
-	 * @param PermissionAttachment $attachment
-	 *
-	 * @return void
-	 */
-	public function removeAttachment(PermissionAttachment $attachment){
-		$this->perm->removeAttachment($attachment);
-	}
-
-	public function recalculatePermissions(){
-		$this->perm->recalculatePermissions();
-	}
-
-	/**
-	 * @return PermissionAttachmentInfo[]
-	 */
-	public function getEffectivePermissions() : array{
-		return $this->perm->getEffectivePermissions();
+		$this->initPermissible();
 	}
 
 	/**

--- a/src/pocketmine/command/ConsoleCommandSender.php
+++ b/src/pocketmine/command/ConsoleCommandSender.php
@@ -24,12 +24,12 @@ declare(strict_types=1);
 namespace pocketmine\command;
 
 use pocketmine\lang\TextContainer;
-use pocketmine\permission\PermissibleBase;
+use pocketmine\permission\PermissibleTrait;
 use pocketmine\Server;
 use pocketmine\utils\MainLogger;
 
 class ConsoleCommandSender implements CommandSender{
-	use PermissibleBase;
+	use PermissibleTrait;
 
 	/** @var int|null */
 	protected $lineHeight = null;

--- a/src/pocketmine/permission/PermissibleTrait.php
+++ b/src/pocketmine/permission/PermissibleTrait.php
@@ -150,8 +150,6 @@ trait PermissibleTrait{
 		$permManager->unsubscribeFromDefaultPerms(true, $this->this);
 
 		$this->permissions = [];
-
-		$this->this = null;
 	}
 
 	/**
@@ -178,5 +176,10 @@ trait PermissibleTrait{
 	 */
 	public function getEffectivePermissions() : array{
 		return $this->permissions;
+	}
+
+	public function destroyPermissible() : void{
+		$this->clearPermissions();
+		$this->this = null;
 	}
 }

--- a/src/pocketmine/permission/PermissibleTrait.php
+++ b/src/pocketmine/permission/PermissibleTrait.php
@@ -27,7 +27,7 @@ use pocketmine\plugin\Plugin;
 use pocketmine\plugin\PluginException;
 use pocketmine\timings\Timings;
 
-trait PermissibleBase{
+trait PermissibleTrait{
 	/** @var Permissible */
 	private $this = null;
 
@@ -43,7 +43,7 @@ trait PermissibleBase{
 
 	public function initPermissible() : void{
 		$this->this = $this;
-		assert($this->this instanceof Permissible, "PermissibleBase can only be used by Permissibles");
+		assert($this->this instanceof Permissible, "PermissibleTrait can only be used by Permissibles");
 	}
 
 	/**


### PR DESCRIPTION
## Introduction
Implementing Permissible is based on PermissibleBase, but redirecting the method calls produces a lot of boilerplate code. This PR converts PermissibleBase to an actual trait that implements the Permissible methods.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
- Added PermissibleTrait
- Removed PermissibleBase

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
none

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Classes that extend/contain PermissibleBase have to switch to `use PermissibleTrait;`. **Remember to call `initPermissible()` and `clearPermissions()`.**

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Works when player join and quits with almost no plugins. Not everything has been carefully tested.