### PR TITLE
added missing setText method for Sign block

### DIFF
--- a/src/block/Sign.php
+++ b/src/block/Sign.php
@@ -143,6 +143,14 @@ class Sign extends Transparent{
 	}
 
 	/**
+	 * @param SignText $text
+	 */
+	public function setText(SignText $text) : void{
+		$this->text = $text;
+		$this->pos->getWorld()->setBlock($this->pos, $this);
+	}
+
+	/**
 	 * Called by the player controller (network session) to update the sign text, firing events as appropriate.
 	 *
 	 * @param Player   $author
@@ -165,8 +173,7 @@ class Sign extends Transparent{
 		}, $text->getLines())));
 		$ev->call();
 		if(!$ev->isCancelled()){
-			$this->text = clone $ev->getNewText();
-			$this->pos->getWorld()->setBlock($this->pos, $this);
+			$this->setText($ev->getNewText());
 			return true;
 		}
 

--- a/src/block/Sign.php
+++ b/src/block/Sign.php
@@ -142,9 +142,6 @@ class Sign extends Transparent{
 		return $this->text;
 	}
 
-	/**
-	 * @param SignText $text
-	 */
 	public function setText(SignText $text) : void{
 		$this->text = $text;
 		$this->pos->getWorld()->setBlock($this->pos, $this);

--- a/src/block/Sign.php
+++ b/src/block/Sign.php
@@ -144,7 +144,6 @@ class Sign extends Transparent{
 
 	public function setText(SignText $text) : void{
 		$this->text = $text;
-		$this->pos->getWorld()->setBlock($this->pos, $this);
 	}
 
 	/**
@@ -171,6 +170,7 @@ class Sign extends Transparent{
 		$ev->call();
 		if(!$ev->isCancelled()){
 			$this->setText($ev->getNewText());
+			$this->pos->getWorld()->setBlock($this->pos, $this);
 			return true;
 		}
 


### PR DESCRIPTION
## Introduction
Now there is no way to change sign text without player. Well, you can only use block entity. However, this is marked as deprecated
