### PR TITLE
Allow to create custom entities

### DIFF
--- a/src/pocketmine/network/mcpe/protocol/AddEntityPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/AddEntityPacket.php
@@ -174,7 +174,7 @@ class AddEntityPacket extends DataPacket implements ClientboundPacket{
 		$this->entityRuntimeId = $this->getEntityRuntimeId();
 		$this->type = array_search($t = $this->getString(), self::LEGACY_ID_MAP_BC, true);
 		if($this->type === false){
-			throw new BadPacketException("Can't map ID $t to legacy ID");
+			$this->type = -1;
 		}
 		$this->position = $this->getVector3();
 		$this->motion = $this->getVector3();
@@ -215,9 +215,10 @@ class AddEntityPacket extends DataPacket implements ClientboundPacket{
 		$this->putEntityUniqueId($this->entityUniqueId ?? $this->entityRuntimeId);
 		$this->putEntityRuntimeId($this->entityRuntimeId);
 		if(!isset(self::LEGACY_ID_MAP_BC[$this->type])){
-			throw new \InvalidArgumentException("Unknown entity numeric ID $this->type");
+			$this->putString(strval($this->type));
+		}else{
+			$this->putString(self::LEGACY_ID_MAP_BC[$this->type]);
 		}
-		$this->putString(self::LEGACY_ID_MAP_BC[$this->type]);
 		$this->putVector3($this->position);
 		$this->putVector3Nullable($this->motion);
 		$this->putLFloat($this->pitch);


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
I created a resource pack and i added custom entities to it and i want to spawn this entities in server but i cant, so i made this commit. Also this may be wrong or hack. we should use entity namespaces(ex: minecraft:zombie) instead of magic numbers with 1.8-1.9, i think

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
We cant spawn our custom entities with resource packs

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
```php
$pk = new AddEntityPacket;
$pk->type = "custom:car";
$pk->position = $pos;
$pk->entityRuntimeId = EntityFactory::nextRuntimeId();

$player->sendDataPacket($pk);
```