### PR TITLE
Fix grammatical error in support.yml

### DIFF
--- a/.github/support.yml
+++ b/.github/support.yml
@@ -5,7 +5,7 @@ supportLabel: "Support request"
 # Comment to post on issues marked as support requests. Add a link
 # to a support page, or set to `false` to disable
 supportComment: >
-  Thanks, but this issue tracker not intended for support requests.  Please read the guidelines on [submitting an issue](https://github.com/pmmp/PocketMine-MP/blob/master/CONTRIBUTING.md#creating-an-issue).
+  Thanks, but this issue tracker is not intended for support requests.  Please read the guidelines on [submitting an issue](https://github.com/pmmp/PocketMine-MP/blob/master/CONTRIBUTING.md#creating-an-issue).
 
 
   [Docs](https://pmmp.rtfd.io) | [Discord](https://discord.gg/bmSAZBG) | [Forums](https://forums.pmmp.io)

--- a/.github/support.yml
+++ b/.github/support.yml
@@ -5,7 +5,7 @@ supportLabel: "Support request"
 # Comment to post on issues marked as support requests. Add a link
 # to a support page, or set to `false` to disable
 supportComment: >
-  Thanks, but this issue tracker is not intended for support requests.  Please read the guidelines on [submitting an issue](https://github.com/pmmp/PocketMine-MP/blob/master/CONTRIBUTING.md#creating-an-issue).
+  Thanks, but this issue tracker is not intended for support requests. Please read the guidelines on [submitting an issue](https://github.com/pmmp/PocketMine-MP/blob/master/CONTRIBUTING.md#creating-an-issue).
 
 
   [Docs](https://pmmp.rtfd.io) | [Discord](https://discord.gg/bmSAZBG) | [Forums](https://forums.pmmp.io)


### PR DESCRIPTION
Not trying to be a grammar Nazi, but it turns out there was a grammatical error in support.yml ¯\_(ツ)_/¯ (8e1d1993c519511dd08cf67beabd6fd06914b130 was the culprit)