### PR TITLE
Use 2 spaces in all YAML files for consistency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,3 +4,7 @@ root = yes
 [*]
 indent_size = 4
 indent_style = tab
+
+[*.yml]
+indent_size = 2
+indent_style = space

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,22 +4,22 @@ php:
  - 7.2
 
 before_script:
-# - pecl install channel://pecl.php.net/pthreads-3.1.6
- - echo | pecl install channel://pecl.php.net/yaml-2.0.2
- - pecl install channel://pecl.php.net/crypto-0.3.1
- - git clone https://github.com/pmmp/pthreads.git
- - cd pthreads
- - git checkout c8cfacda84f21032d6014b53e72bf345ac901dac
- - phpize
- - ./configure
- - make
- - make install
- - cd ..
- - echo "extension=pthreads.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
- - composer install
+#  - pecl install channel://pecl.php.net/pthreads-3.1.6
+  - echo | pecl install channel://pecl.php.net/yaml-2.0.2
+  - pecl install channel://pecl.php.net/crypto-0.3.1
+  - git clone https://github.com/pmmp/pthreads.git
+  - cd pthreads
+  - git checkout c8cfacda84f21032d6014b53e72bf345ac901dac
+  - phpize
+  - ./configure
+  - make
+  - make install
+  - cd ..
+  - echo "extension=pthreads.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - composer install
 
 script:
- - ./tests/travis.sh -t4
+  - ./tests/travis.sh -t4
 
 notifications:
- email: false
+  email: false

--- a/resources/pocketmine.yml
+++ b/resources/pocketmine.yml
@@ -4,201 +4,201 @@
 # New settings/defaults won't appear automatically in this file when upgrading.
 
 settings:
- #Whether to send all strings translated to server locale or let the device handle them
- force-language: false
- shutdown-message: "Server closed"
- #Allow listing plugins via Query
- query-plugins: true
- #Show a console message when a plugin uses deprecated API methods
- deprecated-verbose: true
- #Enable plugin and core profiling by default
- enable-profiling: false
- #Will only add results when tick measurement is below or equal to given value (default 20)
- profile-report-trigger: 20
- #Number of AsyncTask workers.
- #Used for plugin asynchronous tasks, world generation, compression and web communication.
- #Set this approximately to your number of cores.
- #If set to auto, it'll try to detect the number of cores (or use 2)
- async-workers: auto
- #Whether to allow running development builds. Dev builds might crash, break your plugins, corrupt your world and more.
- #It is recommended to avoid using development builds where possible.
- enable-dev-builds: false
+  #Whether to send all strings translated to server locale or let the device handle them
+  force-language: false
+  shutdown-message: "Server closed"
+  #Allow listing plugins via Query
+  query-plugins: true
+  #Show a console message when a plugin uses deprecated API methods
+  deprecated-verbose: true
+  #Enable plugin and core profiling by default
+  enable-profiling: false
+  #Will only add results when tick measurement is below or equal to given value (default 20)
+  profile-report-trigger: 20
+  #Number of AsyncTask workers.
+  #Used for plugin asynchronous tasks, world generation, compression and web communication.
+  #Set this approximately to your number of cores.
+  #If set to auto, it'll try to detect the number of cores (or use 2)
+  async-workers: auto
+  #Whether to allow running development builds. Dev builds might crash, break your plugins, corrupt your world and more.
+  #It is recommended to avoid using development builds where possible.
+  enable-dev-builds: false
 
 memory:
- #Global soft memory limit in megabytes. Set to 0 to disable
- #This will trigger low-memory-triggers and fire an event to free memory when the usage goes over this
- global-limit: 0
+  #Global soft memory limit in megabytes. Set to 0 to disable
+  #This will trigger low-memory-triggers and fire an event to free memory when the usage goes over this
+  global-limit: 0
 
- #Main thread soft memory limit in megabytes. Set to 0 to disable
- #This will trigger low-memory-triggers and fire an event to free memory when the usage goes over this
- main-limit: 0
+  #Main thread soft memory limit in megabytes. Set to 0 to disable
+  #This will trigger low-memory-triggers and fire an event to free memory when the usage goes over this
+  main-limit: 0
 
- #Main thread hard memory limit in megabytes. Set to 0 to disable
- #This will stop the server when the limit is surpassed
- main-hard-limit: 1024
+  #Main thread hard memory limit in megabytes. Set to 0 to disable
+  #This will stop the server when the limit is surpassed
+  main-hard-limit: 1024
 
