### PR TITLE
Fixed internal IP detection

### DIFF
--- a/src/pocketmine/network/upnp/UPnP.php
+++ b/src/pocketmine/network/upnp/UPnP.php
@@ -29,9 +29,7 @@ namespace pocketmine\network\upnp;
 use pocketmine\utils\Internet;
 use pocketmine\utils\Utils;
 use function class_exists;
-use function gethostbyname;
 use function is_object;
-use function trim;
 
 abstract class UPnP{
 

--- a/src/pocketmine/network/upnp/UPnP.php
+++ b/src/pocketmine/network/upnp/UPnP.php
@@ -46,7 +46,7 @@ abstract class UPnP{
 			throw new \RuntimeException("UPnP requires the com_dotnet extension");
 		}
 
-		$myLocalIP = gethostbyname(trim(`hostname`));
+		$myLocalIP = Internet::getInternalIP();
 
 		/** @noinspection PhpUndefinedClassInspection */
 		$com = new \COM("HNetCfg.NATUPnP");

--- a/src/pocketmine/utils/Internet.php
+++ b/src/pocketmine/utils/Internet.php
@@ -98,6 +98,14 @@ class Internet{
 		return false;
 	}
 
+	public static function getInternalIP() : string{
+		$sock = socket_create(AF_INET, SOCK_DGRAM, SOL_UDP);
+		socket_connect($sock, "8.8.8.8", 65534);
+		socket_getsockname($sock, $name); // $name passed by reference
+		socket_close($sock);
+		return $name;
+	}
+
 	/**
 	 * GETs an URL using cURL
 	 * NOTE: This is a blocking operation and can take a significant amount of time. It is inadvisable to use this method on the main thread.

--- a/src/pocketmine/wizard/SetupWizard.php
+++ b/src/pocketmine/wizard/SetupWizard.php
@@ -30,9 +30,9 @@ namespace pocketmine\wizard;
 use pocketmine\lang\BaseLang;
 use pocketmine\utils\Config;
 use pocketmine\utils\Internet;
+use pocketmine\utils\InternetException;
 use function base64_encode;
 use function fgets;
-use function gethostbyname;
 use function random_bytes;
 use function sleep;
 use function strtolower;
@@ -223,7 +223,11 @@ LICENSE;
 		if($externalIP === false){
 			$externalIP = "unknown (server offline)";
 		}
-		$internalIP = Internet::getInternalIP();
+		try{
+			$internalIP = Internet::getInternalIP();
+		}catch(InternetException $e){
+			$internalIP = "unknown (" . $e->getMessage() . ")";
+		}
 
 		$this->error($this->lang->translateString("ip_warning", ["EXTERNAL_IP" => $externalIP, "INTERNAL_IP" => $internalIP]));
 		$this->error($this->lang->get("ip_confirm"));

--- a/src/pocketmine/wizard/SetupWizard.php
+++ b/src/pocketmine/wizard/SetupWizard.php
@@ -223,7 +223,7 @@ LICENSE;
 		if($externalIP === false){
 			$externalIP = "unknown (server offline)";
 		}
-		$internalIP = gethostbyname(trim(`hostname`));
+		$internalIP = Internet::getInternalIP();
 
 		$this->error($this->lang->translateString("ip_warning", ["EXTERNAL_IP" => $externalIP, "INTERNAL_IP" => $internalIP]));
 		$this->error($this->lang->get("ip_confirm"));


### PR DESCRIPTION
## Introduction
Internal IP detection is completely broken on every platform except windows. On Windows, it only works when the correct network adapter has highest priority (see #2702 ). Great!!!

This pull request fixes internal IP address detection for IPv4 local-area networks.

### Relevant issues
fixes #2702 

## Changes
### API changes
- added `Internet::getInternalIP()`

### Behavioural changes
- UPnP now works correctly with multiple net interfaces.
- Setup wizard now reports the correct internal IP on 'nix platforms.

## Tests
I don't know how to test this in an automated fashion, but this has been tested on multiple Windows and Linux devices. Connected vs unconnected state has also been tested.