### PR TITLE
Moved DefaultPermissions declarations to resources/permissions.yml

### DIFF
--- a/resources/permissions.yml
+++ b/resources/permissions.yml
@@ -1,0 +1,138 @@
+pocketmine:
+  description: Allows using all PocketMine commands and utilities
+  children:
+    .broadcast:
+      description: Allows the user to receive all broadcast messages
+      children:
+        .admin:
+          description: Allows the user to receive administrative broadcasts
+        .user:
+          description: Allows the user to receive user broadcasts
+          default: true
+    .spawnprotect.bypass:
+      description: Allows the user to edit blocks within the protected spawn radius
+    .command:
+      description: Allows using all PocketMine commands
+      children:
+        .whitelist:
+          description: Allows the user to modify the server whitelist
+          children:
+            .add:
+              description: Allows the user to add a player to the server whitelist
+            .remove:
+              description: Allows the user to remove a player to the server whitelist
+            .reload:
+              description: Allows the user to reload the server whitelist
+            .enable:
+              description: Allows the user to enable the server whitelist
+            .disable:
+              description: Allows the user to disable the server whitelist
+            .list:
+              description: Allows the user to list all the players on the server whitelist
+        .ban:
+          description: Allows the user to ban people
+          children:
+            .player:
+              description: Allows the user to ban players
+            .ip:
+              description: Allows the user to ban IP addresses
+        .unban:
+          description: Allows the user to unban people
+          children:
+            .player:
+              description: Allows the user to unban players
+            .ip:
+              description: Allows the user to unban IP addresses
+        .op:
+          description: Allows the user to change operators
+          children:
+            .give:
+              description: Allows the user to give a player's operator status
+            .take:
+              description: Allows the user to take a player's operator status
+        .save:
+          description: Allows the user to save the worlds
+          children:
+            .enable:
+              description: Allows the user to enable automatic saving
+            .disable:
+              description: Allows the user to disable automatic saving
+            .perform:
+              description: Allows the user to perform a manual save
+        .time:
+          description: Allows the user to alter the time
+          children:
+            .add:
+              description: Allows the user to fast-forward time
+            .set:
+              description: Allows the user to change the time
+            .start:
+              description: Allows the user to restart the time
+            .stop:
+              description: Allows the user to stop the time
+            .query:
+              description: Allows the user query the time
+        .kill:
+          description: Allows the user to kill players
+          children:
+            .self:
+              description: Allows the user to commit suicide
+              default: true
+            .other:
+              description: Allows the user to kill other players
+        .me:
+          description: Allows the user to perform a chat action
+          default: true
+        .tell:
+          description: Allows the user to privately message another player
+          default: true
+        .say:
+          description: Allows the user to talk as the console
+        .give:
+          description: Allows the user to give items to players
+        .effect:
+          description: Allows the user to give/take potion effects
+        .enchant:
+          description: Allows the user to enchant items
+        .particle:
+          description: Allows the user to create particle effects
+        .teleport:
+          description: Allows the user to teleport players
+        .kick:
+          description: Allows the user to kick players
+        .stop:
+          description: Allows the user to stop the server
+        .list:
+          description: Allows the user to list all online players
+        .help:
+          description: Allows the user to view the help menu
+          default: true
+        .plugins:
+          description: Allows the user to view the list of plugins
+        .reload:
+          description: Allows the user to reload the server settings
+        .version:
+          description: Allows the user to view the version of the server
+          default: true
+        .gamemode:
+          description: Allows the user to change the gamemode of players
+        .defaultgamemode:
+          description: Allows the user to change the default gamemode
+        .seed:
+          description: Allows the user to view the seed of the world
+        .status:
+          description: Allows the user to view the server performance
+        .gc:
+          description: Allows the user to fire garbage collection tasks
+        .dumpmemory:
+          description: Allows the user to dump memory contents
+        .timings:
+          description: Allows the user to records timings for all plugin events
+        .spawnpoint:
+          description: Allows the user to change player's spawnpoint
+        .setworldspawn:
+          description: Allows the user to change the world spawn
+        .transferserver:
+          description: Allows the user to transfer self to another server
+        .title:
+          description: Allows the user to send a title to the specified player