- #AsyncWorker threads' hard memory limit in megabytes. Set to 0 to disable
- #This will crash the task currently executing on the worker if the task exceeds the limit
- #NOTE: THIS LIMIT APPLIES PER WORKER, NOT TO THE WHOLE PROCESS.
- async-worker-hard-limit: 256
+  #AsyncWorker threads' hard memory limit in megabytes. Set to 0 to disable
+  #This will crash the task currently executing on the worker if the task exceeds the limit
+  #NOTE: THIS LIMIT APPLIES PER WORKER, NOT TO THE WHOLE PROCESS.
+  async-worker-hard-limit: 256
 
- #Period in ticks to check memory (default 1 second)
- check-rate: 20
+  #Period in ticks to check memory (default 1 second)
+  check-rate: 20
 
- #Continue firing low-memory-triggers and event while on low memory
- continuous-trigger: true
+  #Continue firing low-memory-triggers and event while on low memory
+  continuous-trigger: true
 
- #Only if memory.continuous-trigger is enabled. Specifies the rate in memory.check-rate steps (default 30 seconds)
- continuous-trigger-rate: 30
+  #Only if memory.continuous-trigger is enabled. Specifies the rate in memory.check-rate steps (default 30 seconds)
+  continuous-trigger-rate: 30
 
- garbage-collection:
-  #Period in ticks to fire the garbage collector manually (default 30 minutes), set to 0 to disable
-  #This only affects the main thread. Other threads should fire their own collections
-  period: 36000
+  garbage-collection:
+    #Period in ticks to fire the garbage collector manually (default 30 minutes), set to 0 to disable
+    #This only affects the main thread. Other threads should fire their own collections
+    period: 36000
 
-  #Fire asynchronous tasks to collect garbage from workers
-  collect-async-worker: true
+    #Fire asynchronous tasks to collect garbage from workers
+    collect-async-worker: true
 
-  #Trigger on low memory
-  low-memory-trigger: true
+    #Trigger on low memory
+    low-memory-trigger: true
 
- #Settings controlling memory dump handling.
- memory-dump:
-  #Dump memory from async workers as well as the main thread. If you have issues with segfaults when dumping memory, disable this setting.
-  dump-async-worker: true
+  #Settings controlling memory dump handling.
+  memory-dump:
+    #Dump memory from async workers as well as the main thread. If you have issues with segfaults when dumping memory, disable this setting.
+    dump-async-worker: true
 
- max-chunks:
-  #Cap maximum render distance per player when low memory is triggered. Set to 0 to disable cap.
-  chunk-radius: 4
+  max-chunks:
+    #Cap maximum render distance per player when low memory is triggered. Set to 0 to disable cap.
+    chunk-radius: 4
 
-  #Do chunk garbage collection on trigger
-  trigger-chunk-collect: true
+    #Do chunk garbage collection on trigger
+    trigger-chunk-collect: true
 
- world-caches:
-  #Disallow adding to world chunk-packet caches when memory is low
-  disable-chunk-cache: true
-  #Clear world caches when memory is low
-  low-memory-trigger: true
+  world-caches:
+    #Disallow adding to world chunk-packet caches when memory is low
+    disable-chunk-cache: true
+    #Clear world caches when memory is low
+    low-memory-trigger: true
 
 
 network:
- #Threshold for batching packets, in bytes. Only these packets will be compressed
- #Set to 0 to compress everything, -1 to disable.
- batch-threshold: 256
- #Compression level used when sending batched packets. Higher = more CPU, less bandwidth usage
- compression-level: 7
- #Use AsyncTasks for compression. Adds half/one tick delay, less CPU load on main thread
- async-compression: false
- #Experimental, only for Windows. Tries to use UPnP to automatically port forward
- upnp-forwarding: false
- #Maximum size in bytes of packets sent over the network (default 1492 bytes). Packets larger than this will be
- #fragmented or split into smaller parts. Clients can request MTU sizes up to but not more than this number.
- max-mtu-size: 1492
- #Enable encryption of Minecraft network traffic. This has an impact on performance, but prevents hackers from stealing sessions and pretending to be other players.
- #DO NOT DISABLE THIS unless you understand the risks involved.
- enable-encryption: true
+  #Threshold for batching packets, in bytes. Only these packets will be compressed
+  #Set to 0 to compress everything, -1 to disable.
+  batch-threshold: 256
+  #Compression level used when sending batched packets. Higher = more CPU, less bandwidth usage
+  compression-level: 7
+  #Use AsyncTasks for compression. Adds half/one tick delay, less CPU load on main thread
+  async-compression: false
+  #Experimental, only for Windows. Tries to use UPnP to automatically port forward
+  upnp-forwarding: false
+  #Maximum size in bytes of packets sent over the network (default 1492 bytes). Packets larger than this will be
+  #fragmented or split into smaller parts. Clients can request MTU sizes up to but not more than this number.
+  max-mtu-size: 1492
+  #Enable encryption of Minecraft network traffic. This has an impact on performance, but prevents hackers from stealing sessions and pretending to be other players.
+  #DO NOT DISABLE THIS unless you understand the risks involved.
+  enable-encryption: true
 
 debug:
