### PR TITLE
Randomize the order of plugins retrieved from disk, fixes #2945

### DIFF
--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -55,7 +55,9 @@ use function is_bool;
 use function is_dir;
 use function is_string;
 use function is_subclass_of;
+use function iterator_to_array;
 use function mkdir;
+use function shuffle;
 use function stripos;
 use function strpos;
 use function strtolower;
@@ -236,12 +238,11 @@ class PluginManager{
 		}else{
 			$loaders = $this->fileAssociations;
 		}
+
+		$files = iterator_to_array(new \FilesystemIterator($directory, \FilesystemIterator::CURRENT_AS_PATHNAME | \FilesystemIterator::SKIP_DOTS));
+		shuffle($files); //this prevents plugins implicitly relying on the filesystem name order when they should be using dependency properties
 		foreach($loaders as $loader){
-			foreach(new \DirectoryIterator($directory) as $file){
-				if($file === "." or $file === ".."){
-					continue;
-				}
-				$file = $directory . $file;
+			foreach($files as $file){
 				if(!$loader->canLoadPlugin($file)){
 					continue;
 				}


### PR DESCRIPTION
On most filesystems, plugins are loaded in lexical order because that's how the filesystem gives the files to us. This is a problem because it can hide bugs with dependency resolution on specific platforms with this behaviour, while inexplicably breaking on other platforms where the load order is different or undefined.

This change prevents plugins depending on any file yield order by randomizing the order in which plugin files are checked for loadability.