### PR TITLE
remove name change case when looking for an offline player

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -780,7 +780,6 @@ class Server{
 	 * @return OfflinePlayer|Player
 	 */
 	public function getOfflinePlayer(string $name){
-		$name = strtolower($name);
 		$result = $this->getPlayerExact($name);
 
 		if($result === null){


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
OfflinePlayer instances always return a lowercase name rather than the (possibly)mixed case argument.

### Relevant issues
<!-- List relevant issues here -->
N/A
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
N/A
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
OfflinePlayer instances returned by this function can now have mixed case names.
## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Is this considered backwards incompatible?
## Follow-up
N/A
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
```php
$name = "Steve101";
echo $name;
$offlinePlayer = $pluginBase->getServer()->getOfflinePlayer($name);
echo $offlinePlayer->getName();
```
Names should match.
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
