### PR TITLE
doxygen: set HIDE_IN_BODY_DOCS = yes

### DIFF
--- a/doxygen/doxygen.conf
+++ b/doxygen/doxygen.conf
@@ -530,7 +530,7 @@ HIDE_FRIEND_COMPOUNDS  = NO
 # blocks will be appended to the function's detailed documentation block.
 # The default value is: NO.
 
-HIDE_IN_BODY_DOCS      = NO
+HIDE_IN_BODY_DOCS      = YES
 
 # The INTERNAL_DOCS tag determines if documentation that is typed after a
 # \internal command is included. If the tag is set to NO then the documentation


### PR DESCRIPTION
This fixes functions containing `@var` comments disappearing as described in #3043 .