### PR TITLE
Fixed setDisplayName() method

### DIFF
--- a/src/pocketmine/network/mcpe/NetworkSession.php
+++ b/src/pocketmine/network/mcpe/NetworkSession.php
@@ -815,7 +815,7 @@ class NetworkSession{
 	}
 
 	public function onPlayerAdded(Player $p) : void{
-		$this->sendDataPacket(PlayerListPacket::add([PlayerListEntry::createAdditionEntry($p->getUniqueId(), $p->getId(), $p->getName(), $p->getSkin(), $p->getXuid())]));
+		$this->sendDataPacket(PlayerListPacket::add([PlayerListEntry::createAdditionEntry($p->getUniqueId(), $p->getId(), $p->getDisplayName(), $p->getSkin(), $p->getXuid())]));
 	}
 
 	public function onPlayerRemoved(Player $p) : void{

--- a/src/pocketmine/player/Player.php
+++ b/src/pocketmine/player/Player.php
@@ -751,8 +751,11 @@ class Player extends Human implements CommandSender, ChunkLoader, ChunkListener,
 	/**
 	 * @param string $name
 	 */
-	public function setDisplayName(string $name){
+	public function setDisplayName(string $name) : void{
 		$this->displayName = $name;
+		foreach($this->getServer()->getOnlinePlayers() as $player){
+			$player->getNetworkSession()->onPlayerAdded($this);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Introduction
This method broken and you can't sync username
Actual result:
![i1](https://media.discordapp.net/attachments/373199722573201410/591608202853089280/unknown.png)
Expected result:
![i2](https://user-images.githubusercontent.com/13465245/59926579-4140db80-9443-11e9-8471-49cd770385f9.png)
