### PR TITLE
Throw TerrainNotLoadedException when accessing unloaded terrain, fixes lots of consistency bugs in chunk handling

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1497,7 +1497,7 @@ class Player extends Human implements CommandSender, ChunkLoader, ChunkListener,
 			$this->server->getLogger()->warning($this->getName() . " moved too fast, reverting movement");
 			$this->server->getLogger()->debug("Old position: " . $this->asVector3() . ", new position: " . $this->newPosition);
 			$revert = true;
-		}elseif(!$this->level->isInLoadedTerrain($newPos) or !$this->level->isChunkGenerated($newPos->getFloorX() >> 4, $newPos->getFloorZ() >> 4)){
+		}elseif(!$this->level->isInLoadedTerrain($newPos) or !$this->level->getChunk($newPos->getFloorX() >> 4, $newPos->getFloorZ() >> 4)->isGenerated()){
 			$revert = true;
 			$this->nextChunkOrderRun = 0;
 		}

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1167,6 +1167,7 @@ class Player extends Human implements CommandSender, ChunkLoader, ChunkListener,
 	 * @param Vector3 $pos
 	 *
 	 * @return bool
+	 * @throws TerrainNotLoadedException
 	 */
 	public function sleepOn(Vector3 $pos) : bool{
 		if(!$this->isOnline()){
@@ -1200,6 +1201,7 @@ class Player extends Human implements CommandSender, ChunkLoader, ChunkListener,
 
 	public function stopSleep(){
 		if($this->sleeping instanceof Vector3){
+			//TODO: is it possible for this to be in unloaded terrain?
 			$b = $this->level->getBlock($this->sleeping);
 			if($b instanceof Bed){
 				$b->setOccupied(false);

--- a/src/pocketmine/block/Block.php
+++ b/src/pocketmine/block/Block.php
@@ -33,6 +33,7 @@ use pocketmine\item\Item;
 use pocketmine\item\ItemFactory;
 use pocketmine\level\Level;
 use pocketmine\level\Position;
+use pocketmine\level\TerrainNotLoadedException;
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Facing;
 use pocketmine\math\RayTraceResult;
@@ -172,6 +173,9 @@ class Block extends Position implements BlockIds, Metadatable{
 		$this->collisionBoxes = null;
 	}
 
+	/**
+	 * @throws TerrainNotLoadedException
+	 */
 	public function writeStateToWorld() : void{
 		$this->level->getChunkAtPosition($this)->setBlock($this->x & 0xf, $this->y, $this->z & 0xf, $this->getId(), $this->getDamage());
 	}

--- a/src/pocketmine/block/Block.php
+++ b/src/pocketmine/block/Block.php
@@ -638,6 +638,7 @@ class Block extends Position implements BlockIds, Metadatable{
 	 * @param int $step
 	 *
 	 * @return Block
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getSide(int $side, int $step = 1){
 		if($this->isValid()){

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -401,10 +401,7 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 		$this->boundingBox = new AxisAlignedBB(0, 0, 0, 0, 0, 0);
 		$this->recalculateBoundingBox();
 
-		$this->chunk = $this->level->getChunkAtPosition($this, false);
-		if($this->chunk === null){
-			throw new \InvalidStateException("Cannot create entities in unloaded chunks");
-		}
+		$this->chunk = $this->level->getChunkAtPosition($this);
 
 		if($nbt->hasTag("Motion", ListTag::class)){
 			/** @var float[] $motion */
@@ -1625,7 +1622,9 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 			if($this->chunk !== null){
 				$this->chunk->removeEntity($this);
 			}
-			$this->chunk = $this->level->getChunk($chunkX, $chunkZ, true);
+			//TODO: this shouldn't be loading chunks, but currently we don't know what to do if they try to move into an
+			//unloaded chunk
+			$this->chunk = $this->level->getOrLoadChunk($chunkX, $chunkZ, true);
 
 			if(!$this->justCreated){
 				$newChunk = $this->level->getViewersForPosition($this);

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -1078,13 +1078,25 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 		}
 
 		if($this->onGround){
-			$friction *= $this->level->getBlockAt((int) floor($this->x), (int) floor($this->y - 1), (int) floor($this->z))->getFrictionFactor();
+			try{
+				$friction *= $this->level->getBlockAt((int) floor($this->x), (int) floor($this->y - 1), (int) floor($this->z))->getFrictionFactor();
+			}catch(TerrainNotLoadedException $_){
+
+			}
 		}
 
 		$this->motion->x *= $friction;
 		$this->motion->z *= $friction;
 	}
 
+	/**
+	 * @param float $x
+	 * @param float $y
+	 * @param float $z
+	 *
+	 * @return bool
+	 * @throws TerrainNotLoadedException
+	 */
 	protected function checkObstruction(float $x, float $y, float $z) : bool{
 		if(count($this->level->getCollisionBoxes($this, $this->getBoundingBox(), false)) === 0){
 			return false;

--- a/src/pocketmine/entity/object/ExperienceOrb.php
+++ b/src/pocketmine/entity/object/ExperienceOrb.php
@@ -25,6 +25,7 @@ namespace pocketmine\entity\object;
 
 use pocketmine\entity\Entity;
 use pocketmine\entity\Human;
+use pocketmine\level\TerrainNotLoadedException;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\IntTag;
 use pocketmine\nbt\tag\ShortTag;
@@ -216,7 +217,11 @@ class ExperienceOrb extends Entity{
 	}
 
 	protected function tryChangeMovement() : void{
-		$this->checkObstruction($this->x, $this->y, $this->z);
+		try{
+			$this->checkObstruction($this->x, $this->y, $this->z);
+		}catch(TerrainNotLoadedException $_){
+
+		}
 		parent::tryChangeMovement();
 	}
 

--- a/src/pocketmine/entity/object/ItemEntity.php
+++ b/src/pocketmine/entity/object/ItemEntity.php
@@ -28,6 +28,7 @@ use pocketmine\event\entity\ItemDespawnEvent;
 use pocketmine\event\entity\ItemSpawnEvent;
 use pocketmine\event\inventory\InventoryPickupItemEvent;
 use pocketmine\item\Item;
+use pocketmine\level\TerrainNotLoadedException;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\network\mcpe\protocol\AddItemEntityPacket;
 use pocketmine\network\mcpe\protocol\TakeItemEntityPacket;
@@ -113,7 +114,11 @@ class ItemEntity extends Entity{
 	}
 
 	protected function tryChangeMovement() : void{
-		$this->checkObstruction($this->x, $this->y, $this->z);
+		try{
+			$this->checkObstruction($this->x, $this->y, $this->z);
+		}catch(TerrainNotLoadedException $_){
+
+		}
 		parent::tryChangeMovement();
 	}
 

--- a/src/pocketmine/level/BlockWriteBatch.php
+++ b/src/pocketmine/level/BlockWriteBatch.php
@@ -75,6 +75,7 @@ class BlockWriteBatch{
 	 * @param Vector3      $pos
 	 *
 	 * @return Block
+	 * @throws TerrainNotLoadedException
 	 */
 	public function fetchBlock(ChunkManager $world, Vector3 $pos) : Block{
 		return $this->fetchBlockAt($world, $pos->getFloorX(), $pos->getFloorY(), $pos->getFloorZ());
@@ -89,6 +90,7 @@ class BlockWriteBatch{
 	 * @param int          $z
 	 *
 	 * @return Block
+	 * @throws TerrainNotLoadedException
 	 */
 	public function fetchBlockAt(ChunkManager $world, int $x, int $y, int $z) : Block{
 		return $this->blocks[$x][$y][$z] ?? $world->getBlockAt($x, $y, $z);

--- a/src/pocketmine/level/ChunkManager.php
+++ b/src/pocketmine/level/ChunkManager.php
@@ -36,6 +36,7 @@ interface ChunkManager{
 	 * @param int $z
 	 *
 	 * @return Block
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getBlockAt(int $x, int $y, int $z) : Block;
 
@@ -48,6 +49,7 @@ interface ChunkManager{
 	 * @param Block $block
 	 *
 	 * @return bool TODO: remove
+	 * @throws TerrainNotLoadedException
 	 */
 	public function setBlockAt(int $x, int $y, int $z, Block $block) : bool;
 
@@ -59,6 +61,7 @@ interface ChunkManager{
 	 * @param int $z
 	 *
 	 * @return int
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getBlockLightAt(int $x, int $y, int $z) : int;
 
@@ -69,6 +72,8 @@ interface ChunkManager{
 	 * @param int $y
 	 * @param int $z
 	 * @param int $level
+	 *
+	 * @throws TerrainNotLoadedException
 	 */
 	public function setBlockLightAt(int $x, int $y, int $z, int $level);
 
@@ -80,6 +85,7 @@ interface ChunkManager{
 	 * @param int $z
 	 *
 	 * @return int
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getBlockSkyLightAt(int $x, int $y, int $z) : int;
 
@@ -90,16 +96,21 @@ interface ChunkManager{
 	 * @param int $y
 	 * @param int $z
 	 * @param int $level
+	 *
+	 * @throws TerrainNotLoadedException
 	 */
 	public function setBlockSkyLightAt(int $x, int $y, int $z, int $level);
 
 	/**
-	 * @param int $chunkX
-	 * @param int $chunkZ
+	 * Returns the chunk at the given coordinates, or throws an exception if it is not loaded.
 	 *
-	 * @return Chunk|null
+	 * @param int $x
+	 * @param int $z
+	 *
+	 * @return Chunk
+	 * @throws TerrainNotLoadedException
 	 */
-	public function getChunk(int $chunkX, int $chunkZ);
+	public function getChunk(int $x, int $z) : Chunk;
 
 	/**
 	 * @param int        $chunkX

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -946,6 +946,8 @@ class Level implements ChunkManager, Metadatable{
 	/**
 	 * @param Player[]  $target
 	 * @param Vector3[] $blocks
+	 *
+	 * @throws TerrainNotLoadedException
 	 */
 	public function sendBlocks(array $target, array $blocks){
 		$packets = [];

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1997,6 +1997,9 @@ class Level implements ChunkManager, Metadatable{
 
 		for($x = $minX; $x <= $maxX; ++$x){
 			for($z = $minZ; $z <= $maxZ; ++$z){
+				if(!$this->isChunkLoaded($x, $z)){
+					continue;
+				}
 				foreach($this->getChunkEntities($x, $z) as $ent){
 					if($ent !== $entity and $ent->boundingBox->intersectsWith($bb)){
 						$nearby[] = $ent;
@@ -2033,6 +2036,9 @@ class Level implements ChunkManager, Metadatable{
 
 		for($x = $minX; $x <= $maxX; ++$x){
 			for($z = $minZ; $z <= $maxZ; ++$z){
+				if(!$this->isChunkLoaded($x, $z)){
+					continue;
+				}
 				foreach($this->getChunkEntities($x, $z) as $entity){
 					if(!($entity instanceof $entityType) or $entity->isClosed() or $entity->isFlaggedForDespawn() or (!$includeDead and !$entity->isAlive())){
 						continue;

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -46,7 +46,6 @@ use pocketmine\item\Item;
 use pocketmine\item\ItemFactory;
 use pocketmine\level\biome\Biome;
 use pocketmine\level\format\Chunk;
-use pocketmine\level\format\ChunkException;
 use pocketmine\level\format\EmptySubChunk;
 use pocketmine\level\format\io\exception\CorruptedChunkException;
 use pocketmine\level\format\io\exception\UnsupportedChunkFormatException;
@@ -1334,9 +1333,10 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $z
 	 *
 	 * @return int bitmap, (id << 4) | data
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getFullBlock(int $x, int $y, int $z) : int{
-		return $this->getChunk($x >> 4, $z >> 4, false)->getFullBlock($x & 0x0f, $y, $z & 0x0f);
+		return $this->getChunk($x >> 4, $z >> 4)->getFullBlock($x & 0x0f, $y, $z & 0x0f);
 	}
 
 	public function isInWorld(int $x, int $y, int $z) : bool{
@@ -1377,6 +1377,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @param bool $addToCache Whether to cache the block object created by this method call.
 	 *
 	 * @return Block
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getBlockAt(int $x, int $y, int $z, bool $cached = true, bool $addToCache = true) : Block{
 		$fullState = 0;
@@ -1394,7 +1395,7 @@ class Level implements ChunkManager, Metadatable{
 			if($chunk !== null){
 				$fullState = $chunk->getFullBlock($x & 0x0f, $y, $z & 0x0f);
 			}else{
-				$addToCache = false;
+				throw new TerrainNotLoadedException("Chunk at block $x $y $z is not loaded");
 			}
 		}
 
@@ -2044,6 +2045,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @param Vector3 $pos
 	 *
 	 * @return Tile|null
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getTile(Vector3 $pos) : ?Tile{
 		return $this->getTileAt((int) floor($pos->x), (int) floor($pos->y), (int) floor($pos->z));
@@ -2057,9 +2059,10 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $z
 	 *
 	 * @return Tile|null
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getTileAt(int $x, int $y, int $z) : ?Tile{
-		return ($chunk = $this->getChunk($x >> 4, $z >> 4)) !== null ? $chunk->getTile($x & 0x0f, $y, $z & 0x0f) : null;
+		return $this->getChunk($x >> 4, $z >> 4)->getTile($x & 0x0f, $y, $z & 0x0f);
 	}
 
 	/**
@@ -2069,9 +2072,11 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $Z
 	 *
 	 * @return Entity[]
+	 *
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getChunkEntities(int $X, int $Z) : array{
-		return ($chunk = $this->getChunk($X, $Z)) !== null ? $chunk->getEntities() : [];
+		return $this->getChunk($X, $Z)->getEntities();
 	}
 
 	/**
@@ -2081,9 +2086,11 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $Z
 	 *
 	 * @return Tile[]
+	 *
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getChunkTiles(int $X, int $Z) : array{
-		return ($chunk = $this->getChunk($X, $Z)) !== null ? $chunk->getTiles() : [];
+		return $this->getChunk($X, $Z)->getTiles();
 	}
 
 	/**
@@ -2094,9 +2101,11 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $z
 	 *
 	 * @return int 0-15
+	 *
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getBlockSkyLightAt(int $x, int $y, int $z) : int{
-		return $this->getChunk($x >> 4, $z >> 4, true)->getBlockSkyLight($x & 0x0f, $y, $z & 0x0f);
+		return $this->getChunk($x >> 4, $z >> 4)->getBlockSkyLight($x & 0x0f, $y, $z & 0x0f);
 	}
 
 	/**
@@ -2106,9 +2115,11 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $y
 	 * @param int $z
 	 * @param int $level 0-15
+	 *
+	 * @throws TerrainNotLoadedException
 	 */
 	public function setBlockSkyLightAt(int $x, int $y, int $z, int $level){
-		$this->getChunk($x >> 4, $z >> 4, true)->setBlockSkyLight($x & 0x0f, $y, $z & 0x0f, $level & 0x0f);
+		$this->getChunk($x >> 4, $z >> 4)->setBlockSkyLight($x & 0x0f, $y, $z & 0x0f, $level & 0x0f);
 	}
 
 	/**
@@ -2119,9 +2130,10 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $z
 	 *
 	 * @return int 0-15
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getBlockLightAt(int $x, int $y, int $z) : int{
-		return $this->getChunk($x >> 4, $z >> 4, true)->getBlockLight($x & 0x0f, $y, $z & 0x0f);
+		return $this->getChunk($x >> 4, $z >> 4)->getBlockLight($x & 0x0f, $y, $z & 0x0f);
 	}
 
 	/**
@@ -2131,9 +2143,11 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $y
 	 * @param int $z
 	 * @param int $level 0-15
+	 *
+	 * @throws TerrainNotLoadedException
 	 */
 	public function setBlockLightAt(int $x, int $y, int $z, int $level){
-		$this->getChunk($x >> 4, $z >> 4, true)->setBlockLight($x & 0x0f, $y, $z & 0x0f, $level & 0x0f);
+		$this->getChunk($x >> 4, $z >> 4)->setBlockLight($x & 0x0f, $y, $z & 0x0f, $level & 0x0f);
 	}
 
 	/**
@@ -2141,9 +2155,10 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $z
 	 *
 	 * @return int
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getBiomeId(int $x, int $z) : int{
-		return $this->getChunk($x >> 4, $z >> 4, true)->getBiomeId($x & 0x0f, $z & 0x0f);
+		return $this->getChunk($x >> 4, $z >> 4)->getBiomeId($x & 0x0f, $z & 0x0f);
 	}
 
 	/**
@@ -2151,6 +2166,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $z
 	 *
 	 * @return Biome
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getBiome(int $x, int $z) : Biome{
 		return Biome::getBiome($this->getBiomeId($x, $z));
@@ -2160,9 +2176,11 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $x
 	 * @param int $z
 	 * @param int $biomeId
+	 *
+	 * @throws TerrainNotLoadedException
 	 */
 	public function setBiomeId(int $x, int $z, int $biomeId){
-		$this->getChunk($x >> 4, $z >> 4, true)->setBiomeId($x & 0x0f, $z & 0x0f, $biomeId);
+		$this->getChunk($x >> 4, $z >> 4)->setBiomeId($x & 0x0f, $z & 0x0f, $biomeId);
 	}
 
 	/**
@@ -2170,18 +2188,21 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $z
 	 *
 	 * @return int
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getHeightMap(int $x, int $z) : int{
-		return $this->getChunk($x >> 4, $z >> 4, true)->getHeightMap($x & 0x0f, $z & 0x0f);
+		return $this->getChunk($x >> 4, $z >> 4)->getHeightMap($x & 0x0f, $z & 0x0f);
 	}
 
 	/**
 	 * @param int $x
 	 * @param int $z
 	 * @param int $value
+	 *
+	 * @throws TerrainNotLoadedException
 	 */
 	public function setHeightMap(int $x, int $z, int $value){
-		$this->getChunk($x >> 4, $z >> 4, true)->setHeightMap($x & 0x0f, $z & 0x0f, $value);
+		$this->getChunk($x >> 4, $z >> 4)->setHeightMap($x & 0x0f, $z & 0x0f, $value);
 	}
 
 	/**
@@ -2201,7 +2222,7 @@ class Level implements ChunkManager, Metadatable{
 	 *
 	 * @return Chunk|null
 	 */
-	public function getChunk(int $x, int $z, bool $create = false){
+	public function getOrLoadChunk(int $x, int $z, bool $create = false){
 		if(isset($this->chunks[$index = Level::chunkHash($x, $z)])){
 			return $this->chunks[$index];
 		}elseif($this->loadChunk($x, $z, $create)){
@@ -2212,15 +2233,32 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
+	 * Returns the chunk at the given coordinates, or throws an exception if it is not loaded.
+	 *
+	 * @param int $x
+	 * @param int $z
+	 *
+	 * @return Chunk
+	 * @throws TerrainNotLoadedException
+	 */
+	public function getChunk(int $x, int $z) : Chunk{
+		$chunk = $this->chunks[Level::chunkHash($x, $z)] ?? null;
+		if($chunk === null){
+			throw new TerrainNotLoadedException("Chunk $x $z is not loaded");
+		}
+		return $chunk;
+	}
+
+	/**
 	 * Returns the chunk containing the given Vector3 position.
 	 *
 	 * @param Vector3 $pos
-	 * @param bool    $create
 	 *
-	 * @return null|Chunk
+	 * @return Chunk
+	 * @throws TerrainNotLoadedException
 	 */
-	public function getChunkAtPosition(Vector3 $pos, bool $create = false) : ?Chunk{
-		return $this->getChunk($pos->getFloorX() >> 4, $pos->getFloorZ() >> 4, $create);
+	public function getChunkAtPosition(Vector3 $pos) : Chunk{
+		return $this->getChunk($pos->getFloorX() >> 4, $pos->getFloorZ() >> 4);
 	}
 
 	/**
@@ -2239,7 +2277,8 @@ class Level implements ChunkManager, Metadatable{
 				if($i === 4){
 					continue; //center chunk
 				}
-				$result[$i] = $this->getChunk($x + $xx - 1, $z + $zz - 1, false);
+				//TODO: loading chunks is not really appropriate here, but currently it's a requirement
+				$result[$i] = $this->getOrLoadChunk($x + $xx - 1, $z + $zz - 1, false);
 			}
 		}
 
@@ -2273,7 +2312,8 @@ class Level implements ChunkManager, Metadatable{
 			unset($this->chunkPopulationQueue[$index]);
 
 			if($chunk !== null){
-				$oldChunk = $this->getChunk($x, $z, false);
+				//TODO: is loading chunks appropriate here?
+				$oldChunk = $this->getOrLoadChunk($x, $z, false);
 				$this->setChunk($x, $z, $chunk, false);
 				if(($oldChunk === null or !$oldChunk->isPopulated()) and $chunk->isPopulated()){
 					(new ChunkPopulateEvent($this, $chunk))->call();
@@ -2309,7 +2349,7 @@ class Level implements ChunkManager, Metadatable{
 		$chunk->setZ($chunkZ);
 
 		$chunkHash = Level::chunkHash($chunkX, $chunkZ);
-		$oldChunk = $this->getChunk($chunkX, $chunkZ, false);
+		$oldChunk = $this->getOrLoadChunk($chunkX, $chunkZ, false);
 		if($oldChunk !== null and $oldChunk !== $chunk){
 			if($deleteEntitiesAndTiles){
 				foreach($oldChunk->getEntities() as $player){
@@ -2363,9 +2403,10 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $z
 	 *
 	 * @return int 0-255
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getHighestBlockAt(int $x, int $z) : int{
-		return $this->getChunk($x >> 4, $z >> 4, true)->getHighestBlockAt($x & 0x0f, $z & 0x0f);
+		return $this->getChunk($x >> 4, $z >> 4)->getHighestBlockAt($x & 0x0f, $z & 0x0f);
 	}
 
 	/**
@@ -2387,28 +2428,6 @@ class Level implements ChunkManager, Metadatable{
 	 */
 	public function isChunkLoaded(int $x, int $z) : bool{
 		return isset($this->chunks[Level::chunkHash($x, $z)]);
-	}
-
-	/**
-	 * @param int $x
-	 * @param int $z
-	 *
-	 * @return bool
-	 */
-	public function isChunkGenerated(int $x, int $z) : bool{
-		$chunk = $this->getChunk($x, $z);
-		return $chunk !== null ? $chunk->isGenerated() : false;
-	}
-
-	/**
-	 * @param int $x
-	 * @param int $z
-	 *
-	 * @return bool
-	 */
-	public function isChunkPopulated(int $x, int $z) : bool{
-		$chunk = $this->getChunk($x, $z);
-		return $chunk !== null ? $chunk->isPopulated() : false;
 	}
 
 	/**
@@ -2476,10 +2495,7 @@ class Level implements ChunkManager, Metadatable{
 
 				$this->timings->syncChunkSendPrepareTimer->startTiming();
 
-				$chunk = $this->chunks[$index] ?? null;
-				if(!($chunk instanceof Chunk)){
-					throw new ChunkException("Invalid Chunk sent");
-				}
+				$chunk = $this->getChunk($x, $z);
 				assert($chunk->getX() === $x and $chunk->getZ() === $z, "Chunk coordinate mismatch: expected $x $z, but chunk has coordinates " . $chunk->getX() . " " . $chunk->getZ() . ", did you forget to clone a chunk before setting?");
 
 				/*
@@ -2558,6 +2574,7 @@ class Level implements ChunkManager, Metadatable{
 	/**
 	 * @param Tile $tile
 	 *
+	 * @throws TerrainNotLoadedException
 	 * @throws \InvalidArgumentException
 	 */
 	public function addTile(Tile $tile){
@@ -2568,14 +2585,7 @@ class Level implements ChunkManager, Metadatable{
 			throw new \InvalidArgumentException("Invalid Tile level");
 		}
 
-		$chunkX = $tile->getFloorX() >> 4;
-		$chunkZ = $tile->getFloorZ() >> 4;
-
-		if(isset($this->chunks[$hash = Level::chunkHash($chunkX, $chunkZ)])){
-			$this->chunks[$hash]->addTile($tile);
-		}else{
-			throw new \InvalidStateException("Attempted to create tile " . get_class($tile) . " in unloaded chunk $chunkX $chunkZ");
-		}
+		$this->getChunk($tile->getFloorX() >> 4, $tile->getFloorZ() >> 4)->addTile($tile);
 
 		$this->tiles[Level::blockHash($tile->x, $tile->y, $tile->z)] = $tile;
 		$tile->scheduleUpdate();
@@ -2766,6 +2776,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @param Vector3|null $spawn
 	 *
 	 * @return Position
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getSafeSpawn(?Vector3 $spawn = null) : Position{
 		if(!($spawn instanceof Vector3) or $spawn->y < 1){
@@ -2774,10 +2785,10 @@ class Level implements ChunkManager, Metadatable{
 
 		$max = $this->worldHeight;
 		$v = $spawn->floor();
-		$chunk = $this->getChunkAtPosition($v, false);
+		$chunk = $this->getChunkAtPosition($v);
 		$x = (int) $v->x;
 		$z = (int) $v->z;
-		if($chunk !== null and $chunk->isGenerated()){
+		if($chunk->isGenerated()){ //TODO: this should throw an exception
 			$y = (int) min($max - 2, $v->y);
 			$wasAir = ($chunk->getBlockId($x & 0x0f, $y - 1, $z & 0x0f) === 0);
 			for(; $y > 0; --$y){
@@ -2918,7 +2929,7 @@ class Level implements ChunkManager, Metadatable{
 			}
 		}
 
-		$chunk = $this->getChunk($x, $z, true);
+		$chunk = $this->getOrLoadChunk($x, $z, true);
 		if(!$chunk->isPopulated()){
 			Timings::$populationTimer->startTiming();
 

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -793,8 +793,13 @@ class Level implements ChunkManager, Metadatable{
 
 		//Delayed updates
 		while($this->scheduledBlockUpdateQueue->count() > 0 and $this->scheduledBlockUpdateQueue->current()["priority"] <= $currentTick){
-			$block = $this->getBlock($this->scheduledBlockUpdateQueue->extract()["data"]);
-			unset($this->scheduledBlockUpdateQueueIndex[Level::blockHash($block->x, $block->y, $block->z)]);
+			$vec = $this->scheduledBlockUpdateQueue->extract()["data"];
+			unset($this->scheduledBlockUpdateQueueIndex[Level::blockHash($vec->x, $vec->y, $vec->z)]);
+			try{
+				$block = $this->getBlock($vec);
+			}catch(TerrainNotLoadedException $e){ //chunk unloaded before update took place
+				continue;
+			}
 			$block->onScheduledUpdate();
 		}
 
@@ -1182,6 +1187,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @param Vector3 $pos
 	 *
 	 * @return bool
+	 * @throws TerrainNotLoadedException
 	 */
 	public function isFullBlock(Vector3 $pos) : bool{
 		if($pos instanceof Block){
@@ -1359,6 +1365,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @param bool    $addToCache Whether to cache the block object created by this method call.
 	 *
 	 * @return Block
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getBlock(Vector3 $pos, bool $cached = true, bool $addToCache = true) : Block{
 		return $this->getBlockAt((int) floor($pos->x), (int) floor($pos->y), (int) floor($pos->z), $cached, $addToCache);
@@ -1422,6 +1429,11 @@ class Level implements ChunkManager, Metadatable{
 		return $block;
 	}
 
+	/**
+	 * @param Vector3 $pos
+	 *
+	 * @throws TerrainNotLoadedException
+	 */
 	public function updateAllLight(Vector3 $pos){
 		$this->updateBlockSkyLight($pos->x, $pos->y, $pos->z);
 		$this->updateBlockLight($pos->x, $pos->y, $pos->z);
@@ -1435,6 +1447,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $z
 	 *
 	 * @return int
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getHighestAdjacentBlockSkyLight(int $x, int $y, int $z) : int{
 		return max([
@@ -1447,6 +1460,13 @@ class Level implements ChunkManager, Metadatable{
 		]);
 	}
 
+	/**
+	 * @param int $x
+	 * @param int $y
+	 * @param int $z
+	 *
+	 * @throws TerrainNotLoadedException
+	 */
 	public function updateBlockSkyLight(int $x, int $y, int $z){
 		$this->timings->doBlockSkyLightUpdates->startTiming();
 
@@ -1495,6 +1515,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @param int $z
 	 *
 	 * @return int
+	 * @throws TerrainNotLoadedException
 	 */
 	public function getHighestAdjacentBlockLight(int $x, int $y, int $z) : int{
 		return max([
@@ -1507,6 +1528,13 @@ class Level implements ChunkManager, Metadatable{
 		]);
 	}
 
+	/**
+	 * @param int $x
+	 * @param int $y
+	 * @param int $z
+	 *
+	 * @throws TerrainNotLoadedException
+	 */
 	public function updateBlockLight(int $x, int $y, int $z){
 		$this->timings->doBlockLightUpdates->startTiming();
 
@@ -1566,6 +1594,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @return bool Whether the block has been updated or not
 	 *
 	 * @throws \InvalidArgumentException if the position is out of the world bounds
+	 * @throws TerrainNotLoadedException
 	 */
 	public function setBlockAt(int $x, int $y, int $z, Block $block, bool $update = true) : bool{
 		if(!$this->isInWorld($x, $y, $z)){
@@ -1673,6 +1702,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @param bool    $createParticles
 	 *
 	 * @return bool
+	 * @throws TerrainNotLoadedException
 	 */
 	public function useBreakOn(Vector3 $vector, Item &$item = null, Player $player = null, bool $createParticles = false) : bool{
 		$target = $this->getBlock($vector);
@@ -1751,6 +1781,14 @@ class Level implements ChunkManager, Metadatable{
 		return true;
 	}
 
+	/**
+	 * @param Block       $target
+	 * @param Item        $item
+	 * @param Player|null $player
+	 * @param bool        $createParticles
+	 *
+	 * @throws TerrainNotLoadedException
+	 */
 	private function destroyBlockInternal(Block $target, Item $item, ?Player $player = null, bool $createParticles = false) : void{
 		if($createParticles){
 			$this->addParticle($target->add(0.5, 0.5, 0.5), new DestroyBlockParticle($target));
@@ -1783,6 +1821,7 @@ class Level implements ChunkManager, Metadatable{
 	 * @param bool         $playSound Whether to play a block-place sound if the block was placed successfully.
 	 *
 	 * @return bool
+	 * @throws TerrainNotLoadedException
 	 */
 	public function useItemOn(Vector3 $vector, Item &$item, int $face, Vector3 $clickVector = null, Player $player = null, bool $playSound = false) : bool{
 		$blockClicked = $this->getBlock($vector);

--- a/src/pocketmine/level/SimpleChunkManager.php
+++ b/src/pocketmine/level/SimpleChunkManager.php
@@ -46,55 +46,43 @@ class SimpleChunkManager implements ChunkManager{
 	}
 
 	public function getBlockAt(int $x, int $y, int $z) : Block{
-		if($chunk = $this->getChunk($x >> 4, $z >> 4)){
-			return BlockFactory::fromFullBlock($chunk->getFullBlock($x & 0xf, $y, $z & 0xf));
-		}
-		return BlockFactory::get(Block::AIR);
+		return BlockFactory::fromFullBlock($this->getChunk($x >> 4, $z >> 4)->getFullBlock($x & 0xf, $y, $z & 0xf));
 	}
 
 	public function setBlockAt(int $x, int $y, int $z, Block $block) : bool{
-		if(($chunk = $this->getChunk($x >> 4, $z >> 4)) !== null){
-			return $chunk->setBlock($x & 0xf, $y, $z & 0xf, $block->getId(), $block->getDamage());
-		}
-		return false;
+		return $this->getChunk($x >> 4, $z >> 4)->setBlock($x & 0xf, $y, $z & 0xf, $block->getId(), $block->getDamage());
 	}
 
 	public function getBlockLightAt(int $x, int $y, int $z) : int{
-		if($chunk = $this->getChunk($x >> 4, $z >> 4)){
-			return $chunk->getBlockLight($x & 0xf, $y, $z & 0xf);
-		}
-
-		return 0;
+		return $this->getChunk($x >> 4, $z >> 4)->getBlockLight($x & 0xf, $y, $z & 0xf);
 	}
 
 	public function setBlockLightAt(int $x, int $y, int $z, int $level){
-		if($chunk = $this->getChunk($x >> 4, $z >> 4)){
-			$chunk->setBlockLight($x & 0xf, $y, $z & 0xf, $level);
-		}
+		$this->getChunk($x >> 4, $z >> 4)->setBlockLight($x & 0xf, $y, $z & 0xf, $level);
 	}
 
 	public function getBlockSkyLightAt(int $x, int $y, int $z) : int{
-		if($chunk = $this->getChunk($x >> 4, $z >> 4)){
-			return $chunk->getBlockSkyLight($x & 0xf, $y, $z & 0xf);
-		}
-
-		return 0;
+		return $this->getChunk($x >> 4, $z >> 4)->getBlockSkyLight($x & 0xf, $y, $z & 0xf);
 	}
 
 	public function setBlockSkyLightAt(int $x, int $y, int $z, int $level){
-		if($chunk = $this->getChunk($x >> 4, $z >> 4)){
-			$chunk->setBlockSkyLight($x & 0xf, $y, $z & 0xf, $level);
-		}
+		$this->getChunk($x >> 4, $z >> 4)->setBlockSkyLight($x & 0xf, $y, $z & 0xf, $level);
 	}
 
 	/**
 	 * @param int $chunkX
 	 * @param int $chunkZ
 	 *
-	 * @return Chunk|null
+	 * @return Chunk
+	 * @throws TerrainNotLoadedException
 	 */
-	public function getChunk(int $chunkX, int $chunkZ){
-		return $this->chunks[Level::chunkHash($chunkX, $chunkZ)] ?? null;
+	public function getChunk(int $chunkX, int $chunkZ) : Chunk{
+		$chunk = $this->chunks[Level::chunkHash($chunkX, $chunkZ)] ?? null;
+		if($chunk === null){
+			throw new TerrainNotLoadedException("Chunk $chunkX $chunkZ is not loaded");
+		}
+
+		return $chunk;
 	}
 
 	/**

--- a/src/pocketmine/level/TerrainNotLoadedException.php
+++ b/src/pocketmine/level/TerrainNotLoadedException.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\level;
+
+class TerrainNotLoadedException extends LevelException{
+
+}

--- a/src/pocketmine/level/utils/SubChunkIteratorManager.php
+++ b/src/pocketmine/level/utils/SubChunkIteratorManager.php
@@ -27,6 +27,7 @@ use pocketmine\level\ChunkManager;
 use pocketmine\level\format\Chunk;
 use pocketmine\level\format\EmptySubChunk;
 use pocketmine\level\format\SubChunkInterface;
+use pocketmine\level\TerrainNotLoadedException;
 
 class SubChunkIteratorManager{
 	/** @var ChunkManager */
@@ -57,8 +58,10 @@ class SubChunkIteratorManager{
 			$this->currentZ = $z >> 4;
 			$this->currentSubChunk = null;
 
-			$this->currentChunk = $this->level->getChunk($this->currentX, $this->currentZ);
-			if($this->currentChunk === null){
+			try{
+				$this->currentChunk = $this->level->getChunk($this->currentX, $this->currentZ);
+			}catch(TerrainNotLoadedException $e){
+				$this->currentChunk = null;
 				return false;
 			}
 		}

--- a/src/pocketmine/network/mcpe/handler/SimpleSessionHandler.php
+++ b/src/pocketmine/network/mcpe/handler/SimpleSessionHandler.php
@@ -27,6 +27,7 @@ use pocketmine\inventory\transaction\action\InventoryAction;
 use pocketmine\inventory\transaction\CraftingTransaction;
 use pocketmine\inventory\transaction\InventoryTransaction;
 use pocketmine\inventory\transaction\TransactionValidationException;
+use pocketmine\level\TerrainNotLoadedException;
 use pocketmine\math\Vector3;
 use pocketmine\network\BadPacketException;
 use pocketmine\network\mcpe\protocol\AdventureSettingsPacket;
@@ -215,6 +216,12 @@ class SimpleSessionHandler extends SessionHandler{
 		return true;
 	}
 
+	/**
+	 * @param UseItemTransactionData $data
+	 *
+	 * @return bool
+	 * @throws BadPacketException
+	 */
 	private function handleUseItemTransaction(UseItemTransactionData $data) : bool{
 		switch($data->getActionType()){
 			case UseItemTransactionData::ACTION_CLICK_BLOCK:
@@ -231,10 +238,18 @@ class SimpleSessionHandler extends SessionHandler{
 					return true;
 				}
 				//TODO: end hack for client spam bug
-				$this->player->interactBlock($data->getBlockPos(), $data->getFace(), $clickPos);
+				try{
+					$this->player->interactBlock($data->getBlockPos(), $data->getFace(), $clickPos);
+				}catch(TerrainNotLoadedException $e){
+					throw new BadPacketException($e->getMessage(), 0, $e);
+				}
 				return true;
 			case UseItemTransactionData::ACTION_BREAK_BLOCK:
-				$this->player->breakBlock($data->getBlockPos());
+				try{
+					$this->player->breakBlock($data->getBlockPos());
+				}catch(TerrainNotLoadedException $e){
+					throw new BadPacketException($e->getMessage(), 0, $e);
+				}
 				return true;
 			case UseItemTransactionData::ACTION_CLICK_AIR:
 				$this->player->useHeldItem();
@@ -296,7 +311,11 @@ class SimpleSessionHandler extends SessionHandler{
 	}
 
 	public function handleBlockPickRequest(BlockPickRequestPacket $packet) : bool{
-		return $this->player->pickBlock(new Vector3($packet->blockX, $packet->blockY, $packet->blockZ), $packet->addUserData);
+		try{
+			return $this->player->pickBlock(new Vector3($packet->blockX, $packet->blockY, $packet->blockZ), $packet->addUserData);
+		}catch(TerrainNotLoadedException $e){
+			throw new BadPacketException($e->getMessage(), 0, $e);
+		}
 	}
 
 	public function handleEntityPickRequest(EntityPickRequestPacket $packet) : bool{
@@ -308,7 +327,11 @@ class SimpleSessionHandler extends SessionHandler{
 
 		switch($packet->action){
 			case PlayerActionPacket::ACTION_START_BREAK:
-				$this->player->startBreakBlock($pos, $packet->face);
+				try{
+					$this->player->startBreakBlock($pos, $packet->face);
+				}catch(TerrainNotLoadedException $e){
+					throw new BadPacketException($e->getMessage(), 0, $e);
+				}
 
 				break;
 
@@ -341,7 +364,11 @@ class SimpleSessionHandler extends SessionHandler{
 			case PlayerActionPacket::ACTION_STOP_GLIDE:
 				break; //TODO
 			case PlayerActionPacket::ACTION_CONTINUE_BREAK:
-				$this->player->continueBreakBlock($pos, $packet->face);
+				try{
+					$this->player->continueBreakBlock($pos, $packet->face);
+				}catch(TerrainNotLoadedException $e){
+					throw new BadPacketException($e->getMessage(), 0, $e);
+				}
 				break;
 			case PlayerActionPacket::ACTION_START_SWIMMING:
 				break; //TODO


### PR DESCRIPTION
## Introduction
This was originally integrated directly into master and then reversed due to stability issues. This is still being worked on and problems still need to be addressed.

The main issue is that chunks are synchronously loaded on the fly whenever `Level->getChunk()` is called (unasked) which causes a whole lot of hidden problems to manifest, including unexplained memory leaks, DoS attack vectors and more.

Second, there is an inconsistency around how unloaded chunks are handled in general. Sometimes they are synchronously loaded, and in other cases they are just skipped and treated like a chunk full of air. This causes a lot of problems with performance, as well as problems with incorrect cached items when caching results of accessing the world.

This PR aims to solve these problems by making unloaded chunk handling 100% consistent.

I opted not to have chunks always autoloaded, since this is not always possible anyway. In addition, it is not possible to synchronously request the generation of a chunk, which causes the same problems under the current architecture as assuming air for an unloaded chunk.

These changes are necessary to facilitate asynchronous I/O, which has been a desired feature for over 2 years.