### PR TITLE
Implement thread safe composer class loading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
       "daverandom/callback-validator": "dev-master",
       "adhocore/json-comment": "^0.0.7",
       "particle/validator": "^2.3",
-      "jacknoordhuis/threaded-class-loader": "^0.0.1"
+      "jacknoordhuis/threaded-class-loader": "^0.0.2"
    },
    "autoload": {
       "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
       "pocketmine/snooze": "^0.1.0",
       "daverandom/callback-validator": "dev-master",
       "adhocore/json-comment": "^0.0.7",
-      "particle/validator": "^2.3"
+      "particle/validator": "^2.3",
+      "jacknoordhuis/threaded-class-loader": "^0.0.1"
    },
    "autoload": {
       "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "959fe32be1db4613fd22eb2c7c7b23c6",
+    "content-hash": "a51250ce87b095da41fbe411776081b3",
     "packages": [
         {
             "name": "adhocore/json-comment",
@@ -160,6 +160,46 @@
             "time": "2018-12-02T01:34:34+00:00"
         },
         {
+            "name": "jacknoordhuis/threaded-class-loader",
+            "version": "0.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/JackNoordhuis/threaded-class-loader.git",
+                "reference": "ae4272719c2f940feda1179b7758273cfc51a7ea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/JackNoordhuis/threaded-class-loader/zipball/ae4272719c2f940feda1179b7758273cfc51a7ea",
+                "reference": "ae4272719c2f940feda1179b7758273cfc51a7ea",
+                "shasum": ""
+            },
+            "require": {
+                "ext-pthreads": "*",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "jacknoordhuis\\Autoload\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Jack Noordhuis",
+                    "email": "me@jacknoordhuis.net"
+                }
+            ],
+            "description": "A thread safe implementation of a PSR-0, PSR-4 and classmap class loader for use with the pthreads extension.",
+            "time": "2019-02-10T08:45:59+00:00"
+        },
+        {
             "name": "mdanter/ecc",
             "version": "v0.5.2",
             "source": {
@@ -277,7 +317,7 @@
                 {
                     "name": "Berry Langerak",
                     "email": "berry@berryllium.nl",
-                    "role": "developer"
+                    "role": "Developer"
                 },
                 {
                     "name": "Rick van der Staaij",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a51250ce87b095da41fbe411776081b3",
+    "content-hash": "6d359911064538d8e03a98e18a8aec5b",
     "packages": [
         {
             "name": "adhocore/json-comment",
@@ -161,16 +161,16 @@
         },
         {
             "name": "jacknoordhuis/threaded-class-loader",
-            "version": "0.0.1",
+            "version": "0.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/JackNoordhuis/threaded-class-loader.git",
-                "reference": "ae4272719c2f940feda1179b7758273cfc51a7ea"
+                "reference": "5703b940aae5cbe9563e910123d971fb59d1b6c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JackNoordhuis/threaded-class-loader/zipball/ae4272719c2f940feda1179b7758273cfc51a7ea",
-                "reference": "ae4272719c2f940feda1179b7758273cfc51a7ea",
+                "url": "https://api.github.com/repos/JackNoordhuis/threaded-class-loader/zipball/5703b940aae5cbe9563e910123d971fb59d1b6c1",
+                "reference": "5703b940aae5cbe9563e910123d971fb59d1b6c1",
                 "shasum": ""
             },
             "require": {
@@ -197,7 +197,7 @@
                 }
             ],
             "description": "A thread safe implementation of a PSR-0, PSR-4 and classmap class loader for use with the pthreads extension.",
-            "time": "2019-02-10T08:45:59+00:00"
+            "time": "2019-02-12T04:32:14+00:00"
         },
         {
             "name": "mdanter/ecc",

--- a/src/pocketmine/PocketMine.php
+++ b/src/pocketmine/PocketMine.php
@@ -29,6 +29,7 @@ namespace {
 namespace pocketmine {
 
 	use pocketmine\utils\MainLogger;
+	use pocketmine\utils\ServerClassLoader;
 	use pocketmine\utils\ServerKiller;
 	use pocketmine\utils\Terminal;
 	use pocketmine\utils\Timezone;
@@ -156,7 +157,7 @@ namespace pocketmine {
 	define('pocketmine\COMPOSER_AUTOLOADER_PATH', $bootstrap);
 
 	if(\pocketmine\COMPOSER_AUTOLOADER_PATH !== false and is_file(\pocketmine\COMPOSER_AUTOLOADER_PATH)){
-		require_once(\pocketmine\COMPOSER_AUTOLOADER_PATH);
+		$autoloader = require_once(\pocketmine\COMPOSER_AUTOLOADER_PATH);
 	}else{
 		critical_error("Composer autoloader not found at " . $bootstrap);
 		critical_error("Please install/update Composer dependencies or use provided builds.");
@@ -168,8 +169,7 @@ namespace pocketmine {
 	/*
 	 * We now use the Composer autoloader, but this autoloader is still for loading plugins.
 	 */
-	$autoloader = new \BaseClassLoader();
-	$autoloader->register(false);
+	$autoloader = ServerClassLoader::fromComposerLoader($autoloader);
 
 	set_time_limit(0); //Who set it to 30 seconds?!?!
 

--- a/src/pocketmine/Thread.php
+++ b/src/pocketmine/Thread.php
@@ -30,8 +30,6 @@ abstract class Thread extends \Thread{
 
 	/** @var \ClassLoader|null */
 	protected $classLoader;
-	/** @var string|null */
-	protected $composerAutoloaderPath;
 
 	protected $isKilled = false;
 
@@ -40,8 +38,6 @@ abstract class Thread extends \Thread{
 	}
 
 	public function setClassLoader(\ClassLoader $loader = null){
-		$this->composerAutoloaderPath = \pocketmine\COMPOSER_AUTOLOADER_PATH;
-
 		if($loader === null){
 			$loader = Server::getInstance()->getLoader();
 		}
@@ -56,9 +52,6 @@ abstract class Thread extends \Thread{
 	 * (unless you are using a custom autoloader).
 	 */
 	public function registerClassLoader(){
-		if($this->composerAutoloaderPath !== null){
-			require $this->composerAutoloaderPath;
-		}
 		if($this->classLoader !== null){
 			$this->classLoader->register(false);
 		}

--- a/src/pocketmine/Worker.php
+++ b/src/pocketmine/Worker.php
@@ -30,8 +30,6 @@ abstract class Worker extends \Worker{
 
 	/** @var \ClassLoader|null */
 	protected $classLoader;
-	/** @var string|null */
-	protected $composerAutoloaderPath;
 
 	protected $isKilled = false;
 
@@ -40,8 +38,6 @@ abstract class Worker extends \Worker{
 	}
 
 	public function setClassLoader(\ClassLoader $loader = null){
-		$this->composerAutoloaderPath = \pocketmine\COMPOSER_AUTOLOADER_PATH;
-
 		if($loader === null){
 			$loader = Server::getInstance()->getLoader();
 		}
@@ -56,9 +52,6 @@ abstract class Worker extends \Worker{
 	 * (unless you are using a custom autoloader).
 	 */
 	public function registerClassLoader(){
-		if($this->composerAutoloaderPath !== null){
-			require $this->composerAutoloaderPath;
-		}
 		if($this->classLoader !== null){
 			$this->classLoader->register(false);
 		}

--- a/src/pocketmine/utils/ServerClassLoader.php
+++ b/src/pocketmine/utils/ServerClassLoader.php
@@ -36,31 +36,17 @@ class ServerClassLoader extends ThreadedClassLoader implements ClassLoader{
 	/**
 	 * Creates a new threaded class loader from a default composer class loader.
 	 *
+	 * Note: This override is here for documentation and code completion purposes only.
+	 *
 	 * @param \Composer\Autoload\ClassLoader $loader The composer class loader.
 	 * @param array $includeFiles Array of files to be included by the loader.
 	 * @param bool $register      If the new autoloader should be registered.
 	 * @param bool $unregister    If the composer autoloader should be unregistered.
 	 *
-	 * @return \pocketmine\utils\ServerClassLoader
+	 * @return ServerClassLoader|ThreadedClassLoader
 	 */
 	public static function fromComposerLoader(ComposerClassLoader $loader, array $includeFiles = [], bool $register = true, bool $unregister = true){
-		$threadedLoader = new self();
-
-		$threadedLoader->mergeComposerLoader($loader);
-
-		foreach($includeFiles as $identifier => $file){
-			$threadedLoader->addFile($identifier, $file, !$register);
-		}
-
-		if($register){
-			$threadedLoader->register();
-		}
-
-		if($unregister){
-			$loader->unregister();
-		}
-
-		return $threadedLoader;
+		return parent::fromComposerLoader($loader, $includeFiles, $register, $unregister);
 	}
 
 }

--- a/src/pocketmine/utils/ServerClassLoader.php
+++ b/src/pocketmine/utils/ServerClassLoader.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\utils;
+
+use ClassLoader;
+use Composer\Autoload\ClassLoader as ComposerClassLoader;
+use jacknoordhuis\Autoload\ThreadedClassLoader;
+
+class ServerClassLoader extends ThreadedClassLoader implements ClassLoader{
+
+	public function addPath($path, $prepend = false){
+		$this->add(null, $path, $prepend);
+	}
+
+	/**
+	 * Creates a new threaded class loader from a default composer class loader.
+	 *
+	 * @param \Composer\Autoload\ClassLoader $loader The composer class loader.
+	 * @param array $includeFiles Array of files to be included by the loader.
+	 * @param bool $register      If the new autoloader should be registered.
+	 * @param bool $unregister    If the composer autoloader should be unregistered.
+	 *
+	 * @return \pocketmine\utils\ServerClassLoader
+	 */
+	public static function fromComposerLoader(ComposerClassLoader $loader, array $includeFiles = [], bool $register = true, bool $unregister = true){
+		$threadedLoader = new self();
+
+		$threadedLoader->mergeComposerLoader($loader);
+
+		foreach($includeFiles as $identifier => $file){
+			$threadedLoader->addFile($identifier, $file, !$register);
+		}
+
+		if($register){
+			$threadedLoader->register();
+		}
+
+		if($unregister){
+			$loader->unregister();
+		}
+
+		return $threadedLoader;
+	}
+
+}


### PR DESCRIPTION
## Introduction
Makes use of a thread-safe/thread friendly version of the composer autoloader. This removes the need to use the `BaseClassLoader` which is currently only used for plugin class loading and is a step towards having plugins loaded from a composer.json instead of the traditional plugin.yml manifest.

## Changes
### API changes
Exposes composer class loader methods from the `ServerClassLoader` which extends the `ThreadedClassLoader` and implements `\ClassLoader` to maintain backwards compatibility.

### Behavioural changes
The server no longer maintains two class loaders. The server performance shouldn't have been impacted, although pthreads inefficencies with `\Threaded` objects may have an effect.

## Backwards compatibility
Removes the protected `$composerAutoloaderPath` property from the `Thread` and `Worker` classes. This could possibly be considered an internal change given the lack of plugins using threading at this level let alone using this property.

## Tests
I ran the travis tests locally before committing and the [threaded-class-loader repository](https://github.com/JackNoordhuis/threaded-class-loader) has it's own tests available [here](https://github.com/JackNoordhuis/threaded-class-loader/blob/master/tests/Autoload/ClassLoaderTest.php).
