### PR TITLE
Remove usages of empty()

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -741,7 +741,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 			$data->overloads[0][0] = $parameter;
 
 			$aliases = $command->getAliases();
-			if(!empty($aliases)){
+			if(count($aliases) > 0){
 				if(!in_array($data->commandName, $aliases, true)){
 					//work around a client bug which makes the original name not show when aliases are used
 					$aliases[] = $data->commandName;
@@ -1208,7 +1208,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		}
 
 		$this->loadQueue = $newOrder;
-		if(!empty($this->loadQueue) or !empty($unloadChunks)){
+		if(count($this->loadQueue) > 0 or count($unloadChunks) > 0){
 			$pk = new NetworkChunkPublisherUpdatePacket();
 			$pk->x = $this->getFloorX();
 			$pk->y = $this->getFloorY();

--- a/src/pocketmine/PocketMine.php
+++ b/src/pocketmine/PocketMine.php
@@ -140,7 +140,7 @@ namespace pocketmine {
 	}
 
 	function server(){
-		if(!empty($messages = check_platform_dependencies())){
+		if(count($messages = check_platform_dependencies()) > 0){
 			echo PHP_EOL;
 			$binary = version_compare(PHP_VERSION, "5.4") >= 0 ? PHP_BINARY : "unknown";
 			critical_error("Selected PHP binary ($binary) does not satisfy some requirements.");

--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -1212,9 +1212,9 @@ class Server{
 		}
 		$path = $this->getDataPath() . "worlds/" . $name . "/";
 		if(!($this->getLevelByName($name) instanceof Level)){
-			return is_dir($path) and !empty(array_filter(scandir($path, SCANDIR_SORT_NONE), function($v){
+			return is_dir($path) and count(array_filter(scandir($path, SCANDIR_SORT_NONE), function($v){
 				return $v !== ".." and $v !== ".";
-			}));
+			})) > 0;
 		}
 
 		return true;
@@ -1928,14 +1928,14 @@ class Server{
 	 * @param bool         $immediate
 	 */
 	public function batchPackets(array $players, array $packets, bool $forceSync = false, bool $immediate = false){
-		if(empty($packets)){
+		if(count($packets) === 0){
 			throw new \InvalidArgumentException("Cannot send empty batch");
 		}
 		Timings::$playerNetworkTimer->startTiming();
 
 		$targets = array_filter($players, function(Player $player) : bool{ return $player->isConnected(); });
 
-		if(!empty($targets)){
+		if(count($targets) > 0){
 			$pk = new BatchPacket();
 
 			foreach($packets as $p){

--- a/src/pocketmine/block/Block.php
+++ b/src/pocketmine/block/Block.php
@@ -40,6 +40,7 @@ use pocketmine\network\mcpe\protocol\types\RuntimeBlockMapping;
 use pocketmine\Player;
 use pocketmine\plugin\Plugin;
 use function array_merge;
+use function count;
 use function get_class;
 use const PHP_INT_MAX;
 
@@ -727,7 +728,7 @@ class Block extends Position implements BlockIds, Metadatable{
 	 */
 	public function calculateIntercept(Vector3 $pos1, Vector3 $pos2) : ?RayTraceResult{
 		$bbs = $this->getCollisionBoxes();
-		if(empty($bbs)){
+		if(count($bbs) === 0){
 			return null;
 		}
 

--- a/src/pocketmine/block/Fence.php
+++ b/src/pocketmine/block/Fence.php
@@ -25,6 +25,7 @@ namespace pocketmine\block;
 
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Vector3;
+use function count;
 
 abstract class Fence extends Transparent{
 
@@ -85,7 +86,7 @@ abstract class Fence extends Transparent{
 			);
 		}
 
-		if(empty($bbs)){
+		if(count($bbs) === 0){
 			//centre post AABB (only needed if not connected on any axis - other BBs overlapping will do this if any connections are made)
 			return [
 				new AxisAlignedBB(

--- a/src/pocketmine/block/Thin.php
+++ b/src/pocketmine/block/Thin.php
@@ -25,6 +25,7 @@ namespace pocketmine\block;
 
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Vector3;
+use function count;
 
 abstract class Thin extends Transparent{
 
@@ -77,7 +78,7 @@ abstract class Thin extends Transparent{
 			);
 		}
 
-		if(empty($bbs)){
+		if(count($bbs) === 0){
 			//centre post AABB (only needed if not connected on any axis - other BBs overlapping will do this if any connections are made)
 			return [
 				new AxisAlignedBB(

--- a/src/pocketmine/command/SimpleCommandMap.php
+++ b/src/pocketmine/command/SimpleCommandMap.php
@@ -328,12 +328,12 @@ class SimpleCommandMap implements CommandMap{
 				}
 			}
 
-			if(!empty($recursive)){
+			if(count($recursive) > 0){
 				$this->server->getLogger()->warning($this->server->getLanguage()->translateString("pocketmine.command.alias.recursive", [$alias, implode(", ", $recursive)]));
 				continue;
 			}
 
-			if(!empty($bad)){
+			if(count($bad) > 0){
 				$this->server->getLogger()->warning($this->server->getLanguage()->translateString("pocketmine.command.alias.notFound", [$alias, implode(", ", $bad)]));
 				continue;
 			}

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -1102,7 +1102,7 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 		$this->justCreated = false;
 
 		$changedProperties = $this->propertyManager->getDirty();
-		if(!empty($changedProperties)){
+		if(count($changedProperties) > 0){
 			$this->sendData($this->hasSpawned, $changedProperties);
 			$this->propertyManager->clearDirtyProperties();
 		}

--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -61,6 +61,7 @@ use function array_merge;
 use function array_rand;
 use function array_values;
 use function ceil;
+use function count;
 use function in_array;
 use function max;
 use function min;
@@ -554,7 +555,7 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 			}
 		}
 
-		if(!empty($equipment)){
+		if(count($equipment) > 0){
 			$repairItem = $equipment[$k = array_rand($equipment)];
 			if($repairItem->getDamage() > 0){
 				$repairAmount = min($repairItem->getDamage(), $xpValue * 2);

--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -263,7 +263,7 @@ abstract class Living extends Entity implements Damageable{
 	 * @return bool
 	 */
 	public function hasEffects() : bool{
-		return !empty($this->effects);
+		return count($this->effects) > 0;
 	}
 
 	/**
@@ -332,7 +332,7 @@ abstract class Living extends Entity implements Damageable{
 			}
 		}
 
-		if(!empty($colors)){
+		if(count($colors) > 0){
 			$this->propertyManager->setInt(Entity::DATA_POTION_COLOR, Color::mix(...$colors)->toARGB());
 			$this->propertyManager->setByte(Entity::DATA_POTION_AMBIENT, $ambient ? 1 : 0);
 		}else{
@@ -713,7 +713,7 @@ abstract class Living extends Entity implements Damageable{
 			}
 		}
 
-		return !empty($this->effects);
+		return count($this->effects) > 0;
 	}
 
 	/**
@@ -893,7 +893,7 @@ abstract class Living extends Entity implements Damageable{
 	 */
 	public function getTargetBlock(int $maxDistance, array $transparent = []) : ?Block{
 		$line = $this->getLineOfSight($maxDistance, 1, $transparent);
-		if(!empty($line)){
+		if(count($line) > 0){
 			return array_shift($line);
 		}
 

--- a/src/pocketmine/entity/projectile/SplashPotion.php
+++ b/src/pocketmine/entity/projectile/SplashPotion.php
@@ -34,6 +34,7 @@ use pocketmine\item\Potion;
 use pocketmine\network\mcpe\protocol\LevelEventPacket;
 use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
 use pocketmine\utils\Color;
+use function count;
 use function round;
 use function sqrt;
 
@@ -63,7 +64,7 @@ class SplashPotion extends Throwable{
 		$effects = $this->getPotionEffects();
 		$hasEffects = true;
 
-		if(empty($effects)){
+		if(count($effects) === 0){
 			$colors = [
 				new Color(0x38, 0x5d, 0xc6) //Default colour for splash water bottle and similar with no effects.
 			];

--- a/src/pocketmine/inventory/ShapelessRecipe.php
+++ b/src/pocketmine/inventory/ShapelessRecipe.php
@@ -135,6 +135,6 @@ class ShapelessRecipe implements CraftingRecipe{
 			return false; //failed to match the needed item to a given item
 		}
 
-		return empty($input); //crafting grid should be empty apart from the given ingredient stacks
+		return count($input) === 0; //crafting grid should be empty apart from the given ingredient stacks
 	}
 }

--- a/src/pocketmine/inventory/transaction/CraftingTransaction.php
+++ b/src/pocketmine/inventory/transaction/CraftingTransaction.php
@@ -68,14 +68,14 @@ class CraftingTransaction extends InventoryTransaction{
 	 * @throws TransactionValidationException
 	 */
 	protected function matchRecipeItems(array $txItems, array $recipeItems, bool $wildcards, int $iterations = 0) : int{
-		if(empty($recipeItems)){
+		if(count($recipeItems) === 0){
 			throw new TransactionValidationException("No recipe items given");
 		}
-		if(empty($txItems)){
+		if(count($txItems) === 0){
 			throw new TransactionValidationException("No transaction items given");
 		}
 
-		while(!empty($recipeItems)){
+		while(count($recipeItems) > 0){
 			/** @var Item $recipeItem */
 			$recipeItem = array_pop($recipeItems);
 			$needCount = $recipeItem->getCount();
@@ -114,7 +114,7 @@ class CraftingTransaction extends InventoryTransaction{
 		if($iterations < 1){
 			throw new TransactionValidationException("Tried to craft zero times");
 		}
-		if(!empty($txItems)){
+		if(count($txItems) > 0){
 			//all items should be destroyed in this process
 			throw new TransactionValidationException("Expected 0 ingredients left over, have " . count($txItems));
 		}

--- a/src/pocketmine/inventory/transaction/InventoryTransaction.php
+++ b/src/pocketmine/inventory/transaction/InventoryTransaction.php
@@ -237,13 +237,13 @@ class InventoryTransaction{
 	 * @return null|Item
 	 */
 	protected function findResultItem(Item $needOrigin, array $possibleActions) : ?Item{
-		assert(!empty($possibleActions));
+		assert(count($possibleActions) > 0);
 
 		foreach($possibleActions as $i => $action){
 			if($action->getSourceItem()->equalsExact($needOrigin)){
 				$newList = $possibleActions;
 				unset($newList[$i]);
-				if(empty($newList)){
+				if(count($newList) === 0){
 					return $action->getTargetItem();
 				}
 				$result = $this->findResultItem($action->getTargetItem(), $newList);

--- a/src/pocketmine/item/PaintingItem.php
+++ b/src/pocketmine/item/PaintingItem.php
@@ -31,6 +31,7 @@ use pocketmine\math\Vector3;
 use pocketmine\network\mcpe\protocol\LevelEventPacket;
 use pocketmine\Player;
 use function array_rand;
+use function count;
 
 class PaintingItem extends Item{
 	public function __construct(int $meta = 0){
@@ -66,7 +67,7 @@ class PaintingItem extends Item{
 			}
 		}
 
-		if(empty($motives)){ //No space available
+		if(count($motives) === 0){ //No space available
 			return false;
 		}
 

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -503,7 +503,7 @@ class Level implements ChunkManager, Metadatable{
 		if(!is_array($pk)){
 			$pk = [$pk];
 		}
-		if(!empty($pk)){
+		if(count($pk) > 0){
 			if($players === null){
 				foreach($pk as $e){
 					$this->broadcastPacketToViewers($sound, $e);
@@ -519,7 +519,7 @@ class Level implements ChunkManager, Metadatable{
 		if(!is_array($pk)){
 			$pk = [$pk];
 		}
-		if(!empty($pk)){
+		if(count($pk) > 0){
 			if($players === null){
 				foreach($pk as $e){
 					$this->broadcastPacketToViewers($particle, $e);
@@ -881,7 +881,7 @@ class Level implements ChunkManager, Metadatable{
 		if(count($this->changedBlocks) > 0){
 			if(count($this->players) > 0){
 				foreach($this->changedBlocks as $index => $blocks){
-					if(empty($blocks)){ //blocks can be set normally and then later re-set with direct send
+					if(count($blocks) === 0){ //blocks can be set normally and then later re-set with direct send
 						continue;
 					}
 					unset($this->chunkCache[$index]);
@@ -909,8 +909,8 @@ class Level implements ChunkManager, Metadatable{
 			$this->checkSleep();
 		}
 
-		if(!empty($this->globalPackets)){
-			if(!empty($this->players)){
+		if(count($this->globalPackets) > 0){
+			if(count($this->players) > 0){
 				$this->server->batchPackets($this->players, $this->globalPackets);
 			}
 			$this->globalPackets = [];
@@ -1845,7 +1845,7 @@ class Level implements ChunkManager, Metadatable{
 
 		$item->onDestroyBlock($target);
 
-		if(!empty($drops)){
+		if(count($drops) > 0){
 			$dropPos = $target->add(0.5, 0.5, 0.5);
 			foreach($drops as $drop){
 				if(!$drop->isNull()){
@@ -1949,7 +1949,7 @@ class Level implements ChunkManager, Metadatable{
 
 		if($hand->isSolid()){
 			foreach($hand->getCollisionBoxes() as $collisionBox){
-				if(!empty($this->getCollidingEntities($collisionBox))){
+				if(count($this->getCollidingEntities($collisionBox)) > 0){
 					return false;  //Entity in block
 				}
 

--- a/src/pocketmine/level/format/io/leveldb/LevelDB.php
+++ b/src/pocketmine/level/format/io/leveldb/LevelDB.php
@@ -45,6 +45,7 @@ use pocketmine\utils\Binary;
 use pocketmine\utils\BinaryStream;
 use function array_values;
 use function chr;
+use function count;
 use function defined;
 use function explode;
 use function extension_loaded;
@@ -519,7 +520,7 @@ class LevelDB extends BaseLevelProvider{
 	 * @param string        $index
 	 */
 	private function writeTags(array $targets, string $index){
-		if(!empty($targets)){
+		if(count($targets) > 0){
 			$nbt = new LittleEndianNBTStream();
 			$this->db->put($index, $nbt->write($targets));
 		}else{

--- a/src/pocketmine/permission/BanEntry.php
+++ b/src/pocketmine/permission/BanEntry.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace pocketmine\permission;
 
 use function array_shift;
+use function count;
 use function explode;
 use function implode;
 use function strlen;
@@ -161,17 +162,17 @@ class BanEntry{
 			$str = explode("|", trim($str));
 			$entry = new BanEntry(trim(array_shift($str)));
 			do{
-				if(empty($str)){
+				if(count($str) === 0){
 					break;
 				}
 
 				$entry->setCreated(self::parseDate(array_shift($str)));
-				if(empty($str)){
+				if(count($str) === 0){
 					break;
 				}
 
 				$entry->setSource(trim(array_shift($str)));
-				if(empty($str)){
+				if(count($str) === 0){
 					break;
 				}
 
@@ -179,7 +180,7 @@ class BanEntry{
 				if($expire !== "" and strtolower($expire) !== "forever"){
 					$entry->setExpires(self::parseDate($expire));
 				}
-				if(empty($str)){
+				if(count($str) === 0){
 					break;
 				}
 

--- a/src/pocketmine/permission/PermissionManager.php
+++ b/src/pocketmine/permission/PermissionManager.php
@@ -168,7 +168,7 @@ class PermissionManager{
 	public function unsubscribeFromAllPermissions(Permissible $permissible) : void{
 		foreach($this->permSubs as $permission => &$subs){
 			unset($subs[spl_object_hash($permissible)]);
-			if(empty($subs)){
+			if(count($subs) === 0){
 				unset($this->permSubs[$permission]);
 			}
 		}

--- a/src/pocketmine/tile/Furnace.php
+++ b/src/pocketmine/tile/Furnace.php
@@ -38,6 +38,7 @@ use pocketmine\level\Level;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\network\mcpe\protocol\ContainerSetDataPacket;
 use function ceil;
+use function count;
 use function max;
 
 class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
@@ -232,7 +233,7 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 			$packets[] = $pk;
 		}
 
-		if(!empty($packets)){
+		if(count($packets) > 0){
 			foreach($this->getInventory()->getViewers() as $player){
 				$windowId = $player->getWindowId($this->getInventory());
 				if($windowId > 0){

--- a/src/pocketmine/utils/Config.php
+++ b/src/pocketmine/utils/Config.php
@@ -420,7 +420,7 @@ class Config{
 		while(count($vars) > 0){
 			$nodeName = array_shift($vars);
 			if(isset($currentNode[$nodeName])){
-				if(empty($vars)){ //final node
+				if(count($vars) === 0){ //final node
 					unset($currentNode[$nodeName]);
 				}elseif(is_array($currentNode[$nodeName])){
 					$currentNode =& $currentNode[$nodeName];

--- a/src/pocketmine/utils/Timezone.php
+++ b/src/pocketmine/utils/Timezone.php
@@ -33,6 +33,7 @@ use function implode;
 use function ini_get;
 use function ini_set;
 use function is_link;
+use function is_string;
 use function json_decode;
 use function parse_ini_file;
 use function preg_match;
@@ -149,7 +150,7 @@ abstract class Timezone{
 				// RHEL / CentOS
 				if(file_exists('/etc/sysconfig/clock')){
 					$data = parse_ini_file('/etc/sysconfig/clock');
-					if(!empty($data['ZONE'])){
+					if(isset($data['ZONE']) and is_string($data['ZONE'])){
 						return trim($data['ZONE']);
 					}
 				}

--- a/src/pocketmine/wizard/SetupWizard.php
+++ b/src/pocketmine/wizard/SetupWizard.php
@@ -33,6 +33,7 @@ use pocketmine\utils\Config;
 use pocketmine\utils\Internet;
 use pocketmine\utils\InternetException;
 use function base64_encode;
+use function count;
 use function fgets;
 use function random_bytes;
 use function sleep;
@@ -59,7 +60,7 @@ class SetupWizard{
 		$this->message(\pocketmine\NAME . " set-up wizard");
 
 		$langs = BaseLang::getLanguageList();
-		if(empty($langs)){
+		if(count($langs) === 0){
 			$this->error("No language files found, please use provided builds or clone the repository recursively.");
 			return false;
 		}

--- a/tests/phpstan/configs/phpstan-bugs.neon
+++ b/tests/phpstan/configs/phpstan-bugs.neon
@@ -59,6 +59,11 @@ parameters:
 			path: ../../../src/pocketmine/plugin/PharPluginLoader.php
 
 		-
+			message: "#^Strict comparison using \\=\\=\\= between int\\<1, max\\> and 0 will always evaluate to false\\.$#"
+			count: 1
+			path: ../../../src/pocketmine/utils/Config.php
+
+		-
 			#ReflectionFunction::getClosureThis() should be nullable
 			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
 			count: 1


### PR DESCRIPTION
## Introduction
`empty()` is evil.

### Relevant issues
closes #3202 

## Tests
This has not been manually tested, but Travis is green.

A new `ignoreErrors` entry was added to `phpstan-bugs.neon` (see https://github.com/phpstan/phpstan/issues/2750).