### PR TITLE
ResourcePacksSessionHandler: Fixed a possible crash

### DIFF
--- a/src/pocketmine/network/mcpe/handler/ResourcePacksSessionHandler.php
+++ b/src/pocketmine/network/mcpe/handler/ResourcePacksSessionHandler.php
@@ -85,7 +85,7 @@ class ResourcePacksSessionHandler extends SessionHandler{
 					if(!($pack instanceof ResourcePack)){
 						//Client requested a resource pack but we don't have it available on the server
 						$this->disconnectWithError("Unknown pack $uuid requested, available packs: " . implode(", ", $this->resourcePackManager->getPackIdList()));
-						return false;
+						return true;
 					}
 
 					$pk = new ResourcePackDataInfoPacket();
@@ -118,20 +118,20 @@ class ResourcePacksSessionHandler extends SessionHandler{
 		$pack = $this->resourcePackManager->getPackById($packet->packId);
 		if(!($pack instanceof ResourcePack)){
 			$this->disconnectWithError("Invalid request for chunk $packet->chunkIndex of unknown pack $packet->packId, available packs: " . implode(", ", $this->resourcePackManager->getPackIdList()));
-			return false;
+			return true;
 		}
 
 		$packId = $pack->getPackId(); //use this because case may be different
 
 		if(isset($this->downloadedChunks[$packId][$packet->chunkIndex])){
 			$this->disconnectWithError("Duplicate request for chunk $packet->chunkIndex of pack $packet->packId");
-			return false;
+			return true;
 		}
 
 		$offset = $packet->chunkIndex * self::PACK_CHUNK_SIZE;
 		if($offset < 0 or $offset >= $pack->getPackSize()){
 			$this->disconnectWithError("Invalid out-of-bounds request for chunk $packet->chunkIndex of $packet->packId: offset $offset, file size " . $pack->getPackSize());
-			return false;
+			return true;
 		}
 
 		if(!isset($this->downloadedChunks[$packId])){


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Fixes a possible crash!

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
- When a player was quit while downloading resource packs, console is giving an error

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Tested without plugins! Working

#### Note: error text is old because it is rare

Error:
```
2018-08-24 [08:47:31] [Server thread/ERROR]: Error while downloading resource packs for EyedAhmetBabo: Duplicate request for chunk 1 of pack 9b647aca-2815-13a7-5411-0e55f8888888
2018-08-24 [08:47:31] [Server thread/INFO]: EyedAhmetBabo[/78.164.10.123:41195], Kaynak paketi indirilirken veya uygulanırken bir sorun oldu. sebebiyle çıkış yaptı
2018-08-24 [08:47:31] [Server thread/CRITICAL]: Error: "Call to a member function getName() on null" (EXCEPTION) in "src/pocketmine/network/mcpe/NetworkSession" at line 202
2018-08-24 [08:47:31] [Server thread/DEBUG]: #0 src/pocketmine/network/mcpe/NetworkSession(186): pocketmine\network\mcpe\NetworkSession->handleDataPacket(pocketmine\network\mcpe\protocol\ResourcePackChunkRequestPacket object)
2018-08-24 [08:47:31] [Server thread/DEBUG]: #1 src/pocketmine/network/mcpe/RakLibInterface(135): pocketmine\network\mcpe\NetworkSession->handleEncoded(string x...a`P.L231OLN.5.04.54N4.5514.5H55M...F......?)
2018-08-24 [08:47:31] [Server thread/DEBUG]: #2 vendor/pocketmine/raklib/src/server/ServerHandler(98): pocketmine\network\mcpe\RakLibInterface->handleEncapsulated(string 78.164.10.123 41195, raklib\protocol\EncapsulatedPacket object, integer 0)
2018-08-24 [08:47:31] [Server thread/DEBUG]: #3 src/pocketmine/network/mcpe/RakLibInterface(75): raklib\server\ServerHandler->handlePacket()
2018-08-24 [08:47:31] [Server thread/DEBUG]: #4 vendor/pocketmine/snooze/src/SleeperHandler(120): pocketmine\network\mcpe\RakLibInterface->pocketmine\network\mcpe{closure}()
2018-08-24 [08:47:31] [Server thread/DEBUG]: #5 vendor/pocketmine/snooze/src/SleeperHandler(82): pocketmine\snooze\SleeperHandler->processNotifications()
2018-08-24 [08:47:31] [Server thread/DEBUG]: #6 src/pocketmine/Server(2519): pocketmine\snooze\SleeperHandler->sleepUntil(double 1535089651.5333)
2018-08-24 [08:47:31] [Server thread/DEBUG]: #7 src/pocketmine/Server(2388): pocketmine\Server->tickProcessor()
2018-08-24 [08:47:31] [Server thread/DEBUG]: #8 src/pocketmine/Server(1890): pocketmine\Server->start()
2018-08-24 [08:47:31] [Server thread/DEBUG]: #9 src/pocketmine/PocketMine(246): pocketmine\Server->__construct(BaseClassLoader object, pocketmine\utils\MainLogger object, string /root/, string /root/plugins/)
2018-08-24 [08:47:31] [Server thread/DEBUG]: #10 /root/PocketMine-MP.phar(1): require_once(string phar:///root/PocketMine-MP.phar/src/pocketmine/PocketMine.php)
2018-08-24 [08:47:31] [RakLibServer thread/NOTICE]: Blocked 78.164.10.123 for 5 seconds ```
