### PR TITLE
Fix a crash and unnecessary packet sending

### DIFF
--- a/src/pocketmine/network/mcpe/NetworkSession.php
+++ b/src/pocketmine/network/mcpe/NetworkSession.php
@@ -411,8 +411,10 @@ class NetworkSession{
 
 	public function onResourcePacksDone() : void{
 		$this->player->_actuallyConstruct();
-
-		$this->setHandler(new PreSpawnSessionHandler($this->server, $this->player, $this));
+		
+		if($this->connected){
+			$this->setHandler(new PreSpawnSessionHandler($this->server, $this->player, $this));
+		}
 	}
 
 	public function onTerrainReady() : void{


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Fixes a crash and unnecessary packet sending

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
- Fixes a crash

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Tested and working.

### Proof
When resource packs are done. networksession starts to construct entity:
![ekran alintisi56565](https://user-images.githubusercontent.com/13833030/52576363-f4b01880-2e30-11e9-832a-40ef8e3e5284.PNG)

When `PlayerLoginEvent` was cancelled, server closes player:

![ekran alintisi4343](https://user-images.githubusercontent.com/13833030/52576342-ef52ce00-2e30-11e9-894d-e246cb4169ad.PNG)
And, Player::close function destroys player and now player's level is null.
![ekran alintisi96794534](https://user-images.githubusercontent.com/13833030/52576366-f679dc00-2e30-11e9-8024-d54ddf179b79.PNG)
but this function doesnt stop and it continues to setup `PreSpawnSessionHandler`
![ekran alintisi564564564564](https://user-images.githubusercontent.com/13833030/52576374-f8dc3600-2e30-11e9-8869-13c79711c7c0.PNG)
and here, this tries to get time of level but level is null and crashes.
![ekran alintisi5645646456456](https://user-images.githubusercontent.com/13833030/52576377-fb3e9000-2e30-11e9-8cd4-98e9c74a2fde.PNG)


