### PR TITLE
Return Item instance for enchant related functions

### DIFF
--- a/src/pocketmine/item/Item.php
+++ b/src/pocketmine/item/Item.php
@@ -305,7 +305,7 @@ class Item implements ItemIds, \JsonSerializable{
 
 		$this->setNamedTagEntry($ench);
 		
-		return $this
+		return $this;
 	}
 
 	/**

--- a/src/pocketmine/item/Item.php
+++ b/src/pocketmine/item/Item.php
@@ -292,7 +292,7 @@ class Item implements ItemIds, \JsonSerializable{
 	public function removeEnchantment(int $id, int $level = -1) : Item{
 		$ench = $this->getNamedTagEntry(self::TAG_ENCH);
 		if(!($ench instanceof ListTag)){
-			return;
+			return $this;
 		}
 
 		/** @var CompoundTag $entry */

--- a/src/pocketmine/item/Item.php
+++ b/src/pocketmine/item/Item.php
@@ -308,6 +308,9 @@ class Item implements ItemIds, \JsonSerializable{
 		return $this
 	}
 
+	/**
+	* @return Item
+	*/
 	public function removeEnchantments() : Item{
 		$this->removeNamedTagEntry(self::TAG_ENCH);
 		

--- a/src/pocketmine/item/Item.php
+++ b/src/pocketmine/item/Item.php
@@ -309,11 +309,10 @@ class Item implements ItemIds, \JsonSerializable{
 	}
 
 	/**
-	* @return Item
-	*/
+	 * @return Item
+	 */
 	public function removeEnchantments() : Item{
 		$this->removeNamedTagEntry(self::TAG_ENCH);
-		
 		return $this;
 	}
 
@@ -350,7 +349,6 @@ class Item implements ItemIds, \JsonSerializable{
 		}
 
 		$this->setNamedTagEntry($ench);
-		
 		return $this;
 	}
 

--- a/src/pocketmine/item/Item.php
+++ b/src/pocketmine/item/Item.php
@@ -304,7 +304,7 @@ class Item implements ItemIds, \JsonSerializable{
 		}
 
 		$this->setNamedTagEntry($ench);
-		
+
 		return $this;
 	}
 
@@ -313,6 +313,7 @@ class Item implements ItemIds, \JsonSerializable{
 	 */
 	public function removeEnchantments() : Item{
 		$this->removeNamedTagEntry(self::TAG_ENCH);
+
 		return $this;
 	}
 
@@ -349,6 +350,7 @@ class Item implements ItemIds, \JsonSerializable{
 		}
 
 		$this->setNamedTagEntry($ench);
+
 		return $this;
 	}
 

--- a/src/pocketmine/item/Item.php
+++ b/src/pocketmine/item/Item.php
@@ -286,8 +286,10 @@ class Item implements ItemIds, \JsonSerializable{
 	/**
 	 * @param int $id
 	 * @param int $level
+	 *
+	 * @return Item
 	 */
-	public function removeEnchantment(int $id, int $level = -1) : void{
+	public function removeEnchantment(int $id, int $level = -1) : Item{
 		$ench = $this->getNamedTagEntry(self::TAG_ENCH);
 		if(!($ench instanceof ListTag)){
 			return;
@@ -302,16 +304,22 @@ class Item implements ItemIds, \JsonSerializable{
 		}
 
 		$this->setNamedTagEntry($ench);
+		
+		return $this
 	}
 
-	public function removeEnchantments() : void{
+	public function removeEnchantments() : Item{
 		$this->removeNamedTagEntry(self::TAG_ENCH);
+		
+		return $this;
 	}
 
 	/**
 	 * @param EnchantmentInstance $enchantment
+	 *
+	 * @return Item
 	 */
-	public function addEnchantment(EnchantmentInstance $enchantment) : void{
+	public function addEnchantment(EnchantmentInstance $enchantment) : Item{
 		$found = false;
 
 		$ench = $this->getNamedTagEntry(self::TAG_ENCH);
@@ -339,6 +347,8 @@ class Item implements ItemIds, \JsonSerializable{
 		}
 
 		$this->setNamedTagEntry($ench);
+		
+		return $this;
 	}
 
 	/**


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
When coding some things - for example adding items to an array - if you want one of the items to be enchanted, you need to do it outside of the array because ``Item::addEnchantment()`` returns void, but things like ``Item::setLore()`` and ``Item:;setCustomName()`` return an Item instance.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
``Item::removeEnchantment()`` returns an Item instance instead of void
``Item::removeEnchantments()`` returns an Item instance instead of void
``Item::addEnchantment()`` returns an Item instance instead of void

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
No

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Don't think it will cause any errors with existing plugins...

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
```php
$item = Item::get(Item::DIAMOND_SWORD)->setCustomName("Sword")->addEnchantment(new EnchantmentInstance(Enchantment::getEnchantment(Enchantment::SHARPNESS), 5));
/** @var Player $player */
$player->getInventory()->addItem($item);
```
![image](https://user-images.githubusercontent.com/30378179/48311085-ee8c7080-e591-11e8-87e2-23bd9dff2a5d.png)
