### PR TITLE
make addMotion more comfortable

### DIFF
--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -1687,7 +1687,7 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 	 * @param float $y
 	 * @param float $z
 	 */
-	public function addMotion(float $x, float $y, float $z) : void{
+	public function addMotion(float $x, float $y = 0, float $z = 0) : void{
 		$this->motion->x += $x;
 		$this->motion->y += $y;
 		$this->motion->z += $z;


### PR DESCRIPTION
## Introduction
with current addMotion if we need to add only X coord need to write Entity->addMotion(1, 0, 0);
This pull request make it more easy to use: Entity->addMotion(1);

## Changes
### API changes
Entity->addMotion(float, float, float) -> Entity->addMotion(float, float = 0, float = 0)

### Behavioural changes
No.

## Backwards compatibility
Full backward compatibility
