### PR TITLE
Implement anvil destorying torches whilst falling down

### DIFF
--- a/src/pocketmine/block/Block.php
+++ b/src/pocketmine/block/Block.php
@@ -849,7 +849,7 @@ class Block extends Position implements BlockLegacyIds, Metadatable{
 	 * 			be destroyed and falling should continue
 	 */
 	public function canBlockLand(Fallable $block) : int{
-		return ($this->getId() > 0 and !$this->isTransparent() and !$this->canBeReplaced()) ?
+		return (!$this->isTransparent() and !$this->canBeReplaced()) ?
 			FallingBlock::STATE_SOLIDIFY : FallingBlock::STATE_DROP_ITEM;
 	}
 

--- a/src/pocketmine/block/Block.php
+++ b/src/pocketmine/block/Block.php
@@ -849,8 +849,7 @@ class Block extends Position implements BlockLegacyIds, Metadatable{
 	 * 			be destroyed and falling should continue
 	 */
 	public function canBlockLand(Fallable $block) : int{
-		return (!$this->isTransparent() and !$this->canBeReplaced()) ?
-			FallingBlock::STATE_SOLIDIFY : FallingBlock::STATE_DROP_ITEM;
+		return FallingBlock::STATE_SOLIDIFY;
 	}
 
 }

--- a/src/pocketmine/block/Block.php
+++ b/src/pocketmine/block/Block.php
@@ -26,8 +26,10 @@ declare(strict_types=1);
  */
 namespace pocketmine\block;
 
+use pocketmine\block\utils\Fallable;
 use pocketmine\block\utils\InvalidBlockStateException;
 use pocketmine\entity\Entity;
+use pocketmine\entity\object\FallingBlock;
 use pocketmine\item\enchantment\Enchantment;
 use pocketmine\item\Item;
 use pocketmine\item\ItemFactory;
@@ -837,4 +839,18 @@ class Block extends Position implements BlockLegacyIds, Metadatable{
 			$this->level->getBlockMetadata()->removeMetadata($this, $metadataKey, $owningPlugin);
 		}
 	}
+
+	/**
+	 * Check if the falling block can be made solid again when hitting this block
+	 *
+	 * @param Fallable $block which is currently falling
+	 *
+	 * @return 	int 0 when block can be solidfy, 1 when the block should drop as item, 2 when this block should
+	 * 			be destroyed and falling should continue
+	 */
+	public function canBlockLand(Fallable $block) : int{
+		return ($this->getId() > 0 and !$this->isTransparent() and !$this->canBeReplaced()) ?
+			FallingBlock::STATE_SOLIDIFY : FallingBlock::STATE_DROP_ITEM;
+	}
+
 }

--- a/src/pocketmine/block/Cactus.php
+++ b/src/pocketmine/block/Cactus.php
@@ -24,7 +24,9 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\block\utils\BlockDataValidator;
+use pocketmine\block\utils\Fallable;
 use pocketmine\entity\Entity;
+use pocketmine\entity\object\FallingBlock;
 use pocketmine\event\block\BlockGrowEvent;
 use pocketmine\event\entity\EntityDamageByBlockEvent;
 use pocketmine\event\entity\EntityDamageEvent;
@@ -127,4 +129,18 @@ class Cactus extends Transparent{
 
 		return false;
 	}
+
+	public function canBlockLand(Fallable $block) : int{
+		$parentDecision = parent::canBlockLand($block);
+		if ($parentDecision == FallingBlock::STATE_DROP_ITEM) {
+			return $parentDecision;
+		}
+
+		if ($block instanceof Sand) {
+			return FallingBlock::STATE_DROP_ITEM;
+		}
+
+		return FallingBlock::STATE_SOLIDIFY;
+	}
+
 }

--- a/src/pocketmine/block/Cactus.php
+++ b/src/pocketmine/block/Cactus.php
@@ -136,11 +136,7 @@ class Cactus extends Transparent{
 			return $parentDecision;
 		}
 
-		if ($block instanceof Sand) {
-			return FallingBlock::STATE_DROP_ITEM;
-		}
-
-		return FallingBlock::STATE_SOLIDIFY;
+		return FallingBlock::STATE_DROP_ITEM;
 	}
 
 }

