### PR TITLE
[4.0.0] Moved some stuff to network namespace

### DIFF
--- a/src/block/tile/Furnace.php
+++ b/src/block/tile/Furnace.php
@@ -202,17 +202,17 @@ class Furnace extends Spawnable implements Container, Nameable{
 
 		if($prevCookTime !== $this->cookTime){
 			foreach($this->inventory->getViewers() as $v){
-				$v->getNetworkSession()->getInvManager()->syncData($this->inventory, ContainerSetDataPacket::PROPERTY_FURNACE_SMELT_PROGRESS, $this->cookTime);
+				$v->getNetworkSession()->getInvManager()->syncFurnaceCookTime($this->inventory, $this->cookTime);
 			}
 		}
 		if($prevRemainingFuelTime !== $this->remainingFuelTime){
 			foreach($this->inventory->getViewers() as $v){
-				$v->getNetworkSession()->getInvManager()->syncData($this->inventory, ContainerSetDataPacket::PROPERTY_FURNACE_REMAINING_FUEL_TIME, $this->remainingFuelTime);
+				$v->getNetworkSession()->getInvManager()->syncFurnaceRemainingFuelTime($this->inventory, $this->remainingFuelTime);
 			}
 		}
 		if($prevMaxFuelTime !== $this->maxFuelTime){
 			foreach($this->inventory->getViewers() as $v){
-				$v->getNetworkSession()->getInvManager()->syncData($this->inventory, ContainerSetDataPacket::PROPERTY_FURNACE_MAX_FUEL_TIME, $this->maxFuelTime);
+				$v->getNetworkSession()->getInvManager()->syncFurnaceMaxFuelTime($this->inventory, $this->maxFuelTime);
 			}
 		}
 

--- a/src/entity/Human.php
+++ b/src/entity/Human.php
@@ -42,12 +42,7 @@ use pocketmine\nbt\tag\IntTag;
 use pocketmine\nbt\tag\ListTag;
 use pocketmine\nbt\tag\StringTag;
 use pocketmine\network\mcpe\protocol\ActorEventPacket;
-use pocketmine\network\mcpe\protocol\AddPlayerPacket;
-use pocketmine\network\mcpe\protocol\PlayerListPacket;
 use pocketmine\network\mcpe\protocol\PlayerSkinPacket;
-use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataProperties;
-use pocketmine\network\mcpe\protocol\types\entity\StringMetadataProperty;
-use pocketmine\network\mcpe\protocol\types\PlayerListEntry;
 use pocketmine\player\Player;
 use pocketmine\utils\Limits;
 use pocketmine\utils\UUID;
@@ -406,30 +401,7 @@ class Human extends Living implements ProjectileSource, InventoryHolder{
 	}
 
 	protected function sendSpawnPacket(Player $player) : void{
-		if(!($this instanceof Player)){
-			$player->getNetworkSession()->sendDataPacket(PlayerListPacket::add([PlayerListEntry::createAdditionEntry($this->uuid, $this->id, $this->getName(), $this->skin)]));
-		}
-
-		$pk = new AddPlayerPacket();
-		$pk->uuid = $this->getUniqueId();
-		$pk->username = $this->getName();
-		$pk->entityRuntimeId = $this->getId();
-		$pk->position = $this->location->asVector3();
-		$pk->motion = $this->getMotion();
-		$pk->yaw = $this->location->yaw;
-		$pk->pitch = $this->location->pitch;
-		$pk->item = $this->getInventory()->getItemInHand();
-		$pk->metadata = $this->getSyncedNetworkData(false);
-		$player->getNetworkSession()->sendDataPacket($pk);
-
-		//TODO: Hack for MCPE 1.2.13: DATA_NAMETAG is useless in AddPlayerPacket, so it has to be sent separately
-		$this->sendData($player, [EntityMetadataProperties::NAMETAG => new StringMetadataProperty($this->getNameTag())]);
-
-		$player->getNetworkSession()->onMobArmorChange($this);
-
-		if(!($this instanceof Player)){
-			$player->getNetworkSession()->sendDataPacket(PlayerListPacket::remove([PlayerListEntry::createRemovalEntry($this->uuid)]));
-		}
+		$player->getNetworkSession()->onHumanSpawned($this);
 	}
 
 	protected function onDispose() : void{

--- a/src/entity/object/ItemEntity.php
+++ b/src/entity/object/ItemEntity.php
@@ -29,7 +29,6 @@ use pocketmine\event\entity\ItemSpawnEvent;
 use pocketmine\event\inventory\InventoryPickupItemEvent;
 use pocketmine\item\Item;
 use pocketmine\nbt\tag\CompoundTag;
-use pocketmine\network\mcpe\protocol\AddItemActorPacket;
 use pocketmine\network\mcpe\protocol\TakeItemActorPacket;
 use pocketmine\network\mcpe\protocol\types\entity\EntityLegacyIds;
 use pocketmine\player\Player;
@@ -233,14 +232,7 @@ class ItemEntity extends Entity{
 	}
 
 	protected function sendSpawnPacket(Player $player) : void{
-		$pk = new AddItemActorPacket();
-		$pk->entityRuntimeId = $this->getId();
-		$pk->position = $this->location->asVector3();
-		$pk->motion = $this->getMotion();
-		$pk->item = $this->getItem();
-		$pk->metadata = $this->getSyncedNetworkData(false);
-
-		$player->getNetworkSession()->sendDataPacket($pk);
+		$player->getNetworkSession()->onItemEntitySpawned($this);
 	}
 
 	public function onCollideWithPlayer(Player $player) : void{

--- a/src/entity/object/Painting.php
+++ b/src/entity/object/Painting.php
@@ -32,7 +32,6 @@ use pocketmine\math\Facing;
 use pocketmine\math\Vector3;
 use pocketmine\nbt\tag\ByteTag;
 use pocketmine\nbt\tag\CompoundTag;
-use pocketmine\network\mcpe\protocol\AddPaintingPacket;
 use pocketmine\network\mcpe\protocol\types\entity\EntityLegacyIds;
 use pocketmine\player\Player;
 use pocketmine\world\particle\DestroyBlockParticle;
@@ -42,13 +41,19 @@ use function ceil;
 class Painting extends Entity{
 	public const NETWORK_ID = EntityLegacyIds::PAINTING;
 
-	private const DATA_TO_FACING = [
+	/**
+	 * @internal
+	 */
+	public const DATA_TO_FACING = [
 		0 => Facing::SOUTH,
 		1 => Facing::WEST,
 		2 => Facing::NORTH,
 		3 => Facing::EAST
 	];
-	private const FACING_TO_DATA = [
+	/**
+	 * @internal
+	 */
+	public const FACING_TO_DATA = [
 		Facing::SOUTH => 0,
 		Facing::WEST => 1,
 		Facing::NORTH => 2,
@@ -149,17 +154,7 @@ class Painting extends Entity{
 	}
 
 	protected function sendSpawnPacket(Player $player) : void{
-		$pk = new AddPaintingPacket();
-		$pk->entityRuntimeId = $this->getId();
-		$pk->position = new Vector3(
-			($this->boundingBox->minX + $this->boundingBox->maxX) / 2,
-			($this->boundingBox->minY + $this->boundingBox->maxY) / 2,
-			($this->boundingBox->minZ + $this->boundingBox->maxZ) / 2
-		);
-		$pk->direction = self::FACING_TO_DATA[$this->facing];
-		$pk->title = $this->motive;
-
-		$player->getNetworkSession()->sendDataPacket($pk);
+		$player->getNetworkSession()->onPaintingSpawned($this);
 	}
 
 	/**

--- a/src/network/mcpe/InventoryManager.php
+++ b/src/network/mcpe/InventoryManager.php
@@ -164,4 +164,25 @@ class InventoryManager{
 
 		$this->session->sendDataPacket(InventoryContentPacket::create(ContainerIds::CREATIVE, $items));
 	}
+
+	public function syncFurnaceCookTime(FurnaceInventory $inventory, int $value) : void{
+		$windowId = $this->getWindowId($inventory);
+		if($windowId !== null){
+			$this->session->sendDataPacket(ContainerSetDataPacket::create($windowId, ContainerSetDataPacket::PROPERTY_FURNACE_SMELT_PROGRESS, $value));
+		}
+	}
+
+	public function syncFurnaceRemainingFuelTime(FurnaceInventory $inventory, int $value) : void{
+		$windowId = $this->getWindowId($inventory);
+		if($windowId !== null){
+			$this->session->sendDataPacket(ContainerSetDataPacket::create($windowId, ContainerSetDataPacket::PROPERTY_FURNACE_REMAINING_FUEL_TIME, $value));
+		}
+	}
+
+	public function syncFurnaceMaxFuelTime(FurnaceInventory $inventory, int $value) : void{
+		$windowId = $this->getWindowId($inventory);
+		if($windowId !== null){
+			$this->session->sendDataPacket(ContainerSetDataPacket::create($windowId, ContainerSetDataPacket::PROPERTY_FURNACE_MAX_FUEL_TIME, $value));
+		}
+	}
 }

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -85,7 +85,6 @@ use pocketmine\network\mcpe\protocol\ActorEventPacket;
 use pocketmine\network\mcpe\protocol\AnimatePacket;
 use pocketmine\network\mcpe\protocol\LevelEventPacket;
 use pocketmine\network\mcpe\protocol\MovePlayerPacket;
-use pocketmine\network\mcpe\protocol\SetTitlePacket;
 use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataFlags;
 use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataProperties;
 use pocketmine\network\mcpe\protocol\types\entity\PlayerMetadataFlags;
@@ -1900,7 +1899,7 @@ class Player extends Human implements CommandSender, ChunkLoader, ChunkListener,
 		if($subtitle !== ""){
 			$this->sendSubTitle($subtitle);
 		}
-		$this->networkSession->sendDataPacket(SetTitlePacket::title($title));
+		$this->networkSession->onTitle($title);
 	}
 
 	/**
@@ -1909,7 +1908,7 @@ class Player extends Human implements CommandSender, ChunkLoader, ChunkListener,
 	 * @param string $subtitle
 	 */
 	public function sendSubTitle(string $subtitle) : void{
-		$this->networkSession->sendDataPacket(SetTitlePacket::subtitle($subtitle));
+		$this->networkSession->onSubTitle($subtitle);
 	}
 
 	/**
@@ -1918,21 +1917,21 @@ class Player extends Human implements CommandSender, ChunkLoader, ChunkListener,
 	 * @param string $message
 	 */
 	public function sendActionBarMessage(string $message) : void{
-		$this->networkSession->sendDataPacket(SetTitlePacket::actionBarMessage($message));
+		$this->networkSession->onActionBar($message);
 	}
 
 	/**
 	 * Removes the title from the client's screen.
 	 */
 	public function removeTitles(){
-		$this->networkSession->sendDataPacket(SetTitlePacket::clearTitle());
+		$this->networkSession->onRemoveTitles();
 	}
 
 	/**
 	 * Resets the title duration settings to defaults and removes any existing titles.
 	 */
 	public function resetTitles(){
-		$this->networkSession->sendDataPacket(SetTitlePacket::resetTitleOptions());
+		$this->networkSession->onResetTitles();
 	}
 
 	/**
@@ -1944,7 +1943,7 @@ class Player extends Human implements CommandSender, ChunkLoader, ChunkListener,
 	 */
 	public function setTitleDuration(int $fadeIn, int $stay, int $fadeOut){
 		if($fadeIn >= 0 and $stay >= 0 and $fadeOut >= 0){
-			$this->networkSession->sendDataPacket(SetTitlePacket::setAnimationTimes($fadeIn, $stay, $fadeOut));
+			$this->networkSession->onTitleDuration($fadeIn, $stay, $fadeOut);
 		}
 	}
 


### PR DESCRIPTION
## Introduction
Moved entity spawning and some other stuff to ``network`` namespace. It will be useful in the future, when there will be a universal (independent from MCPE) ``NetworkSession`` interface or something like that.

### Relevant issues

## Changes
### API changes
- A bunch of new methods in ``network\mcpe\NetworkSession``.
- ``Entity::getSyncedNetworkData()`` and ``Painting`` data conversion constants are now ``public``, but marked as ``@internal``.

### Behavioural changes

## Backwards compatibility

## Follow-up

## Tests
- Spawn entities, drop items, place paintings, join from another device and test behaviour of player spawning, try to melt or cook something in a furnace.
- Everything works finely, just as it did before these changes.
