### PR TITLE
TextFormat: Added compression function

### DIFF
--- a/src/pocketmine/utils/TextFormat.php
+++ b/src/pocketmine/utils/TextFormat.php
@@ -59,12 +59,39 @@ abstract class TextFormat{
 	public const YELLOW = TextFormat::ESCAPE . "e";
 	public const WHITE = TextFormat::ESCAPE . "f";
 
+	public const COLORS = [
+		self::BLACK => true,
+		self::DARK_BLUE => true,
+		self::DARK_GREEN => true,
+		self::DARK_AQUA => true,
+		self::DARK_RED => true,
+		self::DARK_PURPLE => true,
+		self::GOLD => true,
+		self::GRAY => true,
+		self::DARK_GRAY => true,
+		self::BLUE => true,
+		self::GREEN => true,
+		self::AQUA => true,
+		self::RED => true,
+		self::LIGHT_PURPLE => true,
+		self::YELLOW => true,
+		self::WHITE => true
+	];
+
 	public const OBFUSCATED = TextFormat::ESCAPE . "k";
 	public const BOLD = TextFormat::ESCAPE . "l";
 	public const STRIKETHROUGH = TextFormat::ESCAPE . "m";
 	public const UNDERLINE = TextFormat::ESCAPE . "n";
 	public const ITALIC = TextFormat::ESCAPE . "o";
 	public const RESET = TextFormat::ESCAPE . "r";
+
+	public const FORMATS = [
+		self::OBFUSCATED => true,
+		self::BOLD => true,
+		self::STRIKETHROUGH => true,
+		self::UNDERLINE => true,
+		self::ITALIC => true
+	];
 
 	/**
 	 * Splits the string by Format tokens

--- a/tests/phpunit/utils/TextFormatTest.php
+++ b/tests/phpunit/utils/TextFormatTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\utils;
+
+use PHPUnit\Framework\TestCase;
+use pocketmine\utils\TextFormat as T;
+use function array_keys;
+use function implode;
+
+class TextFormatTest extends TestCase{
+
+	public function compressProvider() : \Generator{
+		yield [T::GREEN . T::AQUA . T::RED . T::LIGHT_PURPLE . T::YELLOW . T::WHITE . T::BLACK . T::DARK_BLUE . "&hello " . T::AQUA . "world" . T::RESET, T::DARK_BLUE . "&hello " . T::AQUA . "world" . T::RESET];
+		yield [T::BLACK . T::DARK_BLUE . T::DARK_GREEN . "&" . T::RESET . "hello", T::DARK_GREEN . "&" . T::RESET . "hello"];
+		yield [T::DARK_AQUA . T::DARK_RED . T::DARK_PURPLE . T::ITALIC . T::RESET . "Hello World", "Hello World"];
+		yield [T::RESET . "hello", "hello"];
+		yield ["hello" . T::RESET, "hello"];
+		yield [implode("|", array_keys(T::COLORS)) . "|", implode("|", array_keys(T::COLORS)) . "|"];
+	}
+
+	/**
+	 * @dataProvider compressProvider
+	 * @param string $input
+	 * @param string $expected
+	 *
+	 * @throws \PHPUnit\Framework\ExpectationFailedException
+	 * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+	 */
+	public function testCompress(string $input, string $expected) : void{
+		self::assertSame($expected, TextFormat::compress($input));
+	}
+}


### PR DESCRIPTION
## Introduction
This function will reduce a given string to the minimum amount of formatting codes possible to produce the smallest possible string with the same appearance as the input.

This is needed because formatting code spam can be abused to produce physically large but visually small strings.

## Changes
### API changes
Added new function `TextFormat::compress()`. This is not yet used, but is planned to be used for chat and sign text compression.

## Follow-up
Use this function to compress formatting codes given by users where appropriate, such as in chat, signs, books and item names.

## Tests
PHPUnit tests are included with some test cases, but it would be appreciated if this test case set could be expanded.