### PR TITLE
Fix loadbefore sometimes not working

### DIFF
--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -286,7 +286,7 @@ class PluginManager{
 
 					$plugins[$name] = $file;
 
-					$softDependencies[$name] = $description->getSoftDepend();
+					$softDependencies[$name] = array_merge($softDependencies[$name] ?? [], $description->getSoftDepend());
 					$dependencies[$name] = $description->getDepend();
 
 					foreach($description->getLoadBefore() as $before){


### PR DESCRIPTION
## Introduction
In some circumstances, a plugin that has "loadbefore: AnotherPugin" in its plugin.yml will be loaded after that plugin anyway because of the soft dependencies being overwritten by the ones in plugin.yml at [this line](https://github.com/pmmp/PocketMine-MP/blob/d874be99a693adeaf99de5ccef2b45509a408be2/src/pocketmine/plugin/PluginManager.php#L289)

## Changes
### Behavioural changes
This PR fixes that issue by merging the soft dependencies declared in plugin.yml with the ones that might have been previously set by the loadbefore directive.

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
To reproduce the bug described and therefore to test this fix do the following:
- Have three plugins in the server: pluginA, pluginB, pluginC
- Let pluginA depend on pluginC and loadbefore pluginB
- Restart the server multiple times and notice that, without this fix, 1/3 of the times pluginA will load and enable after pluginB even though pluginA has "loadbefore: pluginB" in his plugin.yml. With this PR pluginA is always loaded and enabled before pluginB