--- a/src/pocketmine/block/Torch.php
+++ b/src/pocketmine/block/Torch.php
@@ -24,6 +24,8 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\block\utils\BlockDataValidator;
+use pocketmine\block\utils\Fallable;
+use pocketmine\entity\object\FallingBlock;
 use pocketmine\item\Item;
 use pocketmine\math\Facing;
 use pocketmine\math\Vector3;
@@ -84,4 +86,13 @@ class Torch extends Flowable{
 		}
 		return false;
 	}
+
+	public function canBlockLand(Fallable $block) : int{
+		if ($block instanceof Anvil) {
+			return FallingBlock::STATE_DESTROY_BLOCK;
+		}
+
+		return parent::canBlockLand($block);
+	}
+
 }

--- a/src/pocketmine/entity/behaviour/Behaviour.php
+++ b/src/pocketmine/entity/behaviour/Behaviour.php
@@ -30,7 +30,7 @@ abstract class Behaviour{
 	/** @var Entity */
 	protected $entity;
 
-	protected function __construct(Entity $entity) {
+	protected function __construct(Entity $entity){
 		$this->entity = $entity;
 	}
 

--- a/src/pocketmine/entity/behaviour/Behaviour.php
+++ b/src/pocketmine/entity/behaviour/Behaviour.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\entity\behaviour;
+
+use pocketmine\entity\Entity;
+
+abstract class Behaviour{
+
+	/** @var Entity */
+	protected $entity;
+
+	protected function __construct(Entity $entity) {
+		$this->entity = $entity;
+	}
+
+	public abstract function update(int $tickDiff = 1) : void;
+}

--- a/src/pocketmine/entity/behaviour/DestroyWhileFalling.php
+++ b/src/pocketmine/entity/behaviour/DestroyWhileFalling.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\entity\behaviour;
+
+
+use pocketmine\block\Block;
+use pocketmine\entity\Entity;
+
+class DestroyWhileFalling extends Behaviour{
+
+	/** @var int[] */
+	private $destroyables;
+	/** @var bool */
+	private $dropItems;
+
+	public function __construct(Entity $entity, array $destroyables, bool $dropItems){
+		parent::__construct($entity);
+
+		$this->destroyables = $destroyables;
+		$this->dropItems = $dropItems;
+	}
+
+	public function update(int $tickDiff = 1) : void{
+		$block = $this->entity->getLevel()->getBlock($this->entity->getPosition());
+		foreach($this->destroyables as $destroyableId) {
+			if($block->getId() == $destroyableId) {
+				if($this->dropItems) {
+					$this->entity->getLevel()->dropItem($this->entity->getPosition(), $block->asItem());
+				}
+
+				$this->entity->getLevel()->setBlock($block, Block::get(Block::AIR));
+			}
+		}
+	}
+}

--- a/src/pocketmine/entity/object/FallingBlock.php
+++ b/src/pocketmine/entity/object/FallingBlock.php
@@ -82,7 +82,7 @@ class FallingBlock extends Entity{
 
 		$this->block = BlockFactory::get($blockId, $damage);
 		if ($this->block instanceof Anvil) {
-			$this->behaviours = [new DestroyWhileFalling($this,	[Block::TORCH, Block::COLORED_TORCH_RG, Block::COLORED_TORCH_BP,
+			$this->behaviours = [new DestroyWhileFalling($this, [Block::TORCH, Block::COLORED_TORCH_RG, Block::COLORED_TORCH_BP,
 					Block::LIT_REDSTONE_TORCH, Block::UNLIT_REDSTONE_TORCH, Block::UNDERWATER_TORCH], true)];
 		}
 


### PR DESCRIPTION
Fix cactus not having vanilla behaviour when sand falls on top.

## Introduction
Added a first entity behaviour. DestroyWhilstFalling can destroy/drop blocks whilst touching them.

### Relevant issues
<!-- List relevant issues here -->
* Fixes #2895 

## Changes
### Behavioural changes
The server now drops all sort of torches when a falling anvil touches them. Also sand gets dropped when hit by a cactus.