### PR TITLE
AvailableCommandsPacket: Updated the argument type constants for 1.10

### DIFF
--- a/src/pocketmine/network/mcpe/protocol/AvailableCommandsPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/AvailableCommandsPacket.php
@@ -60,19 +60,19 @@ class AvailableCommandsPacket extends DataPacket implements ClientboundPacket{
 	public const ARG_TYPE_OPERATOR        = 0x05;
 	public const ARG_TYPE_TARGET          = 0x06;
 
-	public const ARG_TYPE_FILEPATH = 0x0f;
+	public const ARG_TYPE_FILEPATH = 0x0e;
 
-	public const ARG_TYPE_STRING   = 0x1c;
+	public const ARG_TYPE_STRING   = 0x1b;
 
-	public const ARG_TYPE_POSITION = 0x1e;
+	public const ARG_TYPE_POSITION = 0x1d;
 
-	public const ARG_TYPE_MESSAGE  = 0x21;
+	public const ARG_TYPE_MESSAGE  = 0x20;
 
-	public const ARG_TYPE_RAWTEXT  = 0x23;
+	public const ARG_TYPE_RAWTEXT  = 0x22;
 
-	public const ARG_TYPE_JSON     = 0x26;
+	public const ARG_TYPE_JSON     = 0x25;
 
-	public const ARG_TYPE_COMMAND  = 0x2d;
+	public const ARG_TYPE_COMMAND  = 0x2c;
 
 	/**
 	 * Enums are a little different: they are composed as follows:


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

The command constants were recently changed in 1.10 again. This pull request updates them to be up to date for 1.10.
