### PR TITLE
Avoid useless loop into plugin description

### DIFF
--- a/src/pocketmine/plugin/PluginDescription.php
+++ b/src/pocketmine/plugin/PluginDescription.php
@@ -140,7 +140,7 @@ class PluginDescription{
 			$this->authors[] = $plugin["author"];
 		}
 		if(isset($plugin["authors"])){
-			$this->authors = (array) $plugin["authors"];
+			$this->authors[] = (array) $plugin["authors"];
 		}
 
 		if(isset($plugin["permissions"])){

--- a/src/pocketmine/plugin/PluginDescription.php
+++ b/src/pocketmine/plugin/PluginDescription.php
@@ -140,9 +140,7 @@ class PluginDescription{
 			$this->authors[] = $plugin["author"];
 		}
 		if(isset($plugin["authors"])){
-			foreach($plugin["authors"] as $author){
-				$this->authors[] = $author;
-			}
+			$this->authors = (array) $plugin["authors"];
 		}
 
 		if(isset($plugin["permissions"])){


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
The $plugin["authors"] already returns an array if is set, so it's useless iterate it.
### Relevant issues
Any issue. Just a micro optimization.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
No
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
No
## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Yes