### PR TITLE
Load Doxygen Mathjax from https to prevent unsafe scripts error

### DIFF
--- a/doxygen/doxygen.conf
+++ b/doxygen/doxygen.conf
@@ -1565,7 +1565,7 @@ MATHJAX_FORMAT         = HTML-CSS
 # The default value is: https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/.
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
-MATHJAX_RELPATH        = http://cdn.mathjax.org/mathjax/latest
+MATHJAX_RELPATH        = https://cdn.mathjax.org/mathjax/latest
 
 # The MATHJAX_EXTENSIONS tag can be used to specify one or more MathJax
 # extension names that should be enabled during MathJax rendering. For example


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Most browsers will block loading scripts over the http protocol when the site that loads it is served using https.
A warning like this will be displayed and the script will not load:
![image](https://user-images.githubusercontent.com/16354747/61968525-8c1cb880-afd8-11e9-874a-c20d6a15baf4.png)

## Changes
I added a letter

## Tests
https://cdn.mathjax.org/mathjax/latest/MathJax.js does work
