### PR TITLE
Fix Entity::isNameTagAlwaysVisible() was returning the wrong value

### DIFF
--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -662,7 +662,7 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 	 * @return bool
 	 */
 	public function isNameTagAlwaysVisible() : bool{
-		return $this->getGenericFlag(self::DATA_FLAG_ALWAYS_SHOW_NAMETAG);
+		return $this->propertyManager->getByte(self::DATA_ALWAYS_SHOW_NAMETAG) > 0;
 	}
 
 

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -662,7 +662,7 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 	 * @return bool
 	 */
 	public function isNameTagAlwaysVisible() : bool{
-		return $this->propertyManager->getByte(self::DATA_ALWAYS_SHOW_NAMETAG) > 0;
+		return $this->propertyManager->getByte(self::DATA_ALWAYS_SHOW_NAMETAG) === 1;
 	}
 
 


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
While Entity::setNameTagAlwaysVisible() was setting the byte data value, Entity::isNameTagAlwaysVisible() was still returning the unused flag value.
### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Before this commit:
```php
$entity->setNameTagAlwaysVisible(true);
var_dump($entity->isNameTagAlwaysVisible()); //bool(false)
```
After:
```php
$entity->setNameTagAlwaysVisible(true);
var_dump($entity->isNameTagAlwaysVisible()); //bool(true)
```