### PR TITLE
TimeCommand: Fix commands.time.query message

### DIFF
--- a/src/pocketmine/command/defaults/TimeCommand.php
+++ b/src/pocketmine/command/defaults/TimeCommand.php
@@ -81,7 +81,7 @@ class TimeCommand extends VanillaCommand{
 			}else{
 				$level = $sender->getServer()->getDefaultLevel();
 			}
-			$sender->sendMessage(new TranslationContainer("commands.time.query", [$level->getTime()]));
+			$sender->sendMessage($sender->getServer()->getLanguage()->translateString("commands.time.query", [$level->getTime()]));
 			return true;
 		}
 


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
At some point, the commands.time.query has been removed from the client language files. This has resulted in an issue where players cannot query time with /time query. This PR fixes the problem by translating the message server side.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
* The output of /time query is incorrect

## Changes
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
Players can now once again run /time query to query time.

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Tested by executing /time query from the client.