### PR TITLE
Fixed PaintingItem exception after interacting

### DIFF
--- a/src/pocketmine/item/PaintingItem.php
+++ b/src/pocketmine/item/PaintingItem.php
@@ -68,7 +68,7 @@ class PaintingItem extends Item{
 		}
 
 		if(empty($motives)){ //No space available
-			return false;
+			return ItemUseResult::fail();
 		}
 
 		/** @var PaintingMotive $motive */
@@ -83,7 +83,7 @@ class PaintingItem extends Item{
 
 		$direction = $directions[$face] ?? -1;
 		if($direction === -1){
-			return false;
+			return ItemUseResult::fail();
 		}
 
 		$nbt = EntityFactory::createBaseNBT($blockReplace, null, $direction * 90, 0);
@@ -99,6 +99,6 @@ class PaintingItem extends Item{
 		$entity->spawnToAll();
 
 		$player->getLevel()->broadcastLevelEvent($blockReplace->add(0.5, 0.5, 0.5), LevelEventPacket::EVENT_SOUND_ITEMFRAME_PLACE); //item frame and painting have the same sound
-		return true;
+		return ItemUseResult::success();;
 	}
 }


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Fixes a crash with PaintingItem while attempting to change their.

```
Error: Return value of pocketmine\item\PaintingItem::onActivate() must be an instance of pocketmine\item\ItemUseResult, boolean returned
File: src/pocketmine/item/PaintingItem
Line: 102
Type: TypeError
```

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
 * Fixes a crash

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
 Now the PentingItem is working correctly when the player interacts with it.