- #To enable assertion execution, set zend.assertions in your php.ini to 1
- assertions:
-  #Warn if assertions are enabled in php.ini, due to assertions may impact on runtime performance if enabled.
-  warn-if-enabled: true
- #If > 1, it will show debug messages in the console
- level: 1
- #Enables /status, /gc
- commands: false
+  #To enable assertion execution, set zend.assertions in your php.ini to 1
+  assertions:
+    #Warn if assertions are enabled in php.ini, due to assertions may impact on runtime performance if enabled.
+    warn-if-enabled: true
+  #If > 1, it will show debug messages in the console
+  level: 1
+  #Enables /status, /gc
+  commands: false
 
 player:
- #Choose whether to enable player data saving.
- save-player-data: true
- anti-cheat:
-  #If false, will try to prevent speed and noclip cheats. May cause movement issues.
-  allow-movement-cheats: true
+  #Choose whether to enable player data saving.
+  save-player-data: true
+  anti-cheat:
+    #If false, will try to prevent speed and noclip cheats. May cause movement issues.
+    allow-movement-cheats: true
 
 level-settings:
- #The default format that levels will use when created
- default-format: pmanvil
- #Automatically change levels tick rate to maintain 20 ticks per second
- auto-tick-rate: true
- auto-tick-rate-limit: 20
- #Sets the base tick rate (1 = 20 ticks per second, 2 = 10 ticks per second, etc.)
- base-tick-rate: 1
- #Tick all players each tick even when other settings disallow this.
- always-tick-players: false
+  #The default format that levels will use when created
+  default-format: pmanvil
+  #Automatically change levels tick rate to maintain 20 ticks per second
+  auto-tick-rate: true
+  auto-tick-rate-limit: 20
+  #Sets the base tick rate (1 = 20 ticks per second, 2 = 10 ticks per second, etc.)
+  base-tick-rate: 1
+  #Tick all players each tick even when other settings disallow this.
+  always-tick-players: false
 
 chunk-sending:
- #To change server normal render distance, change view-distance in server.properties.
- #Amount of chunks sent to players per tick
- per-tick: 4
- #Radius of chunks that need to be sent before spawning the player
- spawn-radius: 4
+  #To change server normal render distance, change view-distance in server.properties.
+  #Amount of chunks sent to players per tick
+  per-tick: 4
+  #Radius of chunks that need to be sent before spawning the player
+  spawn-radius: 4
 
 chunk-ticking:
- #Max amount of chunks processed each tick
- per-tick: 40
- #Radius of chunks around a player to tick
- tick-radius: 3
- light-updates: false
- clear-tick-list: true
- #IDs of blocks not to perform random ticking on.
- disable-block-ticking:
-  #- 2 # grass
+  #Max amount of chunks processed each tick
+  per-tick: 40
+  #Radius of chunks around a player to tick
+  tick-radius: 3
+  light-updates: false
+  clear-tick-list: true
+  #IDs of blocks not to perform random ticking on.
+  disable-block-ticking:
+    #- 2 # grass
 
 chunk-generation:
- #Max. amount of chunks in the waiting queue to be populated
- population-queue-size: 8
+  #Max. amount of chunks in the waiting queue to be populated
+  population-queue-size: 8
 
 ticks-per:
- autosave: 6000
+  autosave: 6000
 
 auto-report:
- #Send crash reports for processing
- enabled: true
- send-code: true
- send-settings: true
- send-phpinfo: false
- use-https: true
- host: crash.pmmp.io
+  #Send crash reports for processing
+  enabled: true
+  send-code: true
+  send-settings: true
+  send-phpinfo: false
+  use-https: true
+  host: crash.pmmp.io
 
 anonymous-statistics:
- #Sends anonymous statistics for data aggregation, plugin usage tracking
- enabled: false #TODO: re-enable this when we have a new stats host
- host: stats.pocketmine.net
+  #Sends anonymous statistics for data aggregation, plugin usage tracking
+  enabled: false #TODO: re-enable this when we have a new stats host
+  host: stats.pocketmine.net
 
 auto-updater:
- enabled: true
- on-update:
-  warn-console: true
-  warn-ops: true
- #Can be development, alpha, beta or stable.
- preferred-channel: stable
- #If using a development version, it will suggest changing the channel
- suggest-channels: true
- host: update.pmmp.io
+  enabled: true
+  on-update:
+    warn-console: true
+    warn-ops: true
+  #Can be development, alpha, beta or stable.
+  preferred-channel: stable
+  #If using a development version, it will suggest changing the channel
+  suggest-channels: true
+  host: update.pmmp.io
 
 timings:
