### PR TITLE
Remove parameter $isAdmin from Player::kick()

### DIFF
--- a/src/command/defaults/BanIpCommand.php
+++ b/src/command/defaults/BanIpCommand.php
@@ -81,7 +81,7 @@ class BanIpCommand extends VanillaCommand{
 
 		foreach($sender->getServer()->getOnlinePlayers() as $player){
 			if($player->getNetworkSession()->getIp() === $ip){
-				$player->kick($reason !== "" ? $reason : "IP banned.");
+				$player->kick($reason !== "" ? "IP banned by admin. Reason: " . $reason : "IP banned by admin.");
 			}
 		}
 

--- a/src/command/defaults/KickCommand.php
+++ b/src/command/defaults/KickCommand.php
@@ -58,7 +58,7 @@ class KickCommand extends VanillaCommand{
 		$reason = trim(implode(" ", $args));
 
 		if(($player = $sender->getServer()->getPlayer($name)) instanceof Player){
-			$player->kick($reason);
+			$player->kick($reason !== "" ? "Kicked by admin. Reason: " . $reason : "");
 			if($reason !== ""){
 				Command::broadcastCommandMessage($sender, new TranslationContainer("commands.kick.success.reason", [$player->getName(), $reason]));
 			}else{

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -2056,28 +2056,17 @@ class Player extends Human implements CommandSender, ChunkLoader, ChunkListener,
 	 * Kicks a player from the server
 	 *
 	 * @param string               $reason
-	 * @param bool                 $isAdmin
 	 * @param TextContainer|string $quitMessage
 	 *
 	 * @return bool
 	 */
-	public function kick(string $reason = "", bool $isAdmin = true, $quitMessage = null) : bool{
+	public function kick(string $reason = "", $quitMessage = null) : bool{
 		$ev = new PlayerKickEvent($this, $reason, $quitMessage ?? $this->getLeaveMessage());
 		$ev->call();
 		if(!$ev->isCancelled()){
 			$reason = $ev->getReason();
-			$message = $reason;
-			if($isAdmin){
-				if(!$this->isBanned()){
-					$message = "Kicked by admin." . ($reason !== "" ? " Reason: " . $reason : "");
-				}
-			}else{
-				if($reason === ""){
-					$message = "disconnectionScreen.noReason";
-				}
-			}
+			$message = $reason === "" ? "disconnectionScreen.noReason" : $reason;
 			$this->disconnect($message, $ev->getQuitMessage());
-
 			return true;
 		}
 


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
The `$isAdmin` parameter in `Player->kick()` servers not much of a purpose besides further modifying the `$reason` parameter. As by default, the parameter is `true` this could result in a misleading kick message.

Plugins may want to kick players for various other reasons which do not require an admin intervention (eg: anticheat and anti-afk plugins) but the `$isAdmin` parameter is dedicated to serve only the purposes that were resulted by an admin kicking, among the several other purposes.
So the "Kicked by admin." prefix is better handled by the method caller than the method itself.

At the moment, `Player->kick()` is called in 5 places:
```php
BanCommand.php:61:           $player->kick($reason !== "" ? "Banned by admin. Reason: " . $reason : "Banned by admin.");
BanIpCommand.php:84:         $player->kick($reason !== "" ? $reason : "IP banned.");
KickCommand.php:61:          $player->kick($reason);
Player.php:390:              $this->kick("You have been banned");
Player.php:1774:             $this->kick("Attempting to attack an invalid entity");
```
1. The first one, in BanCommand serves no purpose as there's already a "Banned by admin." prefix before the ban reason.
2. The second usage is arguable. Adding a "Banned by admin." over there might be helpful assuming the majority users set a vague ban reason. For example: `/ban-ip player flying` would send the player a disconnect screen with only `flying` displayed. (RFC?)
3. Same as point 2, assuming the majority users `/kick player flying`.
4. Arguable since a ban is most likely the result of an admin intervention. This could be misleading when the server is set to hardcore mode where a player isn't banned as a result of admin intervention.
5. Results in a misleading kick screen as player isn't kicked by an administrator.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Removes optional parameter `$isAdmin` from `Player::kick()`.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
1. The "Kicked by admin." prefix is no longer automatically added when plugins call `Player::kick()`.
2. `/ban-ip` now adds an "IP banned by admin." prefix before the reason instead of displaying only the reason on the disconnect screen when a reason is supplied.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Breaks plugins that supplied more than 1 parameter to `Player::kick()`.
Plugins that would like to maintain the previous behaviour may migrate as follows:

| Before | After |
| --- | --- |
| `$player->kick($reason, false);` | `$player->kick($reason);` |
| `$player->kick($reason, false, $quitMessage);` | `$player->kick($reason, $quitMessage);` |
| `$player->kick($reason, true);` | `$player->kick("Kicked by admin." . ($reason !== "" ? " Reason: " . $reason : ""));` |
| `$player->kick($reason, true, $quitMessage);` | `$player->kick("Kicked by admin." . ($reason !== "" ? " Reason: " . $reason : ""), $quitMessage);` |

## Follow-up
Updating changelog

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Script plugin that tries to kick and ban player by executing commands via console.
https://gist.github.com/Muqsit/645e1e54fc9593416d7fcb5bed29d792