### PR TITLE
Implement saving and loading nametag property 'alwaysVisible'

### DIFF
--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -976,7 +976,7 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 				$this->setNameTagVisible($this->namedtag->getString("CustomNameVisible") !== "");
 				$this->namedtag->removeTag("CustomNameVisible");
 			}else{
-				$this->setNameTagVisible($this->namedtag->getByte("CustomNameVisible", 1) !== 0);
+				$this->setNameTagVisible($this->namedtag->getByte("CustomNameVisible", 0) !== 0);
 			}
 		}
 	}

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -936,8 +936,9 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 			if($this->getNameTag() !== ""){
 				$this->namedtag->setString("CustomName", $this->getNameTag());
 				$this->namedtag->setByte("CustomNameVisible", $this->isNameTagVisible() ? 1 : 0);
+				$this->namedtag->setByte("CustomNameAlwaysVisible", $this->isNameTagAlwaysVisible() ? 1 : 0);
 			}else{
-				$this->namedtag->removeTag("CustomName", "CustomNameVisible");
+				$this->namedtag->removeTag("CustomName", "CustomNameVisible", "CustomNameAlwaysVisible");
 			}
 		}
 
@@ -978,6 +979,13 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 			}else{
 				$this->setNameTagVisible($this->namedtag->getByte("CustomNameVisible", 1) !== 0);
 			}
+			
+			if($this->namedtag->hasTag("CustomNameAlwaysVisible", StringTag::class)){
+                $this->setNameTagAlwaysVisible($this->namedtag->getString("CustomNameAlwaysVisible") !== "");
+                $this->namedtag->removeTag("CustomNameAlwaysVisible");
+            }else{
+			    $this->setNameTagAlwaysVisible($this->namedtag->getByte("CustomNameAlwaysVisible", 1) !== 0);
+            }
 		}
 	}
 

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -977,14 +977,14 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 				$this->setNameTagVisible($this->namedtag->getString("CustomNameVisible") !== "");
 				$this->namedtag->removeTag("CustomNameVisible");
 			}else{
-				$this->setNameTagVisible($this->namedtag->getByte("CustomNameVisible", 0) !== 0);
+				$this->setNameTagVisible($this->namedtag->getByte("CustomNameVisible", 1) !== 0);
 			}
 			
 			if($this->namedtag->hasTag("CustomNameAlwaysVisible", StringTag::class)){
-                $this->setNameTagAlwaysVisible($this->namedtag->getString("CustomNameAlwaysVisible") !== "");
-                $this->namedtag->removeTag("CustomNameAlwaysVisible");
+				$this->setNameTagAlwaysVisible($this->namedtag->getString("CustomNameAlwaysVisible") !== "");
+				$this->namedtag->removeTag("CustomNameAlwaysVisible");
             }else{
-			    $this->setNameTagAlwaysVisible($this->namedtag->getByte("CustomNameAlwaysVisible", 1) !== 0);
+				$this->setNameTagAlwaysVisible($this->namedtag->getByte("CustomNameAlwaysVisible", 0) !== 0);
             }
 		}
 	}


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Currently, this property isn't saved or loaded in any way

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
no changes, just saving and loaded implement. (as title says)

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
server now saves this property to entity's namedtag and loads it from namedtag

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
no bc breaking.

## Follow-up
just re-set this property to your entities if you have so
<!-- Suggest any actions to be done before/after merging this pull request -->

## Tests
script plugin: https://pastebin.com/sbWREvXr
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->