- #Choose the host to use for viewing your timings results.
- host: timings.pmmp.io
+  #Choose the host to use for viewing your timings results.
+  host: timings.pmmp.io
 
 console:
- #Choose whether to enable server stats reporting on the console title.
- #NOTE: The title ticker will be disabled regardless if console colours are not enabled.
- title-tick: true
+  #Choose whether to enable server stats reporting on the console title.
+  #NOTE: The title ticker will be disabled regardless if console colours are not enabled.
+  title-tick: true
 
 aliases:
- #Examples:
- #showtheversion: version
- #savestop: [save-all, stop]
+  #Examples:
+  #showtheversion: version
+  #savestop: [save-all, stop]
 
 worlds:
- #These settings will override the generator set in server.properties and allows loading multiple levels
- #Example:
- #world:
- # seed: 404
- # generator: FLAT:2;7,59x1,3x3,2;1;decoration(treecount=80 grasscount=45)
+  #These settings will override the generator set in server.properties and allows loading multiple levels
+  #Example:
+  #world:
+  #  seed: 404
+  #  generator: FLAT:2;7,59x1,3x3,2;1;decoration(treecount=80 grasscount=45)
 
 plugins:
- #Setting this to true will cause the legacy structure to be used where plugin data is placed inside the --plugins dir.
- #False will place plugin data under plugin_data under --data.
- #This option exists for backwards compatibility with existing installations.
- legacy-data-dir: false
+  #Setting this to true will cause the legacy structure to be used where plugin data is placed inside the --plugins dir.
+  #False will place plugin data under plugin_data under --data.
+  #This option exists for backwards compatibility with existing installations.
+  legacy-data-dir: false

--- a/resources/resource_packs.yml
+++ b/resources/resource_packs.yml
@@ -4,9 +4,9 @@
 #NOTE: This will do nothing if there are no resource packs in the stack below.
 force_resources: false
 resource_stack:
- #Resource packs here are applied from bottom to top. This means that resources in higher packs will override those in lower packs.
- #Entries here must indicate the filename of the resource pack.
- #Example
- # - natural.zip
- # - vanilla.zip
- #If you want to force clients to use vanilla resources, you must place a vanilla resource pack in your resources folder and add it to the stack here.
+  #Resource packs here are applied from bottom to top. This means that resources in higher packs will override those in lower packs.
+  #Entries here must indicate the filename of the resource pack.
+  #Example
+  #  - natural.zip
+  #  - vanilla.zip
+  #If you want to force clients to use vanilla resources, you must place a vanilla resource pack in your resources folder and add it to the stack here.


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
The number of indents in PocketMine is inconsistent, and it is not specified in .editorconfig, leading to confusion when editing new YAML files.

The common candidates are 1 spaces, 2 spaces, 4 spaces and 8 spaces.

### 1 space
1 space is the current format used in pocketmine.yml, resource_packs.yml and .travis.yml. Nevertheless, in my opinion, 1 space looks ugly and hard to spot, and I bet most people will agree with me here. In addition, commenting out one space has a confusing appearance:

```yaml
uncommented:
 still: uncommented
#This line of comment is not supposed to be removed
# commented from: the line start
 #commented after: the indent
#no indent: but commented
```

The prose comment on line 3 does not use any spaces, but some may find `#` look ugly when followed by text without a space in between.
The one-indent line 4 is unclear whether the space in `# commented...` is part of the `#` or an indent.
The one-indent line 5 is more apparent, but I don't see this convention being used in pocketmine.yml comments. It also appears that PhpStorm <kbd><kbd>Ctrl</kbd>+<kbd>/</kbd></kbd> places the comment symbol `#` at the line start rather than between indents and text start.

Since one space behind `#` is trivial but two spaces behind it isn't, this can be considered a disadvantage of one indent.

In short, one indent is ugly, and should be changed.

### 2 spaces
2 spaces is the default output from `yaml_emit()`. Using this format is consistent with autogenerated YAML files. Since both editors display tabs with size of 4 or 8, using 2 spaces can also help distinguish from tabs.

### 4 spaces
4 spaces is consistent with the tab indent size in the `[*]` entry in .editorconfig, but I don't see it used anywhere within the project.

### 8 spaces
I haven't seen anyone use 8 spaces in YAML files, except vim users who are too lazy to setup their indent size.

As such, 2 spaces would be the best choice, especially given the yaml_emit() convention.

## Changes
All resource .yml files use 2 spaces instead of 1 space. This may change the generated pocketmine.yml.

## Follow-up
May have impacts on updating pocketmine.yml automatically. @dktapps please check.

This change is targetted on master due to resources directory moving.