### PR TITLE
AvailableCommandsPacket: Updated the ARG_TYPE constants

### DIFF
--- a/src/pocketmine/network/mcpe/protocol/AvailableCommandsPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/AvailableCommandsPacket.php
@@ -62,6 +62,8 @@ class AvailableCommandsPacket extends DataPacket implements ClientboundPacket{
 
 	public const ARG_TYPE_FILEPATH = 0x0f;
 	
+	public const ARG_TYPE_STRING   = 0x1c;
+	
 	public const ARG_TYPE_POSITION = 0x1e;
 
 	public const ARG_TYPE_MESSAGE  = 0x21;

--- a/src/pocketmine/network/mcpe/protocol/AvailableCommandsPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/AvailableCommandsPacket.php
@@ -57,19 +57,20 @@ class AvailableCommandsPacket extends DataPacket implements ClientboundPacket{
 	public const ARG_TYPE_FLOAT           = 0x02;
 	public const ARG_TYPE_VALUE           = 0x03;
 	public const ARG_TYPE_WILDCARD_INT    = 0x04;
-	public const ARG_TYPE_TARGET          = 0x05;
-	public const ARG_TYPE_WILDCARD_TARGET = 0x06;
+	public const ARG_TYPE_OPERATOR        = 0x05;
+	public const ARG_TYPE_TARGET          = 0x06;
 
-	public const ARG_TYPE_STRING   = 0x0f;
-	public const ARG_TYPE_POSITION = 0x10;
+	public const ARG_TYPE_FILEPATH = 0x0f;
+	
+	public const ARG_TYPE_POSITION = 0x1e;
 
-	public const ARG_TYPE_MESSAGE  = 0x13;
+	public const ARG_TYPE_MESSAGE  = 0x21;
 
-	public const ARG_TYPE_RAWTEXT  = 0x15;
+	public const ARG_TYPE_RAWTEXT  = 0x23;
 
-	public const ARG_TYPE_JSON     = 0x18;
+	public const ARG_TYPE_JSON     = 0x26;
 
-	public const ARG_TYPE_COMMAND  = 0x1f;
+	public const ARG_TYPE_COMMAND  = 0x2d;
 
 	/**
 	 * Enums are a little different: they are composed as follows:


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
The argument type constants in the AvailableCommandsPacket were outdated. Changes have been made since the last time the constants were updated. This merge request updates them.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
No changes in API. There were constants removed/added, but packets are no API anyway.
