### PR TITLE
Exploit PHP copy-on-write behaviour to reduce chunk memory usage by 20-40%

### DIFF
--- a/src/pocketmine/level/format/Chunk.php
+++ b/src/pocketmine/level/format/Chunk.php
@@ -840,8 +840,12 @@ class Chunk{
 	 */
 	public function collectGarbage() : void{
 		foreach($this->subChunks as $y => $subChunk){
-			if(!($subChunk instanceof EmptySubChunk) and $subChunk->isEmpty()){ //normal subchunk full of air, remove it and replace it with an empty stub
-				$this->subChunks[$y] = $this->emptySubChunk;
+			if($subChunk instanceof SubChunk){
+				if($subChunk->isEmpty()){
+					$this->subChunks[$y] = $this->emptySubChunk;
+				}else{
+					$subChunk->collectGarbage();
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This takes advantage of two key behaviours of PHP:

1. Assigning a string does not copy the string.
2. Changing an offset in a string causes the string to be copied.

These two factors combined, along with the fact that blocklight and skylight arrays are usually all-zeros, allow us to produce a significant memory usage reduction of loaded chunks.
A freshly generated PM world with 3,332 chunks loaded drops from 310MB to 200MB memory usage with these changes applied.

This closes #2492 .

## Changes
### Behavioural changes
No behavioural changes are expected except for a 20-40% drop in memory usage (perhaps up to 60% in edge cases).

## Backwards compatibility
This should have zero effects on BC, so it targets 3.4.0.

## Tests
Tested in-game with a freshly-generated PMgen world.
- Before changes, 3,332 chunks occupy 310 MB of RAM.
- After changes, 3,332 chunks occupy 200 MB of RAM.