### PR TITLE
Make DragonEgg::teleport public

### DIFF
--- a/src/pocketmine/block/DragonEgg.php
+++ b/src/pocketmine/block/DragonEgg.php
@@ -61,7 +61,7 @@ class DragonEgg extends Transparent implements Fallable{
 		return true;
 	}
 
-	protected function teleport() : void{
+	public function teleport() : void{
 		for($tries = 0; $tries < 16; ++$tries){
 			$block = $this->world->getBlockAt(
 				$this->x + mt_rand(-16, 16),


### PR DESCRIPTION
## Introduction
This change allows me to teleport the Dragon Egg without having to implement the code myself. This behaviour now matches the TNT block, as the `ignite()` method is public.

## API Changes
I do not believe there is any backwards incompatible changes.