### PR TITLE
Disallow plugin loading after startup

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -179,6 +179,8 @@ class Server{
 
 	/** @var bool */
 	private $isRunning = true;
+	/** @var bool */
+	private $startedTicking = false;
 
 	/** @var bool */
 	private $hasStopped = false;
@@ -306,6 +308,13 @@ class Server{
 	 */
 	public function isRunning() : bool{
 		return $this->isRunning;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function hasStartedTicking() : bool{
+		return $this->startedTicking;
 	}
 
 	/**
@@ -1809,6 +1818,7 @@ class Server{
 	}
 
 	private function tickProcessor() : void{
+		$this->startedTicking = true;
 		$this->nextTick = microtime(true);
 
 		while($this->isRunning){

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -138,6 +138,10 @@ class PluginManager{
 	 * @return Plugin|null
 	 */
 	public function loadPlugin(string $path, ?array $loaders = null) : ?Plugin{
+		if($this->server->hasStartedTicking()){
+			throw new \InvalidStateException("Could not load plugins after server has started");
+		}
+
 		foreach($loaders ?? $this->fileAssociations as $loader){
 			if($loader->canLoadPlugin($path)){
 				$description = $loader->getPluginDescription($path);
@@ -194,6 +198,10 @@ class PluginManager{
 	 * @return Plugin[]
 	 */
 	public function loadPlugins(string $directory, ?array $newLoaders = null) : array{
+		if($this->server->hasStartedTicking()){
+			throw new \InvalidStateException("Could not load plugins after server has started");
+		}
+
 		if(!is_dir($directory)){
 			return [];
 		}


### PR DESCRIPTION
## Introduction
See #2825 for the motivation

## Changes
### API changes
`PluginManager->loadPlugins()` and `PluginManager->loadPlugin()` can no longer be called when the server starts ticking.

### Behavioural changes
New plugins cannot be loaded without restarting the server.

## Backwards compatibility
See #2825 for discussion

## Follow-up
This behaviour should be documented.

## Tests
None yet.