### PR TITLE
Introduce a "block write-batch" concept

### DIFF
--- a/src/pocketmine/block/Door.php
+++ b/src/pocketmine/block/Door.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\item\Item;
+use pocketmine\level\BlockWriteBatch;
 use pocketmine\level\sound\DoorSound;
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Bearing;
@@ -123,9 +124,10 @@ abstract class Door extends Transparent{
 			$topHalf = clone $this;
 			$topHalf->top = true;
 
-			parent::place($item, $blockReplace, $blockClicked, $face, $clickVector, $player);
-			$this->level->setBlock($blockUp, $topHalf); //Top
-			return true;
+			$write = new BlockWriteBatch();
+			$write->addBlock($blockReplace, $this)->addBlock($blockUp, $topHalf);
+
+			return $write->apply($this->level);
 		}
 
 		return false;

--- a/src/pocketmine/block/DoublePlant.php
+++ b/src/pocketmine/block/DoublePlant.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\item\Item;
+use pocketmine\level\BlockWriteBatch;
 use pocketmine\math\Facing;
 use pocketmine\math\Vector3;
 use pocketmine\Player;
@@ -49,12 +50,12 @@ class DoublePlant extends Flowable{
 	public function place(Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, Player $player = null) : bool{
 		$id = $blockReplace->getSide(Facing::DOWN)->getId();
 		if(($id === Block::GRASS or $id === Block::DIRT) and $blockReplace->getSide(Facing::UP)->canBeReplaced()){
-			$this->getLevel()->setBlock($blockReplace, $this, false);
 			$top = clone $this;
 			$top->top = true;
-			$this->getLevel()->setBlock($blockReplace->getSide(Facing::UP), $top, false);
 
-			return true;
+			$write = new BlockWriteBatch();
+			$write->addBlock($blockReplace, $this)->addBlock($blockReplace->getSide(Facing::UP), $top);
+			return $write->apply($this->level);
 		}
 
 		return false;

--- a/src/pocketmine/level/BlockWriteBatch.php
+++ b/src/pocketmine/level/BlockWriteBatch.php
@@ -35,7 +35,7 @@ class BlockWriteBatch{
 	private $validators = [];
 
 	public function __construct(){
-		$this->addValidator(function(ChunkManager $world, int $x, int $y, int $z, Block $candidate) : bool{
+		$this->addValidator(function(ChunkManager $world, int $x, int $y, int $z) : bool{
 			return $world->isInWorld($x, $y, $z);
 		});
 	}
@@ -76,9 +76,9 @@ class BlockWriteBatch{
 	 * @return bool if the application was successful
 	 */
 	public function apply(ChunkManager $world) : bool{
-		foreach($this->getBlocks() as [$x, $y, $z, $block]){
+		foreach($this->getBlocks() as [$x, $y, $z, $_]){
 			foreach($this->validators as $validator){
-				if(!$validator($world, $x, $y, $z, $block)){
+				if(!$validator($world, $x, $y, $z)){
 					return false;
 				}
 			}
@@ -124,11 +124,10 @@ class BlockWriteBatch{
 	 * @param int          $x
 	 * @param int          $y
 	 * @param int          $z
-	 * @param Block        $candidate
 	 *
 	 * @return bool
 	 */
-	public function dummyValidator(ChunkManager $world, int $x, int $y, int $z, Block $candidate) : bool{
+	public function dummyValidator(ChunkManager $world, int $x, int $y, int $z) : bool{
 		return true;
 	}
 }

--- a/src/pocketmine/level/BlockWriteBatch.php
+++ b/src/pocketmine/level/BlockWriteBatch.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\level;
+
+use pocketmine\block\Block;
+use pocketmine\math\Vector3;
+
+class BlockWriteBatch{
+	/** @var Block[][][] */
+	private $blocks = [];
+
+	/**
+	 * Adds a block to the batch at the given position.
+	 *
+	 * @param Vector3 $pos
+	 * @param Block   $state
+	 *
+	 * @return $this
+	 */
+	public function addBlock(Vector3 $pos, Block $state) : self{
+		return $this->addBlockAt($pos->getFloorX(), $pos->getFloorY(), $pos->getFloorZ(), $state);
+	}
+
+	/**
+	 * Adds a block to the batch at the given coordinates.
+	 *
+	 * @param int   $x
+	 * @param int   $y
+	 * @param int   $z
+	 * @param Block $state
+	 *
+	 * @return $this
+	 */
+	public function addBlockAt(int $x, int $y, int $z, Block $state) : self{
+		$this->blocks[$x][$y][$z] = $state;
+		return $this;
+	}
+
+	/**
+	 * Validates and attempts to apply the batch to the given world. If any part of the batch fails to validate, no
+	 * changes will be made to the world.
+	 *
+	 * @param ChunkManager $world
+	 *
+	 * @return bool if the application was successful
+	 */
+	public function apply(ChunkManager $world) : bool{
+		foreach($this->getBlocks() as [$x, $y, $z, $block]){
+			if(!$this->validate($world, $x, $y, $z, $block)){
+				return false;
+			}
+		}
+		foreach($this->getBlocks() as [$x, $y, $z, $block]){
+			$world->setBlockAt($x, $y, $z, $block);
+		}
+		return true;
+	}
+
+	/**
+	 * @return \Generator|mixed[] [int $x, int $y, int $z, Block $block]
+	 */
+	public function getBlocks() : \Generator{
+		foreach($this->blocks as $x => $yLine){
+			foreach($yLine as $y => $zLine){
+				foreach($zLine as $z => $block){
+					yield [$x, $y, $z, $block];
+				}
+			}
+		}
+	}
+
+	/**
+	 * @param ChunkManager $world
+	 * @param int          $x
+	 * @param int          $y
+	 * @param int          $z
+	 * @param Block        $state
+	 *
+	 * @return bool
+	 */
+	private function validate(ChunkManager $world, int $x, int $y, int $z, Block $state) : bool{
+		if(!$world->isInWorld($x, $y, $z)){
+			return false;
+		}
+		//TODO: add ability to inject extra validity checks
+		return true;
+	}
+}

--- a/src/pocketmine/level/generator/object/SpruceTree.php
+++ b/src/pocketmine/level/generator/object/SpruceTree.php
@@ -26,6 +26,7 @@ namespace pocketmine\level\generator\object;
 use pocketmine\block\Block;
 use pocketmine\block\BlockFactory;
 use pocketmine\block\Wood;
+use pocketmine\level\BlockWriteBatch;
 use pocketmine\level\ChunkManager;
 use pocketmine\utils\Random;
 
@@ -35,14 +36,18 @@ class SpruceTree extends Tree{
 		parent::__construct(BlockFactory::get(Block::LOG, Wood::SPRUCE), BlockFactory::get(Block::LEAVES, Wood::SPRUCE), 10);
 	}
 
+	protected function generateChunkHeight(Random $random) : int{
+		return $this->treeHeight - $random->nextBoundedInt(3);
+	}
+
 	public function placeObject(ChunkManager $level, int $x, int $y, int $z, Random $random) : void{
 		$this->treeHeight = $random->nextBoundedInt(4) + 6;
+		parent::placeObject($level, $x, $y, $z, $random);
+	}
 
+	protected function placeCanopy(ChunkManager $level, int $x, int $y, int $z, Random $random, BlockWriteBatch $write) : void{
 		$topSize = $this->treeHeight - (1 + $random->nextBoundedInt(2));
 		$lRadius = 2 + $random->nextBoundedInt(2);
-
-		$this->placeTrunk($level, $x, $y, $z, $random, $this->treeHeight - $random->nextBoundedInt(3));
-
 		$radius = $random->nextBoundedInt(2);
 		$maxR = 1;
 		$minR = 0;
@@ -59,7 +64,7 @@ class SpruceTree extends Tree{
 					}
 
 					if(!$level->getBlockAt($xx, $yyy, $zz)->isSolid()){
-						$level->setBlockAt($xx, $yyy, $zz, $this->leafBlock);
+						$write->addBlockAt($xx, $yyy, $zz, $this->leafBlock);
 					}
 				}
 			}


### PR DESCRIPTION
## Problem
It's often desired to generate structures which are composed of multiple blocks. However, in some situations it's possible that the structure may not be able to be placed. The most common example of this problem is placing large objects at the top or bottom of the world, such as doors, trees, and double plants.

## Solution
This pull request introduces a rough example of a "block write-batch". The aim of this is to provide a "transaction" style block placement method, where if any part of the writebatch cannot apply, the whole writebatch fails and no changes are made to the world.

Currently the only supported check is an in-world check, but I plan to extend this to allow more flexible validity checks.

This fixes various issues with the height limit, including #2441 , #2548 and more.

This has been PR'd to get comments on the concept, and also to find out if there are any further areas where this could be applied. This has been applied ad-hoc in areas where there are problems, but it could probably be better integrated and used more widely.

This also presents interesting opportunities to optimize performance where writebatches are used, but this has not yet been explored.

### Relevant issues
- Fixes #2441 
- Fixes #2548 
- Closes #2498 


## Changes
### API changes
- Added a new `BlockWriteBatch` class.

### Behavioural changes
- Fixed structural bugs described above.
- Tree generation is now slightly different per seed due to different RNG request order by the generation code.