--- a/src/pocketmine/permission/DefaultPermissions.php
+++ b/src/pocketmine/permission/DefaultPermissions.php
@@ -24,8 +24,6 @@ declare(strict_types=1);
 namespace pocketmine\permission;
 
 abstract class DefaultPermissions{
-	public const ROOT = "pocketmine";
-
 	/**
 	 * @param Permission $perm
 	 * @param Permission $parent
@@ -35,99 +33,29 @@ abstract class DefaultPermissions{
 	public static function registerPermission(Permission $perm, Permission $parent = null) : Permission{
 		if($parent instanceof Permission){
 			$parent->getChildren()[$perm->getName()] = true;
-
-			return self::registerPermission($perm);
 		}
+
 		PermissionManager::getInstance()->addPermission($perm);
 
 		return PermissionManager::getInstance()->getPermission($perm->getName());
 	}
 
-	public static function registerCorePermissions(){
-		$parent = self::registerPermission(new Permission(self::ROOT, "Allows using all PocketMine commands and utilities"));
+	public static function registerCorePermissions() : void{
+		$tree = yaml_parse(file_get_contents(\pocketmine\RESOURCE_PATH . "permissions.yml"));
+		self::registerTree(null, $tree);
+	}
 
-		$broadcasts = self::registerPermission(new Permission(self::ROOT . ".broadcast", "Allows the user to receive all broadcast messages"), $parent);
-		self::registerPermission(new Permission(self::ROOT . ".broadcast.admin", "Allows the user to receive administrative broadcasts", Permission::DEFAULT_OP), $broadcasts);
-		self::registerPermission(new Permission(self::ROOT . ".broadcast.user", "Allows the user to receive user broadcasts", Permission::DEFAULT_TRUE), $broadcasts);
-		$broadcasts->recalculatePermissibles();
-
-		$spawnprotect = self::registerPermission(new Permission(self::ROOT . ".spawnprotect.bypass", "Allows the user to edit blocks within the protected spawn radius", Permission::DEFAULT_OP), $parent);
-		$spawnprotect->recalculatePermissibles();
-
-		$commands = self::registerPermission(new Permission(self::ROOT . ".command", "Allows using all PocketMine commands"), $parent);
-
-		$whitelist = self::registerPermission(new Permission(self::ROOT . ".command.whitelist", "Allows the user to modify the server whitelist", Permission::DEFAULT_OP), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.whitelist.add", "Allows the user to add a player to the server whitelist"), $whitelist);
-		self::registerPermission(new Permission(self::ROOT . ".command.whitelist.remove", "Allows the user to remove a player to the server whitelist"), $whitelist);
-		self::registerPermission(new Permission(self::ROOT . ".command.whitelist.reload", "Allows the user to reload the server whitelist"), $whitelist);
-		self::registerPermission(new Permission(self::ROOT . ".command.whitelist.enable", "Allows the user to enable the server whitelist"), $whitelist);
-		self::registerPermission(new Permission(self::ROOT . ".command.whitelist.disable", "Allows the user to disable the server whitelist"), $whitelist);
-		self::registerPermission(new Permission(self::ROOT . ".command.whitelist.list", "Allows the user to list all the players on the server whitelist"), $whitelist);
-		$whitelist->recalculatePermissibles();
-
-		$ban = self::registerPermission(new Permission(self::ROOT . ".command.ban", "Allows the user to ban people", Permission::DEFAULT_OP), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.ban.player", "Allows the user to ban players"), $ban);
-		self::registerPermission(new Permission(self::ROOT . ".command.ban.ip", "Allows the user to ban IP addresses"), $ban);
-		$ban->recalculatePermissibles();
-
-		$unban = self::registerPermission(new Permission(self::ROOT . ".command.unban", "Allows the user to unban people", Permission::DEFAULT_OP), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.unban.player", "Allows the user to unban players"), $unban);
-		self::registerPermission(new Permission(self::ROOT . ".command.unban.ip", "Allows the user to unban IP addresses"), $unban);
-		$unban->recalculatePermissibles();
-
-		$op = self::registerPermission(new Permission(self::ROOT . ".command.op", "Allows the user to change operators", Permission::DEFAULT_OP), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.op.give", "Allows the user to give a player operator status"), $op);
-		self::registerPermission(new Permission(self::ROOT . ".command.op.take", "Allows the user to take a players operator status"), $op);
-		$op->recalculatePermissibles();
-
-		$save = self::registerPermission(new Permission(self::ROOT . ".command.save", "Allows the user to save the worlds", Permission::DEFAULT_OP), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.save.enable", "Allows the user to enable automatic saving"), $save);
-		self::registerPermission(new Permission(self::ROOT . ".command.save.disable", "Allows the user to disable automatic saving"), $save);
-		self::registerPermission(new Permission(self::ROOT . ".command.save.perform", "Allows the user to perform a manual save"), $save);
-		$save->recalculatePermissibles();
-
-		$time = self::registerPermission(new Permission(self::ROOT . ".command.time", "Allows the user to alter the time", Permission::DEFAULT_OP), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.time.add", "Allows the user to fast-forward time"), $time);
-		self::registerPermission(new Permission(self::ROOT . ".command.time.set", "Allows the user to change the time"), $time);
-		self::registerPermission(new Permission(self::ROOT . ".command.time.start", "Allows the user to restart the time"), $time);
-		self::registerPermission(new Permission(self::ROOT . ".command.time.stop", "Allows the user to stop the time"), $time);
-		self::registerPermission(new Permission(self::ROOT . ".command.time.query", "Allows the user query the time"), $time);
-		$time->recalculatePermissibles();
-
-		$kill = self::registerPermission(new Permission(self::ROOT . ".command.kill", "Allows the user to kill players", Permission::DEFAULT_OP), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.kill.self", "Allows the user to commit suicide", Permission::DEFAULT_TRUE), $kill);
-		self::registerPermission(new Permission(self::ROOT . ".command.kill.other", "Allows the user to kill other players"), $kill);
-		$kill->recalculatePermissibles();
-
-		self::registerPermission(new Permission(self::ROOT . ".command.me", "Allows the user to perform a chat action", Permission::DEFAULT_TRUE), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.tell", "Allows the user to privately message another player", Permission::DEFAULT_TRUE), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.say", "Allows the user to talk as the console", Permission::DEFAULT_OP), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.give", "Allows the user to give items to players", Permission::DEFAULT_OP), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.effect", "Allows the user to give/take potion effects", Permission::DEFAULT_OP), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.enchant", "Allows the user to enchant items", Permission::DEFAULT_OP), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.particle", "Allows the user to create particle effects", Permission::DEFAULT_OP), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.teleport", "Allows the user to teleport players", Permission::DEFAULT_OP), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.kick", "Allows the user to kick players", Permission::DEFAULT_OP), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.stop", "Allows the user to stop the server", Permission::DEFAULT_OP), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.list", "Allows the user to list all online players", Permission::DEFAULT_OP), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.help", "Allows the user to view the help menu", Permission::DEFAULT_TRUE), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.plugins", "Allows the user to view the list of plugins", Permission::DEFAULT_OP), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.reload", "Allows the user to reload the server settings", Permission::DEFAULT_OP), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.version", "Allows the user to view the version of the server", Permission::DEFAULT_TRUE), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.gamemode", "Allows the user to change the gamemode of players", Permission::DEFAULT_OP), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.defaultgamemode", "Allows the user to change the default gamemode", Permission::DEFAULT_OP), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.seed", "Allows the user to view the seed of the world", Permission::DEFAULT_OP), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.status", "Allows the user to view the server performance", Permission::DEFAULT_OP), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.gc", "Allows the user to fire garbage collection tasks", Permission::DEFAULT_OP), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.dumpmemory", "Allows the user to dump memory contents", Permission::DEFAULT_OP), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.timings", "Allows the user to records timings for all plugin events", Permission::DEFAULT_OP), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.spawnpoint", "Allows the user to change player's spawnpoint", Permission::DEFAULT_OP), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.setworldspawn", "Allows the user to change the world spawn", Permission::DEFAULT_OP), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.transferserver", "Allows the user to transfer self to another server", Permission::DEFAULT_OP), $commands);
-		self::registerPermission(new Permission(self::ROOT . ".command.title", "Allows the user to send a title to the specified player", Permission::DEFAULT_OP), $commands);
-
-		$commands->recalculatePermissibles();
-
-		$parent->recalculatePermissibles();
+	private static function registerTree(?Permission $parent, array $children) : void{
+		foreach($children as $name => $contents){
+			$default = $contents["default"] ?? "op";
+			if(is_bool($default)){
+				$default = $default ? "true" : "false";
+			}
+			$description = $contents["description"];
+			$name = ($parent !== null ? $parent->getName() : "") . $name;
+			$node = self::registerPermission(new Permission($name, $description, $default), $parent);
+			self::registerTree($node, $contents["children"] ?? []);
+			$node->recalculatePermissibles();
+		}
 	}
 }


### PR DESCRIPTION
## Introduction
This makes permissions easier to manipulate.

## Changes
### API changes
`PermissionManager::ROOT` is removed.

### Behavioural changes
A typo fix for pocketmine.command.give is also made. Although it is irrelevant to this change, it is too small to matter anyway.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Apart from the removal of `PermissionManager::ROOT`, no other problems.

This permission node was removed as it is very pointless to have a constant that only names one of the core permissions.

### Impact assessment
https://poggit.pmmp.io/grepPlugins.php
Only 3 plugins are affected: PurePerms by @64FF00, PluginsInfo by @TheNewHEROBRINEX and ThePermissionManager by @jasonwynn10.

## Tests
A .dot file before and after the change has been generated by a script plugin:

```php
<?php

/**
 * @name dotPermissions
 * @api     4.0.0
 * @version 4.0.0
 * @main    SOFe\dotPermissions
 * @author  SOFe
 */

declare(strict_types=1);

namespace SOFe;

use pocketmine\permission\Permission;
use pocketmine\permission\PermissionManager;
use pocketmine\plugin\PluginBase;
use pocketmine\scheduler\ClosureTask;

class dotPermissions extends PluginBase{
	protected function onEnable() : void{
		$this->getScheduler()->scheduleTask(new ClosureTask(function(int $t) : void{
			$perm = PermissionManager::getInstance()->getPermission("pocketmine");
			assert($perm !== null);
			$fh = fopen($this->getDataFolder() . "permissions.dot", "wb");
			fwrite($fh, "digraph Permissions {\n");
			static::writeNode($fh, $perm, null);
			fwrite($fh, "}\n");
			fclose($fh);
		}));
	}

	private static function writeNode($fh, Permission $permission, ?string $parent) : void{
		$name = str_replace(".", "_", $permission->getName());
		$label = $name . "\\n" . $permission->getDescription();
		$color = substr(md5($permission->getDefault()), 0, 6);
		fwrite($fh, "\t{$name} [label=\"$label\", color=\"#$color\"]\n");
		if($parent !== null){
			fwrite($fh, "\t{$parent} -> {$name}\n");
		}
		foreach($permission->getChildren() as $child => $_){
			self::writeNode($fh, PermissionManager::getInstance()->getPermission($child), $name);
		}
	}
}

```

The diff of the generated files on 20aaa8373a1b37b2f5e12875411a6ec96819a629 and in this pull request has been computed:

```diff
41c41
<       pocketmine_command_op_give [label="pocketmine_command_op_give\nAllows the user to give a player operator status", color="#11d8c2"]
---
>       pocketmine_command_op_give [label="pocketmine_command_op_give\nAllows the user to give a player's operator status", color="#11d8c2"]
43c43
<       pocketmine_command_op_take [label="pocketmine_command_op_take\nAllows the user to take a players operator status", color="#11d8c2"]
---
>       pocketmine_command_op_take [label="pocketmine_command_op_take\nAllows the user to take a player's operator status", color="#11d8c2"]
```

Except the typo fix I mentioned, no behaviour is changed, not even the permission order.