### PR TITLE
Added getPath() in Config.php

### DIFF
--- a/src/pocketmine/utils/Config.php
+++ b/src/pocketmine/utils/Config.php
@@ -193,6 +193,15 @@ class Config{
 	}
 
 	/**
+	 * Returns the path of the config.
+	 *
+	 * @return string
+	 */
+	public function getPath() : string{
+		return $this->file;
+	}
+
+	/**
 	 * Flushes the config to disk in the appropriate format.
 	 *
 	 * @throws \InvalidStateException if config type is not valid


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Its sometimes necessary to get the path or the data folder of where the config file is located either for plugins or elsewhere. The `file` field in Config.php which stores the data path is marked as private and so it cannot be accessed without using some reflection hacks. This PR adds a getter function called `getPath()` which returns the path store in `file` field of the Config.php.
### Relevant issues
<!-- List relevant issues here -->
<!--

* _none_

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
* Added `getPath()` getter function in Config.php.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
* _none_

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
* Yes

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
* _none_

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
```php
$config = $plugin->getConfig();
var_dump($config->getPath());
```
