### PR TITLE
changed the execution sequence of the getCurrentWindow() function

### DIFF
--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -2468,8 +2468,8 @@ class Player extends Human implements CommandSender, ChunkLoader, ChunkListener,
 		$this->removeCurrentWindow();
 
 		$this->logger->debug("Opening inventory " . get_class($inventory) . "#" . spl_object_id($inventory));
-		$this->networkSession->getInvManager()->onCurrentWindowChange($inventory);
 		$inventory->onOpen($this);
+		$this->networkSession->getInvManager()->onCurrentWindowChange($inventory);
 		$this->currentWindow = $inventory;
 		return true;
 	}


### PR DESCRIPTION
due to the fact that the onCurrentWindowChange() function is faster than $inventory->open($this); what happens is that the actions in onOpen() do not have time to be processed before sending the inventory to the player.

This prevents the implementation of custom inventory.