### PR TITLE
Plugin::getLogger() interface no longer depends on PluginLogger

### DIFF
--- a/src/plugin/Plugin.php
+++ b/src/plugin/Plugin.php
@@ -81,9 +81,9 @@ interface Plugin{
 	public function getName() : string;
 
 	/**
-	 * @return PluginLogger
+	 * @return \AttachableLogger
 	 */
-	public function getLogger() : PluginLogger;
+	public function getLogger() : \AttachableLogger;
 
 	/**
 	 * @return PluginLoader

--- a/src/plugin/PluginBase.php
+++ b/src/plugin/PluginBase.php
@@ -163,9 +163,9 @@ abstract class PluginBase implements Plugin, CommandExecutor{
 	}
 
 	/**
-	 * @return PluginLogger
+	 * @return \AttachableLogger
 	 */
-	public function getLogger() : PluginLogger{
+	public function getLogger() : \AttachableLogger{
 		return $this->logger;
 	}
 


### PR DESCRIPTION
## Introduction
This change serves to allow the `pocketmine\plugin\Plugin` interface to be implemented more easily by only depending on the underlying interface it currently relies on –– the `pocketmine\plugin\PluginLogger` class is only an implementation of `\AttachableLogger` and adds no extra functionality.

## Changes
### API changes
`pocketmine\plugin\Plugin::getLogger()` now enforces a return type of `\AttachableLogger` instead of `pocketmine\plugin\PluginLogger`.

### Behavioural changes
None – the type hint has been widened so all existing behavioural should continue to work.

## Backwards compatibility
All classes implementing `pocketmine\plugin\Plugin` will need to change the return type of `getLogger()` from `pocketmine\plugin\PluginLogger` to `\AttachableLogger` (see changes to `pocketmine\plugin\PluginBase`).