### PR TITLE
Force minimum uptime to be >= 120 seconds if the server crashes

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -2247,6 +2247,12 @@ class Server{
 
 		$this->forceShutdown();
 		$this->isRunning = false;
+
+		//Force minimum uptime to be >= 120 seconds, to reduce the impact of spammy crash loops
+		$spacing = ((int) \pocketmine\START_TIME) - time() + 120;
+		if($spacing > 0){
+			sleep($spacing);
+		}
 		@Utils::kill(getmypid());
 		exit(1);
 	}


### PR DESCRIPTION
## Introduction
This is an incremental improvement over 4a6841a5a465c791b512517394241f0ac0b38739. This change works better because it also reduces disk spam of crashdumps.

This will now sleep if the server uptime was less than 120 seconds before crashing. If unattended, this will clamp down on automated crashdump spam. If attended, the user can simply press CTRL+C to abort the process and skip the delay.

## Changes
### Behavioural changes
If the server crashes with < 120 seconds of uptime, it will now sleep until 120 seconds has passed since the start time.