### PR TITLE
Scan load order

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -1207,7 +1207,7 @@ class Server{
 			register_shutdown_function([$this, "crashDump"]);
 
 			$this->pluginManager->loadPlugins($this->pluginPath);
-			$this->enablePlugins(PluginLoadOrder::STARTUP());
+			$this->pluginManager->enablePlugins(PluginLoadOrder::STARTUP());
 
 			foreach((array) $this->getProperty("worlds", []) as $name => $options){
 				if($options === null){
@@ -1256,7 +1256,7 @@ class Server{
 				$this->worldManager->setDefaultWorld($world);
 			}
 
-			$this->enablePlugins(PluginLoadOrder::POSTWORLD());
+			$this->pluginManager->enablePlugins(PluginLoadOrder::POSTWORLD());
 
 			$this->network->registerInterface(new RakLibInterface($this));
 			$this->logger->info($this->getLanguage()->translateString("pocketmine.server.networkStart", [$this->getIp(), $this->getPort()]));
@@ -1495,22 +1495,6 @@ class Server{
 			return $promise;
 		}finally{
 			Timings::$playerNetworkSendCompressTimer->stopTiming();
-		}
-	}
-
-	/**
-	 * @param PluginLoadOrder $type
-	 */
-	public function enablePlugins(PluginLoadOrder $type) : void{
-		foreach($this->pluginManager->getPlugins() as $plugin){
-			if(!$plugin->isEnabled() and $plugin->getDescription()->getOrder()->equals($type)){
-				$this->pluginManager->enablePlugin($plugin);
-			}
-		}
-
-		if($type->equals(PluginLoadOrder::POSTWORLD())){
-			$this->commandMap->registerServerAliases();
-			DefaultPermissions::registerCorePermissions();
 		}
 	}
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -1207,6 +1207,8 @@ class Server{
 			register_shutdown_function([$this, "crashDump"]);
 
 			$this->pluginManager->loadPlugins($this->pluginPath);
+			$this->pluginManager->enablePlugins(PluginLoadOrder::SCAN());
+			$this->pluginManager->loadPlugins($this->pluginPath);
 			$this->pluginManager->enablePlugins(PluginLoadOrder::STARTUP());
 
 			foreach((array) $this->getProperty("worlds", []) as $name => $options){

--- a/src/plugin/PluginLoadOrder.php
+++ b/src/plugin/PluginLoadOrder.php
@@ -30,6 +30,7 @@ use pocketmine\utils\EnumTrait;
  * This must be regenerated whenever enum members are added, removed or changed.
  * @see EnumTrait::_generateMethodAnnotations()
  *
+ * @method static self SCAN()
  * @method static self STARTUP()
  * @method static self POSTWORLD()
  */
@@ -38,6 +39,7 @@ final class PluginLoadOrder{
 
 	protected static function setup() : iterable{
 		return [
+			new self("scan"),
 			new self("startup"),
 			new self("postworld")
 		];

--- a/src/plugin/PluginManager.php
+++ b/src/plugin/PluginManager.php
@@ -430,6 +430,8 @@ class PluginManager{
 	public function enablePlugins(PluginLoadOrder $type) : void{
 		if($this->scanLoaded){
 			$this->scanEnabled = true;
+		}elseif($type->equals(PluginLoadOrder::SCAN())){
+			$this->scanLoaded = true;
 		}
 
 		foreach($this->plugins as $plugin){

--- a/src/plugin/PluginManager.php
+++ b/src/plugin/PluginManager.php
@@ -31,6 +31,7 @@ use pocketmine\event\plugin\PluginDisableEvent;
 use pocketmine\event\plugin\PluginEnableEvent;
 use pocketmine\event\RegisteredListener;
 use pocketmine\network\mcpe\protocol\ProtocolInfo;
+use pocketmine\permission\DefaultPermissions;
 use pocketmine\permission\PermissionManager;
 use pocketmine\Server;
 use pocketmine\timings\TimingsHandler;
@@ -418,6 +419,22 @@ class PluginManager{
 	 */
 	public function isPluginEnabled(Plugin $plugin) : bool{
 		return isset($this->plugins[$plugin->getDescription()->getName()]) and $plugin->isEnabled();
+	}
+
+	/**
+	 * @param PluginLoadOrder $type
+	 */
+	public function enablePlugins(PluginLoadOrder $type) : void{
+		foreach($this->plugins as $plugin){
+			if(!$plugin->isEnabled() and $plugin->getDescription()->getOrder()->equals($type)){
+				$this->enablePlugin($plugin);
+			}
+		}
+
+		if($type->equals(PluginLoadOrder::POSTWORLD())){
+			$this->server->getCommandMap()->registerServerAliases();
+			DefaultPermissions::registerCorePermissions();
+		}
 	}
 
 	/**

--- a/src/plugin/PluginManager.php
+++ b/src/plugin/PluginManager.php
@@ -199,11 +199,10 @@ class PluginManager{
 
 	/**
 	 * @param string $directory
-	 * @param array  $newLoaders
 	 *
 	 * @return Plugin[]
 	 */
-	public function loadPlugins(string $directory, ?array $newLoaders = null) : array{
+	public function loadPlugins(string $directory) : array{
 		if(!is_dir($directory)){
 			return [];
 		}
@@ -212,16 +211,9 @@ class PluginManager{
 		$loadedPlugins = [];
 		$dependencies = [];
 		$softDependencies = [];
-		if(is_array($newLoaders)){
-			$loaders = [];
-			foreach($newLoaders as $key){
-				if(isset($this->fileAssociations[$key])){
-					$loaders[$key] = $this->fileAssociations[$key];
-				}
-			}
-		}else{
-			$loaders = $this->fileAssociations;
-		}
+
+		$loaders = $this->fileAssociations;
+		$this->fileAssociations = [];
 
 		$files = iterator_to_array(new \FilesystemIterator($directory, \FilesystemIterator::CURRENT_AS_PATHNAME | \FilesystemIterator::SKIP_DOTS));
 		shuffle($files); //this prevents plugins implicitly relying on the filesystem name order when they should be using dependency properties


### PR DESCRIPTION
## Introduction

### Relevant issues
* Resolves #2825

## Changes
### API changes
- Added a `SCAN` load order
- `$newLoaders` parameter in `loadPlugins` is automatically detected based on the time it is called

### Behavioural changes
- `loadPlugins` is automatically called again after `SCAN` order plugins are enabled
- Plugins can no longer be loaded after all the second call to `loadPlugins`.

## Backwards compatibility
Plugins that load plugins need to be updated. Refer to the Changes section above.

## Tests
Not yet tested. Needs a modified version of DevTools to test.