### PR TITLE
Added notifications manager

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
  */
 namespace pocketmine;
 
+use LogLevel;
 use pocketmine\block\BlockFactory;
 use pocketmine\command\CommandReader;
 use pocketmine\command\CommandSender;
@@ -102,6 +103,7 @@ use pocketmine\utils\Binary;
 use pocketmine\utils\Config;
 use pocketmine\utils\Internet;
 use pocketmine\utils\MainLogger;
+use pocketmine\utils\NotificationManager;
 use pocketmine\utils\Terminal;
 use pocketmine\utils\TextFormat;
 use pocketmine\utils\Utils;
@@ -249,6 +251,9 @@ class Server{
 
 	/** @var \AttachableThreadedLogger */
 	private $logger;
+
+	/** @var NotificationManager */
+	private $notificationManager;
 
 	/** @var MemoryManager */
 	private $memoryManager;
@@ -660,6 +665,13 @@ class Server{
 	 */
 	public function getLogger(){
 		return $this->logger;
+	}
+
+	/**
+	 * @return NotificationManager
+	 */
+	public function getNotificationManager() : NotificationManager{
+		return $this->notificationManager;
 	}
 
 	/**
@@ -1484,6 +1496,8 @@ class Server{
 		$this->logger = $logger;
 
 		try{
+			$this->notificationManager = new NotificationManager($dataPath . "read-notifications.txt");
+
 			if(!file_exists($dataPath . "worlds/")){
 				mkdir($dataPath . "worlds/", 0777);
 			}
@@ -1652,12 +1666,12 @@ class Server{
 
 			$this->onlineMode = $this->getConfigBool("xbox-auth", true);
 			if($this->onlineMode){
-				$this->logger->notice($this->getLanguage()->translateString("pocketmine.server.auth.enabled"));
-				$this->logger->notice($this->getLanguage()->translateString("pocketmine.server.authProperty.enabled"));
+				$this->notificationManager->post("pocketmine.server.auth.enabled", $this->getLanguage()->translateString("pocketmine.server.auth.enabled"));
+				$this->notificationManager->post("pocketmine.server.authProperty.enabled", $this->getLanguage()->translateString("pocketmine.server.authProperty.enabled"));
 			}else{
-				$this->logger->warning($this->getLanguage()->translateString("pocketmine.server.auth.disabled"));
-				$this->logger->warning($this->getLanguage()->translateString("pocketmine.server.authWarning"));
-				$this->logger->warning($this->getLanguage()->translateString("pocketmine.server.authProperty.disabled"));
+				$this->notificationManager->post("pocketmine.server.auth.disabled", $this->getLanguage()->translateString("pocketmine.server.auth.disabled"), LogLevel::WARNING);
+				$this->notificationManager->post("pocketmine.server.authWarning", $this->getLanguage()->translateString("pocketmine.server.authWarning"), LogLevel::WARNING);
+				$this->notificationManager->post("pocketmine.server.authProperty.disabled", $this->getLanguage()->translateString("pocketmine.server.authProperty.disabled"), LogLevel::WARNING);
 			}
 
 			if($this->getConfigBool("hardcore", false) and $this->getDifficulty() < Level::DIFFICULTY_HARD){
@@ -2199,6 +2213,8 @@ class Server{
 		}
 
 		$this->logger->info($this->getLanguage()->translateString("pocketmine.server.defaultGameMode", [self::getGamemodeString($this->getGamemode())]));
+
+		$this->notificationManager->print($this->logger);
 
 		$this->logger->info($this->getLanguage()->translateString("pocketmine.server.startFinished", [round(microtime(true) - \pocketmine\START_TIME, 3)]));
 

--- a/src/pocketmine/command/SimpleCommandMap.php
+++ b/src/pocketmine/command/SimpleCommandMap.php
@@ -40,6 +40,7 @@ use pocketmine\command\defaults\KickCommand;
 use pocketmine\command\defaults\KillCommand;
 use pocketmine\command\defaults\ListCommand;
 use pocketmine\command\defaults\MeCommand;
+use pocketmine\command\defaults\NotificationsCommand;
 use pocketmine\command\defaults\OpCommand;
 use pocketmine\command\defaults\PardonCommand;
 use pocketmine\command\defaults\PardonIpCommand;
@@ -109,6 +110,7 @@ class SimpleCommandMap implements CommandMap{
 			new KillCommand("kill"),
 			new ListCommand("list"),
 			new MeCommand("me"),
+			new NotificationsCommand("notif"),
 			new OpCommand("op"),
 			new PardonCommand("pardon"),
 			new PardonIpCommand("pardon-ip"),

--- a/src/pocketmine/command/defaults/NotificationsCommand.php
+++ b/src/pocketmine/command/defaults/NotificationsCommand.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\command\defaults;
+
+use pocketmine\command\CommandSender;
+use pocketmine\command\ConsoleCommandSender;
+use pocketmine\command\utils\InvalidCommandSyntaxException;
+use pocketmine\lang\TranslationContainer;
+use pocketmine\Server;
+use pocketmine\utils\TextFormat;
+use function strtolower;
+
+class NotificationsCommand extends VanillaCommand{
+
+	public function __construct(string $name){
+		parent::__construct(
+			$name,
+			"%pocketmine.command.notif.description",
+			"%pocketmine.command.notif.usage",
+			["notification", "notifications", "notifs"]);
+	}
+
+	public function testPermissionSilent(CommandSender $target) : bool{
+		return $target instanceof ConsoleCommandSender;
+	}
+
+	public function execute(CommandSender $sender, string $commandLabel, array $args) : void{
+		if(!($sender instanceof ConsoleCommandSender)){
+			$sender->sendMessage(new TranslationContainer(TextFormat::RED . "%commands.generic.permission"));
+			return;
+		}
+		switch(strtolower($args[0] ?? "list")){
+			case "list":
+				Server::getInstance()->getNotificationManager()->print(Server::getInstance()->getLogger());
+				return;
+			case "read":
+				$manager = Server::getInstance()->getNotificationManager();
+				$cnt = $manager->markRead();
+				$sender->sendMessage(new TranslationContainer("%pocketmine.notification.markedRead", [$cnt]));
+				$manager->save();
+				return;
+			default:
+				throw new InvalidCommandSyntaxException();
+		}
+	}
+}

--- a/src/pocketmine/utils/NotificationManager.php
+++ b/src/pocketmine/utils/NotificationManager.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\utils;
+
+use Logger;
+use LogLevel;
+use pocketmine\Server;
+use function count;
+use function fclose;
+use function fgets;
+use function fopen;
+use function fwrite;
+use function is_file;
+use function trim;
+use const PHP_EOL;
+
+final class NotificationManager{
+	/** @var string */
+	private $path;
+
+	/** @var bool */
+	private $changed = false;
+	/** @var true[] */
+	private $set = [];
+
+	private $queue = [];
+
+	public function __construct(string $path){
+		$this->path = $path;
+		if(is_file($this->path)){
+			$fh = fopen($this->path, "rb");
+			while(($line = fgets($fh)) !== false){
+				$this->set[trim($line)] = true;
+			}
+			fclose($fh);
+		}
+	}
+
+	public function save() : void{
+		$fh = fopen($this->path, "wb");
+		foreach($this->set as $id => $_){
+			fwrite($fh, $id . PHP_EOL);
+		}
+		fclose($fh);
+	}
+
+
+	public function post(string $id, string $message, string $logLevel = LogLevel::NOTICE) : void{
+		if(!isset($this->set[$id])){
+			$this->queue[$id] = [$logLevel, $message];
+		}
+	}
+
+	public function print(Logger $logger) : void{
+		if(empty($this->queue)){
+			return;
+		}
+
+		$logger->notice(Server::getInstance()->getLanguage()->translateString("pocketmine.notification.header", [count($this->queue)]));
+		foreach($this->queue as [$level, $message]){
+			$logger->log($level, $message);
+		}
+		$logger->notice(Server::getInstance()->getLanguage()->translateString("pocketmine.notification.footer"));
+	}
+
+	public function markRead() : int{
+		$cnt = count($this->set);
+		foreach($this->queue as $id => $_){
+			$this->set[$id] = true;
+		}
+		$this->queue = [];
+		return $cnt;
+	}
+}


### PR DESCRIPTION
## Introduction
Some warning messages can be dismissed after the user has read the messages. This pull request adds a manager for dismissed messages, and implements this for the "auth enabled" message.

### Relevant issues

## Changes
### API changes
Added Server->getNotificationManager()

### Behavioural changes
- Added a /notif command.
- The "auth enabled/disabled" notice/warning message is no longer displayed if the user runs `notif read` from console anytime.

## Backwards compatibility
No backward compatibility problems

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `pocketmine.command.notif.description` | `View and manage notifications` |
| `pocketmine.command.notif.usage` | `/notif [list\|read]` |
| `pocketmine.notification.markedRead` | `Marked {%0} notifications as read.` |
| `pocketmine.notification.header` | `There are {%0} unread notifications` |
| `pocketmine.notification.footer` | `Run "/notif read" to not show these notifications again.` |

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->

### Prints unread messages upon startup
Start the default server setup. The startup screen should end with this:
```
[19:29:25] [Server thread/NOTICE]: pocketmine.notification.header
[19:29:25] [Server thread/NOTICE]: Online mode is enabled. The server will verify that players are authenticated to Xbox Live.
[19:29:25] [Server thread/NOTICE]: To disable authentication, set "xbox-auth" to "false" in server.properties.
[19:29:25] [Server thread/NOTICE]: pocketmine.notification.footer
[19:29:25] [Server thread/INFO]: Done (0.884s)! For help, type "help" or "?"
```

### Prints unread messages upon command
Start the default server setup. Run `notif` or `notif list`. The following output is expected:
```
[19:29:28] [Server thread/NOTICE]: pocketmine.notification.header
[19:29:28] [Server thread/NOTICE]: Online mode is enabled. The server will verify that players are authenticated to Xbox Live.
[19:29:28] [Server thread/NOTICE]: To disable authentication, set "xbox-auth" to "false" in server.properties.
[19:29:28] [Server thread/NOTICE]: pocketmine.notification.footer
```

### Mark notifications as read
Start the default server. Run `notif read`. The following output is expected:
```
[19:29:29] [Server thread/INFO]: %pocketmine.notification.markedRead
```

In addition, the file `read-notifications.txt` should be immediately created with the contents:
```
pocketmine.server.auth.enabled
pocketmine.server.authProperty.enabled
```

Then restart the server. The "online mode" notice should no longer be displayed. Nor should `pocketmine.notification.[header|footer]` be displayed.