### PR TITLE
Link to StackOverflow in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@
 - [Docker image](https://hub.docker.com/r/pmmp/pocketmine-mp)
 - [Plugin repository](https://poggit.pmmp.io/plugins)
 
-### Discussion
+### Discussion/Help
 - [Forums](https://forums.pmmp.io/)
 - [Community Discord](https://discord.gg/bmSAZBG)
+- [StackOverflow](https://stackoverflow.com/tags/pocketmine)
 
 ### For developers
  * [Latest API documentation](https://jenkins.pmmp.io/job/PocketMine-MP-doc/doxygen/) - Doxygen documentation generated from development


### PR DESCRIPTION
Usres can get PHP-related help better on StackOverflow than from our toxic community that most of the time only says "Learn PHP" and "Learn OOP" and "Learn the PocketMine API" and "Read the docs".