### PR TITLE
Liquid: Add events to allow controlling flow and fusion

### DIFF
--- a/src/pocketmine/block/Liquid.php
+++ b/src/pocketmine/block/Liquid.php
@@ -24,6 +24,8 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\entity\Entity;
+use pocketmine\event\block\BlockFormEvent;
+use pocketmine\event\block\BlockSpreadEvent;
 use pocketmine\item\Item;
 use pocketmine\level\Level;
 use pocketmine\math\AxisAlignedBB;
@@ -294,12 +296,16 @@ abstract class Liquid extends Transparent{
 
 	protected function flowIntoBlock(Block $block, int $newFlowDecay) : void{
 		if($this->canFlowInto($block) and !($block instanceof Liquid)){
-			if($block->getId() > 0){
-				$this->level->useBreakOn($block);
-			}
+			$ev = new BlockSpreadEvent($block, $this, BlockFactory::get($this->getId(), $newFlowDecay));
+			$ev->call();
+			if(!$ev->isCancelled()){
+				if($block->getId() > 0){
+					$this->level->useBreakOn($block);
+				}
 
-			$this->level->setBlock($block, BlockFactory::get($this->getId(), $newFlowDecay), true, true);
-			$this->level->scheduleDelayedBlockUpdate($block, $this->tickRate());
+				$this->level->setBlock($block, $ev->getNewState(), true, true);
+				$this->level->scheduleDelayedBlockUpdate($block, $this->tickRate());
+			}
 		}
 	}
 
@@ -425,10 +431,12 @@ abstract class Liquid extends Transparent{
 	}
 
 	protected function liquidCollide(Block $cause, Block $result) : bool{
-		//TODO: add events
-
-		$this->level->setBlock($this, $result, true, true);
-		$this->level->broadcastLevelSoundEvent($this->add(0.5, 0.5, 0.5), LevelSoundEventPacket::SOUND_FIZZ, (int) ((2.6 + (lcg_value() - lcg_value()) * 0.8) * 1000));
+		$ev = new BlockFormEvent($this, $result);
+		$ev->call();
+		if(!$ev->isCancelled()){
+			$this->level->setBlock($this, $ev->getNewState(), true, true);
+			$this->level->broadcastLevelSoundEvent($this->add(0.5, 0.5, 0.5), LevelSoundEventPacket::SOUND_FIZZ, (int) ((2.6 + (lcg_value() - lcg_value()) * 0.8) * 1000));
+		}
 		return true;
 	}
 


### PR DESCRIPTION
## Introduction
Liquid has historically been difficult to control by plugins. I remember years ago trying to have water contained within plot bounds for MyPlot, and it was difficult and laggy.

## Changes
### API changes
This adds two event calls fired for liquids:
- `BlockSpreadEvent` is now fired when liquids spread to other blocks.
- `BlockFormEvent` is now called when lava and water collide to form a new block.

## Tests
```php
	public function onBlockSpread(BlockSpreadEvent $event) : void{
		$source = $event->getSource();
		$target = $event->getBlock();
		$level = $target->getLevel();
		if($source instanceof Liquid and $level->getChunkAtPosition($source) !== $level->getChunkAtPosition($target)){
			//prevent liquid flowing outside a chunk :)
			$event->setCancelled();
		}
	}
```
