### PR TITLE
Add test for item's display properties' persistence after deserialization

### DIFF
--- a/tests/phpunit/item/ItemTest.php
+++ b/tests/phpunit/item/ItemTest.php
@@ -62,6 +62,21 @@ class ItemTest extends TestCase{
 		self::assertTrue($item1->equals($item2));
 	}
 
+	/**
+	 * Tests whether items retain their display properties
+	 * after being deserialized
+	 */
+	public function testItemPersistsDisplayProperties() : void{
+		$lore = ["Line A", "Line B"];
+		$name = "HI";
+		$item = ItemFactory::get(Item::DIAMOND_SWORD);
+		$item->setCustomName($name);
+		$item->setLore($lore);
+		$item = Item::nbtDeserialize($item->nbtSerialize());
+		self::assertTrue($item->getCustomName() === $name);
+		self::assertTrue($item->getLore() === $lore);
+	}
+
 	public function testHasEnchantment() : void{
 		$this->item->addEnchantment(new EnchantmentInstance(Enchantment::EFFICIENCY(), 5));
 		self::assertTrue($this->item->hasEnchantment(Enchantment::EFFICIENCY()));


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Items lose their lores during serialization/deserialization.

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Results of the following tests at commit b5b4133c5d0763284fcd9a0e432b2eb26c4f7114
```php
bool(true) // self::assertTrue($item->getCustomName() === $name);
bool(false) // self::assertTrue($item->getLore() === $lore);
```