### PR TITLE
Implemented StructureGrowEvent

### DIFF
--- a/src/pocketmine/block/Sapling.php
+++ b/src/pocketmine/block/Sapling.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\block\utils\TreeType;
+use pocketmine\event\world\StructureGrowEvent;
 use pocketmine\item\Fertilizer;
 use pocketmine\item\Item;
 use pocketmine\math\Facing;
@@ -69,11 +70,14 @@ class Sapling extends Flowable{
 
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
 		if($item instanceof Fertilizer){
-			Tree::growTree($this->getWorld(), $this->x, $this->y, $this->z, new Random(mt_rand()), $this->treeType);
+            $ev = new StructureGrowEvent($this->getWorld(), $this->asVector3(), $this->treeType, true, $player);
+            $ev->call();
+            if(!$ev->isCancelled()){
+                Tree::growTree($this->getWorld(), $this->x, $this->y, $this->z, new Random(mt_rand()), $this->treeType);
+                $item->pop();
 
-			$item->pop();
-
-			return true;
+                return true;
+            }
 		}
 
 		return false;

--- a/src/pocketmine/block/Sapling.php
+++ b/src/pocketmine/block/Sapling.php
@@ -96,7 +96,11 @@ class Sapling extends Flowable{
 	public function onRandomTick() : void{
 		if($this->world->getFullLightAt($this->x, $this->y, $this->z) >= 8 and mt_rand(1, 7) === 1){
 			if($this->ready){
-				Tree::growTree($this->getWorld(), $this->x, $this->y, $this->z, new Random(mt_rand()), $this->treeType);
+                $ev = new StructureGrowEvent($this->getWorld(), $this->asVector3(), $this->treeType, false);
+                $ev->call();
+                if(!$ev->isCancelled()){
+                    Tree::growTree($this->getWorld(), $this->x, $this->y, $this->z, new Random(mt_rand()), $this->treeType);
+                }
 			}else{
 				$this->ready = true;
 				$this->getWorld()->setBlock($this, $this);

--- a/src/pocketmine/event/world/StructureGrowEvent.php
+++ b/src/pocketmine/event/world/StructureGrowEvent.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\event\world;
+
+use pocketmine\block\utils\TreeType;
+use pocketmine\event\Cancellable;
+use pocketmine\event\CancellableTrait;
+use pocketmine\math\Vector3;
+use pocketmine\player\Player;
+use pocketmine\world\World;
+
+/**
+ * Event that is called when an organic structure attempts to grow (Sapling -> Tree), (Mushroom -> Huge Mushroom),
+ * naturally or using fertilizer (bonemeal).
+ */
+class StructureGrowEvent extends WorldEvent implements Cancellable{
+    use CancellableTrait;
+
+    /**@var Vector3 */
+    private $vector3;
+    /**@var TreeType */
+    private $species;
+    /**@var boolean */
+    private $fertilizer;
+    /**@var Player|null */
+    private $player;
+
+    /**
+     * @param World $world
+     * @param Vector3 $vector3
+     * @param TreeType $species
+     * @param bool $fertilizer
+     * @param Player|null $player
+     */
+    public function __construct(World $world, Vector3 $vector3, TreeType $species, bool $fertilizer, ?Player $player = null){ //TODO: Gets a list of all blocks associated with the structure.
+        parent::__construct($world);
+        $this->vector3 = $vector3;
+        $this->species = $species;
+        $this->fertilizer = $fertilizer;
+        $this->player = $player;
+    }
+
+    /**
+     * Returns the structure coordinates.
+     * @return Vector3
+     */
+    public function getVector3(): Vector3{
+        return $this->vector3;
+    }
+
+    /**
+     * @return TreeType
+     */
+    public function getSpecies(): TreeType{
+        return $this->species;
+    }
+
+    /**
+     * @return Player|null
+     */
+    public function getPlayer(): ?Player{
+        return $this->player;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isFromFertilizer(): bool{
+        return $this->fertilizer;
+    }
+}


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Currently is not possible to detect when a tree (or better a structure) is grew.

### Relevant issues
<!-- List relevant issues here -->
- Need to implement Huge Mushroom **(nothing to do with this addition)**.
- Need to get a list of all blocks associated with the structure.
**Currently is not possible to get all structure blocks due to internal usage of BlockTransaction in Tree::placeObject()**
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
**Added StructureGrowEvent.**
Event that is called when an organic structure attempts to grow (Sapling -> Tree), (Mushroom -> Huge Mushroom), naturally or using fertilizer (bonemeal).

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
Doesn't change server behavior.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
It's backward compatible.

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Tested actions:
Event cancelled -> Tree is not grew.