### PR TITLE
Living: Remove Action not present in vanilla

### DIFF
--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -586,10 +586,7 @@ abstract class Living extends Entity implements Damageable{
 			}
 
 			if($e !== null){
-				if((
-					$source->getCause() === EntityDamageEvent::CAUSE_PROJECTILE or
-					$source->getCause() === EntityDamageEvent::CAUSE_ENTITY_ATTACK
-				) and $e->isOnFire()){
+				if($source->getCause() === EntityDamageEvent::CAUSE_PROJECTILE and $e->isOnFire()){
 					$this->setOnFire(2 * $this->level->getDifficulty());
 				}
 


### PR DESCRIPTION
(I use google translate)
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Vanilla mcpe doesn't have a specification that burns when attacked by a burning entity.

### Relevant issues
<!-- List relevant issues here -->

* Fixes #3170 

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
