### PR TITLE
Implement a locking variable to circumvent a infinite regression

### DIFF
--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -562,6 +562,8 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 	/** @var bool */
 	protected $constructed = false;
 
+	/** @var bool */
+	private $closeInFlight = false;
 
 	public function __construct(Level $level, CompoundTag $nbt){
 		$this->constructed = true;
@@ -2108,7 +2110,12 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 	 * WARNING: Entities are unusable after this has been executed!
 	 */
 	public function close() : void{
+		if($this->closeInFlight) {
+			return;
+		}
+
 		if(!$this->closed){
+			$this->closeInFlight = true;
 			(new EntityDespawnEvent($this))->call();
 			$this->closed = true;
 
@@ -2127,6 +2134,7 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 
 			$this->namedtag = null;
 			$this->lastDamageCause = null;
+			$this->closeInFlight = false;
 		}
 	}
 

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -2110,7 +2110,7 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 	 * WARNING: Entities are unusable after this has been executed!
 	 */
 	public function close() : void{
-		if($this->closeInFlight) {
+		if($this->closeInFlight){
 			return;
 		}
 


### PR DESCRIPTION
## Introduction
The current problem is that a plugin could enter a infinite loop when calling Entity::close in a EntityDespawnEvent.

### Relevant issues
<!-- List relevant issues here -->
* Fixes #2876

## Changes
### API changes
Entity::close may not fire any additional events when called from inside the EntityDespawnEvent. 

## Backwards compatibility
I haven't touched the $closed ordering to fix this issue since it would break the event contract on the entity. That should maybe be done on 4.0 but not on 3.x

## Follow-up
Think about reordering close variable state inside Entity::close