### PR TITLE
Close NetworkSession later in the kick/disconnect sequence

### DIFF
--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -2100,8 +2100,6 @@ class Player extends Human implements CommandSender, ChunkLoader, ChunkListener,
 			return;
 		}
 
-		$this->networkSession->onPlayerDestroyed($reason, $notify);
-
 		//prevent the player receiving their own disconnect message
 		PermissionManager::getInstance()->unsubscribeFromPermission(Server::BROADCAST_CHANNEL_USERS, $this);
 		PermissionManager::getInstance()->unsubscribeFromPermission(Server::BROADCAST_CHANNEL_ADMINISTRATIVE, $this);
@@ -2112,6 +2110,8 @@ class Player extends Human implements CommandSender, ChunkLoader, ChunkListener,
 			$this->server->broadcastMessage($ev->getQuitMessage());
 		}
 		$this->save();
+
+		$this->networkSession->onPlayerDestroyed($reason, $notify);
 
 		$this->spawned = false;
 


### PR DESCRIPTION
## Introduction
When a player is kicked, their NetworkSession is closed too early. If a plugin currently tries modifying data related to their NetworkSession (E.g. Their player inventory) in PlayerQuitEvent and the player was kicked, it causes errors and crashes the server.

### Behavioural changes
NetworkSessions close after PlayerQuitEvent and PlayerDataSaveEvent has been called

## Backwards compatibility
This pull request should not cause any BC breaks

## Tests
### Before this pull request:
 - When a player leaves, their NetworkSession gets closed after PlayerQuitEvent:
![image](https://user-images.githubusercontent.com/30378179/72544402-30443580-387f-11ea-8a54-a82c1364e47f.png)
 - When a player is kicked, their NetworkSession gets closed before PlayerQuitEvent:
![image](https://user-images.githubusercontent.com/30378179/72544413-363a1680-387f-11ea-867e-cbbcccf00fe2.png)
### After this pull request:
 - When a player leaves, their NetworkSession gets closed after PlayerQuitEvent:
![image](https://user-images.githubusercontent.com/30378179/72544607-9761ea00-387f-11ea-92f6-d3754f68ddc3.png)
 - When a player is kicked, their NetworkSession gets closed after PlayerQuitEvent
![image](https://user-images.githubusercontent.com/30378179/72544713-c4160180-387f-11ea-82bf-344070afc32c.png)

### Code used for testing:
```php
<?php
declare(strict_types=1);

use pocketmine\event\Listener;
use pocketmine\event\player\PlayerKickEvent;
use pocketmine\event\player\PlayerQuitEvent;
use pocketmine\plugin\PluginBase;
use var_dump;

class Test extends PluginBase implements Listener{

	protected function onEnable() : void{
		$this->getServer()->getPluginManager()->registerEvents($this, $this);
	}

	public function onPlayerKick(PlayerKickEvent $event) : void{
		var_dump("Player Kick Event");
	}

	public function onPlayerQuit(PlayerQuitEvent $event) : void{
		var_dump("Player Quit Event");
	}
}```
