### PR TITLE
Created math-related methods which return Vector3 instances from Position objects

### DIFF
--- a/src/pocketmine/level/Position.php
+++ b/src/pocketmine/level/Position.php
@@ -103,6 +103,47 @@ class Position extends Vector3{
 			return new Position($this->x + $x, $this->y + $y, $this->z + $z);
 		}
 	}
+	
+	/**
+	 * @param Position|int $x
+	 * @param int         $y
+	 * @param int         $z
+	 *
+	 * @return Vector3
+	 */
+	public function subtract($x = 0, $y = 0, $z = 0) : Position{
+		if($x instanceof Position){
+			return $this->add(-$x->x, -$x->y, -$x->z);
+		}else{
+			return $this->add(-$x, -$y, -$z);
+		}
+	}
+	
+	public function multiply(float $number) : Position{
+		return new Position($this->x * $number, $this->y * $number, $this->z * $number, $this->level);
+	}
+	
+	public function divide(float $number) : Position{
+		return new Position($this->x / $number, $this->y / $number, $this->z / $number, $this->level);
+	}
+	
+	public function ceil() : Position{
+		return new Position((int) ceil($this->x), (int) ceil($this->y), (int) ceil($this->z), $this->level);
+	}
+	
+	public function floor() : Position{
+		return new Position((int) floor($this->x), (int) floor($this->y), (int) floor($this->z), $this->level);
+	}
+	
+	public function round(int $precision = 0, int $mode = PHP_ROUND_HALF_UP) : Position{
+		return $precision > 0 ?
+			new Position(round($this->x, $precision, $mode), round($this->y, $precision, $mode), round($this->z, $precision, $mode), $this->level) :
+			new Position((int) round($this->x, $precision, $mode), (int) round($this->y, $precision, $mode), (int) round($this->z, $precision, $mode), $this->level);
+	}
+	
+	public function abs() : Position{
+		return new Position(abs($this->x), abs($this->y), abs($this->z), $this->level);
+	}
 
 	/**
 	 * Checks if this object has a valid reference to a loaded Level

--- a/src/pocketmine/level/Position.php
+++ b/src/pocketmine/level/Position.php
@@ -90,41 +90,33 @@ class Position extends Vector3{
 	}
 
 	/**
-	 * @param Position|int $x
+	 * @param Vector3|int $x
 	 * @param int         $y
 	 * @param int         $z
 	 *
-	 * @return Vector3
+	 * @return Position
 	 */
 	public function add($x, $y = 0, $z = 0) : Position{
-		if($x instanceof Position){
-			return new Position($this->x + $x->x, $this->y + $x->y, $this->z + $x->z);
+		if($x instanceof Vector3){
+			return new Position($this->x + $x->x, $this->y + $x->y, $this->z + $x->z, $this->level);
 		}else{
-			return new Position($this->x + $x, $this->y + $y, $this->z + $z);
+			return new Position($this->x + $x, $this->y + $y, $this->z + $z, $this->level);
 		}
 	}
 	
 	/**
-	 * @param Position|int $x
+	 * @param Vector3|int $x
 	 * @param int         $y
 	 * @param int         $z
 	 *
-	 * @return Vector3
+	 * @return Position
 	 */
 	public function subtract($x = 0, $y = 0, $z = 0) : Position{
-		if($x instanceof Position){
-			return $this->add(-$x->x, -$x->y, -$x->z);
+		if($x instanceof Vector3){
+			return $this->add(-$x->x, -$x->y, -$x->z, $this->level);
 		}else{
-			return $this->add(-$x, -$y, -$z);
+			return $this->add(-$x, -$y, -$z, $this->leve;);
 		}
-	}
-	
-	public function multiply(float $number) : Position{
-		return new Position($this->x * $number, $this->y * $number, $this->z * $number, $this->level);
-	}
-	
-	public function divide(float $number) : Position{
-		return new Position($this->x / $number, $this->y / $number, $this->z / $number, $this->level);
 	}
 	
 	public function ceil() : Position{
@@ -139,10 +131,6 @@ class Position extends Vector3{
 		return $precision > 0 ?
 			new Position(round($this->x, $precision, $mode), round($this->y, $precision, $mode), round($this->z, $precision, $mode), $this->level) :
 			new Position((int) round($this->x, $precision, $mode), (int) round($this->y, $precision, $mode), (int) round($this->z, $precision, $mode), $this->level);
-	}
-	
-	public function abs() : Position{
-		return new Position(abs($this->x), abs($this->y), abs($this->z), $this->level);
 	}
 
 	/**

--- a/src/pocketmine/level/Position.php
+++ b/src/pocketmine/level/Position.php
@@ -90,6 +90,21 @@ class Position extends Vector3{
 	}
 
 	/**
+	 * @param Position|int $x
+	 * @param int         $y
+	 * @param int         $z
+	 *
+	 * @return Vector3
+	 */
+	public function add($x, $y = 0, $z = 0) : Position{
+		if($x instanceof Position){
+			return new Position($this->x + $x->x, $this->y + $x->y, $this->z + $x->z);
+		}else{
+			return new Position($this->x + $x, $this->y + $y, $this->z + $z);
+		}
+	}
+
+	/**
 	 * Checks if this object has a valid reference to a loaded Level
 	 *
 	 * @return bool


### PR DESCRIPTION
Previously, Position::add() and several other methods would return a Vector3 instance as they are from the parent (Vector3) class

## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This pull request implements a method multiple methods to the Position class which were inherited from the parent Vector3 class, but returning an instance of Position instead.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Created ``Position::add()``
Created ``Posisition::subtract()``
Created ``Posisition::multiply()``
Created ``Posisition::divide()``
Created ``Posisition::ceil()``
Created ``Posisition::floor()``
Created ``Posisition::round()``
Created ``Posisition::abs()``

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
None :)

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
There is no backwards compatability changes, only people currently using Position::add() and the other methods will now receive a Position instance, but this will not affect anything.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
```php
$position = new Position(0, 0, 0, Server::getInstance()->getLevelByName("Test"));
$newPosition = $position->add(1, 1, 1);
var_dump($newPosition->__toString());
```
Output: ``string(32) "Position(level=Test,x=1,y=1,z=1)"``
