### PR TITLE
Acquire exclusive lock on <datadir>/server.lock to avoid data corruption

### DIFF
--- a/src/pocketmine/PocketMine.php
+++ b/src/pocketmine/PocketMine.php
@@ -189,6 +189,14 @@ namespace pocketmine {
 		mkdir(\pocketmine\DATA, 0777, true);
 	}
 
+	define('pocketmine\LOCK_FILE_PATH', \pocketmine\DATA . 'server.lock');
+	define('pocketmine\LOCK_FILE', fopen(\pocketmine\LOCK_FILE_PATH, "cb"));
+	if(!flock(\pocketmine\LOCK_FILE, LOCK_EX | LOCK_NB)){
+		critical_error("Another " . \pocketmine\NAME . " instance is already using this folder (" . realpath(\pocketmine\DATA) . ").");
+		critical_error("Please stop the other server first before running a new one.");
+		exit(1);
+	}
+
 	//Logger has a dependency on timezone
 	$tzError = Timezone::init();
 


### PR DESCRIPTION
this fixes #2855.

## Introduction
The problem is described briefly in #2855 - it's possible for server data corruption to occur by accessing the same data (in write mode) from two processes simultaneously. While we can't prevent this from happening if the user really wants to be stupid, we can prevent accidents like this from occurring.

## Changes
### Behavioural changes
Two servers may not use the same datadir at once anymore.

## Follow-up
Users very commonly have problems on Linux SSH losing access to their terminals. It could be advantageous to have the server offer a `--kill-zombies` option or similar which can automatically detect and kill lost servers (with appropriate warnings that this might cause data loss).

## Tests
This has currently been tested on Windows 10 and Ubuntu 16.04.