### PR TITLE
Fixed registerEvents() throwing exceptions on candidate event handler…

### DIFF
--- a/src/pocketmine/event/Listener.php
+++ b/src/pocketmine/event/Listener.php
@@ -43,9 +43,6 @@ use pocketmine\plugin\PluginManager;
  * Functions which meet the criteria can have the following annotations in their doc comments:
  *
  * - `@notHandler`: Marks a function as NOT being an event handler. Only needed if the function meets the above criteria.
- * - `@softDepend [PluginName]`: Handler WILL NOT be registered if its event doesn't exist. Useful for soft-depending
- *     on plugin events. Plugin name is optional.
- *     Example: `@softDepend SimpleAuth`
  * - `@ignoreCancelled`: Cancelled events WILL NOT be passed to this handler.
  * - `@priority <PRIORITY>`: Sets the priority at which this event handler will receive events.
  *     Example: `@priority HIGHEST`

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -747,13 +747,13 @@ class PluginManager{
 				}
 				try{
 					$eventClass = $parameters[0]->getClass();
-				}catch(\ReflectionException $e){ //class doesn't exist
-					if(isset($tags["softDepend"]) && !isset($this->plugins[$tags["softDepend"]])){
-						$this->server->getLogger()->debug("Not registering @softDepend listener " . get_class($listener) . "::" . $method->getName() . "(" . $parameters[0]->getType()->getName() . ") because plugin \"" . $tags["softDepend"] . "\" not found");
-						continue;
-					}
-
-					throw $e;
+				}catch(\ReflectionException $e){
+					//class doesn't exist, skip it
+					//we don't emit an error here because we don't know if the parameter is an Event subclass or not
+					//for consistency, we shouldn't be choking on functions that have bad single parameters, since we
+					//won't choke on functions that have more than 1 parameter since they are skipped by the above check.
+					$plugin->getLogger()->debug("Skipping candidate event handler " . get_class($listener) . "->" . $method->getName() . "(): parameter class does not exist");
+					continue;
 				}
 				if($eventClass === null or !$eventClass->isSubclassOf(Event::class)){
 					continue;


### PR DESCRIPTION
…s with missing classes

If the class is missing, we can't make any assumptions about the class' inheritance chain. While this error might seem nice at first glance, it doesn't make sense for it to only crop up here, when registering handlers. Instead, it would make more sense to have a debugging autoloader which checks ALL the things irrelevant of whether they are handlers or not.

TL;DR: It's not the responsibility of registerEvents() to barf on this, since it will only barf when it's hitting something it likes the look of. While I think crashing is better than bad behaviour, this validation should happen somewhere else where it is more effective.