### PR TITLE
 Add API methods to change a players' player list name

### DIFF
--- a/src/network/mcpe/NetworkSession.php
+++ b/src/network/mcpe/NetworkSession.php
@@ -983,7 +983,7 @@ class NetworkSession{
 	}
 
 	public function onPlayerAdded(Player $p) : void{
-		$this->sendDataPacket(PlayerListPacket::add([PlayerListEntry::createAdditionEntry($p->getUniqueId(), $p->getId(), $p->getDisplayName(), SkinAdapterSingleton::get()->toSkinData($p->getSkin()), $p->getXuid())]));
+		$this->sendDataPacket(PlayerListPacket::add([PlayerListEntry::createAdditionEntry($p->getUniqueId(), $p->getId(), $p->getPlayerListName(), SkinAdapterSingleton::get()->toSkinData($p->getSkin()), $p->getXuid())]));
 	}
 
 	public function onPlayerRemoved(Player $p) : void{

--- a/src/network/mcpe/NetworkSession.php
+++ b/src/network/mcpe/NetworkSession.php
@@ -978,7 +978,7 @@ class NetworkSession{
 	 */
 	public function syncPlayerList(array $players) : void{
 		$this->sendDataPacket(PlayerListPacket::add(array_map(function(Player $player) : PlayerListEntry{
-			return PlayerListEntry::createAdditionEntry($player->getUniqueId(), $player->getId(), $player->getDisplayName(), SkinAdapterSingleton::get()->toSkinData($player->getSkin()), $player->getXuid());
+			return PlayerListEntry::createAdditionEntry($player->getUniqueId(), $player->getId(), $player->getPlayerListName(), SkinAdapterSingleton::get()->toSkinData($player->getSkin()), $player->getXuid());
 		}, $players)));
 	}
 

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -576,7 +576,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		$this->playerListName = $name;
 
 		foreach($this->server->getOnlinePlayers() as $player) {
-			$player->getNetworkSession()->syncPlayerList();
+			$player->getNetworkSession()->onPlayerAdded();
 		}
 	}
 

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -166,6 +166,8 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 	/** @var string */
 	protected $displayName;
 	/** @var string */
+	protected $playerListName;
+	/** @var string */
 	protected $xuid = "";
 	/** @var bool */
 	protected $authenticated;
@@ -272,6 +274,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 
 		$this->username = $username;
 		$this->displayName = $this->username;
+		$this->playerListName = $this->username;
 		$this->locale = $this->playerInfo->getLocale();
 
 		$this->uuid = $this->playerInfo->getUuid();
@@ -555,6 +558,26 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		$ev->call();
 
 		$this->displayName = $ev->getNewName();
+	}
+
+	/**
+	 * Gets the name that is shown on the player list.
+	 * 
+	 * @return string
+	 */
+	public function getPlayerListName(): string {
+		return $this->playerListName;
+	}
+
+	/**
+	 * @param string $name
+	 */
+	public function setPlayerListName(string $name): void {
+		$this->playerListName = $name;
+
+		foreach($this->server->getOnlinePlayers() as $player) {
+			$player->getNetworkSession()->syncPlayerList();
+		}
 	}
 
 	/**

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -565,17 +565,17 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 	 * 
 	 * @return string
 	 */
-	public function getPlayerListName(): string {
+	public function getPlayerListName() : string{
 		return $this->playerListName;
 	}
 
 	/**
 	 * @param string $name
 	 */
-	public function setPlayerListName(string $name): void {
+	public function setPlayerListName(string $name) : void{
 		$this->playerListName = $name;
 
-		foreach($this->server->getOnlinePlayers() as $player) {
+		foreach($this->server->getOnlinePlayers() as $player){
 			$player->getNetworkSession()->onPlayerAdded();
 		}
 	}

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -562,16 +562,11 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 
 	/**
 	 * Gets the name that is shown on the player list.
-	 * 
-	 * @return string
 	 */
 	public function getPlayerListName() : string{
 		return $this->playerListName;
 	}
 
-	/**
-	 * @param string $name
-	 */
 	public function setPlayerListName(string $name) : void{
 		$this->playerListName = $name;
 

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -571,6 +571,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		$this->playerListName = $name;
 
 		foreach($this->server->getOnlinePlayers() as $player){
+			$player->getNetworkSession()->onPlayerRemoved($this);
 			$player->getNetworkSession()->onPlayerAdded($this);
 		}
 	}

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -571,7 +571,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		$this->playerListName = $name;
 
 		foreach($this->server->getOnlinePlayers() as $player){
-			$player->getNetworkSession()->onPlayerAdded();
+			$player->getNetworkSession()->onPlayerAdded($this);
 		}
 	}
 


### PR DESCRIPTION
## Introduction
Since the ability to update the player list was removed when calling `setDisplayName` (and rightly so), we need another method update the name. 

## Changes
### API changes
Add the following methods to Player:
* `getPlayerListName()`
* `setPlayerListName(string $name)`

## Backwards compatibility
It is but does it even really matter at this point? lol

## Follow-up
Maybe use the player list name instead of the username in `NetworkSession->onPlayerAdded()` as the plain username will be displayed until the player actually spawns (if you use my join event example, i'm not sure if it would be possible to change the name in an earlier event)

## Tests
```php
public function onJoin(PlayerJoinEvent $event): void {
        $player = $event->getPlayer();
        $player->setPlayerListName(TF::LIGHT_PURPLE . "[PLN] " . $player->getName());
    }
```