### PR TITLE
Implement device info methods

### DIFF
--- a/src/pocketmine/PlayerInfo.php
+++ b/src/pocketmine/PlayerInfo.php
@@ -43,14 +43,20 @@ class PlayerInfo{
 	private $xuid;
 	/** @var int */
 	private $clientId;
+	/** @var string */
+	private $deviceModel;
+	/** @var int */
+	private $platformType;
 
-	public function __construct(string $username, UUID $uuid, Skin $skin, string $locale, string $xuid, int $clientId){
+	public function __construct(string $username, UUID $uuid, Skin $skin, string $locale, string $xuid, int $clientId, string $deviceModel, int $platformType){
 		$this->username = $username;
 		$this->uuid = $uuid;
 		$this->skin = $skin;
 		$this->locale = $locale;
 		$this->xuid = $xuid;
 		$this->clientId = $clientId;
+		$this->deviceModel = $deviceModel;
+		$this->platformType = $platformType;
 	}
 
 	/**
@@ -93,5 +99,19 @@ class PlayerInfo{
 	 */
 	public function getClientId() : int{
 		return $this->clientId;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getDeviceModel(): string {
+		return $this->deviceModel;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getPlatformType(): int {
+		return $this->platformType;
 	}
 }

--- a/src/pocketmine/PlayerInfo.php
+++ b/src/pocketmine/PlayerInfo.php
@@ -104,14 +104,14 @@ class PlayerInfo{
 	/**
 	 * @return string
 	 */
-	public function getDeviceModel(): string {
+	public function getDeviceModel() : string {
 		return $this->deviceModel;
 	}
 
 	/**
 	 * @return int
 	 */
-	public function getPlatformType(): int {
+	public function getPlatformType() : int {
 		return $this->platformType;
 	}
 }

--- a/src/pocketmine/network/mcpe/protocol/LoginPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/LoginPacket.php
@@ -56,6 +56,9 @@ class LoginPacket extends DataPacket implements ServerboundPacket{
 	public const I_SERVER_ADDRESS = 'ServerAddress';
 	public const I_LANGUAGE_CODE = 'LanguageCode';
 
+	public const I_DEVICE_MODEL = 'DeviceModel';
+	public const I_DEVICE_OS = 'DeviceOS';
+
 	public const I_SKIN_ID = 'SkinId';
 	public const I_SKIN_DATA = 'SkinData';
 	public const I_CAPE_DATA = 'CapeData';
@@ -196,7 +199,9 @@ class LoginPacket extends DataPacket implements ServerboundPacket{
 			),
 			$this->clientData[self::I_LANGUAGE_CODE],
 			$this->extraData[self::I_XUID],
-			$this->clientData[self::I_CLIENT_RANDOM_ID]
+			$this->clientData[self::I_CLIENT_RANDOM_ID],
+			$this->clientData[self::I_DEVICE_MODEL],
+			$this->clientData[self::I_DEVICE_OS]
 		);
 	}
 

--- a/src/pocketmine/network/mcpe/protocol/types/PlatformTypes.php
+++ b/src/pocketmine/network/mcpe/protocol/types/PlatformTypes.php
@@ -27,10 +27,16 @@ interface PlatformTypes{
 
 	public const ANDROID = 1;
 	public const IOS = 2;
-	public const MAC = 3;
+	public const OSX = 3;
 	public const FIRE = 4;
 	public const GEARVR = 5;
 	public const HOLOLENS = 6;
-	public const WINDOWS = 7;
+	public const WIN10 = 7;
+	public const WIN32 = 8;
+	public const DEDICATED = 9;
+	public const TVOS = 10;
+	public const ORBIS = 11;
+	public const NX = 12;
+	public const UNKNOWN = -1;
 
 }

--- a/src/pocketmine/network/mcpe/protocol/types/PlatformTypes.php
+++ b/src/pocketmine/network/mcpe/protocol/types/PlatformTypes.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\network\mcpe\protocol\types;
+
+interface PlatformTypes{
+
+	public const ANDROID = 1;
+	public const IOS = 2;
+	public const MAC = 3;
+	public const FIRE = 4;
+	public const GEARVR = 5;
+	public const HOLOLENS = 6;
+	public const WINDOWS = 7;
+
+}


### PR DESCRIPTION
## Introduction
This PR adds the ability to view the players device model and platform type in PlayerPreLoginEvent. 
Due to some issues this is not yet available in the regular Player class.

This is slightly different to #2216 but maybe that can be closed if this is merged.

## Changes
* Added a PlatformTypes interface with all current platform ids.
* Added `PlayerInfo->getDeviceModel()` and `getPlatformType()`  

### Behavioural changes
None

### Follow up
Unfuck the player class and have access to these methods from there.