### PR TITLE
bump phpstan to level 2 to see what catches fire

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,7 @@
 
 
 parameters:
-	level: 1
+	level: 2
 	autoload_files:
 		- tests/phpstan/bootstrap.php
 		- src/pocketmine/PocketMine.php


### PR DESCRIPTION
## Introduction
Some inspections are not enabled until level 2 (such as undefined field inspection) and I don't have the patience to enable those rules manually.

### Relevant issues
Failure to detect use of undefined fields in #3183 .

## Tests
The CI is doing its job as I write this.