### PR TITLE
Resolve problems with player inventory when canceling ProjectileLaunchEvent

### DIFF
--- a/src/pocketmine/OfflinePlayer.php
+++ b/src/pocketmine/OfflinePlayer.php
@@ -45,9 +45,7 @@ class OfflinePlayer implements IPlayer, Metadatable{
 	public function __construct(Server $server, string $name){
 		$this->server = $server;
 		$this->name = $name;
-		if($this->server->hasOfflinePlayerData($this->name)){
-			$this->namedtag = $this->server->getOfflinePlayerData($this->name);
-		}
+		$this->namedtag = $this->server->getOfflinePlayerData($this->name);
 	}
 
 	public function isOnline() : bool{

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1515,7 +1515,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 			$this->server->getLogger()->warning($this->getName() . " moved too fast, reverting movement");
 			$this->server->getLogger()->debug("Old position: " . $this->asVector3() . ", new position: " . $this->newPosition);
 			$revert = true;
-		}elseif(!$this->level->isInLoadedTerrain($newPos) or !$this->level->isChunkGenerated($newPos->getFloorX() >> 4, $newPos->getFloorZ() >> 4)){
+		}elseif(!$this->level->isInLoadedTerrain($newPos) or !$this->level->getChunk($newPos->getFloorX() >> 4, $newPos->getFloorZ() >> 4)->isGenerated()){
 			$revert = true;
 			$this->nextChunkOrderRun = 0;
 		}

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -84,6 +84,7 @@ use pocketmine\item\WritableBook;
 use pocketmine\item\WrittenBook;
 use pocketmine\lang\TextContainer;
 use pocketmine\lang\TranslationContainer;
+use pocketmine\level\ChunkListener;
 use pocketmine\level\ChunkLoader;
 use pocketmine\level\format\Chunk;
 use pocketmine\level\Level;
@@ -175,7 +176,7 @@ use const PHP_INT_MAX;
 /**
  * Main class that handles networking, recovery, and packet sending to the server part
  */
-class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
+class Player extends Human implements CommandSender, ChunkLoader, ChunkListener, IPlayer{
 
 	/**
 	 * Checks a supplied username and checks it is valid.
@@ -921,6 +922,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 			unset($this->usedChunks[$index]);
 		}
 		$level->unregisterChunkLoader($this, $x, $z);
+		$level->unregisterChunkListener($this, $x, $z);
 		unset($this->loadQueue[$index]);
 	}
 
@@ -978,6 +980,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 			$this->usedChunks[$index] = false;
 			$this->level->registerChunkLoader($this, $X, $Z, true);
+			$this->level->registerChunkListener($this, $X, $Z);
 
 			if(!$this->level->populateChunk($X, $Z)){
 				continue;
@@ -1841,6 +1844,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 		//load the spawn chunk so we can see the terrain
 		$level->registerChunkLoader($this, $spawn->getFloorX() >> 4, $spawn->getFloorZ() >> 4, true);
+		$level->registerChunkListener($this, $spawn->getFloorX() >> 4, $spawn->getFloorZ() >> 4);
 		if($spawnReset){
 			$spawn = $level->getSafeSpawn($spawn);
 		}
@@ -2911,6 +2915,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 				foreach($this->usedChunks as $index => $d){
 					Level::getXZ($index, $chunkX, $chunkZ);
 					$this->level->unregisterChunkLoader($this, $chunkX, $chunkZ);
+					$this->level->unregisterChunkListener($this, $chunkX, $chunkZ);
 					foreach($this->level->getChunkEntities($chunkX, $chunkZ) as $entity){
 						$entity->despawnFrom($this);
 					}

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -87,6 +87,7 @@ use pocketmine\level\ChunkLoader;
 use pocketmine\level\format\Chunk;
 use pocketmine\level\Level;
 use pocketmine\level\Position;
+use pocketmine\level\TerrainNotLoadedException;
 use pocketmine\math\Vector3;
 use pocketmine\metadata\MetadataValue;
 use pocketmine\nbt\NbtDataException;
@@ -2133,6 +2134,13 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		}
 	}
 
+	/**
+	 * @param Vector3 $pos
+	 * @param bool    $addTileNBT
+	 *
+	 * @return bool
+	 * @throws TerrainNotLoadedException
+	 */
 	public function pickBlock(Vector3 $pos, bool $addTileNBT) : bool{
 		$block = $this->level->getBlock($pos);
 		if($block instanceof UnknownBlock){
@@ -2165,6 +2173,13 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		return true;
 	}
 
+	/**
+	 * @param Vector3 $pos
+	 * @param int     $face
+	 *
+	 * @return bool
+	 * @throws TerrainNotLoadedException
+	 */
 	public function startBreakBlock(Vector3 $pos, int $face) : bool{
 		if($pos->distanceSquared($this) > 10000){
 			return false; //TODO: maybe this should throw an exception instead?
@@ -2196,6 +2211,12 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		return true;
 	}
 
+	/**
+	 * @param Vector3 $pos
+	 * @param int     $face
+	 *
+	 * @throws TerrainNotLoadedException
+	 */
 	public function continueBreakBlock(Vector3 $pos, int $face) : void{
 		$block = $this->level->getBlock($pos);
 		$this->level->broadcastLevelEvent(
@@ -2217,6 +2238,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	 * @param Vector3 $pos
 	 *
 	 * @return bool if the block was successfully broken.
+	 * @throws TerrainNotLoadedException
 	 */
 	public function breakBlock(Vector3 $pos) : bool{
 		$this->doCloseInventory();
@@ -2263,6 +2285,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	 * @param Vector3 $clickOffset
 	 *
 	 * @return bool if it did something
+	 * @throws TerrainNotLoadedException
 	 */
 	public function interactBlock(Vector3 $pos, int $face, Vector3 $clickOffset) : bool{
 		$this->setUsingItem(false);
@@ -2472,7 +2495,11 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 			return true;
 		}
 
-		$t = $this->level->getTile($pos);
+		try{
+			$t = $this->level->getTile($pos);
+		}catch(TerrainNotLoadedException $e){
+			throw new BadPacketException($e->getMessage(), 0, $e);
+		}
 		if($t instanceof Spawnable){
 			$nbt = new NetworkNbtSerializer();
 			try{
@@ -2489,7 +2516,11 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	public function handleItemFrameDropItem(ItemFrameDropItemPacket $packet) : bool{
-		$tile = $this->level->getTileAt($packet->x, $packet->y, $packet->z);
+		try{
+			$tile = $this->level->getTileAt($packet->x, $packet->y, $packet->z);
+		}catch(TerrainNotLoadedException $e){
+			throw new BadPacketException($e->getMessage(), 0, $e);
+		}
 		if($tile instanceof ItemFrame){
 			//TODO: use facing blockstate property instead of damage value
 			$ev = new PlayerInteractEvent($this, $this->inventory->getItemInHand(), $tile->getBlock(), null, 5 - $tile->getBlock()->getDamage(), PlayerInteractEvent::LEFT_CLICK_BLOCK);

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -977,7 +977,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 			++$count;
 
 			$this->usedChunks[$index] = false;
-			$this->level->registerChunkLoader($this, $X, $Z, false);
+			$this->level->registerChunkLoader($this, $X, $Z, true);
 
 			if(!$this->level->populateChunk($X, $Z)){
 				continue;

--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -648,31 +648,21 @@ class Server{
 	/**
 	 * @param string $name
 	 *
-	 * @return CompoundTag
+	 * @return CompoundTag|null
 	 */
-	public function getOfflinePlayerData(string $name) : CompoundTag{
+	public function getOfflinePlayerData(string $name) : ?CompoundTag{
 		$name = strtolower($name);
 		$path = $this->getDataPath() . "players/";
-		if($this->shouldSavePlayerData()){
-			if(file_exists($path . "$name.dat")){
-				try{
-					return (new BigEndianNbtSerializer())->readCompressed(file_get_contents($path . "$name.dat"));
-				}catch(NbtDataException $e){ //zlib decode error / corrupt data
-					rename($path . "$name.dat", $path . "$name.dat.bak");
-					$this->logger->error($this->getLanguage()->translateString("pocketmine.data.playerCorrupted", [$name]));
-				}
+
+		if(file_exists($path . "$name.dat")){
+			try{
+				return (new BigEndianNbtSerializer())->readCompressed(file_get_contents($path . "$name.dat"));
+			}catch(NbtDataException $e){ //zlib decode error / corrupt data
+				rename($path . "$name.dat", $path . "$name.dat.bak");
+				$this->logger->error($this->getLanguage()->translateString("pocketmine.data.playerCorrupted", [$name]));
 			}
-			$this->logger->notice($this->getLanguage()->translateString("pocketmine.data.playerNotFound", [$name]));
 		}
-		$spawn = $this->levelManager->getDefaultLevel()->getSafeSpawn();
-
-		$nbt = EntityFactory::createBaseNBT($spawn);
-
-		$nbt->setString("Level", $this->levelManager->getDefaultLevel()->getFolderName());
-		$nbt->setByte("OnGround", 1); //TODO: this hack is needed for new players in-air ticks - they don't get detected as on-ground until they move
-		//TODO: old code had a TODO for SpawnForced
-
-		return $nbt;
+		return null;
 	}
 
 	/**

--- a/src/pocketmine/block/Block.php
+++ b/src/pocketmine/block/Block.php
@@ -33,6 +33,7 @@ use pocketmine\item\Item;
 use pocketmine\item\ItemFactory;
 use pocketmine\level\Level;
 use pocketmine\level\Position;
+use pocketmine\level\TerrainNotLoadedException;
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Facing;
 use pocketmine\math\RayTraceResult;
@@ -172,6 +173,9 @@ class Block extends Position implements BlockIds, Metadatable{
 		$this->collisionBoxes = null;
 	}
 
+	/**
+	 * @throws TerrainNotLoadedException
+	 */
 	public function writeStateToWorld() : void{
 		$this->level->getChunkAtPosition($this)->setBlock($this->x & 0xf, $this->y, $this->z & 0xf, $this->getId(), $this->getDamage());
 	}

--- a/src/pocketmine/block/Block.php
+++ b/src/pocketmine/block/Block.php
@@ -44,6 +44,7 @@ use pocketmine\plugin\Plugin;
 use function array_merge;
 use function assert;
 use function dechex;
+use function get_class;
 use const PHP_INT_MAX;
 
 class Block extends Position implements BlockIds, Metadatable{
@@ -324,6 +325,7 @@ class Block extends Position implements BlockIds, Metadatable{
 	 * @param Item $item
 	 *
 	 * @return float
+	 * @throws \InvalidArgumentException if the item efficiency is not a positive number
 	 */
 	public function getBreakTime(Item $item) : float{
 		$base = $this->getHardness();
@@ -335,7 +337,7 @@ class Block extends Position implements BlockIds, Metadatable{
 
 		$efficiency = $item->getMiningEfficiency($this);
 		if($efficiency <= 0){
-			throw new \RuntimeException("Item efficiency is invalid");
+			throw new \InvalidArgumentException(get_class($item) . " has invalid mining efficiency: expected >= 0, got $efficiency");
 		}
 
 		$base /= $efficiency;

--- a/src/pocketmine/command/Command.php
+++ b/src/pocketmine/command/Command.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
  */
 namespace pocketmine\command;
 
+use pocketmine\command\utils\InvalidCommandSyntaxException;
 use pocketmine\lang\TextContainer;
 use pocketmine\lang\TranslationContainer;
 use pocketmine\permission\PermissionManager;
@@ -92,6 +93,7 @@ abstract class Command{
 	 * @param string[]      $args
 	 *
 	 * @return mixed
+	 * @throws InvalidCommandSyntaxException
 	 */
 	abstract public function execute(CommandSender $sender, string $commandLabel, array $args);
 

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -401,10 +401,7 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 		$this->boundingBox = new AxisAlignedBB(0, 0, 0, 0, 0, 0);
 		$this->recalculateBoundingBox();
 
-		$this->chunk = $this->level->getChunkAtPosition($this, false);
-		if($this->chunk === null){
-			throw new \InvalidStateException("Cannot create entities in unloaded chunks");
-		}
+		$this->chunk = $this->level->getChunkAtPosition($this);
 
 		if($nbt->hasTag("Motion", ListTag::class)){
 			/** @var float[] $motion */
@@ -1629,7 +1626,9 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 			if($this->chunk !== null){
 				$this->chunk->removeEntity($this);
 			}
-			$this->chunk = $this->level->getChunk($chunkX, $chunkZ, true);
+			//TODO: this shouldn't be loading chunks, but currently we don't know what to do if they try to move into an
+			//unloaded chunk
+			$this->chunk = $this->level->getOrLoadChunk($chunkX, $chunkZ, true);
 
 			if(!$this->justCreated){
 				$newChunk = $this->level->getViewersForPosition($this);

--- a/src/pocketmine/entity/projectile/EnderPearl.php
+++ b/src/pocketmine/entity/projectile/EnderPearl.php
@@ -38,16 +38,7 @@ class EnderPearl extends Throwable{
 	protected function calculateInterceptWithBlock(Block $block, Vector3 $start, Vector3 $end) : ?RayTraceResult{
 		if($block->getId() !== Block::AIR and empty($block->getCollisionBoxes())){
 			//TODO: remove this once block collision boxes are fixed properly
-			$bb = new AxisAlignedBB(
-				$block->x,
-				$block->y,
-				$block->z,
-				$block->x + 1,
-				$block->y + 1,
-				$block->z + 1
-			);
-
-			return $bb->calculateIntercept($start, $end);
+			return AxisAlignedBB::one()->offset($block->x, $block->y, $block->z)->calculateIntercept($start, $end);
 		}
 
 		return parent::calculateInterceptWithBlock($block, $start, $end);

--- a/src/pocketmine/event/Event.php
+++ b/src/pocketmine/event/Event.php
@@ -48,8 +48,6 @@ abstract class Event{
 	 * Calls event handlers registered for this event.
 	 *
 	 * @throws \RuntimeException if event call recursion reaches the max depth limit
-	 *
-	 * @throws \ReflectionException
 	 */
 	public function call() : void{
 		if(self::$eventCallDepth >= self::MAX_EVENT_CALL_DEPTH){

--- a/src/pocketmine/inventory/transaction/CraftingTransaction.php
+++ b/src/pocketmine/inventory/transaction/CraftingTransaction.php
@@ -50,6 +50,7 @@ class CraftingTransaction extends InventoryTransaction{
 	 * @param int    $iterations
 	 *
 	 * @return int
+	 * @throws TransactionValidationException
 	 */
 	protected function matchRecipeItems(array $txItems, array $recipeItems, bool $wildcards, int $iterations = 0) : int{
 		if(empty($recipeItems)){

--- a/src/pocketmine/item/Bow.php
+++ b/src/pocketmine/item/Bow.php
@@ -96,24 +96,26 @@ class Bow extends Tool{
 			$player->getInventory()->sendContents($player);
 		}else{
 			$entity->setMotion($entity->getMotion()->multiply($ev->getForce()));
-			if($player->isSurvival()){
-				if(!$infinity){ //TODO: tipped arrows are still consumed when Infinity is applied
-					$player->getInventory()->removeItem(ItemFactory::get(Item::ARROW, 0, 1));
-				}
-				$this->applyDamage(1);
-			}
 
 			if($entity instanceof Projectile){
 				$projectileEv = new ProjectileLaunchEvent($entity);
 				$projectileEv->call();
 				if($projectileEv->isCancelled()){
 					$ev->getProjectile()->flagForDespawn();
+					$player->getInventory()->sendContents($player);
+					return true;
 				}else{
 					$ev->getProjectile()->spawnToAll();
 					$player->getLevel()->broadcastLevelSoundEvent($player, LevelSoundEventPacket::SOUND_BOW);
 				}
 			}else{
 				$entity->spawnToAll();
+			}
+			if($player->isSurvival()){
+				if(!$infinity){ //TODO: tipped arrows are still consumed when Infinity is applied
+					$player->getInventory()->removeItem(ItemFactory::get(Item::ARROW, 0, 1));
+				}
+				$this->applyDamage(1);
 			}
 		}
 

--- a/src/pocketmine/item/ProjectileItem.php
+++ b/src/pocketmine/item/ProjectileItem.php
@@ -69,12 +69,12 @@ abstract class ProjectileItem extends Item{
 		if($projectileEv->isCancelled()){
 			$projectile->flagForDespawn();
 		}else{
+			$this->pop();
 			$projectile->spawnToAll();
 
 			$player->getLevel()->broadcastLevelSoundEvent($player, LevelSoundEventPacket::SOUND_THROW, 0, EntityIds::PLAYER);
 		}
 
-		$this->pop();
 
 		return true;
 	}

--- a/src/pocketmine/level/BlockWriteBatch.php
+++ b/src/pocketmine/level/BlockWriteBatch.php
@@ -75,6 +75,7 @@ class BlockWriteBatch{
 	 * @param Vector3      $pos
 	 *
 	 * @return Block
+	 * @throws TerrainNotLoadedException
 	 */
 	public function fetchBlock(ChunkManager $world, Vector3 $pos) : Block{
 		return $this->fetchBlockAt($world, $pos->getFloorX(), $pos->getFloorY(), $pos->getFloorZ());
@@ -89,6 +90,7 @@ class BlockWriteBatch{
 	 * @param int          $z
 	 *
 	 * @return Block
+	 * @throws TerrainNotLoadedException
 	 */
 	public function fetchBlockAt(ChunkManager $world, int $x, int $y, int $z) : Block{
 		return $this->blocks[$x][$y][$z] ?? $world->getBlockAt($x, $y, $z);

--- a/src/pocketmine/level/ChunkListener.php
+++ b/src/pocketmine/level/ChunkListener.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\level;
+
+use pocketmine\block\Block;
+use pocketmine\level\format\Chunk;
+use pocketmine\math\Vector3;
+
+/**
+ * This interface allows you to listen for events occurring on or in specific chunks. This will receive events for any
+ * chunks which it is registered to listen to.
+ *
+ * @see Level::registerChunkListener()
+ * @see Level::unregisterChunkListener()
+ *
+ * WARNING: When you're done with the listener, make sure you unregister it from all chunks it's listening to, otherwise
+ * the object will not be destroyed.
+ * The listener WILL NOT be unregistered when chunks are unloaded. You need to do this yourself when you're done with
+ * a chunk.
+ */
+interface ChunkListener{
+
+	/**
+	 * This method will be called when a Chunk is replaced by a new one
+	 *
+	 * @param Chunk $chunk
+	 */
+	public function onChunkChanged(Chunk $chunk);
+
+	/**
+	 * This method will be called when a registered chunk is loaded
+	 *
+	 * @param Chunk $chunk
+	 */
+	public function onChunkLoaded(Chunk $chunk);
+
+
+	/**
+	 * This method will be called when a registered chunk is unloaded
+	 *
+	 * @param Chunk $chunk
+	 */
+	public function onChunkUnloaded(Chunk $chunk);
+
+	/**
+	 * This method will be called when a registered chunk is populated
+	 * Usually it'll be sent with another call to onChunkChanged()
+	 *
+	 * @param Chunk $chunk
+	 */
+	public function onChunkPopulated(Chunk $chunk);
+
+	/**
+	 * This method will be called when a block changes in a registered chunk
+	 *
+	 * @param Block|Vector3 $block
+	 */
+	public function onBlockChanged(Vector3 $block);
+}

--- a/src/pocketmine/level/ChunkLoader.php
+++ b/src/pocketmine/level/ChunkLoader.php
@@ -23,19 +23,14 @@ declare(strict_types=1);
 
 namespace pocketmine\level;
 
-use pocketmine\block\Block;
-use pocketmine\level\format\Chunk;
-use pocketmine\math\Vector3;
-
 /**
- * If you want to keep chunks loaded and receive notifications on a specific area,
- * extend this class and register it into Level. This will also tick chunks.
+ * If you want to keep chunks loaded, implement this interface and register it into Level. This will also tick chunks.
  *
- * Register Level->registerChunkLoader($this, $chunkX, $chunkZ)
- * Unregister Level->unregisterChunkLoader($this, $chunkX, $chunkZ)
+ * @see Level::registerChunkLoader()
+ * @see Level::unregisterChunkLoader()
  *
  * WARNING: When moving this object around in the world or destroying it,
- * be sure to free the existing references from Level, otherwise you'll leak memory.
+ * be sure to unregister the loader from chunks you're not using, otherwise you'll leak memory.
  */
 interface ChunkLoader{
 
@@ -48,42 +43,4 @@ interface ChunkLoader{
 	 * @return float
 	 */
 	public function getZ();
-
-	/**
-	 * This method will be called when a Chunk is replaced by a new one
-	 *
-	 * @param Chunk $chunk
-	 */
-	public function onChunkChanged(Chunk $chunk);
-
-	/**
-	 * This method will be called when a registered chunk is loaded
-	 *
-	 * @param Chunk $chunk
-	 */
-	public function onChunkLoaded(Chunk $chunk);
-
-
-	/**
-	 * This method will be called when a registered chunk is unloaded
-	 *
-	 * @param Chunk $chunk
-	 */
-	public function onChunkUnloaded(Chunk $chunk);
-
-	/**
-	 * This method will be called when a registered chunk is populated
-	 * Usually it'll be sent with another call to onChunkChanged()
-	 *
-	 * @param Chunk $chunk
-	 */
-	public function onChunkPopulated(Chunk $chunk);
-
-	/**
-	 * This method will be called when a block changes in a registered chunk
-	 *
-	 * @param Block|Vector3 $block
-	 */
-	public function onBlockChanged(Vector3 $block);
-
 }

--- a/src/pocketmine/level/ChunkManager.php
+++ b/src/pocketmine/level/ChunkManager.php
@@ -36,6 +36,7 @@ interface ChunkManager{
 	 * @param int $z
 	 *
 	 * @return Block
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getBlockAt(int $x, int $y, int $z) : Block;
 
@@ -48,6 +49,7 @@ interface ChunkManager{
 	 * @param Block $block
 	 *
 	 * @return bool TODO: remove
+	 * @throws TerrainNotLoadedException
 	 */
 	public function setBlockAt(int $x, int $y, int $z, Block $block) : bool;
 
@@ -59,6 +61,7 @@ interface ChunkManager{
 	 * @param int $z
 	 *
 	 * @return int
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getBlockLightAt(int $x, int $y, int $z) : int;
 
@@ -69,6 +72,8 @@ interface ChunkManager{
 	 * @param int $y
 	 * @param int $z
 	 * @param int $level
+	 *
+	 * @throws TerrainNotLoadedException
 	 */
 	public function setBlockLightAt(int $x, int $y, int $z, int $level);
 
@@ -80,6 +85,7 @@ interface ChunkManager{
 	 * @param int $z
 	 *
 	 * @return int
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getBlockSkyLightAt(int $x, int $y, int $z) : int;
 
@@ -90,16 +96,21 @@ interface ChunkManager{
 	 * @param int $y
 	 * @param int $z
 	 * @param int $level
+	 *
+	 * @throws TerrainNotLoadedException
 	 */
 	public function setBlockSkyLightAt(int $x, int $y, int $z, int $level);
 
 	/**
-	 * @param int $chunkX
-	 * @param int $chunkZ
+	 * Returns the chunk at the given coordinates, or throws an exception if it is not loaded.
 	 *
-	 * @return Chunk|null
+	 * @param int $x
+	 * @param int $z
+	 *
+	 * @return Chunk
+	 * @throws TerrainNotLoadedException
 	 */
-	public function getChunk(int $chunkX, int $chunkZ);
+	public function getChunk(int $x, int $z) : Chunk;
 
 	/**
 	 * @param int        $chunkX

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -178,6 +178,9 @@ class Level implements ChunkManager, Metadatable{
 	/** @var Player[][] */
 	private $playerLoaders = [];
 
+	/** @var ChunkListener[][] */
+	private $chunkListeners = [];
+
 	/** @var ClientboundPacket[][] */
 	private $chunkPackets = [];
 	/** @var ClientboundPacket[] */
@@ -677,6 +680,52 @@ class Level implements ChunkManager, Metadatable{
 				unset($this->loaders[$loaderId]);
 			}
 		}
+	}
+
+	/**
+	 * Registers a listener to receive events on a chunk.
+	 *
+	 * @param ChunkListener $listener
+	 * @param int           $chunkX
+	 * @param int           $chunkZ
+	 */
+	public function registerChunkListener(ChunkListener $listener, int $chunkX, int $chunkZ) : void{
+		$hash = Level::chunkHash($chunkX, $chunkZ);
+		if(isset($this->chunkListeners[$hash])){
+			$this->chunkListeners[$hash][spl_object_id($listener)] = $listener;
+		}else{
+			$this->chunkListeners[$hash] = [spl_object_id($listener) => $listener];
+		}
+	}
+
+	/**
+	 * Unregisters a chunk listener previously registered.
+	 * @see Level::registerChunkListener()
+	 *
+	 * @param ChunkListener $listener
+	 * @param int           $chunkX
+	 * @param int           $chunkZ
+	 */
+	public function unregisterChunkListener(ChunkListener $listener, int $chunkX, int $chunkZ) : void{
+		$hash = Level::chunkHash($chunkX, $chunkZ);
+		if(isset($this->chunkListeners[$hash])){
+			unset($this->chunkListeners[$hash][spl_object_id($listener)]);
+			if(empty($this->chunkListeners[$hash])){
+				unset($this->chunkListeners[$hash]);
+			}
+		}
+	}
+
+	/**
+	 * Returns all the listeners attached to this chunk.
+	 *
+	 * @param int $chunkX
+	 * @param int $chunkZ
+	 *
+	 * @return ChunkListener[]
+	 */
+	public function getChunkListeners(int $chunkX, int $chunkZ) : array{
+		return $this->chunkListeners[Level::chunkHash($chunkX, $chunkZ)] ?? [];
 	}
 
 	/**
@@ -1569,8 +1618,8 @@ class Level implements ChunkManager, Metadatable{
 		}
 		$this->changedBlocks[$chunkHash][$relativeBlockHash] = $block;
 
-		foreach($this->getChunkLoaders($x >> 4, $z >> 4) as $loader){
-			$loader->onBlockChanged($block);
+		foreach($this->getChunkListeners($x >> 4, $z >> 4) as $listener){
+			$listener->onBlockChanged($block);
 		}
 
 		if($update){
@@ -2308,8 +2357,8 @@ class Level implements ChunkManager, Metadatable{
 				if(($oldChunk === null or !$oldChunk->isPopulated()) and $chunk->isPopulated()){
 					(new ChunkPopulateEvent($this, $chunk))->call();
 
-					foreach($this->getChunkLoaders($x, $z) as $loader){
-						$loader->onChunkPopulated($chunk);
+					foreach($this->getChunkListeners($x, $z) as $listener){
+						$listener->onChunkPopulated($chunk);
 					}
 				}
 			}
@@ -2380,8 +2429,8 @@ class Level implements ChunkManager, Metadatable{
 		if(!$this->isChunkInUse($chunkX, $chunkZ)){
 			$this->unloadChunkRequest($chunkX, $chunkZ);
 		}else{
-			foreach($this->getChunkLoaders($chunkX, $chunkZ) as $loader){
-				$loader->onChunkChanged($chunk);
+			foreach($this->getChunkListeners($chunkX, $chunkZ) as $listener){
+				$listener->onChunkChanged($chunk);
 			}
 		}
 	}
@@ -2666,8 +2715,8 @@ class Level implements ChunkManager, Metadatable{
 		}
 
 		if($this->isChunkInUse($x, $z)){
-			foreach($this->getChunkLoaders($x, $z) as $loader){
-				$loader->onChunkLoaded($chunk);
+			foreach($this->getChunkListeners($x, $z) as $listener){
+				$listener->onChunkLoaded($chunk);
 			}
 		}else{
 			$this->unloadChunkRequest($x, $z);
@@ -2726,8 +2775,8 @@ class Level implements ChunkManager, Metadatable{
 				}
 			}
 
-			foreach($this->getChunkLoaders($x, $z) as $loader){
-				$loader->onChunkUnloaded($chunk);
+			foreach($this->getChunkListeners($x, $z) as $listener){
+				$listener->onChunkUnloaded($chunk);
 			}
 
 			$chunk->onUnload();

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -46,7 +46,6 @@ use pocketmine\item\Item;
 use pocketmine\item\ItemFactory;
 use pocketmine\level\biome\Biome;
 use pocketmine\level\format\Chunk;
-use pocketmine\level\format\ChunkException;
 use pocketmine\level\format\EmptySubChunk;
 use pocketmine\level\format\io\exception\CorruptedChunkException;
 use pocketmine\level\format\io\exception\UnsupportedChunkFormatException;
@@ -1284,9 +1283,10 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $z
 	 *
 	 * @return int bitmap, (id << 4) | data
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getFullBlock(int $x, int $y, int $z) : int{
-		return $this->getChunk($x >> 4, $z >> 4, false)->getFullBlock($x & 0x0f, $y, $z & 0x0f);
+		return $this->getChunk($x >> 4, $z >> 4)->getFullBlock($x & 0x0f, $y, $z & 0x0f);
 	}
 
 	public function isInWorld(int $x, int $y, int $z) : bool{
@@ -1327,6 +1327,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @param bool $addToCache Whether to cache the block object created by this method call.
 	 *
 	 * @return Block
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getBlockAt(int $x, int $y, int $z, bool $cached = true, bool $addToCache = true) : Block{
 		$fullState = 0;
@@ -1344,7 +1345,7 @@ class Level implements ChunkManager, Metadatable{
 			if($chunk !== null){
 				$fullState = $chunk->getFullBlock($x & 0x0f, $y, $z & 0x0f);
 			}else{
-				$addToCache = false;
+				throw new TerrainNotLoadedException("Chunk at block $x $y $z is not loaded");
 			}
 		}
 
@@ -1994,6 +1995,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @param Vector3 $pos
 	 *
 	 * @return Tile|null
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getTile(Vector3 $pos) : ?Tile{
 		return $this->getTileAt((int) floor($pos->x), (int) floor($pos->y), (int) floor($pos->z));
@@ -2007,9 +2009,10 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $z
 	 *
 	 * @return Tile|null
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getTileAt(int $x, int $y, int $z) : ?Tile{
-		return ($chunk = $this->getChunk($x >> 4, $z >> 4)) !== null ? $chunk->getTile($x & 0x0f, $y, $z & 0x0f) : null;
+		return $this->getChunk($x >> 4, $z >> 4)->getTile($x & 0x0f, $y, $z & 0x0f);
 	}
 
 	/**
@@ -2019,9 +2022,11 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $Z
 	 *
 	 * @return Entity[]
+	 *
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getChunkEntities(int $X, int $Z) : array{
-		return ($chunk = $this->getChunk($X, $Z)) !== null ? $chunk->getEntities() : [];
+		return $this->getChunk($X, $Z)->getEntities();
 	}
 
 	/**
@@ -2031,9 +2036,11 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $Z
 	 *
 	 * @return Tile[]
+	 *
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getChunkTiles(int $X, int $Z) : array{
-		return ($chunk = $this->getChunk($X, $Z)) !== null ? $chunk->getTiles() : [];
+		return $this->getChunk($X, $Z)->getTiles();
 	}
 
 	/**
@@ -2044,9 +2051,11 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $z
 	 *
 	 * @return int 0-15
+	 *
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getBlockSkyLightAt(int $x, int $y, int $z) : int{
-		return $this->getChunk($x >> 4, $z >> 4, true)->getBlockSkyLight($x & 0x0f, $y, $z & 0x0f);
+		return $this->getChunk($x >> 4, $z >> 4)->getBlockSkyLight($x & 0x0f, $y, $z & 0x0f);
 	}
 
 	/**
@@ -2056,9 +2065,11 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $y
 	 * @param int $z
 	 * @param int $level 0-15
+	 *
+	 * @throws TerrainNotLoadedException
 	 */
 	public function setBlockSkyLightAt(int $x, int $y, int $z, int $level){
-		$this->getChunk($x >> 4, $z >> 4, true)->setBlockSkyLight($x & 0x0f, $y, $z & 0x0f, $level & 0x0f);
+		$this->getChunk($x >> 4, $z >> 4)->setBlockSkyLight($x & 0x0f, $y, $z & 0x0f, $level & 0x0f);
 	}
 
 	/**
@@ -2069,9 +2080,10 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $z
 	 *
 	 * @return int 0-15
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getBlockLightAt(int $x, int $y, int $z) : int{
-		return $this->getChunk($x >> 4, $z >> 4, true)->getBlockLight($x & 0x0f, $y, $z & 0x0f);
+		return $this->getChunk($x >> 4, $z >> 4)->getBlockLight($x & 0x0f, $y, $z & 0x0f);
 	}
 
 	/**
@@ -2081,9 +2093,11 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $y
 	 * @param int $z
 	 * @param int $level 0-15
+	 *
+	 * @throws TerrainNotLoadedException
 	 */
 	public function setBlockLightAt(int $x, int $y, int $z, int $level){
-		$this->getChunk($x >> 4, $z >> 4, true)->setBlockLight($x & 0x0f, $y, $z & 0x0f, $level & 0x0f);
+		$this->getChunk($x >> 4, $z >> 4)->setBlockLight($x & 0x0f, $y, $z & 0x0f, $level & 0x0f);
 	}
 
 	/**
@@ -2091,9 +2105,10 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $z
 	 *
 	 * @return int
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getBiomeId(int $x, int $z) : int{
-		return $this->getChunk($x >> 4, $z >> 4, true)->getBiomeId($x & 0x0f, $z & 0x0f);
+		return $this->getChunk($x >> 4, $z >> 4)->getBiomeId($x & 0x0f, $z & 0x0f);
 	}
 
 	/**
@@ -2101,6 +2116,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $z
 	 *
 	 * @return Biome
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getBiome(int $x, int $z) : Biome{
 		return Biome::getBiome($this->getBiomeId($x, $z));
@@ -2110,9 +2126,11 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $x
 	 * @param int $z
 	 * @param int $biomeId
+	 *
+	 * @throws TerrainNotLoadedException
 	 */
 	public function setBiomeId(int $x, int $z, int $biomeId){
-		$this->getChunk($x >> 4, $z >> 4, true)->setBiomeId($x & 0x0f, $z & 0x0f, $biomeId);
+		$this->getChunk($x >> 4, $z >> 4)->setBiomeId($x & 0x0f, $z & 0x0f, $biomeId);
 	}
 
 	/**
@@ -2120,18 +2138,21 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $z
 	 *
 	 * @return int
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getHeightMap(int $x, int $z) : int{
-		return $this->getChunk($x >> 4, $z >> 4, true)->getHeightMap($x & 0x0f, $z & 0x0f);
+		return $this->getChunk($x >> 4, $z >> 4)->getHeightMap($x & 0x0f, $z & 0x0f);
 	}
 
 	/**
 	 * @param int $x
 	 * @param int $z
 	 * @param int $value
+	 *
+	 * @throws TerrainNotLoadedException
 	 */
 	public function setHeightMap(int $x, int $z, int $value){
-		$this->getChunk($x >> 4, $z >> 4, true)->setHeightMap($x & 0x0f, $z & 0x0f, $value);
+		$this->getChunk($x >> 4, $z >> 4)->setHeightMap($x & 0x0f, $z & 0x0f, $value);
 	}
 
 	/**
@@ -2151,7 +2172,7 @@ class Level implements ChunkManager, Metadatable{
 	 *
 	 * @return Chunk|null
 	 */
-	public function getChunk(int $x, int $z, bool $create = false){
+	public function getOrLoadChunk(int $x, int $z, bool $create = false){
 		if(isset($this->chunks[$index = Level::chunkHash($x, $z)])){
 			return $this->chunks[$index];
 		}elseif($this->loadChunk($x, $z, $create)){
@@ -2162,15 +2183,32 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
+	 * Returns the chunk at the given coordinates, or throws an exception if it is not loaded.
+	 *
+	 * @param int $x
+	 * @param int $z
+	 *
+	 * @return Chunk
+	 * @throws TerrainNotLoadedException
+	 */
+	public function getChunk(int $x, int $z) : Chunk{
+		$chunk = $this->chunks[Level::chunkHash($x, $z)] ?? null;
+		if($chunk === null){
+			throw new TerrainNotLoadedException("Chunk $x $z is not loaded");
+		}
+		return $chunk;
+	}
+
+	/**
 	 * Returns the chunk containing the given Vector3 position.
 	 *
 	 * @param Vector3 $pos
-	 * @param bool    $create
 	 *
-	 * @return null|Chunk
+	 * @return Chunk
+	 * @throws TerrainNotLoadedException
 	 */
-	public function getChunkAtPosition(Vector3 $pos, bool $create = false) : ?Chunk{
-		return $this->getChunk($pos->getFloorX() >> 4, $pos->getFloorZ() >> 4, $create);
+	public function getChunkAtPosition(Vector3 $pos) : Chunk{
+		return $this->getChunk($pos->getFloorX() >> 4, $pos->getFloorZ() >> 4);
 	}
 
 	/**
@@ -2189,7 +2227,8 @@ class Level implements ChunkManager, Metadatable{
 				if($i === 4){
 					continue; //center chunk
 				}
-				$result[$i] = $this->getChunk($x + $xx - 1, $z + $zz - 1, false);
+				//TODO: loading chunks is not really appropriate here, but currently it's a requirement
+				$result[$i] = $this->getOrLoadChunk($x + $xx - 1, $z + $zz - 1, false);
 			}
 		}
 
@@ -2223,7 +2262,8 @@ class Level implements ChunkManager, Metadatable{
 			unset($this->chunkPopulationQueue[$index]);
 
 			if($chunk !== null){
-				$oldChunk = $this->getChunk($x, $z, false);
+				//TODO: is loading chunks appropriate here?
+				$oldChunk = $this->getOrLoadChunk($x, $z, false);
 				$this->setChunk($x, $z, $chunk, false);
 				if(($oldChunk === null or !$oldChunk->isPopulated()) and $chunk->isPopulated()){
 					(new ChunkPopulateEvent($this, $chunk))->call();
@@ -2259,7 +2299,7 @@ class Level implements ChunkManager, Metadatable{
 		$chunk->setZ($chunkZ);
 
 		$chunkHash = Level::chunkHash($chunkX, $chunkZ);
-		$oldChunk = $this->getChunk($chunkX, $chunkZ, false);
+		$oldChunk = $this->getOrLoadChunk($chunkX, $chunkZ, false);
 		if($oldChunk !== null and $oldChunk !== $chunk){
 			if($deleteEntitiesAndTiles){
 				$players = $this->getChunkPlayers($chunkX, $chunkZ);
@@ -2311,9 +2351,10 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $z
 	 *
 	 * @return int 0-255
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getHighestBlockAt(int $x, int $z) : int{
-		return $this->getChunk($x >> 4, $z >> 4, true)->getHighestBlockAt($x & 0x0f, $z & 0x0f);
+		return $this->getChunk($x >> 4, $z >> 4)->getHighestBlockAt($x & 0x0f, $z & 0x0f);
 	}
 
 	/**
@@ -2335,28 +2376,6 @@ class Level implements ChunkManager, Metadatable{
 	 */
 	public function isChunkLoaded(int $x, int $z) : bool{
 		return isset($this->chunks[Level::chunkHash($x, $z)]);
-	}
-
-	/**
-	 * @param int $x
-	 * @param int $z
-	 *
-	 * @return bool
-	 */
-	public function isChunkGenerated(int $x, int $z) : bool{
-		$chunk = $this->getChunk($x, $z);
-		return $chunk !== null ? $chunk->isGenerated() : false;
-	}
-
-	/**
-	 * @param int $x
-	 * @param int $z
-	 *
-	 * @return bool
-	 */
-	public function isChunkPopulated(int $x, int $z) : bool{
-		$chunk = $this->getChunk($x, $z);
-		return $chunk !== null ? $chunk->isPopulated() : false;
 	}
 
 	/**
@@ -2424,10 +2443,7 @@ class Level implements ChunkManager, Metadatable{
 
 				$this->timings->syncChunkSendPrepareTimer->startTiming();
 
-				$chunk = $this->chunks[$index] ?? null;
-				if(!($chunk instanceof Chunk)){
-					throw new ChunkException("Invalid Chunk sent");
-				}
+				$chunk = $this->getChunk($x, $z);
 				assert($chunk->getX() === $x and $chunk->getZ() === $z, "Chunk coordinate mismatch: expected $x $z, but chunk has coordinates " . $chunk->getX() . " " . $chunk->getZ() . ", did you forget to clone a chunk before setting?");
 
 				/*
@@ -2506,6 +2522,7 @@ class Level implements ChunkManager, Metadatable{
 	/**
 	 * @param Tile $tile
 	 *
+	 * @throws TerrainNotLoadedException
 	 * @throws \InvalidArgumentException
 	 */
 	public function addTile(Tile $tile){
@@ -2516,14 +2533,7 @@ class Level implements ChunkManager, Metadatable{
 			throw new \InvalidArgumentException("Invalid Tile level");
 		}
 
-		$chunkX = $tile->getFloorX() >> 4;
-		$chunkZ = $tile->getFloorZ() >> 4;
-
-		if(isset($this->chunks[$hash = Level::chunkHash($chunkX, $chunkZ)])){
-			$this->chunks[$hash]->addTile($tile);
-		}else{
-			throw new \InvalidStateException("Attempted to create tile " . get_class($tile) . " in unloaded chunk $chunkX $chunkZ");
-		}
+		$this->getChunk($tile->getFloorX() >> 4, $tile->getFloorZ() >> 4)->addTile($tile);
 
 		$this->tiles[Level::blockHash($tile->x, $tile->y, $tile->z)] = $tile;
 		$tile->scheduleUpdate();
@@ -2713,6 +2723,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @param Vector3|null $spawn
 	 *
 	 * @return Position
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getSafeSpawn(?Vector3 $spawn = null) : Position{
 		if(!($spawn instanceof Vector3) or $spawn->y < 1){
@@ -2721,10 +2732,10 @@ class Level implements ChunkManager, Metadatable{
 
 		$max = $this->worldHeight;
 		$v = $spawn->floor();
-		$chunk = $this->getChunkAtPosition($v, false);
+		$chunk = $this->getChunkAtPosition($v);
 		$x = (int) $v->x;
 		$z = (int) $v->z;
-		if($chunk !== null and $chunk->isGenerated()){
+		if($chunk->isGenerated()){ //TODO: this should throw an exception
 			$y = (int) min($max - 2, $v->y);
 			$wasAir = ($chunk->getBlockId($x & 0x0f, $y - 1, $z & 0x0f) === 0);
 			for(; $y > 0; --$y){
@@ -2865,7 +2876,7 @@ class Level implements ChunkManager, Metadatable{
 			}
 		}
 
-		$chunk = $this->getChunk($x, $z, true);
+		$chunk = $this->getOrLoadChunk($x, $z, true);
 		if(!$chunk->isPopulated()){
 			Timings::$populationTimer->startTiming();
 

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -560,7 +560,10 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * Gets the players being used in a specific chunk
+	 * @deprecated WARNING: This function has a misleading name. Contrary to what the name might imply, this function
+	 * DOES NOT return players who are IN a chunk, rather, it returns players who can SEE the chunk.
+	 *
+	 * Returns a list of players who have the target chunk within their view distance.
 	 *
 	 * @param int $chunkX
 	 * @param int $chunkZ
@@ -2341,8 +2344,10 @@ class Level implements ChunkManager, Metadatable{
 		$oldChunk = $this->getOrLoadChunk($chunkX, $chunkZ, false);
 		if($oldChunk !== null and $oldChunk !== $chunk){
 			if($deleteEntitiesAndTiles){
-				$players = $this->getChunkPlayers($chunkX, $chunkZ);
-				foreach($players as $player){
+				foreach($oldChunk->getEntities() as $player){
+					if(!($player instanceof Player)){
+						continue;
+					}
 					$chunk->addEntity($player);
 					$oldChunk->removeEntity($player);
 					$player->chunk = $chunk;

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -680,8 +680,7 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * WARNING: Do not use this, it's only for internal use.
-	 * Changes to this function won't be recorded on the version.
+	 * @internal
 	 *
 	 * @param Player ...$targets If empty, will send to all players in the level.
 	 */
@@ -701,8 +700,7 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * WARNING: Do not use this, it's only for internal use.
-	 * Changes to this function won't be recorded on the version.
+	 * @internal
 	 *
 	 * @param int $currentTick
 	 *

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -2637,7 +2637,7 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	private function queueUnloadChunk(int $x, int $z){
-		$this->unloadQueue[$index = Level::chunkHash($x, $z)] = microtime(true);
+		$this->unloadQueue[Level::chunkHash($x, $z)] = microtime(true);
 	}
 
 	public function unloadChunkRequest(int $x, int $z, bool $safe = true){

--- a/src/pocketmine/level/SimpleChunkManager.php
+++ b/src/pocketmine/level/SimpleChunkManager.php
@@ -46,55 +46,43 @@ class SimpleChunkManager implements ChunkManager{
 	}
 
 	public function getBlockAt(int $x, int $y, int $z) : Block{
-		if($chunk = $this->getChunk($x >> 4, $z >> 4)){
-			return BlockFactory::fromFullBlock($chunk->getFullBlock($x & 0xf, $y, $z & 0xf));
-		}
-		return BlockFactory::get(Block::AIR);
+		return BlockFactory::fromFullBlock($this->getChunk($x >> 4, $z >> 4)->getFullBlock($x & 0xf, $y, $z & 0xf));
 	}
 
 	public function setBlockAt(int $x, int $y, int $z, Block $block) : bool{
-		if(($chunk = $this->getChunk($x >> 4, $z >> 4)) !== null){
-			return $chunk->setBlock($x & 0xf, $y, $z & 0xf, $block->getId(), $block->getDamage());
-		}
-		return false;
+		return $this->getChunk($x >> 4, $z >> 4)->setBlock($x & 0xf, $y, $z & 0xf, $block->getId(), $block->getDamage());
 	}
 
 	public function getBlockLightAt(int $x, int $y, int $z) : int{
-		if($chunk = $this->getChunk($x >> 4, $z >> 4)){
-			return $chunk->getBlockLight($x & 0xf, $y, $z & 0xf);
-		}
-
-		return 0;
+		return $this->getChunk($x >> 4, $z >> 4)->getBlockLight($x & 0xf, $y, $z & 0xf);
 	}
 
 	public function setBlockLightAt(int $x, int $y, int $z, int $level){
-		if($chunk = $this->getChunk($x >> 4, $z >> 4)){
-			$chunk->setBlockLight($x & 0xf, $y, $z & 0xf, $level);
-		}
+		$this->getChunk($x >> 4, $z >> 4)->setBlockLight($x & 0xf, $y, $z & 0xf, $level);
 	}
 
 	public function getBlockSkyLightAt(int $x, int $y, int $z) : int{
-		if($chunk = $this->getChunk($x >> 4, $z >> 4)){
-			return $chunk->getBlockSkyLight($x & 0xf, $y, $z & 0xf);
-		}
-
-		return 0;
+		return $this->getChunk($x >> 4, $z >> 4)->getBlockSkyLight($x & 0xf, $y, $z & 0xf);
 	}
 
 	public function setBlockSkyLightAt(int $x, int $y, int $z, int $level){
-		if($chunk = $this->getChunk($x >> 4, $z >> 4)){
-			$chunk->setBlockSkyLight($x & 0xf, $y, $z & 0xf, $level);
-		}
+		$this->getChunk($x >> 4, $z >> 4)->setBlockSkyLight($x & 0xf, $y, $z & 0xf, $level);
 	}
 
 	/**
 	 * @param int $chunkX
 	 * @param int $chunkZ
 	 *
-	 * @return Chunk|null
+	 * @return Chunk
+	 * @throws TerrainNotLoadedException
 	 */
-	public function getChunk(int $chunkX, int $chunkZ){
-		return $this->chunks[Level::chunkHash($chunkX, $chunkZ)] ?? null;
+	public function getChunk(int $chunkX, int $chunkZ) : Chunk{
+		$chunk = $this->chunks[Level::chunkHash($chunkX, $chunkZ)] ?? null;
+		if($chunk === null){
+			throw new TerrainNotLoadedException("Chunk $chunkX $chunkZ is not loaded");
+		}
+
+		return $chunk;
 	}
 
 	/**

--- a/src/pocketmine/level/TerrainNotLoadedException.php
+++ b/src/pocketmine/level/TerrainNotLoadedException.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\level;
+
+class TerrainNotLoadedException extends LevelException{
+
+}

--- a/src/pocketmine/level/format/io/region/RegionLoader.php
+++ b/src/pocketmine/level/format/io/region/RegionLoader.php
@@ -75,6 +75,9 @@ class RegionLoader{
 		$this->filePath = $filePath;
 	}
 
+	/**
+	 * @throws CorruptedRegionException
+	 */
 	public function open() : void{
 		$exists = file_exists($this->filePath);
 		if(!$exists){
@@ -219,6 +222,9 @@ class RegionLoader{
 		}
 	}
 
+	/**
+	 * @throws CorruptedRegionException
+	 */
 	protected function loadLocationTable() : void{
 		fseek($this->filePointer, 0);
 		$this->lastSector = 1;

--- a/src/pocketmine/level/utils/SubChunkIteratorManager.php
+++ b/src/pocketmine/level/utils/SubChunkIteratorManager.php
@@ -27,6 +27,7 @@ use pocketmine\level\ChunkManager;
 use pocketmine\level\format\Chunk;
 use pocketmine\level\format\EmptySubChunk;
 use pocketmine\level\format\SubChunkInterface;
+use pocketmine\level\TerrainNotLoadedException;
 
 class SubChunkIteratorManager{
 	/** @var ChunkManager */
@@ -57,8 +58,10 @@ class SubChunkIteratorManager{
 			$this->currentZ = $z >> 4;
 			$this->currentSubChunk = null;
 
-			$this->currentChunk = $this->level->getChunk($this->currentX, $this->currentZ);
-			if($this->currentChunk === null){
+			try{
+				$this->currentChunk = $this->level->getChunk($this->currentX, $this->currentZ);
+			}catch(TerrainNotLoadedException $e){
+				$this->currentChunk = null;
 				return false;
 			}
 		}

--- a/src/pocketmine/network/mcpe/NetworkCipher.php
+++ b/src/pocketmine/network/mcpe/NetworkCipher.php
@@ -63,6 +63,12 @@ class NetworkCipher{
 		$this->encryptCipher->encryptInit($this->key, $iv);
 	}
 
+	/**
+	 * @param string $encrypted
+	 *
+	 * @return string
+	 * @throws \UnexpectedValueException
+	 */
 	public function decrypt(string $encrypted) : string{
 		if(strlen($encrypted) < 9){
 			throw new \UnexpectedValueException("Payload is too short");

--- a/src/pocketmine/network/mcpe/handler/SimpleSessionHandler.php
+++ b/src/pocketmine/network/mcpe/handler/SimpleSessionHandler.php
@@ -299,11 +299,12 @@ class SimpleSessionHandler extends SessionHandler{
 	}
 
 	public function handleInteract(InteractPacket $packet) : bool{
-		if($packet->action === InteractPacket::ACTION_MOUSEOVER and $packet->target === 0){
+		if($packet->action === InteractPacket::ACTION_MOUSEOVER){
 			//TODO HACK: silence useless spam (MCPE 1.8)
-			//this packet is EXPECTED to only be sent when interacting with an entity, but due to some messy Mojang
-			//hacks, it also sends it when changing the held item now, which causes us to think the inventory was closed
-			//when it wasn't.
+			//due to some messy Mojang hacks, it sends this when changing the held item now, which causes us to think
+			//the inventory was closed when it wasn't.
+			//this is also sent whenever entity metadata updates, which can get really spammy.
+			//TODO: implement handling for this where it matters
 			return true;
 		}
 		return false; //TODO

--- a/src/pocketmine/network/mcpe/protocol/StartGamePacket.php
+++ b/src/pocketmine/network/mcpe/protocol/StartGamePacket.php
@@ -94,7 +94,9 @@ class StartGamePacket extends DataPacket implements ClientboundPacket{
 	/** @var bool */
 	public $isTexturePacksRequired = true;
 	/** @var array */
-	public $gameRules = []; //TODO: implement this
+	public $gameRules = [ //TODO: implement this
+		"naturalregeneration" => [1, false] //Hack for client side regeneration
+	];
 	/** @var bool */
 	public $hasBonusChestEnabled = false;
 	/** @var bool */

--- a/src/pocketmine/resourcepacks/ResourcePack.php
+++ b/src/pocketmine/resourcepacks/ResourcePack.php
@@ -73,6 +73,7 @@ interface ResourcePack{
 	 * @param int $length Maximum length of data to return.
 	 *
 	 * @return string byte-array
+	 * @throws \InvalidArgumentException if the chunk does not exist
 	 */
 	public function getPackChunk(int $start, int $length) : string;
 }

--- a/src/pocketmine/resourcepacks/ZippedResourcePack.php
+++ b/src/pocketmine/resourcepacks/ZippedResourcePack.php
@@ -75,6 +75,7 @@ class ZippedResourcePack implements ResourcePack{
 
 	/**
 	 * @param string $zipPath Path to the resource pack zip
+	 * @throws ResourcePackException
 	 */
 	public function __construct(string $zipPath){
 		$this->path = $zipPath;
@@ -148,7 +149,7 @@ class ZippedResourcePack implements ResourcePack{
 	public function getPackChunk(int $start, int $length) : string{
 		fseek($this->fileResource, $start);
 		if(feof($this->fileResource)){
-			throw new \RuntimeException("Requested a resource pack chunk with invalid start offset");
+			throw new \InvalidArgumentException("Requested a resource pack chunk with invalid start offset");
 		}
 		return fread($this->fileResource, $length);
 	}


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
When a player triggers ProjectileLaunchEvent by throwing a projectile item (snowballs, splash potions) or shooting a bow, the player's inventory is still reduced but no projectile is created.
### Relevant issues
<!-- List relevant issues here -->
<!--
-->
Fixes #2693 

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
No API changes 
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
No noticeable performance changes.
## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Tested by using a the same plugin listed in the issue. After loading into the server, attempted throwing snowballs, splash potions, and shooting bows. Inventory items did not permanently reduce and bows did not take permanent damage.

