### PR TITLE
Fix bonemeal count not reduced by CocoaBlock

### DIFF
--- a/src/pocketmine/block/CocoaBlock.php
+++ b/src/pocketmine/block/CocoaBlock.php
@@ -98,7 +98,12 @@ class CocoaBlock extends Transparent{
 		if($this->age < 2 and $item->getId() === Item::DYE and $item->getDamage() === 15){ //bone meal
 			$this->age++;
 			$this->level->setBlock($this, $this);
+
+			$item->pop();
+
+			return true;
 		}
+
 		return false;
 	}
 


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Currently you can use bonemeal on cocoa blocks indefinitely. This pull request fixed that behaviour by reducing the count by one after each usage.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
No API changes to note.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
CocoaBlock->onActivate() now returns true when bonemeal was used successfully.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
No concerns regarding backwards compatibility.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
No related follow-up.

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
It was reproduced on the pmmp dev server. The setup is fairly simple:
1. Place jungle wood in the world
2. Attach cocoa on it
3. Try to forcefully grow it using bonemeal
4. Notice you keep your bonemeal using the master branch