### PR TITLE
Rename add(Sub)Title to send(Sub)Title. Deprecate old methods

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -384,9 +384,9 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 	/**
 	 * This might disappear in the future. Please use getUniqueId() instead.
+	 * @return int
 	 * @deprecated
 	 *
-	 * @return int
 	 */
 	public function getClientId(){
 		return $this->randomClientId;
@@ -892,9 +892,10 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	/**
 	 * Updates the player's last ping measurement.
 	 *
+	 * @param int $pingMS
+	 *
 	 * @internal Plugins should not use this method.
 	 *
-	 * @param int $pingMS
 	 */
 	public function updatePing(int $pingMS){
 		$this->lastPingMeasure = $pingMS;
@@ -1370,6 +1371,9 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	/**
+	 * @param int $gamemode
+	 *
+	 * @return int
 	 * @internal
 	 *
 	 * Returns a client-friendly gamemode of the specified real gamemode
@@ -1377,9 +1381,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	 *
 	 * TODO: remove this when Spectator Mode gets added properly to MCPE
 	 *
-	 * @param int $gamemode
-	 *
-	 * @return int
 	 */
 	public static function getClientFriendlyGamemode(int $gamemode) : int{
 		$gamemode &= 0x03;
@@ -3261,28 +3262,29 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	/**
 	 * Adds a title text to the user's screen, with an optional subtitle.
 	 *
-     * @deprecated
-     * @see Player::sendTitle()
-     *
+	 * @param string $title
+	 * @param string $subtitle
+	 * @param int    $fadeIn Duration in ticks for fade-in. If -1 is given, client-sided defaults will be used.
+	 * @param int    $stay Duration in ticks to stay on screen for
+	 * @param int    $fadeOut Duration in ticks for fade-out.
+	 *
+	 * @see Player::sendTitle()
+	 *
+	 * @deprecated
+	 */
+	public function addTitle(string $title, string $subtitle = "", int $fadeIn = -1, int $stay = -1, int $fadeOut = -1){
+		$this->sendTitle($title, $subtitle, $fadeIn, $stay, $fadeOut);
+	}
+
+	/**
+	 * Adds a title text to the user's screen, with an optional subtitle.
+	 *
 	 * @param string $title
 	 * @param string $subtitle
 	 * @param int    $fadeIn Duration in ticks for fade-in. If -1 is given, client-sided defaults will be used.
 	 * @param int    $stay Duration in ticks to stay on screen for
 	 * @param int    $fadeOut Duration in ticks for fade-out.
 	 */
-    public function addTitle(string $title, string $subtitle = "", int $fadeIn = -1, int $stay = -1, int $fadeOut = -1){
-        $this->sendTitle($title,$subtitle,$fadeIn,$stay,$fadeOut);
-    }
-
-    /**
-     * Adds a title text to the user's screen, with an optional subtitle.
-     *
-     * @param string $title
-     * @param string $subtitle
-     * @param int    $fadeIn Duration in ticks for fade-in. If -1 is given, client-sided defaults will be used.
-     * @param int    $stay Duration in ticks to stay on screen for
-     * @param int    $fadeOut Duration in ticks for fade-out.
-     */
 	public function sendTitle(string $title, string $subtitle = "", int $fadeIn = -1, int $stay = -1, int $fadeOut = -1) : void{
 		$this->setTitleDuration($fadeIn, $stay, $fadeOut);
 		if($subtitle !== ""){
@@ -3294,44 +3296,46 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	/**
 	 * Sets the subtitle message, without sending a title.
 	 *
-     * @deprecated
-     * @see Player::sendSubTitle()
-     *
 	 * @param string $subtitle
+	 *
+	 * @see Player::sendSubTitle()
+	 *
+	 * @deprecated
 	 */
 	public function addSubTitle(string $subtitle){
-        $this->sendSubTitle($subtitle);
-    }
+		$this->sendSubTitle($subtitle);
+	}
 
-    /**
-     * Sets the subtitle message, without sending a title.
-     *
-     * @param string $subtitle
-     */
-    public function sendSubTitle(string $subtitle) : void{
+	/**
+	 * Sets the subtitle message, without sending a title.
+	 *
+	 * @param string $subtitle
+	 */
+	public function sendSubTitle(string $subtitle) : void{
 		$this->sendTitleText($subtitle, SetTitlePacket::TYPE_SET_SUBTITLE);
 	}
 
 	/**
 	 * Adds small text to the user's screen.
 	 *
-     * @deprecated
-     * @see Player::sendActionBarMessage()
-     *
 	 * @param string $message
+	 *
+	 * @see Player::sendActionBarMessage()
+	 *
+	 * @deprecated
 	 */
 	public function addActionBarMessage(string $message){
 		$this->sendActionBarMessage($message);
 	}
 
-    /**
-     * Adds small text to the user's screen.
-     *
-     * @param string $message
-     */
-    public function sendActionBarMessage(string $message) : void{
-        $this->sendTitleText($message, SetTitlePacket::TYPE_SET_ACTIONBAR_MESSAGE);
-    }
+	/**
+	 * Adds small text to the user's screen.
+	 *
+	 * @param string $message
+	 */
+	public function sendActionBarMessage(string $message) : void{
+		$this->sendTitleText($message, SetTitlePacket::TYPE_SET_ACTIONBAR_MESSAGE);
+	}
 
 	/**
 	 * Removes the title from the client's screen.

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3261,13 +3261,14 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	/**
 	 * Adds a title text to the user's screen, with an optional subtitle.
 	 *
+     * @deprecated
+     * @see Player::sendTitle()
+     *
 	 * @param string $title
 	 * @param string $subtitle
 	 * @param int    $fadeIn Duration in ticks for fade-in. If -1 is given, client-sided defaults will be used.
 	 * @param int    $stay Duration in ticks to stay on screen for
 	 * @param int    $fadeOut Duration in ticks for fade-out.
-     *
-     * @deprecated please use sendTitle
 	 */
     public function addTitle(string $title, string $subtitle = "", int $fadeIn = -1, int $stay = -1, int $fadeOut = -1){
         $this->sendTitle($title,$subtitle,$fadeIn,$stay,$fadeOut);
@@ -3282,7 +3283,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
      * @param int    $stay Duration in ticks to stay on screen for
      * @param int    $fadeOut Duration in ticks for fade-out.
      */
-	public function sendTitle(string $title, string $subtitle = "", int $fadeIn = -1, int $stay = -1, int $fadeOut = -1){
+	public function sendTitle(string $title, string $subtitle = "", int $fadeIn = -1, int $stay = -1, int $fadeOut = -1) : void{
 		$this->setTitleDuration($fadeIn, $stay, $fadeOut);
 		if($subtitle !== ""){
 			$this->sendSubTitle($subtitle);
@@ -3293,9 +3294,10 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	/**
 	 * Sets the subtitle message, without sending a title.
 	 *
-	 * @param string $subtitle
+     * @deprecated
+     * @see Player::sendSubTitle()
      *
-     * @deprecated please use sendSubTitle
+	 * @param string $subtitle
 	 */
 	public function addSubTitle(string $subtitle){
         $this->sendSubTitle($subtitle);
@@ -3306,18 +3308,30 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
      *
      * @param string $subtitle
      */
-    public function sendSubTitle(string $subtitle){
+    public function sendSubTitle(string $subtitle) : void{
 		$this->sendTitleText($subtitle, SetTitlePacket::TYPE_SET_SUBTITLE);
 	}
 
 	/**
 	 * Adds small text to the user's screen.
 	 *
+     * @deprecated
+     * @see Player::sendActionBarMessage()
+     *
 	 * @param string $message
 	 */
 	public function addActionBarMessage(string $message){
-		$this->sendTitleText($message, SetTitlePacket::TYPE_SET_ACTIONBAR_MESSAGE);
+		$this->sendActionBarMessage($message);
 	}
+
+    /**
+     * Adds small text to the user's screen.
+     *
+     * @param string $message
+     */
+    public function sendActionBarMessage(string $message) : void{
+        $this->sendTitleText($message, SetTitlePacket::TYPE_SET_ACTIONBAR_MESSAGE);
+    }
 
 	/**
 	 * Removes the title from the client's screen.

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -384,9 +384,9 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 	/**
 	 * This might disappear in the future. Please use getUniqueId() instead.
-	 * @return int
 	 * @deprecated
 	 *
+	 * @return int
 	 */
 	public function getClientId(){
 		return $this->randomClientId;
@@ -892,10 +892,9 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	/**
 	 * Updates the player's last ping measurement.
 	 *
-	 * @param int $pingMS
-	 *
 	 * @internal Plugins should not use this method.
 	 *
+	 * @param int $pingMS
 	 */
 	public function updatePing(int $pingMS){
 		$this->lastPingMeasure = $pingMS;
@@ -1371,9 +1370,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	/**
-	 * @param int $gamemode
-	 *
-	 * @return int
 	 * @internal
 	 *
 	 * Returns a client-friendly gamemode of the specified real gamemode
@@ -1381,6 +1377,9 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	 *
 	 * TODO: remove this when Spectator Mode gets added properly to MCPE
 	 *
+	 * @param int $gamemode
+	 *
+	 * @return int
 	 */
 	public static function getClientFriendlyGamemode(int $gamemode) : int{
 		$gamemode &= 0x03;
@@ -3260,17 +3259,14 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	/**
-	 * Adds a title text to the user's screen, with an optional subtitle.
+	 * @deprecated
+	 * @see Player::sendTitle()
 	 *
 	 * @param string $title
 	 * @param string $subtitle
 	 * @param int    $fadeIn Duration in ticks for fade-in. If -1 is given, client-sided defaults will be used.
 	 * @param int    $stay Duration in ticks to stay on screen for
 	 * @param int    $fadeOut Duration in ticks for fade-out.
-	 *
-	 * @see Player::sendTitle()
-	 *
-	 * @deprecated
 	 */
 	public function addTitle(string $title, string $subtitle = "", int $fadeIn = -1, int $stay = -1, int $fadeOut = -1){
 		$this->sendTitle($title, $subtitle, $fadeIn, $stay, $fadeOut);
@@ -3294,13 +3290,10 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	/**
-	 * Sets the subtitle message, without sending a title.
-	 *
-	 * @param string $subtitle
-	 *
+	 * @deprecated
 	 * @see Player::sendSubTitle()
 	 *
-	 * @deprecated
+	 * @param string $subtitle
 	 */
 	public function addSubTitle(string $subtitle){
 		$this->sendSubTitle($subtitle);
@@ -3316,13 +3309,10 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	/**
-	 * Adds small text to the user's screen.
-	 *
-	 * @param string $message
-	 *
+	 * @deprecated
 	 * @see Player::sendActionBarMessage()
 	 *
-	 * @deprecated
+	 * @param string $message
 	 */
 	public function addActionBarMessage(string $message){
 		$this->sendActionBarMessage($message);

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3266,11 +3266,26 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	 * @param int    $fadeIn Duration in ticks for fade-in. If -1 is given, client-sided defaults will be used.
 	 * @param int    $stay Duration in ticks to stay on screen for
 	 * @param int    $fadeOut Duration in ticks for fade-out.
+     *
+     * @deprecated please use sendTitle
 	 */
-	public function addTitle(string $title, string $subtitle = "", int $fadeIn = -1, int $stay = -1, int $fadeOut = -1){
+    public function addTitle(string $title, string $subtitle = "", int $fadeIn = -1, int $stay = -1, int $fadeOut = -1){
+        $this->sendTitle($title,$subtitle,$fadeIn,$stay,$fadeOut);
+    }
+
+    /**
+     * Adds a title text to the user's screen, with an optional subtitle.
+     *
+     * @param string $title
+     * @param string $subtitle
+     * @param int    $fadeIn Duration in ticks for fade-in. If -1 is given, client-sided defaults will be used.
+     * @param int    $stay Duration in ticks to stay on screen for
+     * @param int    $fadeOut Duration in ticks for fade-out.
+     */
+	public function sendTitle(string $title, string $subtitle = "", int $fadeIn = -1, int $stay = -1, int $fadeOut = -1){
 		$this->setTitleDuration($fadeIn, $stay, $fadeOut);
 		if($subtitle !== ""){
-			$this->addSubTitle($subtitle);
+			$this->sendSubTitle($subtitle);
 		}
 		$this->sendTitleText($title, SetTitlePacket::TYPE_SET_TITLE);
 	}
@@ -3279,8 +3294,19 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	 * Sets the subtitle message, without sending a title.
 	 *
 	 * @param string $subtitle
+     *
+     * @deprecated please use sendSubTitle
 	 */
 	public function addSubTitle(string $subtitle){
+        $this->sendSubTitle($subtitle);
+    }
+
+    /**
+     * Sets the subtitle message, without sending a title.
+     *
+     * @param string $subtitle
+     */
+    public function sendSubTitle(string $subtitle){
 		$this->sendTitleText($subtitle, SetTitlePacket::TYPE_SET_SUBTITLE);
 	}
 

--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -1872,7 +1872,7 @@ class Server{
 
 		/** @var Player[] $recipients */
 		foreach($recipients as $recipient){
-			$recipient->addTitle($title, $subtitle, $fadeIn, $stay, $fadeOut);
+			$recipient->sendTitle($title, $subtitle, $fadeIn, $stay, $fadeOut);
 		}
 
 		return count($recipients);

--- a/src/pocketmine/command/defaults/TitleCommand.php
+++ b/src/pocketmine/command/defaults/TitleCommand.php
@@ -68,21 +68,21 @@ class TitleCommand extends VanillaCommand{
 					throw new InvalidCommandSyntaxException();
 				}
 
-				$player->addTitle(implode(" ", array_slice($args, 2)));
+				$player->sendTitle(implode(" ", array_slice($args, 2)));
 				break;
 			case "subtitle":
 				if(count($args) < 3){
 					throw new InvalidCommandSyntaxException();
 				}
 
-				$player->addSubTitle(implode(" ", array_slice($args, 2)));
+				$player->sendSubTitle(implode(" ", array_slice($args, 2)));
 				break;
 			case "actionbar":
 				if(count($args) < 3){
 					throw new InvalidCommandSyntaxException();
 				}
 
-				$player->addActionBarMessage(implode(" ", array_slice($args, 2)));
+				$player->sendActionBarMessage(implode(" ", array_slice($args, 2)));
 				break;
 			case "times":
 				if(count($args) < 5){


### PR DESCRIPTION
## Introduction
See issue #2896.

This PR adds more Consistency to the send/add methods

### Relevant issues
<!-- List relevant issues here -->
* Fixes #2896 

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Deprecated addTitle and addSubTitle
Added sendTitle and sendSubTitle for more consistency with the rest of the API
