### PR TITLE
Implemented plugin loading whitelist/blacklist by config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ crashdumps/*
 *.phar
 server.properties
 /pocketmine.yml
+/plugin_list.yml
 memory_dumps/*
 resource_packs/
 

--- a/resources/plugin_list.yml
+++ b/resources/plugin_list.yml
@@ -1,0 +1,8 @@
+#This configuration file allows you to control which plugins are loaded on your server.
+
+#List behaviour
+# - blacklist: Only plugins which ARE NOT listed will load.
+# - whitelist: Only plugins which ARE listed will load.
+mode: blacklist
+#List names of plugins here.
+plugins: []

--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -105,6 +105,7 @@ use function array_shift;
 use function array_sum;
 use function base64_encode;
 use function bin2hex;
+use function copy;
 use function count;
 use function define;
 use function explode;
@@ -1241,14 +1242,15 @@ class Server{
 
 			$pluginGraylist = null;
 			$graylistFile = $this->dataPath . "plugin_list.yml";
-			if(file_exists($graylistFile)){
-				try{
-					$pluginGraylist = PluginGraylist::fromArray(yaml_parse(file_get_contents($this->dataPath . "plugin_list.yml")));
-				}catch(\InvalidArgumentException $e){
-					$this->logger->emergency("Failed to load $graylistFile: " . $e->getMessage());
-					$this->forceShutdown();
-					return;
-				}
+			if(!file_exists($graylistFile)){
+				copy(\pocketmine\RESOURCE_PATH . 'plugin_list.yml', $graylistFile);
+			}
+			try{
+				$pluginGraylist = PluginGraylist::fromArray(yaml_parse(file_get_contents($graylistFile)));
+			}catch(\InvalidArgumentException $e){
+				$this->logger->emergency("Failed to load $graylistFile: " . $e->getMessage());
+				$this->forceShutdown();
+				return;
 			}
 			$this->pluginManager = new PluginManager($this, ((bool) $this->getProperty("plugins.legacy-data-dir", true)) ? null : $this->getDataPath() . "plugin_data" . DIRECTORY_SEPARATOR, $pluginGraylist);
 			$this->profilingTickRate = (float) $this->getProperty("settings.profile-report-trigger", 20);

--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -80,6 +80,7 @@ use pocketmine\permission\DefaultPermissions;
 use pocketmine\permission\PermissionManager;
 use pocketmine\plugin\PharPluginLoader;
 use pocketmine\plugin\Plugin;
+use pocketmine\plugin\PluginGraylist;
 use pocketmine\plugin\PluginLoadOrder;
 use pocketmine\plugin\PluginManager;
 use pocketmine\plugin\ScriptPluginLoader;
@@ -144,6 +145,7 @@ use function strtolower;
 use function time;
 use function touch;
 use function trim;
+use function yaml_parse;
 use const DIRECTORY_SEPARATOR;
 use const PHP_EOL;
 use const PHP_INT_MAX;
@@ -1237,7 +1239,18 @@ class Server{
 
 			$this->resourceManager = new ResourcePackManager($this->getDataPath() . "resource_packs" . DIRECTORY_SEPARATOR, $this->logger);
 
-			$this->pluginManager = new PluginManager($this, ((bool) $this->getProperty("plugins.legacy-data-dir", true)) ? null : $this->getDataPath() . "plugin_data" . DIRECTORY_SEPARATOR);
+			$pluginGraylist = null;
+			$graylistFile = $this->dataPath . "plugin_list.yml";
+			if(file_exists($graylistFile)){
+				try{
+					$pluginGraylist = PluginGraylist::fromArray(yaml_parse(file_get_contents($this->dataPath . "plugin_list.yml")));
+				}catch(\InvalidArgumentException $e){
+					$this->logger->emergency("Failed to load $graylistFile: " . $e->getMessage());
+					$this->forceShutdown();
+					return;
+				}
+			}
+			$this->pluginManager = new PluginManager($this, ((bool) $this->getProperty("plugins.legacy-data-dir", true)) ? null : $this->getDataPath() . "plugin_data" . DIRECTORY_SEPARATOR, $pluginGraylist);
 			$this->profilingTickRate = (float) $this->getProperty("settings.profile-report-trigger", 20);
 			$this->pluginManager->registerInterface(new PharPluginLoader($this->autoloader));
 			$this->pluginManager->registerInterface(new ScriptPluginLoader());

--- a/src/pocketmine/plugin/PluginGraylist.php
+++ b/src/pocketmine/plugin/PluginGraylist.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\plugin;
+
+use Particle\Validator\Validator;
+use function array_filter;
+use function array_flip;
+use function count;
+use function implode;
+
+class PluginGraylist{
+
+	/** @var string[] */
+	private $plugins;
+	/** @var bool */
+	private $isWhitelist = false;
+
+	public function __construct(array $plugins = [], bool $isWhitelist = false){
+		$this->plugins = array_flip($plugins);
+		$this->isWhitelist = $isWhitelist;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function getPlugins() : array{
+		return array_flip($this->plugins);
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function isWhitelist() : bool{
+		return $this->isWhitelist;
+	}
+
+	/**
+	 * Returns whether the given name is permitted by this graylist.
+	 *
+	 * @param string $name
+	 *
+	 * @return bool
+	 */
+	public function isAllowed(string $name) : bool{
+		return $this->isWhitelist() === isset($this->plugins[$name]);
+	}
+
+	public static function fromArray(array $array) : PluginGraylist{
+		$v = new Validator();
+		$v->optional("whitelist")->bool();
+		$v->required("plugins")->isArray()->callback(function(array $elements) : bool{ return count(array_filter($elements, '\is_string')) === count($elements); });
+
+		$result = $v->validate($array);
+		if($result->isNotValid()){
+			$messages = [];
+			foreach($result->getFailures() as $f){
+				$messages[] = $f->format();
+			}
+			throw new \InvalidArgumentException("Invalid data: " . implode(", ", $messages));
+		}
+		return new PluginGraylist($array["plugins"], $array["whitelist"]);
+	}
+
+	public function toArray() : array{
+		return [
+			"whitelist" => $this->isWhitelist,
+			"plugins" => $this->plugins
+		];
+	}
+}

--- a/src/pocketmine/plugin/PluginGraylist.php
+++ b/src/pocketmine/plugin/PluginGraylist.php
@@ -36,9 +36,9 @@ class PluginGraylist{
 	/** @var bool */
 	private $isWhitelist = false;
 
-	public function __construct(array $plugins = [], bool $isWhitelist = false){
+	public function __construct(array $plugins = [], bool $whitelist = false){
 		$this->plugins = array_flip($plugins);
-		$this->isWhitelist = $isWhitelist;
+		$this->isWhitelist = $whitelist;
 	}
 
 	/**
@@ -68,8 +68,8 @@ class PluginGraylist{
 
 	public static function fromArray(array $array) : PluginGraylist{
 		$v = new Validator();
-		$v->optional("whitelist")->bool();
-		$v->required("plugins")->isArray()->callback(function(array $elements) : bool{ return count(array_filter($elements, '\is_string')) === count($elements); });
+		$v->required("mode")->inArray(['whitelist', 'blacklist'], true);
+		$v->required("plugins")->isArray()->allowEmpty(true)->callback(function(array $elements) : bool{ return count(array_filter($elements, '\is_string')) === count($elements); });
 
 		$result = $v->validate($array);
 		if($result->isNotValid()){
@@ -79,12 +79,12 @@ class PluginGraylist{
 			}
 			throw new \InvalidArgumentException("Invalid data: " . implode(", ", $messages));
 		}
-		return new PluginGraylist($array["plugins"], $array["whitelist"]);
+		return new PluginGraylist($array["plugins"], $array["mode"] === 'whitelist');
 	}
 
 	public function toArray() : array{
 		return [
-			"whitelist" => $this->isWhitelist,
+			"mode" => $this->isWhitelist ? 'whitelist' : 'blacklist',
 			"plugins" => $this->plugins
 		];
 	}

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -80,12 +80,15 @@ class PluginManager{
 
 	/** @var string|null */
 	private $pluginDataDirectory;
+	/** @var PluginGraylist|null */
+	private $graylist;
 
 	/**
-	 * @param Server      $server
-	 * @param null|string $pluginDataDirectory
+	 * @param Server              $server
+	 * @param null|string         $pluginDataDirectory
+	 * @param PluginGraylist|null $graylist
 	 */
-	public function __construct(Server $server, ?string $pluginDataDirectory){
+	public function __construct(Server $server, ?string $pluginDataDirectory, ?PluginGraylist $graylist = null){
 		$this->server = $server;
 		$this->pluginDataDirectory = $pluginDataDirectory;
 		if($this->pluginDataDirectory !== null){
@@ -95,6 +98,8 @@ class PluginManager{
 				throw new \RuntimeException("Plugin data path $this->pluginDataDirectory exists and is not a directory");
 			}
 		}
+
+		$this->graylist = $graylist;
 	}
 
 	/**
@@ -265,6 +270,13 @@ class PluginManager{
 					}
 				}
 
+				if($this->graylist !== null and !$this->graylist->isAllowed($name)){
+					$this->server->getLogger()->error($this->server->getLanguage()->translateString("pocketmine.plugin.loadError", [
+						$name,
+						$this->server->getLanguage()->translateString("Disallowed by graylist")
+					]));
+					continue;
+				}
 				$plugins[$name] = $file;
 
 				$softDependencies[$name] = $description->getSoftDepend();

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -271,9 +271,9 @@ class PluginManager{
 				}
 
 				if($this->graylist !== null and !$this->graylist->isAllowed($name)){
-					$this->server->getLogger()->error($this->server->getLanguage()->translateString("pocketmine.plugin.loadError", [
+					$this->server->getLogger()->notice($this->server->getLanguage()->translateString("pocketmine.plugin.loadError", [
 						$name,
-						$this->server->getLanguage()->translateString("Disallowed by graylist")
+						"Disallowed by graylist"
 					]));
 					continue;
 				}


### PR DESCRIPTION
## Introduction
It's often desirable (particularly while debugging) to prevent a plugin from loading. This is currently hard work and requires hacks like moving the plugin out of the plugins folder, changing the API version to something that won't load, or some other annoying hack.

This pull request introduces an optional plugin whitelist/blacklist configuration which permits selectively enabling plugins.

Since this is a much-desired feature, it may be ported to the 3.x line once complete.

## Changes
### API changes
Added `PluginGraylist` class.

### Behavioural changes
If a `plugin_list.yml` is found in the server's data directory, it will be used as a plugin graylist.

The graylist has the following format:
```
mode: enum(whitelist, blacklist)
plugins: string[]
```

## Backwards compatibility
This is fully backwards compatible.

## Tests
Default (or no) configuration: All plugins load as normal.

The following configuration prevents `DevTools` loading as expected.
```yml
mode: blacklist
plugins: [DevTools]
```

The following configuration prevents everything except `DevTools` loading as expected.
```yml
mode: whitelist
plugins: [DevTools]
```

Any error in configuration will result in a server shutdown with errors indicating what went wrong.