### PR TITLE
Fixed BlockPlaceEvent firing when the block can't be placed.

### DIFF
--- a/src/pocketmine/world/BlockTransaction.php
+++ b/src/pocketmine/world/BlockTransaction.php
@@ -113,7 +113,7 @@ class BlockTransaction{
 			foreach($this->validators as $validator){
 				if(!$validator($this->world, $x, $y, $z)){
 					$this->isValid = false;
-					break 2;
+					return false;
 				}
 			}
 		}

--- a/src/pocketmine/world/BlockTransaction.php
+++ b/src/pocketmine/world/BlockTransaction.php
@@ -70,6 +70,7 @@ class BlockTransaction{
 	 * @return $this
 	 */
 	public function addBlockAt(int $x, int $y, int $z, Block $state) : self{
+		$this->isValid = null;
 		$this->blocks[$x][$y][$z] = $state;
 
 		return $this;
@@ -125,7 +126,7 @@ class BlockTransaction{
 	 */
 	public function apply() : void{
 		if($this->isValid === null){
-			throw new \UnexpectedValueException("The transaction must be validated before applying.");
+			throw new \BadMethodCallException("The transaction must be validated before applying.");
 		}
 
 		if($this->isValid){

--- a/src/pocketmine/world/BlockTransaction.php
+++ b/src/pocketmine/world/BlockTransaction.php
@@ -104,7 +104,7 @@ class BlockTransaction{
 	 * Validates the transaction to the given world. If any part of the transaction fails to
 	 * validate, no changes will be made to the world.
 	 *
-	 * @return bool if validation was successful
+	 * @return bool if the validation was successful
 	 */
 	public function validate() : bool{
 		$this->isValid = true;

--- a/src/pocketmine/world/World.php
+++ b/src/pocketmine/world/World.php
@@ -1754,7 +1754,11 @@ class World implements ChunkManager{
 			}
 		}
 
-
+		$tx = new BlockTransaction($this);
+		if(!$hand->place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player) or !$tx->apply()){
+			return false;
+		}
+		
 		if($player !== null){
 			$ev = new BlockPlaceEvent($player, $hand, $blockReplace, $blockClicked, $item);
 			if($player->isAdventure(true) and !$ev->isCancelled()){
@@ -1780,11 +1784,7 @@ class World implements ChunkManager{
 				return false;
 			}
 		}
-
-		$tx = new BlockTransaction($this);
-		if(!$hand->place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player) or !$tx->apply()){
-			return false;
-		}
+		
 		foreach($tx->getBlocks() as [$x, $y, $z, $_]){
 			$tile = $this->getTileAt($x, $y, $z);
 			if($tile !== null){

--- a/src/pocketmine/world/World.php
+++ b/src/pocketmine/world/World.php
@@ -1755,7 +1755,7 @@ class World implements ChunkManager{
 		}
 
 		$tx = new BlockTransaction($this);
-		if(!$hand->place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player) or !$tx->apply()){
+		if(!$hand->place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player)){
 			return false;
 		}
 		
@@ -1783,6 +1783,10 @@ class World implements ChunkManager{
 			if($ev->isCancelled()){
 				return false;
 			}
+		}
+		
+		if(!$tx->apply()){
+			return false;
 		}
 		
 		foreach($tx->getBlocks() as [$x, $y, $z, $_]){

--- a/src/pocketmine/world/World.php
+++ b/src/pocketmine/world/World.php
@@ -1755,7 +1755,7 @@ class World implements ChunkManager{
 		}
 
 		$tx = new BlockTransaction($this);
-		if(!$hand->place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player)){
+		if(!$hand->place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player) or !$tx->validate()){
 			return false;
 		}
 		
@@ -1785,9 +1785,7 @@ class World implements ChunkManager{
 			}
 		}
 		
-		if(!$tx->apply()){
-			return false;
-		}
+		$tx->apply();
 		
 		foreach($tx->getBlocks() as [$x, $y, $z, $_]){
 			$tile = $this->getTileAt($x, $y, $z);

--- a/src/pocketmine/world/generator/object/Tree.php
+++ b/src/pocketmine/world/generator/object/Tree.php
@@ -112,7 +112,9 @@ abstract class Tree{
 		$this->placeTrunk($x, $y, $z, $random, $this->generateChunkHeight($random), $transaction);
 		$this->placeCanopy($x, $y, $z, $random, $transaction);
 
-		$transaction->apply(); //TODO: handle return value on failure
+		if($transaction->validate()){
+			$transaction->apply(); //TODO: handle return value on failure
+		}
 	}
 
 	protected function generateChunkHeight(Random $random) : int{


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
When you try to place a item/block in a block where it can't be placed (e.g. flowers on sand), the event BlockPlaceEvent is always fired.

### Relevant issues
<!-- List relevant issues here -->
* Fixes BlockPlaceEvent always fired when the block can't be placed.
## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
* Added BlockTransaction::validate() - Must be used before BlockTransaction::apply() else it throws an UnexpectedValueException.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
No.
## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Yes.
## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Before:
```php
public function onPlace(BlockPlaceEvent $event): void{
    var_dump($event->getBlock()->getName()); //Always prints the block name.
}
```
After:
```php
public function onPlace(BlockPlaceEvent $event): void{
    var_dump($event->getBlock()->getName()); //It prints only when the block can be placed.
}
```