### PR TITLE
[4.0.0] Moved SetTitlePacket usage to NetworkSession

### DIFF
--- a/src/network/mcpe/NetworkSession.php
+++ b/src/network/mcpe/NetworkSession.php
@@ -64,6 +64,7 @@ use pocketmine\network\mcpe\protocol\ServerboundPacket;
 use pocketmine\network\mcpe\protocol\ServerToClientHandshakePacket;
 use pocketmine\network\mcpe\protocol\SetPlayerGameTypePacket;
 use pocketmine\network\mcpe\protocol\SetSpawnPositionPacket;
+use pocketmine\network\mcpe\protocol\SetTitlePacket;
 use pocketmine\network\mcpe\protocol\TextPacket;
 use pocketmine\network\mcpe\protocol\TransferPacket;
 use pocketmine\network\mcpe\protocol\types\command\CommandData;
@@ -841,6 +842,30 @@ class NetworkSession{
 		if($p !== $this->player){
 			$this->sendDataPacket(PlayerListPacket::remove([PlayerListEntry::createRemovalEntry($p->getUniqueId())]));
 		}
+	}
+
+	public function onTitle(string $title) : void{
+		$this->sendDataPacket(SetTitlePacket::title($title));
+	}
+
+	public function onSubTitle(string $subtitle) : void{
+		$this->sendDataPacket(SetTitlePacket::subtitle($subtitle));
+	}
+
+	public function onActionBar(string $actionBar) : void{
+		$this->sendDataPacket(SetTitlePacket::actionBarMessage($actionBar));
+	}
+
+	public function onClearTitle() : void{
+		$this->sendDataPacket(SetTitlePacket::clearTitle());
+	}
+
+	public function onResetTitleOptions() : void{
+		$this->sendDataPacket(SetTitlePacket::resetTitleOptions());
+	}
+
+	public function onTitleDuration(int $fadeIn, int $stay, int $fadeOut) : void{
+		$this->sendDataPacket(SetTitlePacket::setAnimationTimes($fadeIn, $stay, $fadeOut));
 	}
 
 	public function tick() : bool{

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -85,7 +85,6 @@ use pocketmine\network\mcpe\protocol\ActorEventPacket;
 use pocketmine\network\mcpe\protocol\AnimatePacket;
 use pocketmine\network\mcpe\protocol\LevelEventPacket;
 use pocketmine\network\mcpe\protocol\MovePlayerPacket;
-use pocketmine\network\mcpe\protocol\SetTitlePacket;
 use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataFlags;
 use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataProperties;
 use pocketmine\network\mcpe\protocol\types\entity\PlayerMetadataFlags;

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1900,7 +1900,7 @@ class Player extends Human implements CommandSender, ChunkLoader, ChunkListener,
 		if($subtitle !== ""){
 			$this->sendSubTitle($subtitle);
 		}
-		$this->networkSession->sendDataPacket(SetTitlePacket::title($title));
+		$this->networkSession->onTitle($title);
 	}
 
 	/**
@@ -1909,7 +1909,7 @@ class Player extends Human implements CommandSender, ChunkLoader, ChunkListener,
 	 * @param string $subtitle
 	 */
 	public function sendSubTitle(string $subtitle) : void{
-		$this->networkSession->sendDataPacket(SetTitlePacket::subtitle($subtitle));
+		$this->networkSession->onSubTitle($subtitle);
 	}
 
 	/**
@@ -1918,21 +1918,21 @@ class Player extends Human implements CommandSender, ChunkLoader, ChunkListener,
 	 * @param string $message
 	 */
 	public function sendActionBarMessage(string $message) : void{
-		$this->networkSession->sendDataPacket(SetTitlePacket::actionBarMessage($message));
+		$this->networkSession->onActionBar($message);
 	}
 
 	/**
 	 * Removes the title from the client's screen.
 	 */
 	public function removeTitles(){
-		$this->networkSession->sendDataPacket(SetTitlePacket::clearTitle());
+		$this->networkSession->onClearTitle();
 	}
 
 	/**
 	 * Resets the title duration settings to defaults and removes any existing titles.
 	 */
 	public function resetTitles(){
-		$this->networkSession->sendDataPacket(SetTitlePacket::resetTitleOptions());
+		$this->networkSession->onResetTitleOptions();
 	}
 
 	/**
@@ -1944,7 +1944,7 @@ class Player extends Human implements CommandSender, ChunkLoader, ChunkListener,
 	 */
 	public function setTitleDuration(int $fadeIn, int $stay, int $fadeOut){
 		if($fadeIn >= 0 and $stay >= 0 and $fadeOut >= 0){
-			$this->networkSession->sendDataPacket(SetTitlePacket::setAnimationTimes($fadeIn, $stay, $fadeOut));
+			$this->networkSession->onTitleDuration($fadeIn, $stay, $fadeOut);
 		}
 	}
 


### PR DESCRIPTION
## Introduction
Moved usage of ``SetTitlePacket`` out of ``Player`` class. This is a part of network refactor.
### Relevant issues

## Changes
### API changes
- New methods in ``NetworkSession``: ``onTitle(string $title) : void``, ``onSubTitle(string $subtitle) : void``, ``onActionBar(string $actionBar) : void``, ``onClearTitle() : void``, ``onResetTitleOptions() : void``, ``onTitleDuration(int $fadeIn, int $stay, int $fadeOut) : void``

### Behavioural changes

## Backwards compatibility

## Follow-up


## Tests
- Use ``/title`` command to test everything related to titles.
- Everything works as it worked before changes were made.
