### PR TITLE
Mass-removal of redundant @param / @return PhpDoc annotations

### DIFF
--- a/src/pocketmine/Achievement.php
+++ b/src/pocketmine/Achievement.php
@@ -106,13 +106,6 @@ abstract class Achievement{
 
 	];
 
-
-	/**
-	 * @param Player $player
-	 * @param string $achievementId
-	 *
-	 * @return bool
-	 */
 	public static function broadcast(Player $player, string $achievementId) : bool{
 		if(isset(Achievement::$list[$achievementId])){
 			$translation = new TranslationContainer("chat.type.achievement", [$player->getDisplayName(), TextFormat::GREEN . Achievement::$list[$achievementId]["name"] . TextFormat::RESET]);
@@ -128,13 +121,6 @@ abstract class Achievement{
 		return false;
 	}
 
-	/**
-	 * @param string $achievementId
-	 * @param string $achievementName
-	 * @param array  $requires
-	 *
-	 * @return bool
-	 */
 	public static function add(string $achievementId, string $achievementName, array $requires = []) : bool{
 		if(!isset(Achievement::$list[$achievementId])){
 			Achievement::$list[$achievementId] = [

--- a/src/pocketmine/IPlayer.php
+++ b/src/pocketmine/IPlayer.php
@@ -27,36 +27,20 @@ use pocketmine\permission\ServerOperator;
 
 interface IPlayer extends ServerOperator{
 
-	/**
-	 * @return bool
-	 */
 	public function isOnline() : bool;
 
-	/**
-	 * @return string
-	 */
 	public function getName() : string;
 
-	/**
-	 * @return bool
-	 */
 	public function isBanned() : bool;
 
 	/**
-	 * @param bool $banned
-	 *
 	 * @return void
 	 */
 	public function setBanned(bool $banned);
 
-	/**
-	 * @return bool
-	 */
 	public function isWhitelisted() : bool;
 
 	/**
-	 * @param bool $value
-	 *
 	 * @return void
 	 */
 	public function setWhitelisted(bool $value);
@@ -76,9 +60,6 @@ interface IPlayer extends ServerOperator{
 	 */
 	public function getLastPlayed();
 
-	/**
-	 * @return bool
-	 */
 	public function hasPlayedBefore() : bool;
 
 }

--- a/src/pocketmine/MemoryManager.php
+++ b/src/pocketmine/MemoryManager.php
@@ -169,26 +169,16 @@ class MemoryManager{
 		gc_enable();
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isLowMemory() : bool{
 		return $this->lowMemory;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function canUseChunkCache() : bool{
 		return !$this->lowMemory or !$this->lowMemDisableChunkCache;
 	}
 
 	/**
 	 * Returns the allowed chunk radius based on the current memory usage.
-	 *
-	 * @param int $distance
-	 *
-	 * @return int
 	 */
 	public function getViewDistance(int $distance) : int{
 		return ($this->lowMemory and $this->lowMemChunkRadiusOverride > 0) ? (int) min($this->lowMemChunkRadiusOverride, $distance) : $distance;
@@ -196,11 +186,6 @@ class MemoryManager{
 
 	/**
 	 * Triggers garbage collection and cache cleanup to try and free memory.
-	 *
-	 * @param int  $memory
-	 * @param int  $limit
-	 * @param bool $global
-	 * @param int  $triggerCount
 	 *
 	 * @return void
 	 */
@@ -272,9 +257,6 @@ class MemoryManager{
 		Timings::$memoryManagerTimer->stopTiming();
 	}
 
-	/**
-	 * @return int
-	 */
 	public function triggerGarbageCollector() : int{
 		Timings::$garbageCollectorTimer->startTiming();
 
@@ -298,10 +280,6 @@ class MemoryManager{
 	/**
 	 * Dumps the server memory into the specified output folder.
 	 *
-	 * @param string $outputFolder
-	 * @param int    $maxNesting
-	 * @param int    $maxStringSize
-	 *
 	 * @return void
 	 */
 	public function dumpServerMemory(string $outputFolder, int $maxNesting, int $maxStringSize){
@@ -320,10 +298,6 @@ class MemoryManager{
 	 * Static memory dumper accessible from any thread.
 	 *
 	 * @param mixed   $startingObject
-	 * @param string  $outputFolder
-	 * @param int     $maxNesting
-	 * @param int     $maxStringSize
-	 * @param \Logger $logger
 	 *
 	 * @return void
 	 * @throws \ReflectionException
@@ -482,9 +456,6 @@ class MemoryManager{
 	 * @param mixed    $data reference parameter
 	 * @param object[] $objects reference parameter
 	 * @param int[]    $refCounts reference parameter
-	 * @param int      $recursion
-	 * @param int      $maxNesting
-	 * @param int      $maxStringSize
 	 */
 	private static function continueDump($from, &$data, array &$objects, array &$refCounts, int $recursion, int $maxNesting, int $maxStringSize) : void{
 		if($maxNesting <= 0){

--- a/src/pocketmine/OfflinePlayer.php
+++ b/src/pocketmine/OfflinePlayer.php
@@ -37,10 +37,6 @@ class OfflinePlayer implements IPlayer, Metadatable{
 	/** @var CompoundTag|null */
 	private $namedtag = null;
 
-	/**
-	 * @param Server $server
-	 * @param string $name
-	 */
 	public function __construct(Server $server, string $name){
 		$this->server = $server;
 		$this->name = $name;

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -218,8 +218,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	 * Validates the given username.
 	 *
 	 * @param string $name
-	 *
-	 * @return bool
 	 */
 	public static function isValidUserName(?string $name) : bool{
 		if($name === null){
@@ -432,8 +430,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	/**
 	 * If the player is logged into Xbox Live, returns their Xbox user ID (XUID) as a string. Returns an empty string if
 	 * the player is not logged into Xbox Live.
-	 *
-	 * @return string
 	 */
 	public function getXuid() : string{
 		return $this->xuid;
@@ -453,8 +449,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	 * (In the olden days this method used to return a fake UUID computed by the server, which was used by plugins such
 	 * as SimpleAuth for authentication. This is NOT SAFE anymore as this UUID is now what was given by the client, NOT
 	 * a server-computed UUID.)
-	 *
-	 * @return UUID|null
 	 */
 	public function getUniqueId() : ?UUID{
 		return parent::getUniqueId();
@@ -477,8 +471,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	/**
-	 * @param bool $value
-	 *
 	 * @return void
 	 */
 	public function setAllowFlight(bool $value){
@@ -491,8 +483,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	/**
-	 * @param bool $value
-	 *
 	 * @return void
 	 */
 	public function setFlying(bool $value){
@@ -508,8 +498,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	/**
-	 * @param bool $value
-	 *
 	 * @return void
 	 */
 	public function setAutoJump(bool $value){
@@ -526,17 +514,12 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	/**
-	 * @param bool $value
-	 *
 	 * @return void
 	 */
 	public function setAllowMovementCheats(bool $value = true){
 		$this->allowMovementCheats = $value;
 	}
 
-	/**
-	 * @param Player $player
-	 */
 	public function spawnTo(Player $player) : void{
 		if($this->spawned and $player->spawned and $this->isAlive() and $player->isAlive() and $player->getLevel() === $this->level and $player->canSee($this) and !$this->isSpectator()){
 			parent::spawnTo($player);
@@ -550,16 +533,11 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		return $this->server;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function getRemoveFormat() : bool{
 		return $this->removeFormat;
 	}
 
 	/**
-	 * @param bool $remove
-	 *
 	 * @return void
 	 */
 	public function setRemoveFormat(bool $remove = true){
@@ -577,18 +555,11 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		$this->lineHeight = $height;
 	}
 
-	/**
-	 * @param Player $player
-	 *
-	 * @return bool
-	 */
 	public function canSee(Player $player) : bool{
 		return !isset($this->hiddenPlayers[$player->getRawUniqueId()]);
 	}
 
 	/**
-	 * @param Player $player
-	 *
 	 * @return void
 	 */
 	public function hidePlayer(Player $player){
@@ -600,8 +571,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	/**
-	 * @param Player $player
-	 *
 	 * @return void
 	 */
 	public function showPlayer(Player $player){
@@ -632,8 +601,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	/**
-	 * @param int $distance
-	 *
 	 * @return void
 	 */
 	public function setViewDistance(int $distance){
@@ -650,23 +617,15 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		$this->server->getLogger()->debug("Setting view distance for " . $this->getName() . " to " . $this->viewDistance . " (requested " . $distance . ")");
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isOnline() : bool{
 		return $this->isConnected() and $this->loggedIn;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isOp() : bool{
 		return $this->server->isOp($this->getName());
 	}
 
 	/**
-	 * @param bool $value
-	 *
 	 * @return void
 	 */
 	public function setOp(bool $value){
@@ -685,8 +644,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 	/**
 	 * @param permission\Permission|string $name
-	 *
-	 * @return bool
 	 */
 	public function isPermissionSet($name) : bool{
 		return $this->perm->isPermissionSet($name);
@@ -694,8 +651,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 	/**
 	 * @param permission\Permission|string $name
-	 *
-	 * @return bool
 	 *
 	 * @throws \InvalidStateException if the player is closed
 	 */
@@ -707,19 +662,14 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	/**
-	 * @param Plugin $plugin
 	 * @param string $name
 	 * @param bool   $value
-	 *
-	 * @return PermissionAttachment
 	 */
 	public function addAttachment(Plugin $plugin, string $name = null, bool $value = null) : PermissionAttachment{
 		return $this->perm->addAttachment($plugin, $name, $value);
 	}
 
 	/**
-	 * @param PermissionAttachment $attachment
-	 *
 	 * @return void
 	 */
 	public function removeAttachment(PermissionAttachment $attachment){
@@ -797,11 +747,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 	}
 
-	/**
-	 * @param SourceInterface $interface
-	 * @param string          $ip
-	 * @param int             $port
-	 */
 	public function __construct(SourceInterface $interface, string $ip, int $port){
 		$this->interface = $interface;
 		$this->perm = new PermissibleBase($this);
@@ -823,40 +768,29 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		$this->sessionAdapter = new PlayerNetworkSessionAdapter($this->server, $this);
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isConnected() : bool{
 		return $this->sessionAdapter !== null;
 	}
 
 	/**
 	 * Gets the username
-	 * @return string
 	 */
 	public function getName() : string{
 		return $this->username;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getLowerCaseName() : string{
 		return $this->iusername;
 	}
 
 	/**
 	 * Returns the "friendly" display name of this player to use in the chat.
-	 *
-	 * @return string
 	 */
 	public function getDisplayName() : string{
 		return $this->displayName;
 	}
 
 	/**
-	 * @param string $name
-	 *
 	 * @return void
 	 */
 	public function setDisplayName(string $name){
@@ -868,7 +802,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 	/**
 	 * Returns the player's locale, e.g. en_US.
-	 * @return string
 	 */
 	public function getLocale() : string{
 		return $this->locale;
@@ -877,12 +810,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	/**
 	 * Called when a player changes their skin.
 	 * Plugin developers should not use this, use setSkin() and sendSkin() instead.
-	 *
-	 * @param Skin   $skin
-	 * @param string $newSkinName
-	 * @param string $oldSkinName
-	 *
-	 * @return bool
 	 */
 	public function changeSkin(Skin $skin, string $newSkinName, string $oldSkinName) : bool{
 		if(!$skin->isValid()){
@@ -913,16 +840,11 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 	/**
 	 * Gets the player IP address
-	 *
-	 * @return string
 	 */
 	public function getAddress() : string{
 		return $this->ip;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getPort() : int{
 		return $this->port;
 	}
@@ -930,8 +852,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	/**
 	 * Returns the last measured latency for this player, in milliseconds. This is measured automatically and reported
 	 * back by the network interface.
-	 *
-	 * @return int
 	 */
 	public function getPing() : int{
 		return $this->lastPingMeasure;
@@ -942,17 +862,12 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	 *
 	 * @internal Plugins should not use this method.
 	 *
-	 * @param int $pingMS
-	 *
 	 * @return void
 	 */
 	public function updatePing(int $pingMS){
 		$this->lastPingMeasure = $pingMS;
 	}
 
-	/**
-	 * @return Position
-	 */
 	public function getNextPosition() : Position{
 		return $this->newPosition !== null ? Position::fromObject($this->newPosition, $this->level) : $this->getPosition();
 	}
@@ -963,15 +878,12 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 	/**
 	 * Returns whether the player is currently using an item (right-click and hold).
-	 * @return bool
 	 */
 	public function isUsingItem() : bool{
 		return $this->getGenericFlag(self::DATA_FLAG_ACTION) and $this->startAction > -1;
 	}
 
 	/**
-	 * @param bool $value
-	 *
 	 * @return void
 	 */
 	public function setUsingItem(bool $value){
@@ -982,8 +894,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	/**
 	 * Returns how long the player has been using their currently-held item for. Used for determining arrow shoot force
 	 * for bows.
-	 *
-	 * @return int
 	 */
 	public function getItemUseDuration() : int{
 		return $this->startAction === -1 ? -1 : ($this->server->getTick() - $this->startAction);
@@ -991,10 +901,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 	/**
 	 * Returns whether the player has a cooldown period left before it can use the given item again.
-	 *
-	 * @param Item $item
-	 *
-	 * @return bool
 	 */
 	public function hasItemCooldown(Item $item) : bool{
 		$this->checkItemCooldowns();
@@ -1003,8 +909,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 	/**
 	 * Resets the player's cooldown time for the given item back to the maximum.
-	 *
-	 * @param Item $item
 	 */
 	public function resetItemCooldown(Item $item) : void{
 		$ticks = $item->getCooldownTicks();
@@ -1044,10 +948,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	/**
-	 * @param int        $x
-	 * @param int        $z
-	 * @param Level|null $level
-	 *
 	 * @return void
 	 */
 	protected function unloadChunk(int $x, int $z, Level $level = null){
@@ -1067,10 +967,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	/**
-	 * @param int         $x
-	 * @param int         $z
-	 * @param BatchPacket $payload
-	 *
 	 * @return void
 	 */
 	public function sendChunk(int $x, int $z, BatchPacket $payload){
@@ -1185,9 +1081,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	/**
-	 * @param Vector3 $pos
-	 * @param int     $respawnState
-	 *
 	 * @return void
 	 */
 	protected function sendRespawnPacket(Vector3 $pos, int $respawnState = RespawnPacket::SEARCHING_FOR_SPAWN){
@@ -1307,9 +1200,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		}
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function hasValidSpawnPosition() : bool{
 		return $this->spawnPosition !== null and $this->spawnPosition->isValid();
 	}
@@ -1338,18 +1228,10 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		$this->dataPacket($pk);
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isSleeping() : bool{
 		return $this->sleeping !== null;
 	}
 
-	/**
-	 * @param Vector3 $pos
-	 *
-	 * @return bool
-	 */
 	public function sleepOn(Vector3 $pos) : bool{
 		if(!$this->isOnline()){
 			return false;
@@ -1404,11 +1286,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		}
 	}
 
-	/**
-	 * @param string $achievementId
-	 *
-	 * @return bool
-	 */
 	public function hasAchievement(string $achievementId) : bool{
 		if(!isset(Achievement::$list[$achievementId])){
 			return false;
@@ -1417,11 +1294,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		return $this->achievements[$achievementId] ?? false;
 	}
 
-	/**
-	 * @param string $achievementId
-	 *
-	 * @return bool
-	 */
 	public function awardAchievement(string $achievementId) : bool{
 		if(isset(Achievement::$list[$achievementId]) and !$this->hasAchievement($achievementId)){
 			foreach(Achievement::$list[$achievementId]["requires"] as $requirementId){
@@ -1445,8 +1317,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	/**
-	 * @param string $achievementId
-	 *
 	 * @return void
 	 */
 	public function removeAchievement(string $achievementId){
@@ -1455,9 +1325,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		}
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getGamemode() : int{
 		return $this->gamemode;
 	}
@@ -1469,10 +1336,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	 * This function takes care of handling gamemodes known to MCPE (as of 1.1.0.3, that includes Survival, Creative and Adventure)
 	 *
 	 * TODO: remove this when Spectator Mode gets added properly to MCPE
-	 *
-	 * @param int $gamemode
-	 *
-	 * @return int
 	 */
 	public static function getClientFriendlyGamemode(int $gamemode) : int{
 		$gamemode &= 0x03;
@@ -1486,10 +1349,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	/**
 	 * Sets the gamemode, and if needed, kicks the Player.
 	 *
-	 * @param int  $gm
 	 * @param bool $client if the client made this change in their GUI
-	 *
-	 * @return bool
 	 */
 	public function setGamemode(int $gm, bool $client = false) : bool{
 		if($gm < 0 or $gm > 3 or $this->gamemode === $gm){
@@ -1572,8 +1432,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	 * in Adventure Mode. Supply the $literal parameter as true to force a literal Survival Mode check.
 	 *
 	 * @param bool $literal whether a literal check should be performed
-	 *
-	 * @return bool
 	 */
 	public function isSurvival(bool $literal = false) : bool{
 		if($literal){
@@ -1588,8 +1446,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	 * in Spectator Mode. Supply the $literal parameter as true to force a literal Creative Mode check.
 	 *
 	 * @param bool $literal whether a literal check should be performed
-	 *
-	 * @return bool
 	 */
 	public function isCreative(bool $literal = false) : bool{
 		if($literal){
@@ -1604,8 +1460,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	 * in Spectator Mode. Supply the $literal parameter as true to force a literal Adventure Mode check.
 	 *
 	 * @param bool $literal whether a literal check should be performed
-	 *
-	 * @return bool
 	 */
 	public function isAdventure(bool $literal = false) : bool{
 		if($literal){
@@ -1615,9 +1469,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		}
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isSpectator() : bool{
 		return $this->gamemode === Player::SPECTATOR;
 	}
@@ -1670,8 +1521,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	/**
-	 * @param int $tickDiff
-	 *
 	 * @return void
 	 */
 	protected function processMovement(int $tickDiff){
@@ -1817,8 +1666,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	/**
-	 * @param bool $sendAll
-	 *
 	 * @return void
 	 */
 	public function sendAttributes(bool $sendAll = false){
@@ -1952,11 +1799,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	/**
 	 * Returns whether the player can interact with the specified position. This checks distance and direction.
 	 *
-	 * @param Vector3 $pos
-	 * @param float   $maxDistance
 	 * @param float   $maxDiff defaults to half of the 3D diagonal width of a block
-	 *
-	 * @return bool
 	 */
 	public function canInteract(Vector3 $pos, float $maxDistance, float $maxDiff = M_SQRT3 / 2) : bool{
 		$eyePos = $this->getPosition()->add(0, $this->getEyeHeight(), 0);
@@ -2078,9 +1921,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	/**
-	 * @param int  $status
-	 * @param bool $immediate
-	 *
 	 * @return void
 	 */
 	public function sendPlayStatus(int $status, bool $immediate = false){
@@ -2342,10 +2182,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	/**
 	 * Sends a chat message as this player. If the message begins with a / (forward-slash) it will be treated
 	 * as a command.
-	 *
-	 * @param string $message
-	 *
-	 * @return bool
 	 */
 	public function chat(string $message) : bool{
 		if(!$this->spawned or !$this->isAlive()){
@@ -2445,10 +2281,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 	/**
 	 * Don't expect much from this handler. Most of it is roughly hacked and duct-taped together.
-	 *
-	 * @param InventoryTransactionPacket $packet
-	 *
-	 * @return bool
 	 */
 	public function handleInventoryTransaction(InventoryTransactionPacket $packet) : bool{
 		if(!$this->spawned or !$this->isAlive()){
@@ -3054,8 +2886,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	/**
 	 * Drops an item on the ground in front of the player. Returns if the item drop was successful.
 	 *
-	 * @param Item $item
-	 *
 	 * @return bool if the item was dropped or if the item was null
 	 */
 	public function dropItem(Item $item) : bool{
@@ -3267,8 +3097,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	/**
 	 * Called when a packet is received from the client. This method will call DataPacketReceiveEvent.
 	 *
-	 * @param DataPacket $packet
-	 *
 	 * @return void
 	 */
 	public function handleDataPacket(DataPacket $packet){
@@ -3279,10 +3107,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 	/**
 	 * Batch a Data packet into the channel list to send at the end of the tick
-	 *
-	 * @param DataPacket $packet
-	 *
-	 * @return bool
 	 */
 	public function batchDataPacket(DataPacket $packet) : bool{
 		if(!$this->isConnected()){
@@ -3304,10 +3128,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	/**
-	 * @param DataPacket $packet
-	 * @param bool       $needACK
-	 * @param bool       $immediate
-	 *
 	 * @return bool|int
 	 */
 	public function sendDataPacket(DataPacket $packet, bool $needACK = false, bool $immediate = false){
@@ -3343,9 +3163,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	/**
-	 * @param DataPacket $packet
-	 * @param bool       $needACK
-	 *
 	 * @return bool|int
 	 */
 	public function dataPacket(DataPacket $packet, bool $needACK = false){
@@ -3353,9 +3170,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	/**
-	 * @param DataPacket $packet
-	 * @param bool       $needACK
-	 *
 	 * @return bool|int
 	 */
 	public function directDataPacket(DataPacket $packet, bool $needACK = false){
@@ -3390,11 +3204,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	/**
 	 * Kicks a player from the server
 	 *
-	 * @param string               $reason
-	 * @param bool                 $isAdmin
 	 * @param TextContainer|string $quitMessage
-	 *
-	 * @return bool
 	 */
 	public function kick(string $reason = "", bool $isAdmin = true, $quitMessage = null) : bool{
 		$ev = new PlayerKickEvent($this, $reason, $quitMessage ?? $this->getLeaveMessage());
@@ -3422,8 +3232,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	/**
 	 * Adds a title text to the user's screen, with an optional subtitle.
 	 *
-	 * @param string $title
-	 * @param string $subtitle
 	 * @param int    $fadeIn Duration in ticks for fade-in. If -1 is given, client-sided defaults will be used.
 	 * @param int    $stay Duration in ticks to stay on screen for
 	 * @param int    $fadeOut Duration in ticks for fade-out.
@@ -3441,8 +3249,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	/**
 	 * Sets the subtitle message, without sending a title.
 	 *
-	 * @param string $subtitle
-	 *
 	 * @return void
 	 */
 	public function addSubTitle(string $subtitle){
@@ -3451,8 +3257,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 	/**
 	 * Adds small text to the user's screen.
-	 *
-	 * @param string $message
 	 *
 	 * @return void
 	 */
@@ -3505,9 +3309,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	/**
 	 * Internal function used for sending titles.
 	 *
-	 * @param string $title
-	 * @param int    $type
-	 *
 	 * @return void
 	 */
 	protected function sendTitleText(string $title, int $type){
@@ -3540,7 +3341,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	/**
-	 * @param string   $message
 	 * @param string[] $parameters
 	 *
 	 * @return void
@@ -3567,7 +3367,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	 *
 	 * TODO: add translation type popups
 	 *
-	 * @param string $message
 	 * @param string $subtitle @deprecated
 	 *
 	 * @return void
@@ -3580,8 +3379,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	/**
-	 * @param string $message
-	 *
 	 * @return void
 	 */
 	public function sendTip(string $message){
@@ -3592,9 +3389,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	/**
-	 * @param string $sender
-	 * @param string $message
-	 *
 	 * @return void
 	 */
 	public function sendWhisper(string $sender, string $message){
@@ -3607,8 +3401,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 	/**
 	 * Sends a Form to the player, or queue to send it if a form is already open.
-	 *
-	 * @param Form $form
 	 */
 	public function sendForm(Form $form) : void{
 		$id = $this->formIdCounter++;
@@ -3624,10 +3416,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	/**
-	 * @param int   $formId
 	 * @param mixed $responseData
-	 *
-	 * @return bool
 	 */
 	public function onFormSubmit(int $formId, $responseData) : bool{
 		if(!isset($this->forms[$formId])){
@@ -3653,7 +3442,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	 *
 	 * @param TextContainer|string $message Message to be broadcasted
 	 * @param string               $reason Reason showed in console
-	 * @param bool                 $notify
 	 */
 	final public function close($message = "", string $reason = "generic reason", bool $notify = true) : void{
 		if($this->isConnected() and !$this->closed){
@@ -3921,10 +3709,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	/**
-	 * @param Vector3       $pos
-	 * @param float|null    $yaw
-	 * @param float|null    $pitch
-	 * @param int           $mode
 	 * @param Player[]|null $targets
 	 *
 	 * @return void
@@ -4004,9 +3788,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		return $this->craftingGrid;
 	}
 
-	/**
-	 * @param CraftingGrid $grid
-	 */
 	public function setCraftingGrid(CraftingGrid $grid) : void{
 		$this->craftingGrid = $grid;
 	}
@@ -4033,10 +3814,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 	/**
 	 * Returns the window ID which the inventory has for this player, or -1 if the window is not open to the player.
-	 *
-	 * @param Inventory $inventory
-	 *
-	 * @return int
 	 */
 	public function getWindowId(Inventory $inventory) : int{
 		return $this->windows[spl_object_hash($inventory)] ?? ContainerIds::NONE;
@@ -4045,8 +3822,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	/**
 	 * Returns the inventory window open to the player with the specified window ID, or null if no window is open with
 	 * that ID.
-	 *
-	 * @param int $windowId
 	 *
 	 * @return Inventory|null
 	 */
@@ -4058,11 +3833,8 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	 * Opens an inventory window to the player. Returns the ID of the created window, or the existing window ID if the
 	 * player is already viewing the specified inventory.
 	 *
-	 * @param Inventory $inventory
 	 * @param int|null  $forceId Forces a special ID for the window
 	 * @param bool      $isPermanent Prevents the window being removed if true.
-	 *
-	 * @return int
 	 *
 	 * @throws \InvalidArgumentException if a forceID which is already in use is specified
 	 * @throws \InvalidStateException if trying to add a window without forceID when no slots are free
@@ -4105,7 +3877,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	/**
 	 * Removes an inventory window from the player.
 	 *
-	 * @param Inventory $inventory
 	 * @param bool      $force Forces removal of permanent windows such as normal inventory, cursor
 	 *
 	 * @return void

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -216,8 +216,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 	/**
 	 * Validates the given username.
-	 *
-	 * @param string $name
 	 */
 	public static function isValidUserName(?string $name) : bool{
 		if($name === null){
@@ -661,10 +659,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		return $this->perm->hasPermission($name);
 	}
 
-	/**
-	 * @param string $name
-	 * @param bool   $value
-	 */
 	public function addAttachment(Plugin $plugin, string $name = null, bool $value = null) : PermissionAttachment{
 		return $this->perm->addAttachment($plugin, $name, $value);
 	}

--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -346,72 +346,42 @@ class Server{
 	/** @var Level */
 	private $levelDefault = null;
 
-	/**
-	 * @return string
-	 */
 	public function getName() : string{
 		return \pocketmine\NAME;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isRunning() : bool{
 		return $this->isRunning;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getPocketMineVersion() : string{
 		return \pocketmine\VERSION;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getVersion() : string{
 		return ProtocolInfo::MINECRAFT_VERSION;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getApiVersion() : string{
 		return \pocketmine\BASE_VERSION;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getFilePath() : string{
 		return \pocketmine\PATH;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getResourcePath() : string{
 		return \pocketmine\RESOURCE_PATH;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getDataPath() : string{
 		return $this->dataPath;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getPluginPath() : string{
 		return $this->pluginPath;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getMaxPlayers() : int{
 		return $this->maxPlayers;
 	}
@@ -419,8 +389,6 @@ class Server{
 	/**
 	 * Returns whether the server requires that players be authenticated to Xbox Live. If true, connecting players who
 	 * are not logged into Xbox Live will be disconnected.
-	 *
-	 * @return bool
 	 */
 	public function getOnlineMode() : bool{
 		return $this->onlineMode;
@@ -428,40 +396,26 @@ class Server{
 
 	/**
 	 * Alias of {@link #getOnlineMode()}.
-	 * @return bool
 	 */
 	public function requiresAuthentication() : bool{
 		return $this->getOnlineMode();
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getPort() : int{
 		return $this->getConfigInt("server-port", 19132);
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getViewDistance() : int{
 		return max(2, $this->getConfigInt("view-distance", 8));
 	}
 
 	/**
 	 * Returns a view distance up to the currently-allowed limit.
-	 *
-	 * @param int $distance
-	 *
-	 * @return int
 	 */
 	public function getAllowedViewDistance(int $distance) : int{
 		return max(2, min($distance, $this->memoryManager->getViewDistance($this->getViewDistance())));
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getIp() : string{
 		$str = $this->getConfigString("server-ip");
 		return $str !== "" ? $str : "0.0.0.0";
@@ -474,16 +428,11 @@ class Server{
 		return $this->serverID;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function getAutoSave() : bool{
 		return $this->autoSave;
 	}
 
 	/**
-	 * @param bool $value
-	 *
 	 * @return void
 	 */
 	public function setAutoSave(bool $value){
@@ -493,40 +442,24 @@ class Server{
 		}
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getLevelType() : string{
 		return $this->getConfigString("level-type", "DEFAULT");
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function getGenerateStructures() : bool{
 		return $this->getConfigBool("generate-structures", true);
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getGamemode() : int{
 		return $this->getConfigInt("gamemode", 0) & 0b11;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function getForceGamemode() : bool{
 		return $this->getConfigBool("force-gamemode", false);
 	}
 
 	/**
 	 * Returns the gamemode text name
-	 *
-	 * @param int $mode
-	 *
-	 * @return string
 	 */
 	public static function getGamemodeString(int $mode) : string{
 		switch($mode){
@@ -560,10 +493,6 @@ class Server{
 
 	/**
 	 * Parses a string and returns a gamemode integer, -1 if not found
-	 *
-	 * @param string $str
-	 *
-	 * @return int
 	 */
 	public static function getGamemodeFromString(string $str) : int{
 		switch(strtolower(trim($str))){
@@ -593,51 +522,34 @@ class Server{
 
 	/**
 	 * Returns Server global difficulty. Note that this may be overridden in individual Levels.
-	 * @return int
 	 */
 	public function getDifficulty() : int{
 		return $this->getConfigInt("difficulty", Level::DIFFICULTY_NORMAL);
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function hasWhitelist() : bool{
 		return $this->getConfigBool("white-list", false);
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getSpawnRadius() : int{
 		return $this->getConfigInt("spawn-protection", 16);
 	}
 
 	/**
 	 * @deprecated
-	 * @return bool
 	 */
 	public function getAllowFlight() : bool{
 		return true;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isHardcore() : bool{
 		return $this->getConfigBool("hardcore", false);
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getDefaultGamemode() : int{
 		return $this->getConfigInt("gamemode", 0) & 0b11;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getMotd() : string{
 		return $this->getConfigString("motd", \pocketmine\NAME . " Server");
 	}
@@ -698,9 +610,6 @@ class Server{
 		return $this->craftingManager;
 	}
 
-	/**
-	 * @return ResourcePackManager
-	 */
 	public function getResourcePackManager() : ResourcePackManager{
 		return $this->resourceManager;
 	}
@@ -709,17 +618,12 @@ class Server{
 		return $this->asyncPool;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getTick() : int{
 		return $this->tickCounter;
 	}
 
 	/**
 	 * Returns the last server TPS measure
-	 *
-	 * @return float
 	 */
 	public function getTicksPerSecond() : float{
 		return round($this->currentTPS, 2);
@@ -727,8 +631,6 @@ class Server{
 
 	/**
 	 * Returns the last server TPS average measure
-	 *
-	 * @return float
 	 */
 	public function getTicksPerSecondAverage() : float{
 		return round(array_sum($this->tickAverage) / count($this->tickAverage), 2);
@@ -736,8 +638,6 @@ class Server{
 
 	/**
 	 * Returns the TPS usage/load in %
-	 *
-	 * @return float
 	 */
 	public function getTickUsage() : float{
 		return round($this->currentUse * 100, 2);
@@ -745,8 +645,6 @@ class Server{
 
 	/**
 	 * Returns the TPS usage/load average in %
-	 *
-	 * @return float
 	 */
 	public function getTickUsageAverage() : float{
 		return round((array_sum($this->useAverage) / count($this->useAverage)) * 100, 2);
@@ -778,8 +676,6 @@ class Server{
 	}
 
 	/**
-	 * @param string $name
-	 *
 	 * @return OfflinePlayer|Player
 	 */
 	public function getOfflinePlayer(string $name){
@@ -795,21 +691,12 @@ class Server{
 
 	/**
 	 * Returns whether the server has stored any saved data for this player.
-	 *
-	 * @param string $name
-	 *
-	 * @return bool
 	 */
 	public function hasOfflinePlayerData(string $name) : bool{
 		$name = strtolower($name);
 		return file_exists($this->getDataPath() . "players/$name.dat");
 	}
 
-	/**
-	 * @param string $name
-	 *
-	 * @return CompoundTag
-	 */
 	public function getOfflinePlayerData(string $name) : CompoundTag{
 		$name = strtolower($name);
 		$path = $this->getDataPath() . "players/";
@@ -874,9 +761,6 @@ class Server{
 	}
 
 	/**
-	 * @param string      $name
-	 * @param CompoundTag $nbtTag
-	 *
 	 * @return void
 	 */
 	public function saveOfflinePlayerData(string $name, CompoundTag $nbtTag){
@@ -901,8 +785,6 @@ class Server{
 	 * The closest match will be returned, or null if there are no online matches.
 	 *
 	 * @see Server::getPlayerExact()
-	 *
-	 * @param string $name
 	 *
 	 * @return Player|null
 	 */
@@ -929,8 +811,6 @@ class Server{
 	/**
 	 * Returns an online player with the given name (case insensitive), or null if not found.
 	 *
-	 * @param string $name
-	 *
 	 * @return Player|null
 	 */
 	public function getPlayerExact(string $name){
@@ -947,8 +827,6 @@ class Server{
 	/**
 	 * Returns a list of online players whose names contain with the given string (case insensitive).
 	 * If an exact match is found, only that match is returned.
-	 *
-	 * @param string $partialName
 	 *
 	 * @return Player[]
 	 */
@@ -969,10 +847,6 @@ class Server{
 
 	/**
 	 * Returns the player online with the specified raw UUID, or null if not found
-	 *
-	 * @param string $rawUUID
-	 *
-	 * @return null|Player
 	 */
 	public function getPlayerByRawUUID(string $rawUUID) : ?Player{
 		return $this->playerList[$rawUUID] ?? null;
@@ -980,10 +854,6 @@ class Server{
 
 	/**
 	 * Returns the player online with a UUID equivalent to the specified UUID object, or null if not found
-	 *
-	 * @param UUID $uuid
-	 *
-	 * @return null|Player
 	 */
 	public function getPlayerByUUID(UUID $uuid) : ?Player{
 		return $this->getPlayerByRawUUID($uuid->toBinary());
@@ -996,9 +866,6 @@ class Server{
 		return $this->levels;
 	}
 
-	/**
-	 * @return Level|null
-	 */
 	public function getDefaultLevel() : ?Level{
 		return $this->levelDefault;
 	}
@@ -1007,8 +874,6 @@ class Server{
 	 * Sets the default level to a different level
 	 * This won't change the level-name property,
 	 * it only affects the server on runtime
-	 *
-	 * @param Level|null $level
 	 */
 	public function setDefaultLevel(?Level $level) : void{
 		if($level === null or ($this->isLevelLoaded($level->getFolderName()) and $level !== $this->levelDefault)){
@@ -1016,30 +881,16 @@ class Server{
 		}
 	}
 
-	/**
-	 * @param string $name
-	 *
-	 * @return bool
-	 */
 	public function isLevelLoaded(string $name) : bool{
 		return $this->getLevelByName($name) instanceof Level;
 	}
 
-	/**
-	 * @param int $levelId
-	 *
-	 * @return Level|null
-	 */
 	public function getLevel(int $levelId) : ?Level{
 		return $this->levels[$levelId] ?? null;
 	}
 
 	/**
 	 * NOTE: This matches levels based on the FOLDER name, NOT the display name.
-	 *
-	 * @param string $name
-	 *
-	 * @return Level|null
 	 */
 	public function getLevelByName(string $name) : ?Level{
 		foreach($this->getLevels() as $level){
@@ -1052,11 +903,6 @@ class Server{
 	}
 
 	/**
-	 * @param Level $level
-	 * @param bool  $forceUnload
-	 *
-	 * @return bool
-	 *
 	 * @throws \InvalidStateException
 	 */
 	public function unloadLevel(Level $level, bool $forceUnload = false) : bool{
@@ -1069,8 +915,6 @@ class Server{
 
 	/**
 	 * @internal
-	 *
-	 * @param Level $level
 	 */
 	public function removeLevel(Level $level) : void{
 		unset($this->levels[$level->getId()]);
@@ -1078,10 +922,6 @@ class Server{
 
 	/**
 	 * Loads a level from the data directory
-	 *
-	 * @param string $name
-	 *
-	 * @return bool
 	 *
 	 * @throws LevelException
 	 */
@@ -1136,12 +976,7 @@ class Server{
 	/**
 	 * Generates a new level if it does not exist
 	 *
-	 * @param string      $name
-	 * @param int|null    $seed
 	 * @param string|null $generator Class name that extends pocketmine\level\generator\Generator
-	 * @param array       $options
-	 *
-	 * @return bool
 	 */
 	public function generateLevel(string $name, int $seed = null, $generator = null, array $options = []) : bool{
 		if(trim($name) === "" or $this->isLevelGenerated($name)){
@@ -1205,11 +1040,6 @@ class Server{
 		return true;
 	}
 
-	/**
-	 * @param string $name
-	 *
-	 * @return bool
-	 */
 	public function isLevelGenerated(string $name) : bool{
 		if(trim($name) === ""){
 			return false;
@@ -1228,7 +1058,6 @@ class Server{
 	 * Searches all levels for the entity with the specified ID.
 	 * Useful for tracking entities across multiple worlds without needing strong references.
 	 *
-	 * @param int        $entityId
 	 * @param Level|null $expectedLevel @deprecated Level to look in first for the target
 	 *
 	 * @return Entity|null
@@ -1245,7 +1074,6 @@ class Server{
 	}
 
 	/**
-	 * @param string $variable
 	 * @param mixed  $defaultValue
 	 *
 	 * @return mixed
@@ -1263,12 +1091,6 @@ class Server{
 		return $this->propertyCache[$variable] ?? $defaultValue;
 	}
 
-	/**
-	 * @param string $variable
-	 * @param string $defaultValue
-	 *
-	 * @return string
-	 */
 	public function getConfigString(string $variable, string $defaultValue = "") : string{
 		$v = getopt("", ["$variable::"]);
 		if(isset($v[$variable])){
@@ -1279,21 +1101,12 @@ class Server{
 	}
 
 	/**
-	 * @param string $variable
-	 * @param string $value
-	 *
 	 * @return void
 	 */
 	public function setConfigString(string $variable, string $value){
 		$this->properties->set($variable, $value);
 	}
 
-	/**
-	 * @param string $variable
-	 * @param int    $defaultValue
-	 *
-	 * @return int
-	 */
 	public function getConfigInt(string $variable, int $defaultValue = 0) : int{
 		$v = getopt("", ["$variable::"]);
 		if(isset($v[$variable])){
@@ -1304,21 +1117,12 @@ class Server{
 	}
 
 	/**
-	 * @param string $variable
-	 * @param int    $value
-	 *
 	 * @return void
 	 */
 	public function setConfigInt(string $variable, int $value){
 		$this->properties->set($variable, $value);
 	}
 
-	/**
-	 * @param string $variable
-	 * @param bool   $defaultValue
-	 *
-	 * @return bool
-	 */
 	public function getConfigBool(string $variable, bool $defaultValue = false) : bool{
 		$v = getopt("", ["$variable::"]);
 		if(isset($v[$variable])){
@@ -1342,9 +1146,6 @@ class Server{
 	}
 
 	/**
-	 * @param string $variable
-	 * @param bool   $value
-	 *
 	 * @return void
 	 */
 	public function setConfigBool(string $variable, bool $value){
@@ -1352,8 +1153,6 @@ class Server{
 	}
 
 	/**
-	 * @param string $name
-	 *
 	 * @return PluginIdentifiableCommand|null
 	 */
 	public function getPluginCommand(string $name){
@@ -1379,8 +1178,6 @@ class Server{
 	}
 
 	/**
-	 * @param string $name
-	 *
 	 * @return void
 	 */
 	public function addOp(string $name){
@@ -1393,8 +1190,6 @@ class Server{
 	}
 
 	/**
-	 * @param string $name
-	 *
 	 * @return void
 	 */
 	public function removeOp(string $name){
@@ -1407,8 +1202,6 @@ class Server{
 	}
 
 	/**
-	 * @param string $name
-	 *
 	 * @return void
 	 */
 	public function addWhitelist(string $name){
@@ -1417,8 +1210,6 @@ class Server{
 	}
 
 	/**
-	 * @param string $name
-	 *
 	 * @return void
 	 */
 	public function removeWhitelist(string $name){
@@ -1426,20 +1217,10 @@ class Server{
 		$this->whitelist->save();
 	}
 
-	/**
-	 * @param string $name
-	 *
-	 * @return bool
-	 */
 	public function isWhitelisted(string $name) : bool{
 		return !$this->hasWhitelist() or $this->operators->exists($name, true) or $this->whitelist->exists($name, true);
 	}
 
-	/**
-	 * @param string $name
-	 *
-	 * @return bool
-	 */
 	public function isOp(string $name) : bool{
 		return $this->operators->exists($name, true);
 	}
@@ -1487,9 +1268,6 @@ class Server{
 		return $result;
 	}
 
-	/**
-	 * @return Server
-	 */
 	public static function getInstance() : Server{
 		if(self::$instance === null){
 			throw new \RuntimeException("Attempt to retrieve Server instance outside server thread");
@@ -1498,8 +1276,6 @@ class Server{
 	}
 
 	/**
-	 * @param int $microseconds
-	 *
 	 * @return void
 	 */
 	public static function microSleep(int $microseconds){
@@ -1508,12 +1284,6 @@ class Server{
 		}, $microseconds);
 	}
 
-	/**
-	 * @param \ClassLoader              $autoloader
-	 * @param \AttachableThreadedLogger $logger
-	 * @param string                    $dataPath
-	 * @param string                    $pluginPath
-	 */
 	public function __construct(\ClassLoader $autoloader, \AttachableThreadedLogger $logger, string $dataPath, string $pluginPath){
 		if(self::$instance !== null){
 			throw new \InvalidStateException("Only one server instance can exist at once");
@@ -1817,8 +1587,6 @@ class Server{
 	/**
 	 * @param TextContainer|string $message
 	 * @param CommandSender[]      $recipients
-	 *
-	 * @return int
 	 */
 	public function broadcastMessage($message, array $recipients = null) : int{
 		if(!is_array($recipients)){
@@ -1833,10 +1601,7 @@ class Server{
 	}
 
 	/**
-	 * @param string   $tip
 	 * @param Player[] $recipients
-	 *
-	 * @return int
 	 */
 	public function broadcastTip(string $tip, array $recipients = null) : int{
 		if(!is_array($recipients)){
@@ -1857,10 +1622,7 @@ class Server{
 	}
 
 	/**
-	 * @param string   $popup
 	 * @param Player[] $recipients
-	 *
-	 * @return int
 	 */
 	public function broadcastPopup(string $popup, array $recipients = null) : int{
 		if(!is_array($recipients)){
@@ -1882,14 +1644,10 @@ class Server{
 	}
 
 	/**
-	 * @param string        $title
-	 * @param string        $subtitle
 	 * @param int           $fadeIn Duration in ticks for fade-in. If -1 is given, client-sided defaults will be used.
 	 * @param int           $stay Duration in ticks to stay on screen for
 	 * @param int           $fadeOut Duration in ticks for fade-out.
 	 * @param Player[]|null $recipients
-	 *
-	 * @return int
 	 */
 	public function broadcastTitle(string $title, string $subtitle = "", int $fadeIn = -1, int $stay = -1, int $fadeOut = -1, array $recipients = null) : int{
 		if(!is_array($recipients)){
@@ -1912,9 +1670,6 @@ class Server{
 
 	/**
 	 * @param TextContainer|string $message
-	 * @param string               $permissions
-	 *
-	 * @return int
 	 */
 	public function broadcast($message, string $permissions) : int{
 		/** @var CommandSender[] $recipients */
@@ -1938,7 +1693,6 @@ class Server{
 	 * Broadcasts a Minecraft packet to a list of players
 	 *
 	 * @param Player[]   $players
-	 * @param DataPacket $packet
 	 *
 	 * @return void
 	 */
@@ -1952,8 +1706,6 @@ class Server{
 	 *
 	 * @param Player[]     $players
 	 * @param DataPacket[] $packets
-	 * @param bool         $forceSync
-	 * @param bool         $immediate
 	 *
 	 * @return void
 	 */
@@ -1991,9 +1743,7 @@ class Server{
 	}
 
 	/**
-	 * @param BatchPacket $pk
 	 * @param Player[]    $players
-	 * @param bool        $immediate
 	 *
 	 * @return void
 	 */
@@ -2009,8 +1759,6 @@ class Server{
 
 
 	/**
-	 * @param int $type
-	 *
 	 * @return void
 	 */
 	public function enablePlugins(int $type){
@@ -2027,8 +1775,6 @@ class Server{
 	}
 
 	/**
-	 * @param Plugin $plugin
-	 *
 	 * @return void
 	 */
 	public function enablePlugin(Plugin $plugin){
@@ -2044,12 +1790,6 @@ class Server{
 
 	/**
 	 * Executes a command from a CommandSender
-	 *
-	 * @param CommandSender $sender
-	 * @param string        $commandLine
-	 * @param bool          $internal
-	 *
-	 * @return bool
 	 */
 	public function dispatchCommand(CommandSender $sender, string $commandLine, bool $internal = false) : bool{
 		if(!$internal){
@@ -2263,7 +2003,6 @@ class Server{
 	}
 
 	/**
-	 * @param \Throwable $e
 	 * @param array|null $trace
 	 *
 	 * @return void
@@ -2408,8 +2147,6 @@ class Server{
 	}
 
 	/**
-	 * @param Player $player
-	 *
 	 * @return void
 	 */
 	public function onPlayerLogin(Player $player){
@@ -2421,8 +2158,6 @@ class Server{
 	}
 
 	/**
-	 * @param Player $player
-	 *
 	 * @return void
 	 */
 	public function onPlayerLogout(Player $player){
@@ -2430,8 +2165,6 @@ class Server{
 	}
 
 	/**
-	 * @param Player $player
-	 *
 	 * @return void
 	 */
 	public function addPlayer(Player $player){
@@ -2439,8 +2172,6 @@ class Server{
 	}
 
 	/**
-	 * @param Player $player
-	 *
 	 * @return void
 	 */
 	public function removePlayer(Player $player){
@@ -2448,8 +2179,6 @@ class Server{
 	}
 
 	/**
-	 * @param Player $player
-	 *
 	 * @return void
 	 */
 	public function addOnlinePlayer(Player $player){
@@ -2459,8 +2188,6 @@ class Server{
 	}
 
 	/**
-	 * @param Player $player
-	 *
 	 * @return void
 	 */
 	public function removeOnlinePlayer(Player $player){
@@ -2472,11 +2199,6 @@ class Server{
 	}
 
 	/**
-	 * @param UUID          $uuid
-	 * @param int           $entityId
-	 * @param string        $name
-	 * @param Skin          $skin
-	 * @param string        $xboxUserId
 	 * @param Player[]|null $players
 	 *
 	 * @return void
@@ -2491,7 +2213,6 @@ class Server{
 	}
 
 	/**
-	 * @param UUID          $uuid
 	 * @param Player[]|null $players
 	 *
 	 * @return void
@@ -2504,8 +2225,6 @@ class Server{
 	}
 
 	/**
-	 * @param Player $p
-	 *
 	 * @return void
 	 */
 	public function sendFullPlayerListData(Player $p){
@@ -2583,9 +2302,6 @@ class Server{
 		return $this->baseLang;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isLanguageForced() : bool{
 		return $this->forceLanguage;
 	}
@@ -2624,11 +2340,6 @@ class Server{
 	}
 
 	/**
-	 * @param AdvancedSourceInterface $interface
-	 * @param string                  $address
-	 * @param int                     $port
-	 * @param string                  $payload
-	 *
 	 * @return void
 	 *
 	 * TODO: move this to Network

--- a/src/pocketmine/Thread.php
+++ b/src/pocketmine/Thread.php
@@ -44,8 +44,6 @@ abstract class Thread extends \Thread{
 	}
 
 	/**
-	 * @param \ClassLoader|null $loader
-	 *
 	 * @return void
 	 */
 	public function setClassLoader(\ClassLoader $loader = null){

--- a/src/pocketmine/Worker.php
+++ b/src/pocketmine/Worker.php
@@ -44,8 +44,6 @@ abstract class Worker extends \Worker{
 	}
 
 	/**
-	 * @param \ClassLoader|null $loader
-	 *
 	 * @return void
 	 */
 	public function setClassLoader(\ClassLoader $loader = null){

--- a/src/pocketmine/block/BaseRail.php
+++ b/src/pocketmine/block/BaseRail.php
@@ -114,10 +114,6 @@ abstract class BaseRail extends Flowable{
 	/**
 	 * Returns a meta value for the rail with the given connections.
 	 *
-	 * @param array $connections
-	 *
-	 * @return int
-	 *
 	 * @throws \InvalidArgumentException if no state matches the given connections
 	 */
 	protected function getMetaForState(array $connections) : int{

--- a/src/pocketmine/block/Bed.php
+++ b/src/pocketmine/block/Bed.php
@@ -69,16 +69,11 @@ class Bed extends Transparent{
 		return ($this->meta & self::BITFLAG_HEAD) !== 0;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isOccupied() : bool{
 		return ($this->meta & self::BITFLAG_OCCUPIED) !== 0;
 	}
 
 	/**
-	 * @param bool $occupied
-	 *
 	 * @return void
 	 */
 	public function setOccupied(bool $occupied = true){
@@ -95,12 +90,6 @@ class Bed extends Transparent{
 		}
 	}
 
-	/**
-	 * @param int  $meta
-	 * @param bool $isHead
-	 *
-	 * @return int
-	 */
 	public static function getOtherHalfSide(int $meta, bool $isHead = false) : int{
 		$rotation = $meta & 0x03;
 		$side = -1;
@@ -127,9 +116,6 @@ class Bed extends Transparent{
 		return $side;
 	}
 
-	/**
-	 * @return Bed|null
-	 */
 	public function getOtherHalf() : ?Bed{
 		$other = $this->getSide(self::getOtherHalfSide($this->meta, $this->isHeadPart()));
 		if($other instanceof Bed and $other->getId() === $this->getId() and $other->isHeadPart() !== $this->isHeadPart() and (($other->getDamage() & 0x03) === ($this->getDamage() & 0x03))){

--- a/src/pocketmine/block/Block.php
+++ b/src/pocketmine/block/Block.php
@@ -50,12 +50,6 @@ class Block extends Position implements BlockIds, Metadatable{
 	 * Returns a new Block instance with the specified ID, meta and position.
 	 *
 	 * This function redirects to {@link BlockFactory#get}.
-	 *
-	 * @param int           $id
-	 * @param int           $meta
-	 * @param Position|null $pos
-	 *
-	 * @return Block
 	 */
 	public static function get(int $id, int $meta = 0, Position $pos = null) : Block{
 		return BlockFactory::get($id, $meta, $pos);
@@ -90,16 +84,10 @@ class Block extends Position implements BlockIds, Metadatable{
 		$this->itemId = $itemId;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getName() : string{
 		return $this->fallbackName ?? "Unknown";
 	}
 
-	/**
-	 * @return int
-	 */
 	final public function getId() : int{
 		return $this->id;
 	}
@@ -107,8 +95,6 @@ class Block extends Position implements BlockIds, Metadatable{
 	/**
 	 * Returns the ID of the item form of the block.
 	 * Used for drops for blocks (some blocks such as doors have a different item ID).
-	 *
-	 * @return int
 	 */
 	public function getItemId() : int{
 		return $this->itemId ?? $this->getId();
@@ -116,22 +102,15 @@ class Block extends Position implements BlockIds, Metadatable{
 
 	/**
 	 * @internal
-	 * @return int
 	 */
 	public function getRuntimeId() : int{
 		return RuntimeBlockMapping::toStaticRuntimeId($this->getId(), $this->getDamage());
 	}
 
-	/**
-	 * @return int
-	 */
 	final public function getDamage() : int{
 		return $this->meta;
 	}
 
-	/**
-	 * @param int $meta
-	 */
 	final public function setDamage(int $meta) : void{
 		if($meta < 0 or $meta > 0xf){
 			throw new \InvalidArgumentException("Block damage values must be 0-15, not $meta");
@@ -145,8 +124,6 @@ class Block extends Position implements BlockIds, Metadatable{
 	 *
 	 * If your block should not have any meta value when it's dropped as an item, override this to return 0 in
 	 * descendent classes.
-	 *
-	 * @return int
 	 */
 	public function getVariantBitmask() : int{
 		return -1;
@@ -154,24 +131,18 @@ class Block extends Position implements BlockIds, Metadatable{
 
 	/**
 	 * Returns the block meta, stripped of non-variant flags.
-	 * @return int
 	 */
 	public function getVariant() : int{
 		return $this->meta & $this->getVariantBitmask();
 	}
 
-
 	/**
 	 * AKA: Block->isPlaceable
-	 * @return bool
 	 */
 	public function canBePlaced() : bool{
 		return true;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function canBeReplaced() : bool{
 		return false;
 	}
@@ -182,15 +153,6 @@ class Block extends Position implements BlockIds, Metadatable{
 
 	/**
 	 * Places the Block, using block space and block target, and side. Returns if the block has been placed.
-	 *
-	 * @param Item        $item
-	 * @param Block       $blockReplace
-	 * @param Block       $blockClicked
-	 * @param int         $face
-	 * @param Vector3     $clickVector
-	 * @param Player|null $player
-	 *
-	 * @return bool
 	 */
 	public function place(Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, Player $player = null) : bool{
 		return $this->getLevel()->setBlock($this, $this, true, true);
@@ -198,18 +160,11 @@ class Block extends Position implements BlockIds, Metadatable{
 
 	/**
 	 * Returns if the block can be broken with an specific Item
-	 *
-	 * @param Item $item
-	 *
-	 * @return bool
 	 */
 	public function isBreakable(Item $item) : bool{
 		return true;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getToolType() : int{
 		return BlockToolType::TYPE_NONE;
 	}
@@ -223,8 +178,6 @@ class Block extends Position implements BlockIds, Metadatable{
 	 * Otherwise, 1 should be returned if a tool is required, 0 if not.
 	 *
 	 * @see Item::getBlockToolHarvestLevel()
-	 *
-	 * @return int
 	 */
 	public function getToolHarvestLevel() : int{
 		return 0;
@@ -236,10 +189,6 @@ class Block extends Position implements BlockIds, Metadatable{
 	 *
 	 * In most cases this is also used to determine whether block drops should be created or not, except in some
 	 * special cases such as vines.
-	 *
-	 * @param Item $tool
-	 *
-	 * @return bool
 	 */
 	public function isCompatibleWithTool(Item $tool) : bool{
 		if($this->getHardness() < 0){
@@ -254,23 +203,14 @@ class Block extends Position implements BlockIds, Metadatable{
 
 	/**
 	 * Do the actions needed so the block is broken with the Item
-	 *
-	 * @param Item        $item
-	 * @param Player|null $player
-	 *
-	 * @return bool
 	 */
 	public function onBreak(Item $item, Player $player = null) : bool{
 		return $this->getLevel()->setBlock($this, BlockFactory::get(Block::AIR), true, true);
 	}
 
-
 	/**
 	 * Returns the seconds that this block takes to be broken using an specific Item
 	 *
-	 * @param Item $item
-	 *
-	 * @return float
 	 * @throws \InvalidArgumentException if the item efficiency is not a positive number
 	 */
 	public function getBreakTime(Item $item) : float{
@@ -300,8 +240,6 @@ class Block extends Position implements BlockIds, Metadatable{
 
 	/**
 	 * Returns whether random block updates will be done on this block.
-	 *
-	 * @return bool
 	 */
 	public function ticksRandomly() : bool{
 		return false;
@@ -324,11 +262,6 @@ class Block extends Position implements BlockIds, Metadatable{
 
 	/**
 	 * Do actions when activated by Item. Returns if it has done anything
-	 *
-	 * @param Item        $item
-	 * @param Player|null $player
-	 *
-	 * @return bool
 	 */
 	public function onActivate(Item $item, Player $player = null) : bool{
 		return false;
@@ -336,7 +269,6 @@ class Block extends Position implements BlockIds, Metadatable{
 
 	/**
 	 * Returns a base value used to compute block break times.
-	 * @return float
 	 */
 	public function getHardness() : float{
 		return 10;
@@ -344,15 +276,11 @@ class Block extends Position implements BlockIds, Metadatable{
 
 	/**
 	 * Returns the block's resistance to explosions. Usually 5x hardness.
-	 * @return float
 	 */
 	public function getBlastResistance() : float{
 		return $this->getHardness() * 5;
 	}
 
-	/**
-	 * @return float
-	 */
 	public function getFrictionFactor() : float{
 		return 0.6;
 	}
@@ -380,16 +308,11 @@ class Block extends Position implements BlockIds, Metadatable{
 	 * Examples of this behaviour include leaves and cobwebs.
 	 *
 	 * Light-diffusing blocks are included by the heightmap.
-	 *
-	 * @return bool
 	 */
 	public function diffusesSkyLight() : bool{
 		return false;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isTransparent() : bool{
 		return false;
 	}
@@ -400,7 +323,6 @@ class Block extends Position implements BlockIds, Metadatable{
 
 	/**
 	 * AKA: Block->isFlowable
-	 * @return bool
 	 */
 	public function canBeFlowedInto() : bool{
 		return false;
@@ -416,12 +338,10 @@ class Block extends Position implements BlockIds, Metadatable{
 
 	/**
 	 * Returns whether entities can climb up this block.
-	 * @return bool
 	 */
 	public function canClimb() : bool{
 		return false;
 	}
-
 
 	public function addVelocityToEntity(Entity $entity, Vector3 $vector) : void{
 
@@ -429,8 +349,6 @@ class Block extends Position implements BlockIds, Metadatable{
 
 	/**
 	 * Sets the block position to a new Position object
-	 *
-	 * @param Position $v
 	 */
 	final public function position(Position $v) : void{
 		$this->x = (int) $v->x;
@@ -442,8 +360,6 @@ class Block extends Position implements BlockIds, Metadatable{
 
 	/**
 	 * Returns an array of Item objects to be dropped
-	 *
-	 * @param Item $item
 	 *
 	 * @return Item[]
 	 */
@@ -462,8 +378,6 @@ class Block extends Position implements BlockIds, Metadatable{
 	/**
 	 * Returns an array of Items to be dropped when the block is broken using the correct tool type.
 	 *
-	 * @param Item $item
-	 *
 	 * @return Item[]
 	 */
 	public function getDropsForCompatibleTool(Item $item) : array{
@@ -475,8 +389,6 @@ class Block extends Position implements BlockIds, Metadatable{
 	/**
 	 * Returns an array of Items to be dropped when the block is broken using a compatible Silk Touch-enchanted tool.
 	 *
-	 * @param Item $item
-	 *
 	 * @return Item[]
 	 */
 	public function getSilkTouchDrops(Item $item) : array{
@@ -487,10 +399,6 @@ class Block extends Position implements BlockIds, Metadatable{
 
 	/**
 	 * Returns how much XP will be dropped by breaking this block with the given item.
-	 *
-	 * @param Item $item
-	 *
-	 * @return int
 	 */
 	public function getXpDropForTool(Item $item) : int{
 		if($item->hasEnchantment(Enchantment::SILK_TOUCH) or !$this->isCompatibleWithTool($item)){
@@ -502,8 +410,6 @@ class Block extends Position implements BlockIds, Metadatable{
 
 	/**
 	 * Returns how much XP this block will drop when broken with an appropriate tool.
-	 *
-	 * @return int
 	 */
 	protected function getXpDropAmount() : int{
 		return 0;
@@ -512,8 +418,6 @@ class Block extends Position implements BlockIds, Metadatable{
 	/**
 	 * Returns whether Silk Touch enchanted tools will cause this block to drop as itself. Since most blocks drop
 	 * themselves anyway, this is implicitly true.
-	 *
-	 * @return bool
 	 */
 	public function isAffectedBySilkTouch() : bool{
 		return true;
@@ -521,7 +425,6 @@ class Block extends Position implements BlockIds, Metadatable{
 
 	/**
 	 * Returns the item that players will equip when middle-clicking on this block.
-	 * @return Item
 	 */
 	public function getPickedItem() : Item{
 		return ItemFactory::get($this->getItemId(), $this->getVariant());
@@ -529,7 +432,6 @@ class Block extends Position implements BlockIds, Metadatable{
 
 	/**
 	 * Returns the time in ticks which the block will fuel a furnace for.
-	 * @return int
 	 */
 	public function getFuelTime() : int{
 		return 0;
@@ -538,8 +440,6 @@ class Block extends Position implements BlockIds, Metadatable{
 	/**
 	 * Returns the chance that the block will catch fire from nearby fire sources. Higher values lead to faster catching
 	 * fire.
-	 *
-	 * @return int
 	 */
 	public function getFlameEncouragement() : int{
 		return 0;
@@ -547,8 +447,6 @@ class Block extends Position implements BlockIds, Metadatable{
 
 	/**
 	 * Returns the base flammability of this block. Higher values lead to the block burning away more quickly.
-	 *
-	 * @return int
 	 */
 	public function getFlammability() : int{
 		return 0;
@@ -556,8 +454,6 @@ class Block extends Position implements BlockIds, Metadatable{
 
 	/**
 	 * Returns whether fire lit on this block will burn indefinitely.
-	 *
-	 * @return bool
 	 */
 	public function burnsForever() : bool{
 		return false;
@@ -565,8 +461,6 @@ class Block extends Position implements BlockIds, Metadatable{
 
 	/**
 	 * Returns whether this block can catch fire.
-	 *
-	 * @return bool
 	 */
 	public function isFlammable() : bool{
 		return $this->getFlammability() > 0;
@@ -581,9 +475,6 @@ class Block extends Position implements BlockIds, Metadatable{
 
 	/**
 	 * Returns the Block on the side $side, works like Vector3::getSide()
-	 *
-	 * @param int $side
-	 * @param int $step
 	 *
 	 * @return Block
 	 */
@@ -643,10 +534,6 @@ class Block extends Position implements BlockIds, Metadatable{
 
 	/**
 	 * Checks for collision against an AxisAlignedBB
-	 *
-	 * @param AxisAlignedBB $bb
-	 *
-	 * @return bool
 	 */
 	public function collidesWithBB(AxisAlignedBB $bb) : bool{
 		foreach($this->getCollisionBoxes() as $bb2){
@@ -658,9 +545,6 @@ class Block extends Position implements BlockIds, Metadatable{
 		return false;
 	}
 
-	/**
-	 * @param Entity $entity
-	 */
 	public function onEntityCollide(Entity $entity) : void{
 
 	}
@@ -687,9 +571,6 @@ class Block extends Position implements BlockIds, Metadatable{
 		return [];
 	}
 
-	/**
-	 * @return AxisAlignedBB|null
-	 */
 	public function getBoundingBox() : ?AxisAlignedBB{
 		if($this->boundingBox === null){
 			$this->boundingBox = $this->recalculateBoundingBox();
@@ -697,9 +578,6 @@ class Block extends Position implements BlockIds, Metadatable{
 		return $this->boundingBox;
 	}
 
-	/**
-	 * @return AxisAlignedBB|null
-	 */
 	protected function recalculateBoundingBox() : ?AxisAlignedBB{
 		return new AxisAlignedBB(
 			$this->x,
@@ -720,12 +598,6 @@ class Block extends Position implements BlockIds, Metadatable{
 		$this->collisionBoxes = null;
 	}
 
-	/**
-	 * @param Vector3 $pos1
-	 * @param Vector3 $pos2
-	 *
-	 * @return RayTraceResult|null
-	 */
 	public function calculateIntercept(Vector3 $pos1, Vector3 $pos2) : ?RayTraceResult{
 		$bbs = $this->getCollisionBoxes();
 		if(count($bbs) === 0){

--- a/src/pocketmine/block/BlockFactory.php
+++ b/src/pocketmine/block/BlockFactory.php
@@ -334,7 +334,6 @@ class BlockFactory{
 	 * NOTE: If you are registering a new block type, you will need to add it to the creative inventory yourself - it
 	 * will not automatically appear there.
 	 *
-	 * @param Block $block
 	 * @param bool  $override Whether to override existing registrations
 	 *
 	 * @throws \RuntimeException if something attempted to override an already-registered block without specifying the
@@ -365,11 +364,7 @@ class BlockFactory{
 	/**
 	 * Returns a new Block instance with the specified ID, meta and position.
 	 *
-	 * @param int      $id
-	 * @param int      $meta
 	 * @param Position $pos
-	 *
-	 * @return Block
 	 */
 	public static function get(int $id, int $meta = 0, Position $pos = null) : Block{
 		if($meta < 0 or $meta > 0xf){
@@ -398,7 +393,6 @@ class BlockFactory{
 
 	/**
 	 * @internal
-	 * @return \SplFixedArray
 	 */
 	public static function getBlockStatesArray() : \SplFixedArray{
 		return self::$fullList;
@@ -406,10 +400,6 @@ class BlockFactory{
 
 	/**
 	 * Returns whether a specified block ID is already registered in the block factory.
-	 *
-	 * @param int $id
-	 *
-	 * @return bool
 	 */
 	public static function isRegistered(int $id) : bool{
 		$b = self::$fullList[$id << 4];
@@ -419,11 +409,6 @@ class BlockFactory{
 	/**
 	 * @internal
 	 * @deprecated
-	 *
-	 * @param int $id
-	 * @param int $meta
-	 *
-	 * @return int
 	 */
 	public static function toStaticRuntimeId(int $id, int $meta = 0) : int{
 		return RuntimeBlockMapping::toStaticRuntimeId($id, $meta);
@@ -432,8 +417,6 @@ class BlockFactory{
 	/**
 	 * @deprecated
 	 * @internal
-	 *
-	 * @param int $runtimeId
 	 *
 	 * @return int[] [id, meta]
 	 */

--- a/src/pocketmine/block/BlockFactory.php
+++ b/src/pocketmine/block/BlockFactory.php
@@ -363,8 +363,6 @@ class BlockFactory{
 
 	/**
 	 * Returns a new Block instance with the specified ID, meta and position.
-	 *
-	 * @param Position $pos
 	 */
 	public static function get(int $id, int $meta = 0, Position $pos = null) : Block{
 		if($meta < 0 or $meta > 0xf){

--- a/src/pocketmine/block/CobblestoneWall.php
+++ b/src/pocketmine/block/CobblestoneWall.php
@@ -112,8 +112,6 @@ class CobblestoneWall extends Transparent{
 	}
 
 	/**
-	 * @param Block $block
-	 *
 	 * @return bool
 	 */
 	public function canConnect(Block $block){

--- a/src/pocketmine/block/ConcretePowder.php
+++ b/src/pocketmine/block/ConcretePowder.php
@@ -53,16 +53,10 @@ class ConcretePowder extends Fallable{
 		}
 	}
 
-	/**
-	 * @return null|Block
-	 */
 	public function tickFalling() : ?Block{
 		return $this->checkAdjacentWater();
 	}
 
-	/**
-	 * @return null|Block
-	 */
 	private function checkAdjacentWater() : ?Block{
 		for($i = 1; $i < 6; ++$i){ //Do not check underneath
 			if($this->getSide($i) instanceof Water){

--- a/src/pocketmine/block/DoublePlant.php
+++ b/src/pocketmine/block/DoublePlant.php
@@ -68,7 +68,6 @@ class DoublePlant extends Flowable{
 
 	/**
 	 * Returns whether this double-plant has a corresponding other half.
-	 * @return bool
 	 */
 	public function isValidHalfPlant() : bool{
 		if($this->meta & self::BITFLAG_TOP){

--- a/src/pocketmine/block/Fallable.php
+++ b/src/pocketmine/block/Fallable.php
@@ -45,9 +45,6 @@ abstract class Fallable extends Solid{
 		}
 	}
 
-	/**
-	 * @return null|Block
-	 */
 	public function tickFalling() : ?Block{
 		return null;
 	}

--- a/src/pocketmine/block/Fence.php
+++ b/src/pocketmine/block/Fence.php
@@ -104,8 +104,6 @@ abstract class Fence extends Transparent{
 	}
 
 	/**
-	 * @param Block $block
-	 *
 	 * @return bool
 	 */
 	public function canConnect(Block $block){

--- a/src/pocketmine/block/Liquid.php
+++ b/src/pocketmine/block/Liquid.php
@@ -211,8 +211,6 @@ abstract class Liquid extends Transparent{
 
 	/**
 	 * Returns how many liquid levels are lost per block flowed horizontally. Affects how far the liquid can flow.
-	 *
-	 * @return int
 	 */
 	public function getFlowDecayPerBlock() : int{
 		return 1;

--- a/src/pocketmine/block/TNT.php
+++ b/src/pocketmine/block/TNT.php
@@ -75,8 +75,6 @@ class TNT extends Solid{
 	}
 
 	/**
-	 * @param int $fuse
-	 *
 	 * @return void
 	 */
 	public function ignite(int $fuse = 80){

--- a/src/pocketmine/command/Command.php
+++ b/src/pocketmine/command/Command.php
@@ -74,7 +74,6 @@ abstract class Command{
 	public $timings;
 
 	/**
-	 * @param string   $usageMessage
 	 * @param string[] $aliases
 	 */
 	public function __construct(string $name, string $description = "", string $usageMessage = null, array $aliases = []){

--- a/src/pocketmine/command/Command.php
+++ b/src/pocketmine/command/Command.php
@@ -74,8 +74,6 @@ abstract class Command{
 	public $timings;
 
 	/**
-	 * @param string   $name
-	 * @param string   $description
 	 * @param string   $usageMessage
 	 * @param string[] $aliases
 	 */
@@ -88,8 +86,6 @@ abstract class Command{
 	}
 
 	/**
-	 * @param CommandSender $sender
-	 * @param string        $commandLabel
 	 * @param string[]      $args
 	 *
 	 * @return mixed
@@ -97,9 +93,6 @@ abstract class Command{
 	 */
 	abstract public function execute(CommandSender $sender, string $commandLabel, array $args);
 
-	/**
-	 * @return string
-	 */
 	public function getName() : string{
 		return $this->name;
 	}
@@ -113,19 +106,12 @@ abstract class Command{
 
 
 	/**
-	 * @param string|null $permission
-	 *
 	 * @return void
 	 */
 	public function setPermission(string $permission = null){
 		$this->permission = $permission;
 	}
 
-	/**
-	 * @param CommandSender $target
-	 *
-	 * @return bool
-	 */
 	public function testPermission(CommandSender $target) : bool{
 		if($this->testPermissionSilent($target)){
 			return true;
@@ -140,11 +126,6 @@ abstract class Command{
 		return false;
 	}
 
-	/**
-	 * @param CommandSender $target
-	 *
-	 * @return bool
-	 */
 	public function testPermissionSilent(CommandSender $target) : bool{
 		if($this->permission === null or $this->permission === ""){
 			return true;
@@ -159,9 +140,6 @@ abstract class Command{
 		return false;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getLabel() : string{
 		return $this->label;
 	}
@@ -183,10 +161,6 @@ abstract class Command{
 
 	/**
 	 * Registers the command into a Command map
-	 *
-	 * @param CommandMap $commandMap
-	 *
-	 * @return bool
 	 */
 	public function register(CommandMap $commandMap) : bool{
 		if($this->allowChangesFrom($commandMap)){
@@ -198,11 +172,6 @@ abstract class Command{
 		return false;
 	}
 
-	/**
-	 * @param CommandMap $commandMap
-	 *
-	 * @return bool
-	 */
 	public function unregister(CommandMap $commandMap) : bool{
 		if($this->allowChangesFrom($commandMap)){
 			$this->commandMap = null;
@@ -215,18 +184,10 @@ abstract class Command{
 		return false;
 	}
 
-	/**
-	 * @param CommandMap $commandMap
-	 *
-	 * @return bool
-	 */
 	private function allowChangesFrom(CommandMap $commandMap) : bool{
 		return $this->commandMap === null or $this->commandMap === $commandMap;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isRegistered() : bool{
 		return $this->commandMap !== null;
 	}
@@ -238,23 +199,14 @@ abstract class Command{
 		return $this->activeAliases;
 	}
 
-	/**
-	 * @return string|null
-	 */
 	public function getPermissionMessage() : ?string{
 		return $this->permissionMessage;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getDescription() : string{
 		return $this->description;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getUsage() : string{
 		return $this->usageMessage;
 	}
@@ -272,8 +224,6 @@ abstract class Command{
 	}
 
 	/**
-	 * @param string $description
-	 *
 	 * @return void
 	 */
 	public function setDescription(string $description){
@@ -281,8 +231,6 @@ abstract class Command{
 	}
 
 	/**
-	 * @param string $permissionMessage
-	 *
 	 * @return void
 	 */
 	public function setPermissionMessage(string $permissionMessage){
@@ -290,8 +238,6 @@ abstract class Command{
 	}
 
 	/**
-	 * @param string $usage
-	 *
 	 * @return void
 	 */
 	public function setUsage(string $usage){
@@ -299,9 +245,7 @@ abstract class Command{
 	}
 
 	/**
-	 * @param CommandSender        $source
 	 * @param TextContainer|string $message
-	 * @param bool                 $sendToSource
 	 *
 	 * @return void
 	 */
@@ -338,9 +282,6 @@ abstract class Command{
 		}
 	}
 
-	/**
-	 * @return string
-	 */
 	public function __toString() : string{
 		return $this->name;
 	}

--- a/src/pocketmine/command/CommandExecutor.php
+++ b/src/pocketmine/command/CommandExecutor.php
@@ -27,12 +27,7 @@ namespace pocketmine\command;
 interface CommandExecutor{
 
 	/**
-	 * @param CommandSender $sender
-	 * @param Command       $command
-	 * @param string        $label
 	 * @param string[]      $args
-	 *
-	 * @return bool
 	 */
 	public function onCommand(CommandSender $sender, Command $command, string $label, array $args) : bool;
 

--- a/src/pocketmine/command/CommandMap.php
+++ b/src/pocketmine/command/CommandMap.php
@@ -27,28 +27,14 @@ namespace pocketmine\command;
 interface CommandMap{
 
 	/**
-	 * @param string    $fallbackPrefix
 	 * @param Command[] $commands
 	 *
 	 * @return void
 	 */
 	public function registerAll(string $fallbackPrefix, array $commands);
 
-	/**
-	 * @param string      $fallbackPrefix
-	 * @param Command     $command
-	 * @param string|null $label
-	 *
-	 * @return bool
-	 */
 	public function register(string $fallbackPrefix, Command $command, string $label = null) : bool;
 
-	/**
-	 * @param CommandSender $sender
-	 * @param string        $cmdLine
-	 *
-	 * @return bool
-	 */
 	public function dispatch(CommandSender $sender, string $cmdLine) : bool;
 
 	/**
@@ -57,8 +43,6 @@ interface CommandMap{
 	public function clearCommands();
 
 	/**
-	 * @param string $name
-	 *
 	 * @return Command|null
 	 */
 	public function getCommand(string $name);

--- a/src/pocketmine/command/CommandReader.php
+++ b/src/pocketmine/command/CommandReader.php
@@ -116,8 +116,6 @@ class CommandReader extends Thread{
 	 * Checks if the specified stream is a FIFO pipe.
 	 *
 	 * @param resource $stream
-	 *
-	 * @return bool
 	 */
 	private function isPipe($stream) : bool{
 		return is_resource($stream) and (!stream_isatty($stream) or ((fstat($stream)["mode"] & 0170000) === 0010000));

--- a/src/pocketmine/command/CommandSender.php
+++ b/src/pocketmine/command/CommandSender.php
@@ -41,23 +41,16 @@ interface CommandSender extends Permissible{
 	 */
 	public function getServer();
 
-	/**
-	 * @return string
-	 */
 	public function getName() : string;
 
 	/**
 	 * Returns the line height of the command-sender's screen. Used for determining sizes for command output pagination
 	 * such as in the /help command.
-	 *
-	 * @return int
 	 */
 	public function getScreenLineHeight() : int;
 
 	/**
 	 * Sets the line height used for command output pagination for this command sender. `null` will reset it to default.
-	 *
-	 * @param int|null $height
 	 *
 	 * @return void
 	 */

--- a/src/pocketmine/command/ConsoleCommandSender.php
+++ b/src/pocketmine/command/ConsoleCommandSender.php
@@ -49,8 +49,6 @@ class ConsoleCommandSender implements CommandSender{
 
 	/**
 	 * @param Permission|string $name
-	 *
-	 * @return bool
 	 */
 	public function isPermissionSet($name) : bool{
 		return $this->perm->isPermissionSet($name);
@@ -58,27 +56,20 @@ class ConsoleCommandSender implements CommandSender{
 
 	/**
 	 * @param Permission|string $name
-	 *
-	 * @return bool
 	 */
 	public function hasPermission($name) : bool{
 		return $this->perm->hasPermission($name);
 	}
 
 	/**
-	 * @param Plugin $plugin
 	 * @param string $name
 	 * @param bool   $value
-	 *
-	 * @return PermissionAttachment
 	 */
 	public function addAttachment(Plugin $plugin, string $name = null, bool $value = null) : PermissionAttachment{
 		return $this->perm->addAttachment($plugin, $name, $value);
 	}
 
 	/**
-	 * @param PermissionAttachment $attachment
-	 *
 	 * @return void
 	 */
 	public function removeAttachment(PermissionAttachment $attachment){
@@ -120,23 +111,15 @@ class ConsoleCommandSender implements CommandSender{
 		}
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getName() : string{
 		return "CONSOLE";
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isOp() : bool{
 		return true;
 	}
 
 	/**
-	 * @param bool $value
-	 *
 	 * @return void
 	 */
 	public function setOp(bool $value){

--- a/src/pocketmine/command/ConsoleCommandSender.php
+++ b/src/pocketmine/command/ConsoleCommandSender.php
@@ -61,10 +61,6 @@ class ConsoleCommandSender implements CommandSender{
 		return $this->perm->hasPermission($name);
 	}
 
-	/**
-	 * @param string $name
-	 * @param bool   $value
-	 */
 	public function addAttachment(Plugin $plugin, string $name = null, bool $value = null) : PermissionAttachment{
 		return $this->perm->addAttachment($plugin, $name, $value);
 	}

--- a/src/pocketmine/command/FormattedCommandAlias.php
+++ b/src/pocketmine/command/FormattedCommandAlias.php
@@ -36,7 +36,6 @@ class FormattedCommandAlias extends Command{
 	private $formatStrings = [];
 
 	/**
-	 * @param string   $alias
 	 * @param string[] $formatStrings
 	 */
 	public function __construct(string $alias, array $formatStrings){
@@ -65,12 +64,6 @@ class FormattedCommandAlias extends Command{
 		return (bool) $result;
 	}
 
-	/**
-	 * @param string $formatString
-	 * @param array  $args
-	 *
-	 * @return string
-	 */
 	private function buildCommand(string $formatString, array $args) : string{
 		$index = strpos($formatString, '$');
 		while($index !== false){
@@ -144,13 +137,6 @@ class FormattedCommandAlias extends Command{
 		return $formatString;
 	}
 
-	/**
-	 * @param int $i
-	 * @param int $j
-	 * @param int $k
-	 *
-	 * @return bool
-	 */
 	private static function inRange(int $i, int $j, int $k) : bool{
 		return $i >= $j and $i <= $k;
 	}

--- a/src/pocketmine/command/PluginCommand.php
+++ b/src/pocketmine/command/PluginCommand.php
@@ -34,10 +34,6 @@ class PluginCommand extends Command implements PluginIdentifiableCommand{
 	/** @var CommandExecutor */
 	private $executor;
 
-	/**
-	 * @param string $name
-	 * @param Plugin $owner
-	 */
 	public function __construct(string $name, Plugin $owner){
 		parent::__construct($name);
 		$this->owningPlugin = $owner;
@@ -69,17 +65,12 @@ class PluginCommand extends Command implements PluginIdentifiableCommand{
 	}
 
 	/**
-	 * @param CommandExecutor $executor
-	 *
 	 * @return void
 	 */
 	public function setExecutor(CommandExecutor $executor){
 		$this->executor = $executor;
 	}
 
-	/**
-	 * @return Plugin
-	 */
 	public function getPlugin() : Plugin{
 		return $this->owningPlugin;
 	}

--- a/src/pocketmine/command/PluginIdentifiableCommand.php
+++ b/src/pocketmine/command/PluginIdentifiableCommand.php
@@ -27,8 +27,5 @@ use pocketmine\plugin\Plugin;
 
 interface PluginIdentifiableCommand{
 
-	/**
-	 * @return Plugin
-	 */
 	public function getPlugin() : Plugin;
 }

--- a/src/pocketmine/command/SimpleCommandMap.php
+++ b/src/pocketmine/command/SimpleCommandMap.php
@@ -144,13 +144,6 @@ class SimpleCommandMap implements CommandMap{
 		}
 	}
 
-	/**
-	 * @param string      $fallbackPrefix
-	 * @param Command     $command
-	 * @param string|null $label
-	 *
-	 * @return bool
-	 */
 	public function register(string $fallbackPrefix, Command $command, string $label = null) : bool{
 		if($label === null){
 			$label = $command->getName();
@@ -177,11 +170,6 @@ class SimpleCommandMap implements CommandMap{
 		return $registered;
 	}
 
-	/**
-	 * @param Command $command
-	 *
-	 * @return bool
-	 */
 	public function unregister(Command $command) : bool{
 		foreach($this->knownCommands as $lbl => $cmd){
 			if($cmd === $command){
@@ -194,14 +182,6 @@ class SimpleCommandMap implements CommandMap{
 		return true;
 	}
 
-	/**
-	 * @param Command $command
-	 * @param bool    $isAlias
-	 * @param string  $fallbackPrefix
-	 * @param string  $label
-	 *
-	 * @return bool
-	 */
 	private function registerAlias(Command $command, bool $isAlias, string $fallbackPrefix, string $label) : bool{
 		$this->knownCommands[$fallbackPrefix . ":" . $label] = $command;
 		if(($command instanceof VanillaCommand or $isAlias) and isset($this->knownCommands[$label])){

--- a/src/pocketmine/command/defaults/ParticleCommand.php
+++ b/src/pocketmine/command/defaults/ParticleCommand.php
@@ -137,13 +137,6 @@ class ParticleCommand extends VanillaCommand{
 	}
 
 	/**
-	 * @param string   $name
-	 * @param Vector3  $pos
-	 * @param float    $xd
-	 * @param float    $yd
-	 * @param float    $zd
-	 * @param int|null $data
-	 *
 	 * @return Particle|null
 	 */
 	private function getParticle(string $name, Vector3 $pos, float $xd, float $yd, float $zd, int $data = null){

--- a/src/pocketmine/command/defaults/VanillaCommand.php
+++ b/src/pocketmine/command/defaults/VanillaCommand.php
@@ -36,12 +36,7 @@ abstract class VanillaCommand extends Command{
 	public const MIN_COORD = -30000000;
 
 	/**
-	 * @param CommandSender $sender
 	 * @param mixed         $value
-	 * @param int           $min
-	 * @param int           $max
-	 *
-	 * @return int
 	 */
 	protected function getInteger(CommandSender $sender, $value, int $min = self::MIN_COORD, int $max = self::MAX_COORD) : int{
 		$i = (int) $value;
@@ -55,15 +50,6 @@ abstract class VanillaCommand extends Command{
 		return $i;
 	}
 
-	/**
-	 * @param float         $original
-	 * @param CommandSender $sender
-	 * @param string        $input
-	 * @param float         $min
-	 * @param float         $max
-	 *
-	 * @return float
-	 */
 	protected function getRelativeDouble(float $original, CommandSender $sender, string $input, float $min = self::MIN_COORD, float $max = self::MAX_COORD) : float{
 		if($input[0] === "~"){
 			$value = $this->getDouble($sender, substr($input, 1));
@@ -75,12 +61,7 @@ abstract class VanillaCommand extends Command{
 	}
 
 	/**
-	 * @param CommandSender $sender
 	 * @param mixed         $value
-	 * @param float         $min
-	 * @param float         $max
-	 *
-	 * @return float
 	 */
 	protected function getDouble(CommandSender $sender, $value, float $min = self::MIN_COORD, float $max = self::MAX_COORD) : float{
 		$i = (double) $value;

--- a/src/pocketmine/entity/Attribute.php
+++ b/src/pocketmine/entity/Attribute.php
@@ -87,15 +87,6 @@ class Attribute{
 	}
 
 	/**
-	 * @param int    $id
-	 * @param string $name
-	 * @param float  $minValue
-	 * @param float  $maxValue
-	 * @param float  $defaultValue
-	 * @param bool   $shouldSend
-	 *
-	 * @return Attribute
-	 *
 	 * @throws \InvalidArgumentException
 	 */
 	public static function addAttribute(int $id, string $name, float $minValue, float $maxValue, float $defaultValue, bool $shouldSend = true) : Attribute{
@@ -106,20 +97,10 @@ class Attribute{
 		return self::$attributes[$id] = new Attribute($id, $name, $minValue, $maxValue, $defaultValue, $shouldSend);
 	}
 
-	/**
-	 * @param int $id
-	 *
-	 * @return Attribute|null
-	 */
 	public static function getAttribute(int $id) : ?Attribute{
 		return isset(self::$attributes[$id]) ? clone self::$attributes[$id] : null;
 	}
 
-	/**
-	 * @param string $name
-	 *
-	 * @return Attribute|null
-	 */
 	public static function getAttributeByName(string $name) : ?Attribute{
 		foreach(self::$attributes as $a){
 			if($a->getName() === $name){
@@ -146,8 +127,6 @@ class Attribute{
 	}
 
 	/**
-	 * @param float $minValue
-	 *
 	 * @return $this
 	 */
 	public function setMinValue(float $minValue){
@@ -167,8 +146,6 @@ class Attribute{
 	}
 
 	/**
-	 * @param float $maxValue
-	 *
 	 * @return $this
 	 */
 	public function setMaxValue(float $maxValue){
@@ -188,8 +165,6 @@ class Attribute{
 	}
 
 	/**
-	 * @param float $defaultValue
-	 *
 	 * @return $this
 	 */
 	public function setDefaultValue(float $defaultValue){
@@ -213,10 +188,6 @@ class Attribute{
 	}
 
 	/**
-	 * @param float $value
-	 * @param bool  $fit
-	 * @param bool  $forceSend
-	 *
 	 * @return $this
 	 */
 	public function setValue(float $value, bool $fit = false, bool $forceSend = false){

--- a/src/pocketmine/entity/AttributeMap.php
+++ b/src/pocketmine/entity/AttributeMap.php
@@ -36,11 +36,6 @@ class AttributeMap implements \ArrayAccess{
 		$this->attributes[$attribute->getId()] = $attribute;
 	}
 
-	/**
-	 * @param int $id
-	 *
-	 * @return Attribute|null
-	 */
 	public function getAttribute(int $id) : ?Attribute{
 		return $this->attributes[$id] ?? null;
 	}
@@ -63,8 +58,6 @@ class AttributeMap implements \ArrayAccess{
 
 	/**
 	 * @param int $offset
-	 *
-	 * @return bool
 	 */
 	public function offsetExists($offset) : bool{
 		return isset($this->attributes[$offset]);
@@ -72,8 +65,6 @@ class AttributeMap implements \ArrayAccess{
 
 	/**
 	 * @param int $offset
-	 *
-	 * @return float
 	 */
 	public function offsetGet($offset) : float{
 		return $this->attributes[$offset]->getValue();

--- a/src/pocketmine/entity/DataPropertyManager.php
+++ b/src/pocketmine/entity/DataPropertyManager.php
@@ -42,102 +42,52 @@ class DataPropertyManager{
 
 	}
 
-	/**
-	 * @param int $key
-	 *
-	 * @return int|null
-	 */
 	public function getByte(int $key) : ?int{
 		$value = $this->getPropertyValue($key, Entity::DATA_TYPE_BYTE);
 		assert(is_int($value) or $value === null);
 		return $value;
 	}
 
-	/**
-	 * @param int  $key
-	 * @param int  $value
-	 * @param bool $force
-	 */
 	public function setByte(int $key, int $value, bool $force = false) : void{
 		$this->setPropertyValue($key, Entity::DATA_TYPE_BYTE, $value, $force);
 	}
 
-	/**
-	 * @param int $key
-	 *
-	 * @return int|null
-	 */
 	public function getShort(int $key) : ?int{
 		$value = $this->getPropertyValue($key, Entity::DATA_TYPE_SHORT);
 		assert(is_int($value) or $value === null);
 		return $value;
 	}
 
-	/**
-	 * @param int  $key
-	 * @param int  $value
-	 * @param bool $force
-	 */
 	public function setShort(int $key, int $value, bool $force = false) : void{
 		$this->setPropertyValue($key, Entity::DATA_TYPE_SHORT, $value, $force);
 	}
 
-	/**
-	 * @param int $key
-	 *
-	 * @return int|null
-	 */
 	public function getInt(int $key) : ?int{
 		$value = $this->getPropertyValue($key, Entity::DATA_TYPE_INT);
 		assert(is_int($value) or $value === null);
 		return $value;
 	}
 
-	/**
-	 * @param int  $key
-	 * @param int  $value
-	 * @param bool $force
-	 */
 	public function setInt(int $key, int $value, bool $force = false) : void{
 		$this->setPropertyValue($key, Entity::DATA_TYPE_INT, $value, $force);
 	}
 
-	/**
-	 * @param int $key
-	 *
-	 * @return float|null
-	 */
 	public function getFloat(int $key) : ?float{
 		$value = $this->getPropertyValue($key, Entity::DATA_TYPE_FLOAT);
 		assert(is_float($value) or $value === null);
 		return $value;
 	}
 
-	/**
-	 * @param int   $key
-	 * @param float $value
-	 * @param bool  $force
-	 */
 	public function setFloat(int $key, float $value, bool $force = false) : void{
 		$this->setPropertyValue($key, Entity::DATA_TYPE_FLOAT, $value, $force);
 	}
 
-	/**
-	 * @param int $key
-	 *
-	 * @return null|string
-	 */
 	public function getString(int $key) : ?string{
 		$value = $this->getPropertyValue($key, Entity::DATA_TYPE_STRING);
 		assert(is_string($value) or $value === null);
 		return $value;
 	}
 
-	/**
-	 * @param int    $key
-	 * @param string $value
-	 * @param bool   $force
-	 */
 	public function setString(int $key, string $value, bool $force = false) : void{
 		$this->setPropertyValue($key, Entity::DATA_TYPE_STRING, $value, $force);
 	}
@@ -152,87 +102,44 @@ class DataPropertyManager{
 		$this->setPropertyValue($key, Entity::DATA_TYPE_COMPOUND_TAG, $value, $force);
 	}
 
-	/**
-	 * @param int $key
-	 *
-	 * @return null|Vector3
-	 */
 	public function getBlockPos(int $key) : ?Vector3{
 		$value = $this->getPropertyValue($key, Entity::DATA_TYPE_POS);
 		assert($value instanceof Vector3 or $value === null);
 		return $value;
 	}
 
-	/**
-	 * @param int          $key
-	 * @param null|Vector3 $value
-	 * @param bool         $force
-	 */
 	public function setBlockPos(int $key, ?Vector3 $value, bool $force = false) : void{
 		$this->setPropertyValue($key, Entity::DATA_TYPE_POS, $value ? $value->floor() : null, $force);
 	}
 
-	/**
-	 * @param int $key
-	 *
-	 * @return int|null
-	 */
 	public function getLong(int $key) : ?int{
 		$value = $this->getPropertyValue($key, Entity::DATA_TYPE_LONG);
 		assert(is_int($value) or $value === null);
 		return $value;
 	}
 
-	/**
-	 * @param int  $key
-	 * @param int  $value
-	 * @param bool $force
-	 */
 	public function setLong(int $key, int $value, bool $force = false) : void{
 		$this->setPropertyValue($key, Entity::DATA_TYPE_LONG, $value, $force);
 	}
 
-	/**
-	 * @param int $key
-	 *
-	 * @return null|Vector3
-	 */
 	public function getVector3(int $key) : ?Vector3{
 		$value = $this->getPropertyValue($key, Entity::DATA_TYPE_VECTOR3F);
 		assert($value instanceof Vector3 or $value === null);
 		return $value;
 	}
 
-	/**
-	 * @param int          $key
-	 * @param null|Vector3 $value
-	 * @param bool         $force
-	 */
 	public function setVector3(int $key, ?Vector3 $value, bool $force = false) : void{
 		$this->setPropertyValue($key, Entity::DATA_TYPE_VECTOR3F, $value ? $value->asVector3() : null, $force);
 	}
 
-	/**
-	 * @param int $key
-	 */
 	public function removeProperty(int $key) : void{
 		unset($this->properties[$key]);
 	}
 
-	/**
-	 * @param int $key
-	 *
-	 * @return bool
-	 */
 	public function hasProperty(int $key) : bool{
 		return isset($this->properties[$key]);
 	}
 
-	/**
-	 * @param int $key
-	 *
-	 * @return int
-	 */
 	public function getPropertyType(int $key) : int{
 		if(isset($this->properties[$key])){
 			return $this->properties[$key][0];
@@ -248,9 +155,6 @@ class DataPropertyManager{
 	}
 
 	/**
-	 * @param int $key
-	 * @param int $type
-	 *
 	 * @return mixed
 	 */
 	public function getPropertyValue(int $key, int $type){
@@ -261,10 +165,7 @@ class DataPropertyManager{
 	}
 
 	/**
-	 * @param int   $key
-	 * @param int   $type
 	 * @param mixed $value
-	 * @param bool  $force
 	 */
 	public function setPropertyValue(int $key, int $type, $value, bool $force = false) : void{
 		if(!$force){
@@ -275,8 +176,6 @@ class DataPropertyManager{
 
 	/**
 	 * Returns all properties.
-	 *
-	 * @return array
 	 */
 	public function getAll() : array{
 		return $this->properties;
@@ -284,8 +183,6 @@ class DataPropertyManager{
 
 	/**
 	 * Returns properties that have changed and need to be broadcasted.
-	 *
-	 * @return array
 	 */
 	public function getDirty() : array{
 		return $this->dirtyProperties;

--- a/src/pocketmine/entity/Effect.php
+++ b/src/pocketmine/entity/Effect.php
@@ -93,27 +93,14 @@ class Effect{
 		self::registerEffect(new Effect(Effect::CONDUIT_POWER, "%potion.conduitPower", new Color(0x1d, 0xc2, 0xd1)));
 	}
 
-	/**
-	 * @param Effect $effect
-	 */
 	public static function registerEffect(Effect $effect) : void{
 		self::$effects[$effect->getId()] = $effect;
 	}
 
-	/**
-	 * @param int $id
-	 *
-	 * @return Effect|null
-	 */
 	public static function getEffect(int $id) : ?Effect{
 		return self::$effects[$id] ?? null;
 	}
 
-	/**
-	 * @param string $name
-	 *
-	 * @return Effect|null
-	 */
 	public static function getEffectByName(string $name) : ?Effect{
 		$const = self::class . "::" . strtoupper($name);
 		if(defined($const)){
@@ -154,7 +141,6 @@ class Effect{
 
 	/**
 	 * Returns the effect ID as per Minecraft PE
-	 * @return int
 	 */
 	public function getId() : int{
 		return $this->id;
@@ -162,7 +148,6 @@ class Effect{
 
 	/**
 	 * Returns the translation key used to translate this effect's name.
-	 * @return string
 	 */
 	public function getName() : string{
 		return $this->name;
@@ -170,7 +155,6 @@ class Effect{
 
 	/**
 	 * Returns a Color object representing this effect's particle colour.
-	 * @return Color
 	 */
 	public function getColor() : Color{
 		return clone $this->color;
@@ -179,8 +163,6 @@ class Effect{
 	/**
 	 * Returns whether this effect is harmful.
 	 * TODO: implement inverse effect results for undead mobs
-	 *
-	 * @return bool
 	 */
 	public function isBad() : bool{
 		return $this->bad;
@@ -188,7 +170,6 @@ class Effect{
 
 	/**
 	 * Returns whether the effect is by default an instant effect.
-	 * @return bool
 	 */
 	public function isInstantEffect() : bool{
 		return $this->defaultDuration <= 1;
@@ -196,8 +177,6 @@ class Effect{
 
 	/**
 	 * Returns the default duration (in ticks) this effect will apply for if a duration is not specified.
-	 *
-	 * @return int
 	 */
 	public function getDefaultDuration() : int{
 		return $this->defaultDuration;
@@ -205,7 +184,6 @@ class Effect{
 
 	/**
 	 * Returns whether this effect will give the subject potion bubbles.
-	 * @return bool
 	 */
 	public function hasBubbles() : bool{
 		return $this->hasBubbles;
@@ -213,10 +191,6 @@ class Effect{
 
 	/**
 	 * Returns whether the effect will do something on the current tick.
-	 *
-	 * @param EffectInstance $instance
-	 *
-	 * @return bool
 	 */
 	public function canTick(EffectInstance $instance) : bool{
 		switch($this->id){
@@ -249,12 +223,6 @@ class Effect{
 
 	/**
 	 * Applies effect results to an entity. This will not be called unless canTick() returns true.
-	 *
-	 * @param Living         $entity
-	 * @param EffectInstance $instance
-	 * @param float          $potency
-	 * @param null|Entity    $source
-	 * @param null|Entity    $sourceOwner
 	 */
 	public function applyEffect(Living $entity, EffectInstance $instance, float $potency = 1.0, ?Entity $source = null, ?Entity $sourceOwner = null) : void{
 		switch($this->id){
@@ -315,9 +283,6 @@ class Effect{
 
 	/**
 	 * Applies effects to the entity when the effect is first added.
-	 *
-	 * @param Living         $entity
-	 * @param EffectInstance $instance
 	 */
 	public function add(Living $entity, EffectInstance $instance) : void{
 		switch($this->id){
@@ -348,9 +313,6 @@ class Effect{
 
 	/**
 	 * Removes the effect from the entity, resetting any changed values back to their original defaults.
-	 *
-	 * @param Living         $entity
-	 * @param EffectInstance $instance
 	 */
 	public function remove(Living $entity, EffectInstance $instance) : void{
 		switch($this->id){

--- a/src/pocketmine/entity/EffectInstance.php
+++ b/src/pocketmine/entity/EffectInstance.php
@@ -47,12 +47,7 @@ class EffectInstance{
 	private $color;
 
 	/**
-	 * @param Effect     $effectType
 	 * @param int|null   $duration Passing null will use the effect type's default duration
-	 * @param int        $amplifier
-	 * @param bool       $visible
-	 * @param bool       $ambient
-	 * @param null|Color $overrideColor
 	 */
 	public function __construct(Effect $effectType, ?int $duration = null, int $amplifier = 0, bool $visible = true, bool $ambient = false, ?Color $overrideColor = null){
 		$this->effectType = $effectType;
@@ -67,17 +62,12 @@ class EffectInstance{
 		return $this->effectType->getId();
 	}
 
-	/**
-	 * @return Effect
-	 */
 	public function getType() : Effect{
 		return $this->effectType;
 	}
 
 	/**
 	 * Returns the number of ticks remaining until the effect expires.
-	 *
-	 * @return int
 	 */
 	public function getDuration() : int{
 		return $this->duration;
@@ -85,8 +75,6 @@ class EffectInstance{
 
 	/**
 	 * Sets the number of ticks remaining until the effect expires.
-	 *
-	 * @param int $duration
 	 *
 	 * @throws \InvalidArgumentException
 	 *
@@ -104,8 +92,6 @@ class EffectInstance{
 	/**
 	 * Decreases the duration by the given number of ticks, without dropping below zero.
 	 *
-	 * @param int $ticks
-	 *
 	 * @return $this
 	 */
 	public function decreaseDuration(int $ticks) : EffectInstance{
@@ -116,32 +102,23 @@ class EffectInstance{
 
 	/**
 	 * Returns whether the duration has run out.
-	 *
-	 * @return bool
 	 */
 	public function hasExpired() : bool{
 		return $this->duration <= 0;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getAmplifier() : int{
 		return $this->amplifier;
 	}
 
 	/**
 	 * Returns the level of this effect, which is always one higher than the amplifier.
-	 *
-	 * @return int
 	 */
 	public function getEffectLevel() : int{
 		return $this->amplifier + 1;
 	}
 
 	/**
-	 * @param int $amplifier
-	 *
 	 * @return $this
 	 */
 	public function setAmplifier(int $amplifier) : EffectInstance{
@@ -152,16 +129,12 @@ class EffectInstance{
 
 	/**
 	 * Returns whether this effect will produce some visible effect, such as bubbles or particles.
-	 *
-	 * @return bool
 	 */
 	public function isVisible() : bool{
 		return $this->visible;
 	}
 
 	/**
-	 * @param bool $visible
-	 *
 	 * @return $this
 	 */
 	public function setVisible(bool $visible = true) : EffectInstance{
@@ -174,16 +147,12 @@ class EffectInstance{
 	 * Returns whether the effect originated from the ambient environment.
 	 * Ambient effects can originate from things such as a Beacon's area of effect radius.
 	 * If this flag is set, the amount of visible particles will be reduced by a factor of 5.
-	 *
-	 * @return bool
 	 */
 	public function isAmbient() : bool{
 		return $this->ambient;
 	}
 
 	/**
-	 * @param bool $ambient
-	 *
 	 * @return $this
 	 */
 	public function setAmbient(bool $ambient = true) : EffectInstance{
@@ -195,8 +164,6 @@ class EffectInstance{
 	/**
 	 * Returns the particle colour of this effect instance. This can be overridden on a per-EffectInstance basis, so it
 	 * is not reflective of the default colour of the effect.
-	 *
-	 * @return Color
 	 */
 	public function getColor() : Color{
 		return clone $this->color;
@@ -204,10 +171,6 @@ class EffectInstance{
 
 	/**
 	 * Sets the colour of this EffectInstance.
-	 *
-	 * @param Color $color
-	 *
-	 * @return EffectInstance
 	 */
 	public function setColor(Color $color) : EffectInstance{
 		$this->color = clone $color;
@@ -217,8 +180,6 @@ class EffectInstance{
 
 	/**
 	 * Resets the colour of this EffectInstance to the default specified by its type.
-	 *
-	 * @return EffectInstance
 	 */
 	public function resetColor() : EffectInstance{
 		$this->color = $this->effectType->getColor();

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -353,17 +353,12 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 		PaintingMotive::init();
 	}
 
-
 	/**
 	 * Creates an entity with the specified type, level and NBT, with optional additional arguments to pass to the
 	 * entity's constructor
 	 *
 	 * @param int|string  $type
-	 * @param Level       $level
-	 * @param CompoundTag $nbt
 	 * @param mixed       ...$args
-	 *
-	 * @return Entity|null
 	 */
 	public static function createEntity($type, Level $level, CompoundTag $nbt, ...$args) : ?Entity{
 		if(isset(self::$knownEntities[$type])){
@@ -384,8 +379,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 	 *
 	 * NOTE: The first save name in the $saveNames array will be used when saving the entity to disk. The reflection
 	 * name of the class will be appended to the end and only used if no other save names are specified.
-	 *
-	 * @return bool
 	 */
 	public static function registerEntity(string $className, bool $force = false, array $saveNames = []) : bool{
 		/** @var Entity $className */
@@ -417,13 +410,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 
 	/**
 	 * Helper function which creates minimal NBT needed to spawn an entity.
-	 *
-	 * @param Vector3      $pos
-	 * @param Vector3|null $motion
-	 * @param float        $yaw
-	 * @param float        $pitch
-	 *
-	 * @return CompoundTag
 	 */
 	public static function createBaseNBT(Vector3 $pos, ?Vector3 $motion = null, float $yaw = 0.0, float $pitch = 0.0) : CompoundTag{
 		return new CompoundTag("", [
@@ -652,73 +638,42 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getNameTag() : string{
 		return $this->propertyManager->getString(self::DATA_NAMETAG);
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isNameTagVisible() : bool{
 		return $this->getGenericFlag(self::DATA_FLAG_CAN_SHOW_NAMETAG);
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isNameTagAlwaysVisible() : bool{
 		return $this->propertyManager->getByte(self::DATA_ALWAYS_SHOW_NAMETAG) === 1;
 	}
 
-
-	/**
-	 * @param string $name
-	 */
 	public function setNameTag(string $name) : void{
 		$this->propertyManager->setString(self::DATA_NAMETAG, $name);
 	}
 
-	/**
-	 * @param bool $value
-	 */
 	public function setNameTagVisible(bool $value = true) : void{
 		$this->setGenericFlag(self::DATA_FLAG_CAN_SHOW_NAMETAG, $value);
 	}
 
-	/**
-	 * @param bool $value
-	 */
 	public function setNameTagAlwaysVisible(bool $value = true) : void{
 		$this->propertyManager->setByte(self::DATA_ALWAYS_SHOW_NAMETAG, $value ? 1 : 0);
 	}
 
-	/**
-	 * @return string|null
-	 */
 	public function getScoreTag() : ?string{
 		return $this->propertyManager->getString(self::DATA_SCORE_TAG);
 	}
 
-	/**
-	 * @param string $score
-	 */
 	public function setScoreTag(string $score) : void{
 		$this->propertyManager->setString(self::DATA_SCORE_TAG, $score);
 	}
 
-	/**
-	 * @return float
-	 */
 	public function getScale() : float{
 		return $this->propertyManager->getFloat(self::DATA_SCALE);
 	}
 
-	/**
-	 * @param float $value
-	 */
 	public function setScale(float $value) : void{
 		if($value <= 0){
 			throw new \InvalidArgumentException("Scale must be greater than 0");
@@ -789,7 +744,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 
 	/**
 	 * Returns whether the entity is able to climb blocks such as ladders or vines.
-	 * @return bool
 	 */
 	public function canClimb() : bool{
 		return $this->getGenericFlag(self::DATA_FLAG_CAN_CLIMB);
@@ -797,8 +751,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 
 	/**
 	 * Sets whether the entity is able to climb climbable blocks.
-	 *
-	 * @param bool $value
 	 */
 	public function setCanClimb(bool $value = true) : void{
 		$this->setGenericFlag(self::DATA_FLAG_CAN_CLIMB, $value);
@@ -806,8 +758,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 
 	/**
 	 * Returns whether this entity is climbing a block. By default this is only true if the entity is climbing a ladder or vine or similar block.
-	 *
-	 * @return bool
 	 */
 	public function canClimbWalls() : bool{
 		return $this->getGenericFlag(self::DATA_FLAG_WALLCLIMBING);
@@ -815,8 +765,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 
 	/**
 	 * Sets whether the entity is climbing a block. If true, the entity can climb anything.
-	 *
-	 * @param bool $value
 	 */
 	public function setCanClimbWalls(bool $value = true) : void{
 		$this->setGenericFlag(self::DATA_FLAG_WALLCLIMBING, $value);
@@ -824,7 +772,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 
 	/**
 	 * Returns the entity ID of the owning entity, or null if the entity doesn't have an owner.
-	 * @return int|null
 	 */
 	public function getOwningEntityId() : ?int{
 		return $this->propertyManager->getLong(self::DATA_OWNER_EID);
@@ -832,7 +779,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 
 	/**
 	 * Returns the owning entity, or null if the entity was not found.
-	 * @return Entity|null
 	 */
 	public function getOwningEntity() : ?Entity{
 		$eid = $this->getOwningEntityId();
@@ -845,8 +791,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 
 	/**
 	 * Sets the owner of the entity. Passing null will remove the current owner.
-	 *
-	 * @param Entity|null $owner
 	 *
 	 * @throws \InvalidArgumentException if the supplied entity is not valid
 	 */
@@ -862,7 +806,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 
 	/**
 	 * Returns the entity ID of the entity's target, or null if it doesn't have a target.
-	 * @return int|null
 	 */
 	public function getTargetEntityId() : ?int{
 		return $this->propertyManager->getLong(self::DATA_TARGET_EID);
@@ -871,8 +814,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 	/**
 	 * Returns the entity's target entity, or null if not found.
 	 * This is used for things like hostile mobs attacking entities, and for fishing rods reeling hit entities in.
-	 *
-	 * @return Entity|null
 	 */
 	public function getTargetEntity() : ?Entity{
 		$eid = $this->getTargetEntityId();
@@ -885,8 +826,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 
 	/**
 	 * Sets the entity's target entity. Passing null will remove the current target.
-	 *
-	 * @param Entity|null $target
 	 *
 	 * @throws \InvalidArgumentException if the target entity is not valid
 	 */
@@ -902,7 +841,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 
 	/**
 	 * Returns whether this entity will be saved when its chunk is unloaded.
-	 * @return bool
 	 */
 	public function canSaveWithChunk() : bool{
 		return $this->savedWithChunk;
@@ -911,8 +849,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 	/**
 	 * Sets whether this entity will be saved when its chunk is unloaded. This can be used to prevent the entity being
 	 * saved to disk.
-	 *
-	 * @param bool $value
 	 */
 	public function setCanSaveWithChunk(bool $value) : void{
 		$this->savedWithChunk = $value;
@@ -920,8 +856,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 
 	/**
 	 * Returns the short save name
-	 *
-	 * @return string
 	 */
 	public function getSaveId() : string{
 		if(!isset(self::$saveNames[static::class])){
@@ -987,9 +921,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 
 	}
 
-	/**
-	 * @param EntityDamageEvent $source
-	 */
 	public function attack(EntityDamageEvent $source) : void{
 		$source->call();
 		if($source->isCancelled()){
@@ -1001,9 +932,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 		$this->setHealth($this->getHealth() - $source->getFinalDamage());
 	}
 
-	/**
-	 * @param EntityRegainHealthEvent $source
-	 */
 	public function heal(EntityRegainHealthEvent $source) : void{
 		$source->call();
 		if($source->isCancelled()){
@@ -1020,10 +948,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 
 	/**
 	 * Called to tick entities while dead. Returns whether the entity should be flagged for despawn yet.
-	 *
-	 * @param int $tickDiff
-	 *
-	 * @return bool
 	 */
 	protected function onDeathUpdate(int $tickDiff) : bool{
 		return true;
@@ -1033,17 +957,12 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 		return $this->health > 0;
 	}
 
-	/**
-	 * @return float
-	 */
 	public function getHealth() : float{
 		return $this->health;
 	}
 
 	/**
 	 * Sets the health of the Entity. This won't send any update to the players
-	 *
-	 * @param float $amount
 	 */
 	public function setHealth(float $amount) : void{
 		if($amount == $this->health){
@@ -1062,30 +981,18 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 		}
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getMaxHealth() : int{
 		return $this->maxHealth;
 	}
 
-	/**
-	 * @param int $amount
-	 */
 	public function setMaxHealth(int $amount) : void{
 		$this->maxHealth = $amount;
 	}
 
-	/**
-	 * @param EntityDamageEvent $type
-	 */
 	public function setLastDamageCause(EntityDamageEvent $type) : void{
 		$this->lastDamageCause = $type;
 	}
 
-	/**
-	 * @return EntityDamageEvent|null
-	 */
 	public function getLastDamageCause() : ?EntityDamageEvent{
 		return $this->lastDamageCause;
 	}
@@ -1148,15 +1055,11 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 		$this->setGenericFlag(self::DATA_FLAG_ONFIRE, $this->isOnFire());
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getFireTicks() : int{
 		return $this->fireTicks;
 	}
 
 	/**
-	 * @param int $fireTicks
 	 * @throws \InvalidArgumentException
 	 */
 	public function setFireTicks(int $fireTicks) : void{
@@ -1397,9 +1300,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 		return false;
 	}
 
-	/**
-	 * @return int|null
-	 */
 	public function getDirection() : ?int{
 		$rotation = ($this->yaw - 90) % 360;
 		if($rotation < 0){
@@ -1418,9 +1318,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 		}
 	}
 
-	/**
-	 * @return Vector3
-	 */
 	public function getDirectionVector() : Vector3{
 		$y = -sin(deg2rad($this->pitch));
 		$xz = cos(deg2rad($this->pitch));
@@ -1510,8 +1407,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 	/**
 	 * Flags the entity as needing a movement update on the next tick. Setting this forces a movement update even if the
 	 * entity's motion is zero. Used to trigger movement updates when blocks change near entities.
-	 *
-	 * @param bool $value
 	 */
 	final public function setForceMovementUpdate(bool $value = true) : void{
 		$this->forceMovementUpdate = $value;
@@ -1521,7 +1416,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 
 	/**
 	 * Returns whether the entity needs a movement update on the next tick.
-	 * @return bool
 	 */
 	public function hasMovementUpdate() : bool{
 		return (
@@ -1541,10 +1435,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 		$this->fallDistance = 0.0;
 	}
 
-	/**
-	 * @param float $distanceThisTick
-	 * @param bool  $onGround
-	 */
 	protected function updateFallState(float $distanceThisTick, bool $onGround) : void{
 		if($onGround){
 			if($this->fallDistance > 0){
@@ -1558,8 +1448,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 
 	/**
 	 * Called when a falling entity hits the ground.
-	 *
-	 * @param float $fallDistance
 	 */
 	public function fall(float $fallDistance) : void{
 
@@ -1823,8 +1711,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 
 	/**
 	 * Returns whether this entity can be moved by currents in liquids.
-	 *
-	 * @return bool
 	 */
 	public function canBeMovedByCurrents() : bool{
 		return true;
@@ -1960,10 +1846,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 
 	/**
 	 * @param Vector3|Position|Location $pos
-	 * @param float|null                $yaw
-	 * @param float|null                $pitch
-	 *
-	 * @return bool
 	 */
 	public function teleport(Vector3 $pos, ?float $yaw = null, ?float $pitch = null) : bool{
 		if($pos instanceof Location){
@@ -2032,8 +1914,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 
 	/**
 	 * Called by spawnTo() to send whatever packets needed to spawn the entity to the client.
-	 *
-	 * @param Player $player
 	 */
 	protected function sendSpawnPacket(Player $player) : void{
 		$pk = new AddActorPacket();
@@ -2050,9 +1930,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 		$player->dataPacket($pk);
 	}
 
-	/**
-	 * @param Player $player
-	 */
 	public function spawnTo(Player $player) : void{
 		if(!isset($this->hasSpawned[$player->getLoaderId()]) and $this->chunk !== null and isset($player->usedChunks[Level::chunkHash($this->chunk->getX(), $this->chunk->getZ())])){
 			$this->hasSpawned[$player->getLoaderId()] = $player;
@@ -2082,9 +1959,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 	/**
 	 * @deprecated WARNING: This function DOES NOT permanently hide the entity from the player. As soon as the entity or
 	 * player moves, the player will once again be able to see the entity.
-	 *
-	 * @param Player $player
-	 * @param bool   $send
 	 */
 	public function despawnFrom(Player $player, bool $send = true) : void{
 		if(isset($this->hasSpawned[$player->getLoaderId()])){
@@ -2121,7 +1995,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 
 	/**
 	 * Returns whether the entity has been "closed".
-	 * @return bool
 	 */
 	public function isClosed() : bool{
 		return $this->closed;
@@ -2161,12 +2034,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 		}
 	}
 
-	/**
-	 * @param int  $propertyId
-	 * @param int  $flagId
-	 * @param bool $value
-	 * @param int  $propertyType
-	 */
 	public function setDataFlag(int $propertyId, int $flagId, bool $value = true, int $propertyType = self::DATA_TYPE_LONG) : void{
 		if($this->getDataFlag($propertyId, $flagId) !== $value){
 			$flags = (int) $this->propertyManager->getPropertyValue($propertyId, $propertyType);
@@ -2175,22 +2042,12 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 		}
 	}
 
-	/**
-	 * @param int $propertyId
-	 * @param int $flagId
-	 *
-	 * @return bool
-	 */
 	public function getDataFlag(int $propertyId, int $flagId) : bool{
 		return (((int) $this->propertyManager->getPropertyValue($propertyId, -1)) & (1 << $flagId)) > 0;
 	}
 
 	/**
 	 * Wrapper around {@link Entity#getDataFlag} for generic data flag reading.
-	 *
-	 * @param int $flagId
-	 *
-	 * @return bool
 	 */
 	public function getGenericFlag(int $flagId) : bool{
 		return $this->getDataFlag($flagId >= 64 ? self::DATA_FLAGS2 : self::DATA_FLAGS, $flagId % 64);
@@ -2198,9 +2055,6 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 
 	/**
 	 * Wrapper around {@link Entity#setDataFlag} for generic data flag setting.
-	 *
-	 * @param int  $flagId
-	 * @param bool $value
 	 */
 	public function setGenericFlag(int $flagId, bool $value = true) : void{
 		$this->setDataFlag($flagId >= 64 ? self::DATA_FLAGS2 : self::DATA_FLAGS, $flagId % 64, $value, self::DATA_TYPE_LONG);

--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -116,9 +116,6 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 	}
 
 	/**
-	 * @param CompoundTag $skinTag
-	 *
-	 * @return Skin
 	 * @throws \InvalidArgumentException
 	 */
 	protected static function deserializeSkinNBT(CompoundTag $skinTag) : Skin{
@@ -137,32 +134,21 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 	 * @deprecated
 	 *
 	 * Checks the length of a supplied skin bitmap and returns whether the length is valid.
-	 *
-	 * @param string $skin
-	 *
-	 * @return bool
 	 */
 	public static function isValidSkin(string $skin) : bool{
 		return in_array(strlen($skin), Skin::ACCEPTED_SKIN_SIZES, true);
 	}
 
-	/**
-	 * @return UUID|null
-	 */
 	public function getUniqueId() : ?UUID{
 		return $this->uuid;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getRawUniqueId() : string{
 		return $this->rawUUID;
 	}
 
 	/**
 	 * Returns a Skin object containing information about this human's skin.
-	 * @return Skin
 	 */
 	public function getSkin() : Skin{
 		return $this->skin;
@@ -171,8 +157,6 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 	/**
 	 * Sets the human's skin. This will not send any update to viewers, you need to do that manually using
 	 * {@link sendSkin}.
-	 *
-	 * @param Skin $skin
 	 */
 	public function setSkin(Skin $skin) : void{
 		$skin->validate();
@@ -210,8 +194,6 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 	 * WARNING: This method does not check if full and may throw an exception if out of bounds.
 	 * Use {@link Human::addFood()} for this purpose
 	 *
-	 * @param float $new
-	 *
 	 * @throws \InvalidArgumentException
 	 */
 	public function setFood(float $new) : void{
@@ -241,8 +223,6 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 
 	/**
 	 * Returns whether this Human may consume objects requiring hunger.
-	 *
-	 * @return bool
 	 */
 	public function isHungry() : bool{
 		return $this->getFood() < $this->getMaxFood();
@@ -255,8 +235,6 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 	/**
 	 * WARNING: This method does not check if saturated and may throw an exception if out of bounds.
 	 * Use {@link Human::addSaturation()} for this purpose
-	 *
-	 * @param float $saturation
 	 *
 	 * @throws \InvalidArgumentException
 	 */
@@ -276,8 +254,6 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 	/**
 	 * WARNING: This method does not check if exhausted and does not consume saturation/food.
 	 * Use {@link Human::exhaust()} for this purpose.
-	 *
-	 * @param float $exhaustion
 	 */
 	public function setExhaustion(float $exhaustion) : void{
 		$this->attributeMap->getAttribute(Attribute::EXHAUSTION)->setValue($exhaustion);
@@ -285,9 +261,6 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 
 	/**
 	 * Increases a human's exhaustion level.
-	 *
-	 * @param float $amount
-	 * @param int   $cause
 	 *
 	 * @return float the amount of exhaustion level increased
 	 */
@@ -336,7 +309,6 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 
 	/**
 	 * Returns the player's experience level.
-	 * @return int
 	 */
 	public function getXpLevel() : int{
 		return (int) $this->attributeMap->getAttribute(Attribute::EXPERIENCE_LEVEL)->getValue();
@@ -344,10 +316,6 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 
 	/**
 	 * Sets the player's experience level. This does not affect their total XP or their XP progress.
-	 *
-	 * @param int $level
-	 *
-	 * @return bool
 	 */
 	public function setXpLevel(int $level) : bool{
 		return $this->setXpAndProgress($level, null);
@@ -355,11 +323,6 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 
 	/**
 	 * Adds a number of XP levels to the player.
-	 *
-	 * @param int  $amount
-	 * @param bool $playSound
-	 *
-	 * @return bool
 	 */
 	public function addXpLevels(int $amount, bool $playSound = true) : bool{
 		$oldLevel = $this->getXpLevel();
@@ -379,10 +342,6 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 
 	/**
 	 * Subtracts a number of XP levels from the player.
-	 *
-	 * @param int $amount
-	 *
-	 * @return bool
 	 */
 	public function subtractXpLevels(int $amount) : bool{
 		return $this->addXpLevels(-$amount);
@@ -390,7 +349,6 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 
 	/**
 	 * Returns a value between 0.0 and 1.0 to indicate how far through the current level the player is.
-	 * @return float
 	 */
 	public function getXpProgress() : float{
 		return $this->attributeMap->getAttribute(Attribute::EXPERIENCE)->getValue();
@@ -398,10 +356,6 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 
 	/**
 	 * Sets the player's progress through the current level to a value between 0.0 and 1.0.
-	 *
-	 * @param float $progress
-	 *
-	 * @return bool
 	 */
 	public function setXpProgress(float $progress) : bool{
 		return $this->setXpAndProgress(null, $progress);
@@ -409,7 +363,6 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 
 	/**
 	 * Returns the number of XP points the player has progressed into their current level.
-	 * @return int
 	 */
 	public function getRemainderXp() : int{
 		return (int) (ExperienceUtils::getXpToCompleteLevel($this->getXpLevel()) * $this->getXpProgress());
@@ -419,8 +372,6 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 	 * Returns the amount of XP points the player currently has, calculated from their current level and progress
 	 * through their current level. This will be reduced by enchanting deducting levels and is used to calculate the
 	 * amount of XP the player drops on death.
-	 *
-	 * @return int
 	 */
 	public function getCurrentTotalXp() : int{
 		return ExperienceUtils::getXpToReachLevel($this->getXpLevel()) + $this->getRemainderXp();
@@ -429,10 +380,6 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 	/**
 	 * Sets the current total of XP the player has, recalculating their XP level and progress.
 	 * Note that this DOES NOT update the player's lifetime total XP.
-	 *
-	 * @param int $amount
-	 *
-	 * @return bool
 	 */
 	public function setCurrentTotalXp(int $amount) : bool{
 		$newLevel = ExperienceUtils::getLevelFromXp($amount);
@@ -444,10 +391,7 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 	 * Adds an amount of XP to the player, recalculating their XP level and progress. XP amount will be added to the
 	 * player's lifetime XP.
 	 *
-	 * @param int  $amount
 	 * @param bool $playSound Whether to play level-up and XP gained sounds.
-	 *
-	 * @return bool
 	 */
 	public function addXp(int $amount, bool $playSound = true) : bool{
 		$this->totalXp += $amount;
@@ -478,10 +422,6 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 
 	/**
 	 * Takes an amount of XP from the player, recalculating their XP level and progress.
-	 *
-	 * @param int $amount
-	 *
-	 * @return bool
 	 */
 	public function subtractXp(int $amount) : bool{
 		return $this->addXp(-$amount);
@@ -514,8 +454,6 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 	/**
 	 * Returns the total XP the player has collected in their lifetime. Resets when the player dies.
 	 * XP levels being removed in enchanting do not reduce this number.
-	 *
-	 * @return int
 	 */
 	public function getLifetimeTotalXp() : int{
 		return $this->totalXp;
@@ -524,8 +462,6 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 	/**
 	 * Sets the lifetime total XP of the player. This does not recalculate their level or progress. Used for player
 	 * score when they die. (TODO: add this when MCPE supports it)
-	 *
-	 * @param int $amount
 	 */
 	public function setLifetimeTotalXp(int $amount) : void{
 		if($amount < 0){
@@ -537,7 +473,6 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 
 	/**
 	 * Returns whether the human can pickup XP orbs (checks cooldown time)
-	 * @return bool
 	 */
 	public function canPickupXp() : bool{
 		return $this->xpCooldown === 0;
@@ -581,8 +516,6 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 
 	/**
 	 * Sets the duration in ticks until the human can pick up another XP orb.
-	 *
-	 * @param int $value
 	 */
 	public function resetXpCooldown(int $value = 2) : void{
 		$this->xpCooldown = $value;
@@ -902,10 +835,6 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 
 	/**
 	 * Wrapper around {@link Entity#getDataFlag} for player-specific data flag reading.
-	 *
-	 * @param int $flagId
-	 *
-	 * @return bool
 	 */
 	public function getPlayerFlag(int $flagId) : bool{
 		return $this->getDataFlag(self::DATA_PLAYER_FLAGS, $flagId);
@@ -913,9 +842,6 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 
 	/**
 	 * Wrapper around {@link Entity#setDataFlag} for player-specific data flag setting.
-	 *
-	 * @param int  $flagId
-	 * @param bool $value
 	 */
 	public function setPlayerFlag(int $flagId, bool $value = true) : void{
 		$this->setDataFlag(self::DATA_PLAYER_FLAGS, $flagId, $value, self::DATA_TYPE_BYTE);

--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -213,8 +213,6 @@ abstract class Living extends Entity implements Damageable{
 
 	/**
 	 * Removes the effect with the specified ID from the mob.
-	 *
-	 * @param int $effectId
 	 */
 	public function removeEffect(int $effectId) : void{
 		if(isset($this->effects[$effectId])){
@@ -240,10 +238,6 @@ abstract class Living extends Entity implements Damageable{
 	/**
 	 * Returns the effect instance active on this entity with the specified ID, or null if the mob does not have the
 	 * effect.
-	 *
-	 * @param int $effectId
-	 *
-	 * @return EffectInstance|null
 	 */
 	public function getEffect(int $effectId) : ?EffectInstance{
 		return $this->effects[$effectId] ?? null;
@@ -251,10 +245,6 @@ abstract class Living extends Entity implements Damageable{
 
 	/**
 	 * Returns whether the specified effect is active on the mob.
-	 *
-	 * @param int $effectId
-	 *
-	 * @return bool
 	 */
 	public function hasEffect(int $effectId) : bool{
 		return isset($this->effects[$effectId]);
@@ -262,7 +252,6 @@ abstract class Living extends Entity implements Damageable{
 
 	/**
 	 * Returns whether the mob has any active effects.
-	 * @return bool
 	 */
 	public function hasEffects() : bool{
 		return count($this->effects) > 0;
@@ -272,8 +261,6 @@ abstract class Living extends Entity implements Damageable{
 	 * Adds an effect to the mob.
 	 * If a weaker effect of the same type is already applied, it will be replaced.
 	 * If a weaker or equal-strength effect is already applied but has a shorter duration, it will be replaced.
-	 *
-	 * @param EffectInstance $effect
 	 *
 	 * @return bool whether the effect has been successfully applied.
 	 */
@@ -345,8 +332,6 @@ abstract class Living extends Entity implements Damageable{
 
 	/**
 	 * Sends the mob's potion effects to the specified player.
-	 *
-	 * @param Player $player
 	 */
 	public function sendPotionEffects(Player $player) : void{
 		foreach($this->effects as $effect){
@@ -373,10 +358,6 @@ abstract class Living extends Entity implements Damageable{
 	/**
 	 * Causes the mob to consume the given Consumable object, applying applicable effects, health bonuses, food bonuses,
 	 * etc.
-	 *
-	 * @param Consumable $consumable
-	 *
-	 * @return bool
 	 */
 	public function consumeObject(Consumable $consumable) : bool{
 		foreach($consumable->getAdditionalEffects() as $effect){
@@ -390,7 +371,6 @@ abstract class Living extends Entity implements Damageable{
 
 	/**
 	 * Returns the initial upwards velocity of a jumping entity in blocks/tick, including additional velocity due to effects.
-	 * @return float
 	 */
 	public function getJumpVelocity() : float{
 		return $this->jumpVelocity + ($this->hasEffect(Effect::JUMP) ? ($this->getEffect(Effect::JUMP)->getEffectLevel() / 10) : 0);
@@ -417,8 +397,6 @@ abstract class Living extends Entity implements Damageable{
 	 * Returns how many armour points this mob has. Armour points provide a percentage reduction to damage.
 	 * For mobs which can wear armour, this should return the sum total of the armour points provided by their
 	 * equipment.
-	 *
-	 * @return int
 	 */
 	public function getArmorPoints() : int{
 		$total = 0;
@@ -431,10 +409,6 @@ abstract class Living extends Entity implements Damageable{
 
 	/**
 	 * Returns the highest level of the specified enchantment on any armour piece that the entity is currently wearing.
-	 *
-	 * @param int $enchantmentId
-	 *
-	 * @return int
 	 */
 	public function getHighestArmorEnchantmentLevel(int $enchantmentId) : int{
 		$result = 0;
@@ -445,9 +419,6 @@ abstract class Living extends Entity implements Damageable{
 		return $result;
 	}
 
-	/**
-	 * @return ArmorInventory
-	 */
 	public function getArmorInventory() : ArmorInventory{
 		return $this->armorInventory;
 	}
@@ -459,8 +430,6 @@ abstract class Living extends Entity implements Damageable{
 	/**
 	 * Called prior to EntityDamageEvent execution to apply modifications to the event's damage, such as reduction due
 	 * to effects or armour.
-	 *
-	 * @param EntityDamageEvent $source
 	 */
 	public function applyDamageModifiers(EntityDamageEvent $source) : void{
 		if($source->canBeReducedByArmor()){
@@ -488,8 +457,6 @@ abstract class Living extends Entity implements Damageable{
 	 * Called after EntityDamageEvent execution to apply post-hurt effects, such as reducing absorption or modifying
 	 * armour durability.
 	 * This will not be called by damage sources causing death.
-	 *
-	 * @param EntityDamageEvent $source
 	 */
 	protected function applyPostDamageEffects(EntityDamageEvent $source) : void{
 		$this->setAbsorption(max(0, $this->getAbsorption() + $source->getModifier(EntityDamageEvent::MODIFIER_ABSORPTION)));
@@ -519,8 +486,6 @@ abstract class Living extends Entity implements Damageable{
 	/**
 	 * Damages the worn armour according to the amount of damage given. Each 4 points (rounded down) deals 1 damage
 	 * point to each armour piece, but never less than 1 total.
-	 *
-	 * @param float $damage
 	 */
 	public function damageArmor(float $damage) : void{
 		$durabilityRemoved = (int) max(floor($damage / 4), 1);
@@ -720,10 +685,6 @@ abstract class Living extends Entity implements Damageable{
 
 	/**
 	 * Ticks the entity's air supply, consuming it when underwater and regenerating it when out of water.
-	 *
-	 * @param int $tickDiff
-	 *
-	 * @return bool
 	 */
 	protected function doAirSupplyTick(int $tickDiff) : bool{
 		$ticks = $this->getAirSupplyTicks();
@@ -759,7 +720,6 @@ abstract class Living extends Entity implements Damageable{
 
 	/**
 	 * Returns whether the entity can currently breathe.
-	 * @return bool
 	 */
 	public function canBreathe() : bool{
 		return $this->hasEffect(Effect::WATER_BREATHING) or $this->hasEffect(Effect::CONDUIT_POWER) or !$this->isUnderwater();
@@ -767,7 +727,6 @@ abstract class Living extends Entity implements Damageable{
 
 	/**
 	 * Returns whether the entity is currently breathing or not. If this is false, the entity's air supply will be used.
-	 * @return bool
 	 */
 	public function isBreathing() : bool{
 		return $this->getGenericFlag(self::DATA_FLAG_BREATHING);
@@ -776,8 +735,6 @@ abstract class Living extends Entity implements Damageable{
 	/**
 	 * Sets whether the entity is currently breathing. If false, it will cause the entity's air supply to be used.
 	 * For players, this also shows the oxygen bar.
-	 *
-	 * @param bool $value
 	 */
 	public function setBreathing(bool $value = true) : void{
 		$this->setGenericFlag(self::DATA_FLAG_BREATHING, $value);
@@ -786,8 +743,6 @@ abstract class Living extends Entity implements Damageable{
 	/**
 	 * Returns the number of ticks remaining in the entity's air supply. Note that the entity may survive longer than
 	 * this amount of time without damage due to enchantments such as Respiration.
-	 *
-	 * @return int
 	 */
 	public function getAirSupplyTicks() : int{
 		return $this->propertyManager->getShort(self::DATA_AIR);
@@ -795,8 +750,6 @@ abstract class Living extends Entity implements Damageable{
 
 	/**
 	 * Sets the number of air ticks left in the entity's air supply.
-	 *
-	 * @param int $ticks
 	 */
 	public function setAirSupplyTicks(int $ticks) : void{
 		$this->propertyManager->setShort(self::DATA_AIR, $ticks);
@@ -804,7 +757,6 @@ abstract class Living extends Entity implements Damageable{
 
 	/**
 	 * Returns the maximum amount of air ticks the entity's air supply can contain.
-	 * @return int
 	 */
 	public function getMaxAirSupplyTicks() : int{
 		return $this->propertyManager->getShort(self::DATA_MAX_AIR);
@@ -812,8 +764,6 @@ abstract class Living extends Entity implements Damageable{
 
 	/**
 	 * Sets the maximum amount of air ticks the air supply can hold.
-	 *
-	 * @param int $ticks
 	 */
 	public function setMaxAirSupplyTicks(int $ticks) : void{
 		$this->propertyManager->setShort(self::DATA_MAX_AIR, $ticks);
@@ -837,17 +787,12 @@ abstract class Living extends Entity implements Damageable{
 
 	/**
 	 * Returns the amount of XP this mob will drop on death.
-	 * @return int
 	 */
 	public function getXpDropAmount() : int{
 		return 0;
 	}
 
 	/**
-	 * @param int   $maxDistance
-	 * @param int   $maxLength
-	 * @param array $transparent
-	 *
 	 * @return Block[]
 	 */
 	public function getLineOfSight(int $maxDistance, int $maxLength = 0, array $transparent = []) : array{
@@ -887,12 +832,6 @@ abstract class Living extends Entity implements Damageable{
 		return $blocks;
 	}
 
-	/**
-	 * @param int   $maxDistance
-	 * @param array $transparent
-	 *
-	 * @return Block|null
-	 */
 	public function getTargetBlock(int $maxDistance, array $transparent = []) : ?Block{
 		$line = $this->getLineOfSight($maxDistance, 1, $transparent);
 		if(count($line) > 0){
@@ -905,8 +844,6 @@ abstract class Living extends Entity implements Damageable{
 	/**
 	 * Changes the entity's yaw and pitch to make it look at the specified Vector3 position. For mobs, this will cause
 	 * their heads to turn.
-	 *
-	 * @param Vector3 $target
 	 */
 	public function lookAt(Vector3 $target) : void{
 		$horizontal = sqrt(($target->x - $this->x) ** 2 + ($target->z - $this->z) ** 2);

--- a/src/pocketmine/entity/Skin.php
+++ b/src/pocketmine/entity/Skin.php
@@ -57,7 +57,6 @@ class Skin{
 
 	/**
 	 * @deprecated
-	 * @return bool
 	 */
 	public function isValid() : bool{
 		try{

--- a/src/pocketmine/entity/Skin.php
+++ b/src/pocketmine/entity/Skin.php
@@ -85,37 +85,22 @@ class Skin{
 		//TODO: validate geometry
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getSkinId() : string{
 		return $this->skinId;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getSkinData() : string{
 		return $this->skinData;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getCapeData() : string{
 		return $this->capeData;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getGeometryName() : string{
 		return $this->geometryName;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getGeometryData() : string{
 		return $this->geometryData;
 	}

--- a/src/pocketmine/entity/Villager.php
+++ b/src/pocketmine/entity/Villager.php
@@ -59,8 +59,6 @@ class Villager extends Creature implements NPC, Ageable{
 
 	/**
 	 * Sets the villager profession
-	 *
-	 * @param int $profession
 	 */
 	public function setProfession(int $profession) : void{
 		$this->propertyManager->setInt(self::DATA_VARIANT, $profession);

--- a/src/pocketmine/entity/object/ExperienceOrb.php
+++ b/src/pocketmine/entity/object/ExperienceOrb.php
@@ -49,10 +49,6 @@ class ExperienceOrb extends Entity{
 	/**
 	 * Returns the largest size of normal XP orb that will be spawned for the specified amount of XP. Used to split XP
 	 * up into multiple orbs when an amount of XP is dropped.
-	 *
-	 * @param int $amount
-	 *
-	 * @return int
 	 */
 	public static function getMaxOrbSize(int $amount) : int{
 		foreach(self::ORB_SPLIT_SIZES as $split){
@@ -66,8 +62,6 @@ class ExperienceOrb extends Entity{
 
 	/**
 	 * Splits the specified amount of XP into an array of acceptable XP orb sizes.
-	 *
-	 * @param int $amount
 	 *
 	 * @return int[]
 	 */

--- a/src/pocketmine/entity/object/ItemEntity.php
+++ b/src/pocketmine/entity/object/ItemEntity.php
@@ -134,9 +134,6 @@ class ItemEntity extends Entity{
 		}
 	}
 
-	/**
-	 * @return Item
-	 */
 	public function getItem() : Item{
 		return $this->item;
 	}
@@ -149,44 +146,26 @@ class ItemEntity extends Entity{
 		return false;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getPickupDelay() : int{
 		return $this->pickupDelay;
 	}
 
-	/**
-	 * @param int $delay
-	 */
 	public function setPickupDelay(int $delay) : void{
 		$this->pickupDelay = $delay;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getOwner() : string{
 		return $this->owner;
 	}
 
-	/**
-	 * @param string $owner
-	 */
 	public function setOwner(string $owner) : void{
 		$this->owner = $owner;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getThrower() : string{
 		return $this->thrower;
 	}
 
-	/**
-	 * @param string $thrower
-	 */
 	public function setThrower(string $thrower) : void{
 		$this->thrower = $thrower;
 	}

--- a/src/pocketmine/entity/object/Painting.php
+++ b/src/pocketmine/entity/object/Painting.php
@@ -168,7 +168,6 @@ class Painting extends Entity{
 
 	/**
 	 * Returns the painting motive (which image is displayed on the painting)
-	 * @return PaintingMotive
 	 */
 	public function getMotive() : PaintingMotive{
 		return PaintingMotive::getMotiveByName($this->motive);
@@ -180,12 +179,6 @@ class Painting extends Entity{
 
 	/**
 	 * Returns the bounding-box a painting with the specified motive would have at the given position and direction.
-	 *
-	 * @param Vector3        $blockIn
-	 * @param int            $facing
-	 * @param PaintingMotive $motive
-	 *
-	 * @return AxisAlignedBB
 	 */
 	private static function getPaintingBB(Vector3 $blockIn, int $facing, PaintingMotive $motive) : AxisAlignedBB{
 		$width = $motive->getWidth();
@@ -241,14 +234,6 @@ class Painting extends Entity{
 
 	/**
 	 * Returns whether a painting with the specified motive can be placed at the given position.
-	 *
-	 * @param Level          $level
-	 * @param Vector3        $blockIn
-	 * @param int            $facing
-	 * @param bool           $checkOverlap
-	 * @param PaintingMotive $motive
-	 *
-	 * @return bool
 	 */
 	public static function canFit(Level $level, Vector3 $blockIn, int $facing, bool $checkOverlap, PaintingMotive $motive) : bool{
 		$width = $motive->getWidth();

--- a/src/pocketmine/entity/object/PaintingMotive.php
+++ b/src/pocketmine/entity/object/PaintingMotive.php
@@ -64,18 +64,10 @@ class PaintingMotive{
 		}
 	}
 
-	/**
-	 * @param PaintingMotive $motive
-	 */
 	public static function registerMotive(PaintingMotive $motive) : void{
 		self::$motives[$motive->getName()] = $motive;
 	}
 
-	/**
-	 * @param string $name
-	 *
-	 * @return PaintingMotive|null
-	 */
 	public static function getMotiveByName(string $name) : ?PaintingMotive{
 		return self::$motives[$name] ?? null;
 	}
@@ -101,23 +93,14 @@ class PaintingMotive{
 		$this->height = $height;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getName() : string{
 		return $this->name;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getWidth() : int{
 		return $this->width;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getHeight() : int{
 		return $this->height;
 	}

--- a/src/pocketmine/entity/projectile/Arrow.php
+++ b/src/pocketmine/entity/projectile/Arrow.php
@@ -102,16 +102,10 @@ class Arrow extends Projectile{
 		}
 	}
 
-	/**
-	 * @return float
-	 */
 	public function getPunchKnockback() : float{
 		return $this->punchKnockback;
 	}
 
-	/**
-	 * @param float $punchKnockback
-	 */
 	public function setPunchKnockback(float $punchKnockback) : void{
 		$this->punchKnockback = $punchKnockback;
 	}
@@ -157,16 +151,10 @@ class Arrow extends Projectile{
 		}
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getPickupMode() : int{
 		return $this->pickupMode;
 	}
 
-	/**
-	 * @param int $pickupMode
-	 */
 	public function setPickupMode(int $pickupMode) : void{
 		$this->pickupMode = $pickupMode;
 	}

--- a/src/pocketmine/entity/projectile/Projectile.php
+++ b/src/pocketmine/entity/projectile/Projectile.php
@@ -120,8 +120,6 @@ abstract class Projectile extends Entity{
 	/**
 	 * Returns the base damage applied on collision. This is multiplied by the projectile's speed to give a result
 	 * damage.
-	 *
-	 * @return float
 	 */
 	public function getBaseDamage() : float{
 		return $this->damage;
@@ -129,8 +127,6 @@ abstract class Projectile extends Entity{
 
 	/**
 	 * Sets the base amount of damage applied by the projectile.
-	 *
-	 * @param float $damage
 	 */
 	public function setBaseDamage(float $damage) : void{
 		$this->damage = $damage;
@@ -138,7 +134,6 @@ abstract class Projectile extends Entity{
 
 	/**
 	 * Returns the amount of damage this projectile will deal to the entity it hits.
-	 * @return int
 	 */
 	public function getResultDamage() : int{
 		return (int) ceil($this->motion->length() * $this->damage);
@@ -279,10 +274,6 @@ abstract class Projectile extends Entity{
 	 * This can be overridden by other projectiles to allow altering the blocks which are collided with (for example
 	 * some projectiles collide with any non-air block).
 	 *
-	 * @param Block   $block
-	 * @param Vector3 $start
-	 * @param Vector3 $end
-	 *
 	 * @return RayTraceResult|null the result of the ray trace if successful, or null if no interception is found.
 	 */
 	protected function calculateInterceptWithBlock(Block $block, Vector3 $start, Vector3 $end) : ?RayTraceResult{
@@ -292,8 +283,6 @@ abstract class Projectile extends Entity{
 	/**
 	 * Called when the projectile hits something. Override this to perform non-target-specific effects when the
 	 * projectile hits something.
-	 *
-	 * @param ProjectileHitEvent $event
 	 */
 	protected function onHit(ProjectileHitEvent $event) : void{
 
@@ -301,9 +290,6 @@ abstract class Projectile extends Entity{
 
 	/**
 	 * Called when the projectile collides with an Entity.
-	 *
-	 * @param Entity         $entityHit
-	 * @param RayTraceResult $hitResult
 	 */
 	protected function onHitEntity(Entity $entityHit, RayTraceResult $hitResult) : void{
 		$damage = $this->getResultDamage();
@@ -331,9 +317,6 @@ abstract class Projectile extends Entity{
 
 	/**
 	 * Called when the projectile collides with a Block.
-	 *
-	 * @param Block          $blockHit
-	 * @param RayTraceResult $hitResult
 	 */
 	protected function onHitBlock(Block $blockHit, RayTraceResult $hitResult) : void{
 		$this->blockHit = $blockHit->asVector3();

--- a/src/pocketmine/entity/projectile/SplashPotion.php
+++ b/src/pocketmine/entity/projectile/SplashPotion.php
@@ -131,22 +131,17 @@ class SplashPotion extends Throwable{
 
 	/**
 	 * Returns the meta value of the potion item that this splash potion corresponds to. This decides what effects will be applied to the entity when it collides with its target.
-	 * @return int
 	 */
 	public function getPotionId() : int{
 		return $this->propertyManager->getShort(self::DATA_POTION_AUX_VALUE) ?? 0;
 	}
 
-	/**
-	 * @param int $id
-	 */
 	public function setPotionId(int $id) : void{
 		$this->propertyManager->setShort(self::DATA_POTION_AUX_VALUE, $id);
 	}
 
 	/**
 	 * Returns whether this splash potion will create an area-effect cloud when it lands.
-	 * @return bool
 	 */
 	public function willLinger() : bool{
 		return $this->getDataFlag(self::DATA_FLAGS, self::DATA_FLAG_LINGER);
@@ -154,8 +149,6 @@ class SplashPotion extends Throwable{
 
 	/**
 	 * Sets whether this splash potion will create an area-effect-cloud when it lands.
-	 *
-	 * @param bool $value
 	 */
 	public function setLinger(bool $value = true) : void{
 		$this->setDataFlag(self::DATA_FLAGS, self::DATA_FLAG_LINGER, $value);

--- a/src/pocketmine/entity/utils/ExperienceUtils.php
+++ b/src/pocketmine/entity/utils/ExperienceUtils.php
@@ -30,10 +30,6 @@ abstract class ExperienceUtils{
 
 	/**
 	 * Calculates and returns the amount of XP needed to get from level 0 to level $level
-	 *
-	 * @param int $level
-	 *
-	 * @return int
 	 */
 	public static function getXpToReachLevel(int $level) : int{
 		if($level <= 16){
@@ -47,10 +43,6 @@ abstract class ExperienceUtils{
 
 	/**
 	 * Returns the amount of XP needed to reach $level + 1.
-	 *
-	 * @param int $level
-	 *
-	 * @return int
 	 */
 	public static function getXpToCompleteLevel(int $level) : int{
 		if($level <= 15){
@@ -65,10 +57,6 @@ abstract class ExperienceUtils{
 	/**
 	 * Calculates and returns the number of XP levels the specified amount of XP points are worth.
 	 * This returns a floating-point number, the decimal part being the progress through the resulting level.
-	 *
-	 * @param int $xp
-	 *
-	 * @return float
 	 */
 	public static function getLevelFromXp(int $xp) : float{
 		if($xp <= self::getXpToReachLevel(16)){

--- a/src/pocketmine/event/Cancellable.php
+++ b/src/pocketmine/event/Cancellable.php
@@ -28,14 +28,9 @@ namespace pocketmine\event;
  * Events that can be cancelled must use the interface Cancellable
  */
 interface Cancellable{
-	/**
-	 * @return bool
-	 */
 	public function isCancelled() : bool;
 
 	/**
-	 * @param bool $value
-	 *
 	 * @return void
 	 */
 	public function setCancelled(bool $value = true);

--- a/src/pocketmine/event/Event.php
+++ b/src/pocketmine/event/Event.php
@@ -39,16 +39,11 @@ abstract class Event{
 	/** @var bool */
 	private $isCancelled = false;
 
-	/**
-	 * @return string
-	 */
 	final public function getEventName() : string{
 		return $this->eventName ?? get_class($this);
 	}
 
 	/**
-	 * @return bool
-	 *
 	 * @throws \BadMethodCallException
 	 */
 	public function isCancelled() : bool{
@@ -60,8 +55,6 @@ abstract class Event{
 	}
 
 	/**
-	 * @param bool $value
-	 *
 	 * @throws \BadMethodCallException
 	 */
 	public function setCancelled(bool $value = true) : void{

--- a/src/pocketmine/event/EventPriority.php
+++ b/src/pocketmine/event/EventPriority.php
@@ -76,10 +76,6 @@ abstract class EventPriority{
 	public const MONITOR = 0;
 
 	/**
-	 * @param string $name
-	 *
-	 * @return int
-	 *
 	 * @throws \InvalidArgumentException
 	 */
 	public static function fromString(string $name) : int{

--- a/src/pocketmine/event/HandlerList.php
+++ b/src/pocketmine/event/HandlerList.php
@@ -61,9 +61,6 @@ class HandlerList{
 	 *
 	 * Calling this method also lazily initializes the $classMap inheritance tree of handler lists.
 	 *
-	 * @param string $event
-	 *
-	 * @return null|HandlerList
 	 * @throws \ReflectionException
 	 */
 	public static function getHandlerListFor(string $event) : ?HandlerList{
@@ -112,8 +109,6 @@ class HandlerList{
 	}
 
 	/**
-	 * @param RegisteredListener $listener
-	 *
 	 * @throws \Exception
 	 */
 	public function register(RegisteredListener $listener) : void{
@@ -157,17 +152,12 @@ class HandlerList{
 	}
 
 	/**
-	 * @param int $priority
-	 *
 	 * @return RegisteredListener[]
 	 */
 	public function getListenersByPriority(int $priority) : array{
 		return $this->handlerSlots[$priority];
 	}
 
-	/**
-	 * @return null|HandlerList
-	 */
 	public function getParent() : ?HandlerList{
 		return $this->parentList;
 	}

--- a/src/pocketmine/event/block/BlockBreakEvent.php
+++ b/src/pocketmine/event/block/BlockBreakEvent.php
@@ -46,12 +46,7 @@ class BlockBreakEvent extends BlockEvent implements Cancellable{
 	protected $xpDrops;
 
 	/**
-	 * @param Player $player
-	 * @param Block  $block
-	 * @param Item   $item
-	 * @param bool   $instaBreak
 	 * @param Item[] $drops
-	 * @param int    $xpDrops
 	 */
 	public function __construct(Player $player, Block $block, Item $item, bool $instaBreak = false, array $drops, int $xpDrops = 0){
 		parent::__construct($block);
@@ -65,7 +60,6 @@ class BlockBreakEvent extends BlockEvent implements Cancellable{
 
 	/**
 	 * Returns the player who is destroying the block.
-	 * @return Player
 	 */
 	public function getPlayer() : Player{
 		return $this->player;
@@ -73,7 +67,6 @@ class BlockBreakEvent extends BlockEvent implements Cancellable{
 
 	/**
 	 * Returns the item used to destroy the block.
-	 * @return Item
 	 */
 	public function getItem() : Item{
 		return $this->item;
@@ -82,16 +75,11 @@ class BlockBreakEvent extends BlockEvent implements Cancellable{
 	/**
 	 * Returns whether the block may be broken in less than the amount of time calculated. This is usually true for
 	 * creative players.
-	 *
-	 * @return bool
 	 */
 	public function getInstaBreak() : bool{
 		return $this->instaBreak;
 	}
 
-	/**
-	 * @param bool $instaBreak
-	 */
 	public function setInstaBreak(bool $instaBreak) : void{
 		$this->instaBreak = $instaBreak;
 	}
@@ -122,8 +110,6 @@ class BlockBreakEvent extends BlockEvent implements Cancellable{
 
 	/**
 	 * Returns how much XP will be dropped by breaking this block.
-	 *
-	 * @return int
 	 */
 	public function getXpDropAmount() : int{
 		return $this->xpDrops;
@@ -131,8 +117,6 @@ class BlockBreakEvent extends BlockEvent implements Cancellable{
 
 	/**
 	 * Sets how much XP will be dropped by breaking this block.
-	 *
-	 * @param int $amount
 	 */
 	public function setXpDropAmount(int $amount) : void{
 		if($amount < 0){

--- a/src/pocketmine/event/block/BlockBurnEvent.php
+++ b/src/pocketmine/event/block/BlockBurnEvent.php
@@ -40,7 +40,6 @@ class BlockBurnEvent extends BlockEvent implements Cancellable{
 
 	/**
 	 * Returns the block (usually Fire) which caused the target block to be burned away.
-	 * @return Block
 	 */
 	public function getCausingBlock() : Block{
 		return $this->causingBlock;

--- a/src/pocketmine/event/block/BlockEvent.php
+++ b/src/pocketmine/event/block/BlockEvent.php
@@ -33,16 +33,10 @@ abstract class BlockEvent extends Event{
 	/** @var Block */
 	protected $block;
 
-	/**
-	 * @param Block $block
-	 */
 	public function __construct(Block $block){
 		$this->block = $block;
 	}
 
-	/**
-	 * @return Block
-	 */
 	public function getBlock() : Block{
 		return $this->block;
 	}

--- a/src/pocketmine/event/block/BlockGrowEvent.php
+++ b/src/pocketmine/event/block/BlockGrowEvent.php
@@ -38,9 +38,6 @@ class BlockGrowEvent extends BlockEvent implements Cancellable{
 		$this->newState = $newState;
 	}
 
-	/**
-	 * @return Block
-	 */
 	public function getNewState() : Block{
 		return $this->newState;
 	}

--- a/src/pocketmine/event/block/BlockPlaceEvent.php
+++ b/src/pocketmine/event/block/BlockPlaceEvent.php
@@ -53,7 +53,6 @@ class BlockPlaceEvent extends BlockEvent implements Cancellable{
 
 	/**
 	 * Returns the player who is placing the block.
-	 * @return Player
 	 */
 	public function getPlayer() : Player{
 		return $this->player;
@@ -61,22 +60,15 @@ class BlockPlaceEvent extends BlockEvent implements Cancellable{
 
 	/**
 	 * Gets the item in hand
-	 * @return Item
 	 */
 	public function getItem() : Item{
 		return $this->item;
 	}
 
-	/**
-	 * @return Block
-	 */
 	public function getBlockReplaced() : Block{
 		return $this->blockReplace;
 	}
 
-	/**
-	 * @return Block
-	 */
 	public function getBlockAgainst() : Block{
 		return $this->blockAgainst;
 	}

--- a/src/pocketmine/event/block/BlockSpreadEvent.php
+++ b/src/pocketmine/event/block/BlockSpreadEvent.php
@@ -37,9 +37,6 @@ class BlockSpreadEvent extends BlockFormEvent{
 		$this->source = $source;
 	}
 
-	/**
-	 * @return Block
-	 */
 	public function getSource() : Block{
 		return $this->source;
 	}

--- a/src/pocketmine/event/block/SignChangeEvent.php
+++ b/src/pocketmine/event/block/SignChangeEvent.php
@@ -38,8 +38,6 @@ class SignChangeEvent extends BlockEvent implements Cancellable{
 	private $lines = [];
 
 	/**
-	 * @param Block    $theBlock
-	 * @param Player   $thePlayer
 	 * @param string[] $theLines
 	 */
 	public function __construct(Block $theBlock, Player $thePlayer, array $theLines){
@@ -48,9 +46,6 @@ class SignChangeEvent extends BlockEvent implements Cancellable{
 		$this->setLines($theLines);
 	}
 
-	/**
-	 * @return Player
-	 */
 	public function getPlayer() : Player{
 		return $this->player;
 	}
@@ -64,8 +59,6 @@ class SignChangeEvent extends BlockEvent implements Cancellable{
 
 	/**
 	 * @param int $index 0-3
-	 *
-	 * @return string
 	 *
 	 * @throws \InvalidArgumentException if the index is out of bounds
 	 */
@@ -91,7 +84,6 @@ class SignChangeEvent extends BlockEvent implements Cancellable{
 
 	/**
 	 * @param int    $index 0-3
-	 * @param string $line
 	 *
 	 * @throws \InvalidArgumentException if the index is out of bounds
 	 */

--- a/src/pocketmine/event/entity/EntityBlockChangeEvent.php
+++ b/src/pocketmine/event/entity/EntityBlockChangeEvent.php
@@ -42,16 +42,10 @@ class EntityBlockChangeEvent extends EntityEvent implements Cancellable{
 		$this->to = $to;
 	}
 
-	/**
-	 * @return Block
-	 */
 	public function getBlock() : Block{
 		return $this->from;
 	}
 
-	/**
-	 * @return Block
-	 */
 	public function getTo() : Block{
 		return $this->to;
 	}

--- a/src/pocketmine/event/entity/EntityCombustByBlockEvent.php
+++ b/src/pocketmine/event/entity/EntityCombustByBlockEvent.php
@@ -30,19 +30,11 @@ class EntityCombustByBlockEvent extends EntityCombustEvent{
 	/** @var Block */
 	protected $combuster;
 
-	/**
-	 * @param Block  $combuster
-	 * @param Entity $combustee
-	 * @param int    $duration
-	 */
 	public function __construct(Block $combuster, Entity $combustee, int $duration){
 		parent::__construct($combustee, $duration);
 		$this->combuster = $combuster;
 	}
 
-	/**
-	 * @return Block
-	 */
 	public function getCombuster() : Block{
 		return $this->combuster;
 	}

--- a/src/pocketmine/event/entity/EntityCombustByEntityEvent.php
+++ b/src/pocketmine/event/entity/EntityCombustByEntityEvent.php
@@ -29,19 +29,11 @@ class EntityCombustByEntityEvent extends EntityCombustEvent{
 	/** @var Entity */
 	protected $combuster;
 
-	/**
-	 * @param Entity $combuster
-	 * @param Entity $combustee
-	 * @param int    $duration
-	 */
 	public function __construct(Entity $combuster, Entity $combustee, int $duration){
 		parent::__construct($combustee, $duration);
 		$this->combuster = $combuster;
 	}
 
-	/**
-	 * @return Entity
-	 */
 	public function getCombuster() : Entity{
 		return $this->combuster;
 	}

--- a/src/pocketmine/event/entity/EntityCombustEvent.php
+++ b/src/pocketmine/event/entity/EntityCombustEvent.php
@@ -30,10 +30,6 @@ class EntityCombustEvent extends EntityEvent implements Cancellable{
 	/** @var int */
 	protected $duration;
 
-	/**
-	 * @param Entity $combustee
-	 * @param int    $duration
-	 */
 	public function __construct(Entity $combustee, int $duration){
 		$this->entity = $combustee;
 		$this->duration = $duration;
@@ -41,7 +37,6 @@ class EntityCombustEvent extends EntityEvent implements Cancellable{
 
 	/**
 	 * Returns the duration in seconds the entity will burn for.
-	 * @return int
 	 */
 	public function getDuration() : int{
 		return $this->duration;

--- a/src/pocketmine/event/entity/EntityDamageByBlockEvent.php
+++ b/src/pocketmine/event/entity/EntityDamageByBlockEvent.php
@@ -34,10 +34,6 @@ class EntityDamageByBlockEvent extends EntityDamageEvent{
 	private $damager;
 
 	/**
-	 * @param Block   $damager
-	 * @param Entity  $entity
-	 * @param int     $cause
-	 * @param float   $damage
 	 * @param float[] $modifiers
 	 */
 	public function __construct(Block $damager, Entity $entity, int $cause, float $damage, array $modifiers = []){
@@ -45,9 +41,6 @@ class EntityDamageByBlockEvent extends EntityDamageEvent{
 		parent::__construct($entity, $cause, $damage, $modifiers);
 	}
 
-	/**
-	 * @return Block
-	 */
 	public function getDamager() : Block{
 		return $this->damager;
 	}

--- a/src/pocketmine/event/entity/EntityDamageByChildEntityEvent.php
+++ b/src/pocketmine/event/entity/EntityDamageByChildEntityEvent.php
@@ -33,11 +33,6 @@ class EntityDamageByChildEntityEvent extends EntityDamageByEntityEvent{
 	private $childEntityEid;
 
 	/**
-	 * @param Entity  $damager
-	 * @param Entity  $childEntity
-	 * @param Entity  $entity
-	 * @param int     $cause
-	 * @param float   $damage
 	 * @param float[] $modifiers
 	 */
 	public function __construct(Entity $damager, Entity $childEntity, Entity $entity, int $cause, float $damage, array $modifiers = []){
@@ -47,8 +42,6 @@ class EntityDamageByChildEntityEvent extends EntityDamageByEntityEvent{
 
 	/**
 	 * Returns the entity which caused the damage, or null if the entity has been killed or closed.
-	 *
-	 * @return Entity|null
 	 */
 	public function getChild() : ?Entity{
 		return $this->getEntity()->getLevel()->getServer()->findEntity($this->childEntityEid);

--- a/src/pocketmine/event/entity/EntityDamageByEntityEvent.php
+++ b/src/pocketmine/event/entity/EntityDamageByEntityEvent.php
@@ -37,12 +37,7 @@ class EntityDamageByEntityEvent extends EntityDamageEvent{
 	private $knockBack;
 
 	/**
-	 * @param Entity  $damager
-	 * @param Entity  $entity
-	 * @param int     $cause
-	 * @param float   $damage
 	 * @param float[] $modifiers
-	 * @param float   $knockBack
 	 */
 	public function __construct(Entity $damager, Entity $entity, int $cause, float $damage, array $modifiers = [], float $knockBack = 0.4){
 		$this->damagerEntityId = $damager->getId();
@@ -65,23 +60,15 @@ class EntityDamageByEntityEvent extends EntityDamageEvent{
 
 	/**
 	 * Returns the attacking entity, or null if the attacker has been killed or closed.
-	 *
-	 * @return Entity|null
 	 */
 	public function getDamager() : ?Entity{
 		return $this->getEntity()->getLevel()->getServer()->findEntity($this->damagerEntityId);
 	}
 
-	/**
-	 * @return float
-	 */
 	public function getKnockBack() : float{
 		return $this->knockBack;
 	}
 
-	/**
-	 * @param float $knockBack
-	 */
 	public function setKnockBack(float $knockBack) : void{
 		$this->knockBack = $knockBack;
 	}

--- a/src/pocketmine/event/entity/EntityDamageEvent.php
+++ b/src/pocketmine/event/entity/EntityDamageEvent.php
@@ -75,9 +75,6 @@ class EntityDamageEvent extends EntityEvent implements Cancellable{
 
 
 	/**
-	 * @param Entity  $entity
-	 * @param int     $cause
-	 * @param float   $damage
 	 * @param float[] $modifiers
 	 */
 	public function __construct(Entity $entity, int $cause, float $damage, array $modifiers = []){
@@ -89,17 +86,12 @@ class EntityDamageEvent extends EntityEvent implements Cancellable{
 		$this->originals = $this->modifiers;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getCause() : int{
 		return $this->cause;
 	}
 
 	/**
 	 * Returns the base amount of damage applied, before modifiers.
-	 *
-	 * @return float
 	 */
 	public function getBaseDamage() : float{
 		return $this->baseDamage;
@@ -109,8 +101,6 @@ class EntityDamageEvent extends EntityEvent implements Cancellable{
 	 * Sets the base amount of damage applied, optionally recalculating modifiers.
 	 *
 	 * TODO: add ability to recalculate modifiers when this is set
-	 *
-	 * @param float $damage
 	 */
 	public function setBaseDamage(float $damage) : void{
 		$this->baseDamage = $damage;
@@ -118,8 +108,6 @@ class EntityDamageEvent extends EntityEvent implements Cancellable{
 
 	/**
 	 * Returns the original base amount of damage applied, before alterations by plugins.
-	 *
-	 * @return float
 	 */
 	public function getOriginalBaseDamage() : float{
 		return $this->originalBase;
@@ -132,11 +120,6 @@ class EntityDamageEvent extends EntityEvent implements Cancellable{
 		return $this->originals;
 	}
 
-	/**
-	 * @param int $type
-	 *
-	 * @return float
-	 */
 	public function getOriginalModifier(int $type) : float{
 		return $this->originals[$type] ?? 0.0;
 	}
@@ -148,42 +131,24 @@ class EntityDamageEvent extends EntityEvent implements Cancellable{
 		return $this->modifiers;
 	}
 
-	/**
-	 * @param int $type
-	 *
-	 * @return float
-	 */
 	public function getModifier(int $type) : float{
 		return $this->modifiers[$type] ?? 0.0;
 	}
 
-	/**
-	 * @param float $damage
-	 * @param int   $type
-	 */
 	public function setModifier(float $damage, int $type) : void{
 		$this->modifiers[$type] = $damage;
 	}
 
-	/**
-	 * @param int $type
-	 *
-	 * @return bool
-	 */
 	public function isApplicable(int $type) : bool{
 		return isset($this->modifiers[$type]);
 	}
 
-	/**
-	 * @return float
-	 */
 	public function getFinalDamage() : float{
 		return $this->baseDamage + array_sum($this->modifiers);
 	}
 
 	/**
 	 * Returns whether an entity can use armour points to reduce this type of damage.
-	 * @return bool
 	 */
 	public function canBeReducedByArmor() : bool{
 		switch($this->cause){
@@ -204,8 +169,6 @@ class EntityDamageEvent extends EntityEvent implements Cancellable{
 
 	/**
 	 * Returns the cooldown in ticks before the target entity can be attacked again.
-	 *
-	 * @return int
 	 */
 	public function getAttackCooldown() : int{
 		return $this->attackCooldown;
@@ -215,8 +178,6 @@ class EntityDamageEvent extends EntityEvent implements Cancellable{
 	 * Sets the cooldown in ticks before the target entity can be attacked again.
 	 *
 	 * NOTE: This value is not used in non-Living entities
-	 *
-	 * @param int $attackCooldown
 	 */
 	public function setAttackCooldown(int $attackCooldown) : void{
 		$this->attackCooldown = $attackCooldown;

--- a/src/pocketmine/event/entity/EntityDeathEvent.php
+++ b/src/pocketmine/event/entity/EntityDeathEvent.php
@@ -31,7 +31,6 @@ class EntityDeathEvent extends EntityEvent{
 	private $drops = [];
 
 	/**
-	 * @param Living $entity
 	 * @param Item[] $drops
 	 */
 	public function __construct(Living $entity, array $drops = []){

--- a/src/pocketmine/event/entity/EntityDespawnEvent.php
+++ b/src/pocketmine/event/entity/EntityDespawnEvent.php
@@ -37,52 +37,31 @@ class EntityDespawnEvent extends EntityEvent{
 	/** @var int */
 	private $entityType;
 
-	/**
-	 * @param Entity $entity
-	 */
 	public function __construct(Entity $entity){
 		$this->entity = $entity;
 		$this->entityType = $entity::NETWORK_ID;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getType() : int{
 		return $this->entityType;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isCreature() : bool{
 		return $this->entity instanceof Creature;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isHuman() : bool{
 		return $this->entity instanceof Human;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isProjectile() : bool{
 		return $this->entity instanceof Projectile;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isVehicle() : bool{
 		return $this->entity instanceof Vehicle;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isItem() : bool{
 		return $this->entity instanceof ItemEntity;
 	}

--- a/src/pocketmine/event/entity/EntityEffectAddEvent.php
+++ b/src/pocketmine/event/entity/EntityEffectAddEvent.php
@@ -33,9 +33,6 @@ class EntityEffectAddEvent extends EntityEffectEvent{
 	/** @var EffectInstance|null */
 	private $oldEffect;
 
-	/**
-	 * @param EffectInstance $oldEffect
-	 */
 	public function __construct(Entity $entity, EffectInstance $effect, EffectInstance $oldEffect = null){
 		parent::__construct($entity, $effect);
 		$this->oldEffect = $oldEffect;

--- a/src/pocketmine/event/entity/EntityEffectAddEvent.php
+++ b/src/pocketmine/event/entity/EntityEffectAddEvent.php
@@ -34,8 +34,6 @@ class EntityEffectAddEvent extends EntityEffectEvent{
 	private $oldEffect;
 
 	/**
-	 * @param Entity         $entity
-	 * @param EffectInstance $effect
 	 * @param EffectInstance $oldEffect
 	 */
 	public function __construct(Entity $entity, EffectInstance $effect, EffectInstance $oldEffect = null){
@@ -45,23 +43,15 @@ class EntityEffectAddEvent extends EntityEffectEvent{
 
 	/**
 	 * Returns whether the effect addition will replace an existing effect already applied to the entity.
-	 *
-	 * @return bool
 	 */
 	public function willModify() : bool{
 		return $this->hasOldEffect();
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function hasOldEffect() : bool{
 		return $this->oldEffect instanceof EffectInstance;
 	}
 
-	/**
-	 * @return EffectInstance|null
-	 */
 	public function getOldEffect() : ?EffectInstance{
 		return $this->oldEffect;
 	}

--- a/src/pocketmine/event/entity/EntityExplodeEvent.php
+++ b/src/pocketmine/event/entity/EntityExplodeEvent.php
@@ -44,10 +44,7 @@ class EntityExplodeEvent extends EntityEvent implements Cancellable{
 	protected $yield;
 
 	/**
-	 * @param Entity   $entity
-	 * @param Position $position
 	 * @param Block[]  $blocks
-	 * @param float    $yield
 	 */
 	public function __construct(Entity $entity, Position $position, array $blocks, float $yield){
 		$this->entity = $entity;
@@ -56,9 +53,6 @@ class EntityExplodeEvent extends EntityEvent implements Cancellable{
 		$this->yield = $yield;
 	}
 
-	/**
-	 * @return Position
-	 */
 	public function getPosition() : Position{
 		return $this->position;
 	}
@@ -77,16 +71,10 @@ class EntityExplodeEvent extends EntityEvent implements Cancellable{
 		$this->blocks = $blocks;
 	}
 
-	/**
-	 * @return float
-	 */
 	public function getYield() : float{
 		return $this->yield;
 	}
 
-	/**
-	 * @param float $yield
-	 */
 	public function setYield(float $yield) : void{
 		$this->yield = $yield;
 	}

--- a/src/pocketmine/event/entity/EntityInventoryChangeEvent.php
+++ b/src/pocketmine/event/entity/EntityInventoryChangeEvent.php
@@ -47,7 +47,6 @@ class EntityInventoryChangeEvent extends EntityEvent implements Cancellable{
 
 	/**
 	 * Returns the inventory slot number affected by the event.
-	 * @return int
 	 */
 	public function getSlot() : int{
 		return $this->slot;
@@ -55,22 +54,17 @@ class EntityInventoryChangeEvent extends EntityEvent implements Cancellable{
 
 	/**
 	 * Returns the item which will be in the slot after the event.
-	 * @return Item
 	 */
 	public function getNewItem() : Item{
 		return $this->newItem;
 	}
 
-	/**
-	 * @param Item $item
-	 */
 	public function setNewItem(Item $item) : void{
 		$this->newItem = $item;
 	}
 
 	/**
 	 * Returns the item currently in the slot.
-	 * @return Item
 	 */
 	public function getOldItem() : Item{
 		return $this->oldItem;

--- a/src/pocketmine/event/entity/EntityMotionEvent.php
+++ b/src/pocketmine/event/entity/EntityMotionEvent.php
@@ -36,9 +36,6 @@ class EntityMotionEvent extends EntityEvent implements Cancellable{
 		$this->mot = $mot;
 	}
 
-	/**
-	 * @return Vector3
-	 */
 	public function getVector() : Vector3{
 		return $this->mot;
 	}

--- a/src/pocketmine/event/entity/EntityRegainHealthEvent.php
+++ b/src/pocketmine/event/entity/EntityRegainHealthEvent.php
@@ -38,35 +38,22 @@ class EntityRegainHealthEvent extends EntityEvent implements Cancellable{
 	/** @var int */
 	private $reason;
 
-
-	/**
-	 * @param Entity $entity
-	 * @param float  $amount
-	 * @param int    $regainReason
-	 */
 	public function __construct(Entity $entity, float $amount, int $regainReason){
 		$this->entity = $entity;
 		$this->amount = $amount;
 		$this->reason = $regainReason;
 	}
 
-	/**
-	 * @return float
-	 */
 	public function getAmount() : float{
 		return $this->amount;
 	}
 
-	/**
-	 * @param float $amount
-	 */
 	public function setAmount(float $amount) : void{
 		$this->amount = $amount;
 	}
 
 	/**
 	 * Returns one of the CAUSE_* constants to indicate why this regeneration occurred.
-	 * @return int
 	 */
 	public function getRegainReason() : int{
 		return $this->reason;

--- a/src/pocketmine/event/entity/EntityShootBowEvent.php
+++ b/src/pocketmine/event/entity/EntityShootBowEvent.php
@@ -38,12 +38,6 @@ class EntityShootBowEvent extends EntityEvent implements Cancellable{
 	/** @var float */
 	private $force;
 
-	/**
-	 * @param Living     $shooter
-	 * @param Item       $bow
-	 * @param Projectile $projectile
-	 * @param float      $force
-	 */
 	public function __construct(Living $shooter, Item $bow, Projectile $projectile, float $force){
 		$this->entity = $shooter;
 		$this->bow = $bow;
@@ -58,9 +52,6 @@ class EntityShootBowEvent extends EntityEvent implements Cancellable{
 		return $this->entity;
 	}
 
-	/**
-	 * @return Item
-	 */
 	public function getBow() : Item{
 		return $this->bow;
 	}
@@ -69,16 +60,11 @@ class EntityShootBowEvent extends EntityEvent implements Cancellable{
 	 * Returns the entity considered as the projectile in this event.
 	 *
 	 * NOTE: This might not return a Projectile if a plugin modified the target entity.
-	 *
-	 * @return Entity
 	 */
 	public function getProjectile() : Entity{
 		return $this->projectile;
 	}
 
-	/**
-	 * @param Entity $projectile
-	 */
 	public function setProjectile(Entity $projectile) : void{
 		if($projectile !== $this->projectile){
 			if(count($this->projectile->getViewers()) === 0){
@@ -88,16 +74,10 @@ class EntityShootBowEvent extends EntityEvent implements Cancellable{
 		}
 	}
 
-	/**
-	 * @return float
-	 */
 	public function getForce() : float{
 		return $this->force;
 	}
 
-	/**
-	 * @param float $force
-	 */
 	public function setForce(float $force) : void{
 		$this->force = $force;
 	}

--- a/src/pocketmine/event/entity/EntitySpawnEvent.php
+++ b/src/pocketmine/event/entity/EntitySpawnEvent.php
@@ -38,59 +38,35 @@ class EntitySpawnEvent extends EntityEvent{
 	/** @var int */
 	private $entityType;
 
-	/**
-	 * @param Entity $entity
-	 */
 	public function __construct(Entity $entity){
 		$this->entity = $entity;
 		$this->entityType = $entity::NETWORK_ID;
 	}
 
-	/**
-	 * @return Position
-	 */
 	public function getPosition() : Position{
 		return $this->entity->getPosition();
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getType() : int{
 		return $this->entityType;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isCreature() : bool{
 		return $this->entity instanceof Creature;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isHuman() : bool{
 		return $this->entity instanceof Human;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isProjectile() : bool{
 		return $this->entity instanceof Projectile;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isVehicle() : bool{
 		return $this->entity instanceof Vehicle;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isItem() : bool{
 		return $this->entity instanceof ItemEntity;
 	}

--- a/src/pocketmine/event/entity/EntityTeleportEvent.php
+++ b/src/pocketmine/event/entity/EntityTeleportEvent.php
@@ -39,23 +39,14 @@ class EntityTeleportEvent extends EntityEvent implements Cancellable{
 		$this->to = $to;
 	}
 
-	/**
-	 * @return Position
-	 */
 	public function getFrom() : Position{
 		return $this->from;
 	}
 
-	/**
-	 * @return Position
-	 */
 	public function getTo() : Position{
 		return $this->to;
 	}
 
-	/**
-	 * @param Position $to
-	 */
 	public function setTo(Position $to) : void{
 		$this->to = $to;
 	}

--- a/src/pocketmine/event/entity/ExplosionPrimeEvent.php
+++ b/src/pocketmine/event/entity/ExplosionPrimeEvent.php
@@ -35,19 +35,12 @@ class ExplosionPrimeEvent extends EntityEvent implements Cancellable{
 	/** @var bool */
 	private $blockBreaking;
 
-	/**
-	 * @param Entity $entity
-	 * @param float  $force
-	 */
 	public function __construct(Entity $entity, float $force){
 		$this->entity = $entity;
 		$this->force = $force;
 		$this->blockBreaking = true;
 	}
 
-	/**
-	 * @return float
-	 */
 	public function getForce() : float{
 		return $this->force;
 	}
@@ -56,16 +49,10 @@ class ExplosionPrimeEvent extends EntityEvent implements Cancellable{
 		$this->force = $force;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isBlockBreaking() : bool{
 		return $this->blockBreaking;
 	}
 
-	/**
-	 * @param bool $affectsBlocks
-	 */
 	public function setBlockBreaking(bool $affectsBlocks) : void{
 		$this->blockBreaking = $affectsBlocks;
 	}

--- a/src/pocketmine/event/entity/ItemDespawnEvent.php
+++ b/src/pocketmine/event/entity/ItemDespawnEvent.php
@@ -28,9 +28,6 @@ use pocketmine\event\Cancellable;
 
 class ItemDespawnEvent extends EntityEvent implements Cancellable{
 
-	/**
-	 * @param ItemEntity $item
-	 */
 	public function __construct(ItemEntity $item){
 		$this->entity = $item;
 

--- a/src/pocketmine/event/entity/ItemSpawnEvent.php
+++ b/src/pocketmine/event/entity/ItemSpawnEvent.php
@@ -27,9 +27,6 @@ use pocketmine\entity\object\ItemEntity;
 
 class ItemSpawnEvent extends EntityEvent{
 
-	/**
-	 * @param ItemEntity $item
-	 */
 	public function __construct(ItemEntity $item){
 		$this->entity = $item;
 

--- a/src/pocketmine/event/entity/ProjectileHitBlockEvent.php
+++ b/src/pocketmine/event/entity/ProjectileHitBlockEvent.php
@@ -39,8 +39,6 @@ class ProjectileHitBlockEvent extends ProjectileHitEvent{
 	/**
 	 * Returns the Block struck by the projectile.
 	 * Hint: to get the block face hit, look at the RayTraceResult.
-	 *
-	 * @return Block
 	 */
 	public function getBlockHit() : Block{
 		return $this->blockHit;

--- a/src/pocketmine/event/entity/ProjectileHitEntityEvent.php
+++ b/src/pocketmine/event/entity/ProjectileHitEntityEvent.php
@@ -38,8 +38,6 @@ class ProjectileHitEntityEvent extends ProjectileHitEvent{
 
 	/**
 	 * Returns the Entity struck by the projectile.
-	 *
-	 * @return Entity
 	 */
 	public function getEntityHit() : Entity{
 		return $this->entityHit;

--- a/src/pocketmine/event/entity/ProjectileHitEvent.php
+++ b/src/pocketmine/event/entity/ProjectileHitEvent.php
@@ -33,10 +33,6 @@ abstract class ProjectileHitEvent extends EntityEvent{
 	/** @var RayTraceResult */
 	private $rayTraceResult;
 
-	/**
-	 * @param Projectile     $entity
-	 * @param RayTraceResult $rayTraceResult
-	 */
 	public function __construct(Projectile $entity, RayTraceResult $rayTraceResult){
 		$this->entity = $entity;
 		$this->rayTraceResult = $rayTraceResult;
@@ -52,8 +48,6 @@ abstract class ProjectileHitEvent extends EntityEvent{
 	/**
 	 * Returns a RayTraceResult object containing information such as the exact position struck, the AABB it hit, and
 	 * the face of the AABB that it hit.
-	 *
-	 * @return RayTraceResult
 	 */
 	public function getRayTraceResult() : RayTraceResult{
 		return $this->rayTraceResult;

--- a/src/pocketmine/event/entity/ProjectileLaunchEvent.php
+++ b/src/pocketmine/event/entity/ProjectileLaunchEvent.php
@@ -27,9 +27,6 @@ use pocketmine\entity\projectile\Projectile;
 use pocketmine\event\Cancellable;
 
 class ProjectileLaunchEvent extends EntityEvent implements Cancellable{
-	/**
-	 * @param Projectile $entity
-	 */
 	public function __construct(Projectile $entity){
 		$this->entity = $entity;
 

--- a/src/pocketmine/event/inventory/CraftItemEvent.php
+++ b/src/pocketmine/event/inventory/CraftItemEvent.php
@@ -43,9 +43,6 @@ class CraftItemEvent extends Event implements Cancellable{
 	private $outputs;
 
 	/**
-	 * @param CraftingTransaction $transaction
-	 * @param CraftingRecipe      $recipe
-	 * @param int                 $repetitions
 	 * @param Item[]              $inputs
 	 * @param Item[]              $outputs
 	 */
@@ -59,8 +56,6 @@ class CraftItemEvent extends Event implements Cancellable{
 
 	/**
 	 * Returns the inventory transaction involved in this crafting event.
-	 *
-	 * @return CraftingTransaction
 	 */
 	public function getTransaction() : CraftingTransaction{
 		return $this->transaction;
@@ -68,8 +63,6 @@ class CraftItemEvent extends Event implements Cancellable{
 
 	/**
 	 * Returns the recipe crafted.
-	 *
-	 * @return CraftingRecipe
 	 */
 	public function getRecipe() : CraftingRecipe{
 		return $this->recipe;
@@ -78,8 +71,6 @@ class CraftItemEvent extends Event implements Cancellable{
 	/**
 	 * Returns the number of times the recipe was crafted. This is usually 1, but might be more in the case of recipe
 	 * book shift-clicks (which craft lots of items in a batch).
-	 *
-	 * @return int
 	 */
 	public function getRepetitions() : int{
 		return $this->repetitions;
@@ -103,9 +94,6 @@ class CraftItemEvent extends Event implements Cancellable{
 		return $this->outputs;
 	}
 
-	/**
-	 * @return Player
-	 */
 	public function getPlayer() : Player{
 		return $this->transaction->getSource();
 	}

--- a/src/pocketmine/event/inventory/FurnaceBurnEvent.php
+++ b/src/pocketmine/event/inventory/FurnaceBurnEvent.php
@@ -38,11 +38,6 @@ class FurnaceBurnEvent extends BlockEvent implements Cancellable{
 	/** @var bool */
 	private $burning = true;
 
-	/**
-	 * @param Furnace $furnace
-	 * @param Item    $fuel
-	 * @param int     $burnTime
-	 */
 	public function __construct(Furnace $furnace, Item $fuel, int $burnTime){
 		parent::__construct($furnace->getBlock());
 		$this->fuel = $fuel;
@@ -50,44 +45,26 @@ class FurnaceBurnEvent extends BlockEvent implements Cancellable{
 		$this->furnace = $furnace;
 	}
 
-	/**
-	 * @return Furnace
-	 */
 	public function getFurnace() : Furnace{
 		return $this->furnace;
 	}
 
-	/**
-	 * @return Item
-	 */
 	public function getFuel() : Item{
 		return $this->fuel;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getBurnTime() : int{
 		return $this->burnTime;
 	}
 
-	/**
-	 * @param int $burnTime
-	 */
 	public function setBurnTime(int $burnTime) : void{
 		$this->burnTime = $burnTime;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isBurning() : bool{
 		return $this->burning;
 	}
 
-	/**
-	 * @param bool $burning
-	 */
 	public function setBurning(bool $burning) : void{
 		$this->burning = $burning;
 	}

--- a/src/pocketmine/event/inventory/FurnaceSmeltEvent.php
+++ b/src/pocketmine/event/inventory/FurnaceSmeltEvent.php
@@ -36,11 +36,6 @@ class FurnaceSmeltEvent extends BlockEvent implements Cancellable{
 	/** @var Item */
 	private $result;
 
-	/**
-	 * @param Furnace $furnace
-	 * @param Item    $source
-	 * @param Item    $result
-	 */
 	public function __construct(Furnace $furnace, Item $source, Item $result){
 		parent::__construct($furnace->getBlock());
 		$this->source = clone $source;
@@ -49,30 +44,18 @@ class FurnaceSmeltEvent extends BlockEvent implements Cancellable{
 		$this->furnace = $furnace;
 	}
 
-	/**
-	 * @return Furnace
-	 */
 	public function getFurnace() : Furnace{
 		return $this->furnace;
 	}
 
-	/**
-	 * @return Item
-	 */
 	public function getSource() : Item{
 		return $this->source;
 	}
 
-	/**
-	 * @return Item
-	 */
 	public function getResult() : Item{
 		return $this->result;
 	}
 
-	/**
-	 * @param Item $result
-	 */
 	public function setResult(Item $result) : void{
 		$this->result = $result;
 	}

--- a/src/pocketmine/event/inventory/InventoryCloseEvent.php
+++ b/src/pocketmine/event/inventory/InventoryCloseEvent.php
@@ -30,18 +30,11 @@ class InventoryCloseEvent extends InventoryEvent{
 	/** @var Player */
 	private $who;
 
-	/**
-	 * @param Inventory $inventory
-	 * @param Player    $who
-	 */
 	public function __construct(Inventory $inventory, Player $who){
 		$this->who = $who;
 		parent::__construct($inventory);
 	}
 
-	/**
-	 * @return Player
-	 */
 	public function getPlayer() : Player{
 		return $this->who;
 	}

--- a/src/pocketmine/event/inventory/InventoryEvent.php
+++ b/src/pocketmine/event/inventory/InventoryEvent.php
@@ -38,9 +38,6 @@ abstract class InventoryEvent extends Event{
 		$this->inventory = $inventory;
 	}
 
-	/**
-	 * @return Inventory
-	 */
 	public function getInventory() : Inventory{
 		return $this->inventory;
 	}

--- a/src/pocketmine/event/inventory/InventoryOpenEvent.php
+++ b/src/pocketmine/event/inventory/InventoryOpenEvent.php
@@ -31,18 +31,11 @@ class InventoryOpenEvent extends InventoryEvent implements Cancellable{
 	/** @var Player */
 	private $who;
 
-	/**
-	 * @param Inventory $inventory
-	 * @param Player    $who
-	 */
 	public function __construct(Inventory $inventory, Player $who){
 		$this->who = $who;
 		parent::__construct($inventory);
 	}
 
-	/**
-	 * @return Player
-	 */
 	public function getPlayer() : Player{
 		return $this->who;
 	}

--- a/src/pocketmine/event/inventory/InventoryPickupArrowEvent.php
+++ b/src/pocketmine/event/inventory/InventoryPickupArrowEvent.php
@@ -31,18 +31,11 @@ class InventoryPickupArrowEvent extends InventoryEvent implements Cancellable{
 	/** @var Arrow */
 	private $arrow;
 
-	/**
-	 * @param Inventory $inventory
-	 * @param Arrow     $arrow
-	 */
 	public function __construct(Inventory $inventory, Arrow $arrow){
 		$this->arrow = $arrow;
 		parent::__construct($inventory);
 	}
 
-	/**
-	 * @return Arrow
-	 */
 	public function getArrow() : Arrow{
 		return $this->arrow;
 	}

--- a/src/pocketmine/event/inventory/InventoryPickupItemEvent.php
+++ b/src/pocketmine/event/inventory/InventoryPickupItemEvent.php
@@ -31,18 +31,11 @@ class InventoryPickupItemEvent extends InventoryEvent implements Cancellable{
 	/** @var ItemEntity */
 	private $item;
 
-	/**
-	 * @param Inventory  $inventory
-	 * @param ItemEntity $item
-	 */
 	public function __construct(Inventory $inventory, ItemEntity $item){
 		$this->item = $item;
 		parent::__construct($inventory);
 	}
 
-	/**
-	 * @return ItemEntity
-	 */
 	public function getItem() : ItemEntity{
 		return $this->item;
 	}

--- a/src/pocketmine/event/inventory/InventoryTransactionEvent.php
+++ b/src/pocketmine/event/inventory/InventoryTransactionEvent.php
@@ -35,16 +35,10 @@ class InventoryTransactionEvent extends Event implements Cancellable{
 	/** @var InventoryTransaction */
 	private $transaction;
 
-	/**
-	 * @param InventoryTransaction $transaction
-	 */
 	public function __construct(InventoryTransaction $transaction){
 		$this->transaction = $transaction;
 	}
 
-	/**
-	 * @return InventoryTransaction
-	 */
 	public function getTransaction() : InventoryTransaction{
 		return $this->transaction;
 	}

--- a/src/pocketmine/event/level/ChunkEvent.php
+++ b/src/pocketmine/event/level/ChunkEvent.php
@@ -34,18 +34,11 @@ abstract class ChunkEvent extends LevelEvent{
 	/** @var Chunk */
 	private $chunk;
 
-	/**
-	 * @param Level $level
-	 * @param Chunk $chunk
-	 */
 	public function __construct(Level $level, Chunk $chunk){
 		parent::__construct($level);
 		$this->chunk = $chunk;
 	}
 
-	/**
-	 * @return Chunk
-	 */
 	public function getChunk() : Chunk{
 		return $this->chunk;
 	}

--- a/src/pocketmine/event/level/ChunkLoadEvent.php
+++ b/src/pocketmine/event/level/ChunkLoadEvent.php
@@ -39,9 +39,6 @@ class ChunkLoadEvent extends ChunkEvent{
 		$this->newChunk = $newChunk;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isNewChunk() : bool{
 		return $this->newChunk;
 	}

--- a/src/pocketmine/event/level/LevelEvent.php
+++ b/src/pocketmine/event/level/LevelEvent.php
@@ -33,16 +33,10 @@ abstract class LevelEvent extends Event{
 	/** @var Level */
 	private $level;
 
-	/**
-	 * @param Level $level
-	 */
 	public function __construct(Level $level){
 		$this->level = $level;
 	}
 
-	/**
-	 * @return Level
-	 */
 	public function getLevel() : Level{
 		return $this->level;
 	}

--- a/src/pocketmine/event/level/SpawnChangeEvent.php
+++ b/src/pocketmine/event/level/SpawnChangeEvent.php
@@ -34,18 +34,11 @@ class SpawnChangeEvent extends LevelEvent{
 	/** @var Position */
 	private $previousSpawn;
 
-	/**
-	 * @param Level    $level
-	 * @param Position $previousSpawn
-	 */
 	public function __construct(Level $level, Position $previousSpawn){
 		parent::__construct($level);
 		$this->previousSpawn = $previousSpawn;
 	}
 
-	/**
-	 * @return Position
-	 */
 	public function getPreviousSpawn() : Position{
 		return $this->previousSpawn;
 	}

--- a/src/pocketmine/event/player/PlayerAchievementAwardedEvent.php
+++ b/src/pocketmine/event/player/PlayerAchievementAwardedEvent.php
@@ -33,18 +33,11 @@ class PlayerAchievementAwardedEvent extends PlayerEvent implements Cancellable{
 	/** @var string */
 	protected $achievement;
 
-	/**
-	 * @param Player $player
-	 * @param string $achievementId
-	 */
 	public function __construct(Player $player, string $achievementId){
 		$this->player = $player;
 		$this->achievement = $achievementId;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getAchievement() : string{
 		return $this->achievement;
 	}

--- a/src/pocketmine/event/player/PlayerAnimationEvent.php
+++ b/src/pocketmine/event/player/PlayerAnimationEvent.php
@@ -33,18 +33,11 @@ class PlayerAnimationEvent extends PlayerEvent implements Cancellable{
 	/** @var int */
 	private $animationType;
 
-	/**
-	 * @param Player $player
-	 * @param int    $animation
-	 */
 	public function __construct(Player $player, int $animation){
 		$this->player = $player;
 		$this->animationType = $animation;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getAnimationType() : int{
 		return $this->animationType;
 	}

--- a/src/pocketmine/event/player/PlayerBedEnterEvent.php
+++ b/src/pocketmine/event/player/PlayerBedEnterEvent.php
@@ -36,9 +36,6 @@ class PlayerBedEnterEvent extends PlayerEvent implements Cancellable{
 		$this->bed = $bed;
 	}
 
-	/**
-	 * @return Block
-	 */
 	public function getBed() : Block{
 		return $this->bed;
 	}

--- a/src/pocketmine/event/player/PlayerBedLeaveEvent.php
+++ b/src/pocketmine/event/player/PlayerBedLeaveEvent.php
@@ -35,9 +35,6 @@ class PlayerBedLeaveEvent extends PlayerEvent{
 		$this->bed = $bed;
 	}
 
-	/**
-	 * @return Block
-	 */
 	public function getBed() : Block{
 		return $this->bed;
 	}

--- a/src/pocketmine/event/player/PlayerBucketEvent.php
+++ b/src/pocketmine/event/player/PlayerBucketEvent.php
@@ -41,13 +41,6 @@ abstract class PlayerBucketEvent extends PlayerEvent implements Cancellable{
 	/** @var Item */
 	private $item;
 
-	/**
-	 * @param Player $who
-	 * @param Block  $blockClicked
-	 * @param int    $blockFace
-	 * @param Item   $bucket
-	 * @param Item   $itemInHand
-	 */
 	public function __construct(Player $who, Block $blockClicked, int $blockFace, Item $bucket, Item $itemInHand){
 		$this->player = $who;
 		$this->blockClicked = $blockClicked;
@@ -58,8 +51,6 @@ abstract class PlayerBucketEvent extends PlayerEvent implements Cancellable{
 
 	/**
 	 * Returns the bucket used in this event
-	 *
-	 * @return Item
 	 */
 	public function getBucket() : Item{
 		return $this->bucket;
@@ -67,30 +58,19 @@ abstract class PlayerBucketEvent extends PlayerEvent implements Cancellable{
 
 	/**
 	 * Returns the item in hand after the event
-	 *
-	 * @return Item
 	 */
 	public function getItem() : Item{
 		return $this->item;
 	}
 
-	/**
-	 * @param Item $item
-	 */
 	public function setItem(Item $item) : void{
 		$this->item = $item;
 	}
 
-	/**
-	 * @return Block
-	 */
 	public function getBlockClicked() : Block{
 		return $this->blockClicked;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getBlockFace() : int{
 		return $this->blockFace;
 	}

--- a/src/pocketmine/event/player/PlayerChangeSkinEvent.php
+++ b/src/pocketmine/event/player/PlayerChangeSkinEvent.php
@@ -36,34 +36,21 @@ class PlayerChangeSkinEvent extends PlayerEvent implements Cancellable{
 	/** @var Skin */
 	private $newSkin;
 
-	/**
-	 * @param Player $player
-	 * @param Skin   $oldSkin
-	 * @param Skin   $newSkin
-	 */
 	public function __construct(Player $player, Skin $oldSkin, Skin $newSkin){
 		$this->player = $player;
 		$this->oldSkin = $oldSkin;
 		$this->newSkin = $newSkin;
 	}
 
-	/**
-	 * @return Skin
-	 */
 	public function getOldSkin() : Skin{
 		return $this->oldSkin;
 	}
 
-	/**
-	 * @return Skin
-	 */
 	public function getNewSkin() : Skin{
 		return $this->newSkin;
 	}
 
 	/**
-	 * @param Skin $skin
-	 *
 	 * @throws \InvalidArgumentException if the specified skin is not valid
 	 */
 	public function setNewSkin(Skin $skin) : void{

--- a/src/pocketmine/event/player/PlayerChatEvent.php
+++ b/src/pocketmine/event/player/PlayerChatEvent.php
@@ -46,9 +46,6 @@ class PlayerChatEvent extends PlayerEvent implements Cancellable{
 	protected $recipients = [];
 
 	/**
-	 * @param Player          $player
-	 * @param string          $message
-	 * @param string          $format
 	 * @param CommandSender[] $recipients
 	 */
 	public function __construct(Player $player, string $message, string $format = "chat.type.text", array $recipients = null){
@@ -68,39 +65,25 @@ class PlayerChatEvent extends PlayerEvent implements Cancellable{
 		}
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getMessage() : string{
 		return $this->message;
 	}
 
-	/**
-	 * @param string $message
-	 */
 	public function setMessage(string $message) : void{
 		$this->message = $message;
 	}
 
 	/**
 	 * Changes the player that is sending the message
-	 *
-	 * @param Player $player
 	 */
 	public function setPlayer(Player $player) : void{
 		$this->player = $player;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getFormat() : string{
 		return $this->format;
 	}
 
-	/**
-	 * @param string $format
-	 */
 	public function setFormat(string $format) : void{
 		$this->format = $format;
 	}

--- a/src/pocketmine/event/player/PlayerCommandPreprocessEvent.php
+++ b/src/pocketmine/event/player/PlayerCommandPreprocessEvent.php
@@ -38,33 +38,19 @@ class PlayerCommandPreprocessEvent extends PlayerEvent implements Cancellable{
 	/** @var string */
 	protected $message;
 
-
-	/**
-	 * @param Player $player
-	 * @param string $message
-	 */
 	public function __construct(Player $player, string $message){
 		$this->player = $player;
 		$this->message = $message;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getMessage() : string{
 		return $this->message;
 	}
 
-	/**
-	 * @param string $message
-	 */
 	public function setMessage(string $message) : void{
 		$this->message = $message;
 	}
 
-	/**
-	 * @param Player $player
-	 */
 	public function setPlayer(Player $player) : void{
 		$this->player = $player;
 	}

--- a/src/pocketmine/event/player/PlayerCreationEvent.php
+++ b/src/pocketmine/event/player/PlayerCreationEvent.php
@@ -45,11 +45,8 @@ class PlayerCreationEvent extends Event{
 	private $playerClass;
 
 	/**
-	 * @param SourceInterface $interface
 	 * @param string          $baseClass
 	 * @param string          $playerClass
-	 * @param string          $address
-	 * @param int             $port
 	 */
 	public function __construct(SourceInterface $interface, $baseClass, $playerClass, string $address, int $port){
 		$this->interface = $interface;
@@ -69,23 +66,14 @@ class PlayerCreationEvent extends Event{
 		$this->playerClass = $playerClass;
 	}
 
-	/**
-	 * @return SourceInterface
-	 */
 	public function getInterface() : SourceInterface{
 		return $this->interface;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getAddress() : string{
 		return $this->address;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getPort() : int{
 		return $this->port;
 	}

--- a/src/pocketmine/event/player/PlayerDataSaveEvent.php
+++ b/src/pocketmine/event/player/PlayerDataSaveEvent.php
@@ -45,22 +45,17 @@ class PlayerDataSaveEvent extends Event implements Cancellable{
 
 	/**
 	 * Returns the data to be written to disk as a CompoundTag
-	 * @return CompoundTag
 	 */
 	public function getSaveData() : CompoundTag{
 		return $this->data;
 	}
 
-	/**
-	 * @param CompoundTag $data
-	 */
 	public function setSaveData(CompoundTag $data) : void{
 		$this->data = $data;
 	}
 
 	/**
 	 * Returns the username of the player whose data is being saved. This is not necessarily an online player.
-	 * @return string
 	 */
 	public function getPlayerName() : string{
 		return $this->playerName;

--- a/src/pocketmine/event/player/PlayerDeathEvent.php
+++ b/src/pocketmine/event/player/PlayerDeathEvent.php
@@ -44,7 +44,6 @@ class PlayerDeathEvent extends EntityDeathEvent{
 	private $keepInventory = false;
 
 	/**
-	 * @param Player                    $entity
 	 * @param Item[]                    $drops
 	 * @param string|TextContainer|null $deathMessage Null will cause the default vanilla message to be used
 	 */
@@ -60,9 +59,6 @@ class PlayerDeathEvent extends EntityDeathEvent{
 		return $this->entity;
 	}
 
-	/**
-	 * @return Player
-	 */
 	public function getPlayer() : Player{
 		return $this->entity;
 	}
@@ -91,11 +87,6 @@ class PlayerDeathEvent extends EntityDeathEvent{
 
 	/**
 	 * Returns the vanilla death message for the given death cause.
-	 *
-	 * @param string                 $name
-	 * @param null|EntityDamageEvent $deathCause
-	 *
-	 * @return TranslationContainer
 	 */
 	public static function deriveMessage(string $name, ?EntityDamageEvent $deathCause) : TranslationContainer{
 		$message = "death.attack.generic";

--- a/src/pocketmine/event/player/PlayerDropItemEvent.php
+++ b/src/pocketmine/event/player/PlayerDropItemEvent.php
@@ -34,18 +34,11 @@ class PlayerDropItemEvent extends PlayerEvent implements Cancellable{
 	/** @var Item */
 	private $drop;
 
-	/**
-	 * @param Player $player
-	 * @param Item   $drop
-	 */
 	public function __construct(Player $player, Item $drop){
 		$this->player = $player;
 		$this->drop = $drop;
 	}
 
-	/**
-	 * @return Item
-	 */
 	public function getItem() : Item{
 		return $this->drop;
 	}

--- a/src/pocketmine/event/player/PlayerEditBookEvent.php
+++ b/src/pocketmine/event/player/PlayerEditBookEvent.php
@@ -53,8 +53,6 @@ class PlayerEditBookEvent extends PlayerEvent implements Cancellable{
 
 	/**
 	 * Returns the action of the event.
-	 *
-	 * @return int
 	 */
 	public function getAction() : int{
 		return $this->action;
@@ -62,8 +60,6 @@ class PlayerEditBookEvent extends PlayerEvent implements Cancellable{
 
 	/**
 	 * Returns the book before it was modified.
-	 *
-	 * @return WritableBook
 	 */
 	public function getOldBook() : WritableBook{
 		return $this->oldBook;
@@ -72,8 +68,6 @@ class PlayerEditBookEvent extends PlayerEvent implements Cancellable{
 	/**
 	 * Returns the book after it was modified.
 	 * The new book may be a written book, if the book was signed.
-	 *
-	 * @return WritableBook
 	 */
 	public function getNewBook() : WritableBook{
 		return $this->newBook;
@@ -81,8 +75,6 @@ class PlayerEditBookEvent extends PlayerEvent implements Cancellable{
 
 	/**
 	 * Sets the new book as the given instance.
-	 *
-	 * @param WritableBook $book
 	 */
 	public function setNewBook(WritableBook $book) : void{
 		$this->newBook = $book;

--- a/src/pocketmine/event/player/PlayerExhaustEvent.php
+++ b/src/pocketmine/event/player/PlayerExhaustEvent.php
@@ -72,7 +72,6 @@ class PlayerExhaustEvent extends EntityEvent implements Cancellable{
 
 	/**
 	 * Returns an int cause of the exhaustion - one of the constants at the top of this class.
-	 * @return int
 	 */
 	public function getCause() : int{
 		return $this->cause;

--- a/src/pocketmine/event/player/PlayerExperienceChangeEvent.php
+++ b/src/pocketmine/event/player/PlayerExperienceChangeEvent.php
@@ -51,16 +51,10 @@ class PlayerExperienceChangeEvent extends EntityEvent implements Cancellable{
 		$this->newProgress = $newProgress;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getOldLevel() : int{
 		return $this->oldLevel;
 	}
 
-	/**
-	 * @return float
-	 */
 	public function getOldProgress() : float{
 		return $this->oldProgress;
 	}
@@ -79,16 +73,10 @@ class PlayerExperienceChangeEvent extends EntityEvent implements Cancellable{
 		return $this->newProgress;
 	}
 
-	/**
-	 * @param int|null $newLevel
-	 */
 	public function setNewLevel(?int $newLevel) : void{
 		$this->newLevel = $newLevel;
 	}
 
-	/**
-	 * @param float|null $newProgress
-	 */
 	public function setNewProgress(?float $newProgress) : void{
 		$this->newProgress = $newProgress;
 	}

--- a/src/pocketmine/event/player/PlayerInteractEvent.php
+++ b/src/pocketmine/event/player/PlayerInteractEvent.php
@@ -57,14 +57,6 @@ class PlayerInteractEvent extends PlayerEvent implements Cancellable{
 	/** @var int */
 	protected $action;
 
-	/**
-	 * @param Player       $player
-	 * @param Item         $item
-	 * @param Block|null   $block
-	 * @param Vector3|null $touchVector
-	 * @param int          $face
-	 * @param int          $action
-	 */
 	public function __construct(Player $player, Item $item, ?Block $block, ?Vector3 $touchVector, int $face, int $action = PlayerInteractEvent::RIGHT_CLICK_BLOCK){
 		assert($block !== null or $touchVector !== null);
 		$this->player = $player;
@@ -75,37 +67,22 @@ class PlayerInteractEvent extends PlayerEvent implements Cancellable{
 		$this->action = $action;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getAction() : int{
 		return $this->action;
 	}
 
-	/**
-	 * @return Item
-	 */
 	public function getItem() : Item{
 		return $this->item;
 	}
 
-	/**
-	 * @return Block
-	 */
 	public function getBlock() : Block{
 		return $this->blockTouched;
 	}
 
-	/**
-	 * @return Vector3
-	 */
 	public function getTouchVector() : Vector3{
 		return $this->touchVector;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getFace() : int{
 		return $this->blockFace;
 	}

--- a/src/pocketmine/event/player/PlayerItemConsumeEvent.php
+++ b/src/pocketmine/event/player/PlayerItemConsumeEvent.php
@@ -34,18 +34,11 @@ class PlayerItemConsumeEvent extends PlayerEvent implements Cancellable{
 	/** @var Item */
 	private $item;
 
-	/**
-	 * @param Player $player
-	 * @param Item   $item
-	 */
 	public function __construct(Player $player, Item $item){
 		$this->player = $player;
 		$this->item = $item;
 	}
 
-	/**
-	 * @return Item
-	 */
 	public function getItem() : Item{
 		return clone $this->item;
 	}

--- a/src/pocketmine/event/player/PlayerItemHeldEvent.php
+++ b/src/pocketmine/event/player/PlayerItemHeldEvent.php
@@ -46,8 +46,6 @@ class PlayerItemHeldEvent extends PlayerEvent implements Cancellable{
 	 * event will result in the **old** slot being changed, not this one.
 	 *
 	 * To change the item in the slot that the player is attempting to hold, set the slot that this function reports.
-	 *
-	 * @return int
 	 */
 	public function getSlot() : int{
 		return $this->hotbarSlot;
@@ -55,8 +53,6 @@ class PlayerItemHeldEvent extends PlayerEvent implements Cancellable{
 
 	/**
 	 * Returns the item in the slot that the player is trying to equip.
-	 *
-	 * @return Item
 	 */
 	public function getItem() : Item{
 		return $this->item;

--- a/src/pocketmine/event/player/PlayerJoinEvent.php
+++ b/src/pocketmine/event/player/PlayerJoinEvent.php
@@ -40,7 +40,6 @@ class PlayerJoinEvent extends PlayerEvent{
 	/**
 	 * PlayerJoinEvent constructor.
 	 *
-	 * @param Player               $player
 	 * @param TextContainer|string $joinMessage
 	 */
 	public function __construct(Player $player, $joinMessage){

--- a/src/pocketmine/event/player/PlayerJumpEvent.php
+++ b/src/pocketmine/event/player/PlayerJumpEvent.php
@@ -32,8 +32,6 @@ class PlayerJumpEvent extends PlayerEvent{
 
 	/**
 	 * PlayerJumpEvent constructor.
-	 *
-	 * @param Player $player
 	 */
 	public function __construct(Player $player){
 		$this->player = $player;

--- a/src/pocketmine/event/player/PlayerKickEvent.php
+++ b/src/pocketmine/event/player/PlayerKickEvent.php
@@ -40,8 +40,6 @@ class PlayerKickEvent extends PlayerEvent implements Cancellable{
 	/**
 	 * PlayerKickEvent constructor.
 	 *
-	 * @param Player               $player
-	 * @param string               $reason
 	 * @param TextContainer|string $quitMessage
 	 */
 	public function __construct(Player $player, string $reason, $quitMessage){
@@ -50,9 +48,6 @@ class PlayerKickEvent extends PlayerEvent implements Cancellable{
 		$this->reason = $reason;
 	}
 
-	/**
-	 * @param string $reason
-	 */
 	public function setReason(string $reason) : void{
 		$this->reason = $reason;
 	}

--- a/src/pocketmine/event/player/PlayerLoginEvent.php
+++ b/src/pocketmine/event/player/PlayerLoginEvent.php
@@ -35,25 +35,15 @@ class PlayerLoginEvent extends PlayerEvent implements Cancellable{
 	/** @var string */
 	protected $kickMessage;
 
-	/**
-	 * @param Player $player
-	 * @param string $kickMessage
-	 */
 	public function __construct(Player $player, string $kickMessage){
 		$this->player = $player;
 		$this->kickMessage = $kickMessage;
 	}
 
-	/**
-	 * @param string $kickMessage
-	 */
 	public function setKickMessage(string $kickMessage) : void{
 		$this->kickMessage = $kickMessage;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getKickMessage() : string{
 		return $this->kickMessage;
 	}

--- a/src/pocketmine/event/player/PlayerMoveEvent.php
+++ b/src/pocketmine/event/player/PlayerMoveEvent.php
@@ -33,34 +33,20 @@ class PlayerMoveEvent extends PlayerEvent implements Cancellable{
 	/** @var Location */
 	private $to;
 
-	/**
-	 * @param Player   $player
-	 * @param Location $from
-	 * @param Location $to
-	 */
 	public function __construct(Player $player, Location $from, Location $to){
 		$this->player = $player;
 		$this->from = $from;
 		$this->to = $to;
 	}
 
-	/**
-	 * @return Location
-	 */
 	public function getFrom() : Location{
 		return $this->from;
 	}
 
-	/**
-	 * @return Location
-	 */
 	public function getTo() : Location{
 		return $this->to;
 	}
 
-	/**
-	 * @param Location $to
-	 */
 	public function setTo(Location $to) : void{
 		$this->to = $to;
 	}

--- a/src/pocketmine/event/player/PlayerPreLoginEvent.php
+++ b/src/pocketmine/event/player/PlayerPreLoginEvent.php
@@ -43,25 +43,15 @@ class PlayerPreLoginEvent extends PlayerEvent implements Cancellable{
 	/** @var string */
 	protected $kickMessage;
 
-	/**
-	 * @param Player $player
-	 * @param string $kickMessage
-	 */
 	public function __construct(Player $player, string $kickMessage){
 		$this->player = $player;
 		$this->kickMessage = $kickMessage;
 	}
 
-	/**
-	 * @param string $kickMessage
-	 */
 	public function setKickMessage(string $kickMessage) : void{
 		$this->kickMessage = $kickMessage;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getKickMessage() : string{
 		return $this->kickMessage;
 	}

--- a/src/pocketmine/event/player/PlayerQuitEvent.php
+++ b/src/pocketmine/event/player/PlayerQuitEvent.php
@@ -37,9 +37,7 @@ class PlayerQuitEvent extends PlayerEvent{
 	protected $quitReason;
 
 	/**
-	 * @param Player                      $player
 	 * @param TranslationContainer|string $quitMessage
-	 * @param string                      $quitReason
 	 */
 	public function __construct(Player $player, $quitMessage, string $quitReason){
 		$this->player = $player;
@@ -61,9 +59,6 @@ class PlayerQuitEvent extends PlayerEvent{
 		return $this->quitMessage;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getQuitReason() : string{
 		return $this->quitReason;
 	}

--- a/src/pocketmine/event/player/PlayerRespawnEvent.php
+++ b/src/pocketmine/event/player/PlayerRespawnEvent.php
@@ -33,25 +33,15 @@ class PlayerRespawnEvent extends PlayerEvent{
 	/** @var Position */
 	protected $position;
 
-	/**
-	 * @param Player   $player
-	 * @param Position $position
-	 */
 	public function __construct(Player $player, Position $position){
 		$this->player = $player;
 		$this->position = $position;
 	}
 
-	/**
-	 * @return Position
-	 */
 	public function getRespawnPosition() : Position{
 		return $this->position;
 	}
 
-	/**
-	 * @param Position $position
-	 */
 	public function setRespawnPosition(Position $position) : void{
 		$this->position = $position;
 	}

--- a/src/pocketmine/event/player/PlayerToggleFlightEvent.php
+++ b/src/pocketmine/event/player/PlayerToggleFlightEvent.php
@@ -30,18 +30,11 @@ class PlayerToggleFlightEvent extends PlayerEvent implements Cancellable{
 	/** @var bool */
 	protected $isFlying;
 
-	/**
-	 * @param Player $player
-	 * @param bool   $isFlying
-	 */
 	public function __construct(Player $player, bool $isFlying){
 		$this->player = $player;
 		$this->isFlying = $isFlying;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isFlying() : bool{
 		return $this->isFlying;
 	}

--- a/src/pocketmine/event/player/PlayerToggleSneakEvent.php
+++ b/src/pocketmine/event/player/PlayerToggleSneakEvent.php
@@ -30,18 +30,11 @@ class PlayerToggleSneakEvent extends PlayerEvent implements Cancellable{
 	/** @var bool */
 	protected $isSneaking;
 
-	/**
-	 * @param Player $player
-	 * @param bool   $isSneaking
-	 */
 	public function __construct(Player $player, bool $isSneaking){
 		$this->player = $player;
 		$this->isSneaking = $isSneaking;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isSneaking() : bool{
 		return $this->isSneaking;
 	}

--- a/src/pocketmine/event/player/PlayerToggleSprintEvent.php
+++ b/src/pocketmine/event/player/PlayerToggleSprintEvent.php
@@ -30,18 +30,11 @@ class PlayerToggleSprintEvent extends PlayerEvent implements Cancellable{
 	/** @var bool */
 	protected $isSprinting;
 
-	/**
-	 * @param Player $player
-	 * @param bool   $isSprinting
-	 */
 	public function __construct(Player $player, bool $isSprinting){
 		$this->player = $player;
 		$this->isSprinting = $isSprinting;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isSprinting() : bool{
 		return $this->isSprinting;
 	}

--- a/src/pocketmine/event/player/PlayerTransferEvent.php
+++ b/src/pocketmine/event/player/PlayerTransferEvent.php
@@ -34,12 +34,6 @@ class PlayerTransferEvent extends PlayerEvent implements Cancellable{
 	/** @var string */
 	protected $message;
 
-	/**
-	 * @param Player $player
-	 * @param string $address
-	 * @param int    $port
-	 * @param string $message
-	 */
 	public function __construct(Player $player, string $address, int $port, string $message){
 		$this->player = $player;
 		$this->address = $address;
@@ -47,44 +41,26 @@ class PlayerTransferEvent extends PlayerEvent implements Cancellable{
 		$this->message = $message;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getAddress() : string{
 		return $this->address;
 	}
 
-	/**
-	 * @param string $address
-	 */
 	public function setAddress(string $address) : void{
 		$this->address = $address;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getPort() : int{
 		return $this->port;
 	}
 
-	/**
-	 * @param int $port
-	 */
 	public function setPort(int $port) : void{
 		$this->port = $port;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getMessage() : string{
 		return $this->message;
 	}
 
-	/**
-	 * @param string $message
-	 */
 	public function setMessage(string $message) : void{
 		$this->message = $message;
 	}

--- a/src/pocketmine/event/player/cheat/PlayerIllegalMoveEvent.php
+++ b/src/pocketmine/event/player/cheat/PlayerIllegalMoveEvent.php
@@ -40,11 +40,6 @@ class PlayerIllegalMoveEvent extends PlayerCheatEvent implements Cancellable{
 	/** @var Vector3 */
 	private $expectedPosition;
 
-	/**
-	 * @param Player  $player
-	 * @param Vector3 $attemptedPosition
-	 * @param Vector3 $originalPosition
-	 */
 	public function __construct(Player $player, Vector3 $attemptedPosition, Vector3 $originalPosition){
 		$this->player = $player;
 		$this->attemptedPosition = $attemptedPosition;
@@ -54,22 +49,15 @@ class PlayerIllegalMoveEvent extends PlayerCheatEvent implements Cancellable{
 
 	/**
 	 * Returns the position the player attempted to move to.
-	 * @return Vector3
 	 */
 	public function getAttemptedPosition() : Vector3{
 		return $this->attemptedPosition;
 	}
 
-	/**
-	 * @return Vector3
-	 */
 	public function getOriginalPosition() : Vector3{
 		return $this->originalPosition;
 	}
 
-	/**
-	 * @return Vector3
-	 */
 	public function getExpectedPosition() : Vector3{
 		return $this->expectedPosition;
 	}

--- a/src/pocketmine/event/plugin/PluginEvent.php
+++ b/src/pocketmine/event/plugin/PluginEvent.php
@@ -37,9 +37,6 @@ abstract class PluginEvent extends Event{
 		$this->plugin = $plugin;
 	}
 
-	/**
-	 * @return Plugin
-	 */
 	public function getPlugin() : Plugin{
 		return $this->plugin;
 	}

--- a/src/pocketmine/event/server/CommandEvent.php
+++ b/src/pocketmine/event/server/CommandEvent.php
@@ -41,32 +41,19 @@ class CommandEvent extends ServerEvent implements Cancellable{
 	/** @var CommandSender */
 	protected $sender;
 
-	/**
-	 * @param CommandSender $sender
-	 * @param string        $command
-	 */
 	public function __construct(CommandSender $sender, string $command){
 		$this->sender = $sender;
 		$this->command = $command;
 	}
 
-	/**
-	 * @return CommandSender
-	 */
 	public function getSender() : CommandSender{
 		return $this->sender;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getCommand() : string{
 		return $this->command;
 	}
 
-	/**
-	 * @param string $command
-	 */
 	public function setCommand(string $command) : void{
 		$this->command = $command;
 	}

--- a/src/pocketmine/event/server/DataPacketReceiveEvent.php
+++ b/src/pocketmine/event/server/DataPacketReceiveEvent.php
@@ -33,25 +33,15 @@ class DataPacketReceiveEvent extends ServerEvent implements Cancellable{
 	/** @var Player */
 	private $player;
 
-	/**
-	 * @param Player     $player
-	 * @param DataPacket $packet
-	 */
 	public function __construct(Player $player, DataPacket $packet){
 		$this->packet = $packet;
 		$this->player = $player;
 	}
 
-	/**
-	 * @return DataPacket
-	 */
 	public function getPacket() : DataPacket{
 		return $this->packet;
 	}
 
-	/**
-	 * @return Player
-	 */
 	public function getPlayer() : Player{
 		return $this->player;
 	}

--- a/src/pocketmine/event/server/DataPacketSendEvent.php
+++ b/src/pocketmine/event/server/DataPacketSendEvent.php
@@ -33,25 +33,15 @@ class DataPacketSendEvent extends ServerEvent implements Cancellable{
 	/** @var Player */
 	private $player;
 
-	/**
-	 * @param Player     $player
-	 * @param DataPacket $packet
-	 */
 	public function __construct(Player $player, DataPacket $packet){
 		$this->packet = $packet;
 		$this->player = $player;
 	}
 
-	/**
-	 * @return DataPacket
-	 */
 	public function getPacket() : DataPacket{
 		return $this->packet;
 	}
 
-	/**
-	 * @return Player
-	 */
 	public function getPlayer() : Player{
 		return $this->player;
 	}

--- a/src/pocketmine/event/server/LowMemoryEvent.php
+++ b/src/pocketmine/event/server/LowMemoryEvent.php
@@ -49,8 +49,6 @@ class LowMemoryEvent extends ServerEvent{
 
 	/**
 	 * Returns the memory usage at the time of the event call (in bytes)
-	 *
-	 * @return int
 	 */
 	public function getMemory() : int{
 		return $this->memory;
@@ -58,8 +56,6 @@ class LowMemoryEvent extends ServerEvent{
 
 	/**
 	 * Returns the memory limit defined (in bytes)
-	 *
-	 * @return int
 	 */
 	public function getMemoryLimit() : int{
 		return $this->memoryLimit;
@@ -67,24 +63,17 @@ class LowMemoryEvent extends ServerEvent{
 
 	/**
 	 * Returns the times this event has been called in the current low-memory state
-	 *
-	 * @return int
 	 */
 	public function getTriggerCount() : int{
 		return $this->triggerCount;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isGlobal() : bool{
 		return $this->global;
 	}
 
 	/**
 	 * Amount of memory already freed
-	 *
-	 * @return int
 	 */
 	public function getMemoryFreed() : int{
 		return $this->getMemory() - ($this->isGlobal() ? Utils::getMemoryUsage(true)[1] : Utils::getMemoryUsage(true)[0]);

--- a/src/pocketmine/event/server/NetworkInterfaceCrashEvent.php
+++ b/src/pocketmine/event/server/NetworkInterfaceCrashEvent.php
@@ -40,9 +40,6 @@ class NetworkInterfaceCrashEvent extends NetworkInterfaceEvent{
 		$this->exception = $throwable;
 	}
 
-	/**
-	 * @return \Throwable
-	 */
 	public function getCrashInformation() : \Throwable{
 		return $this->exception;
 	}

--- a/src/pocketmine/event/server/NetworkInterfaceEvent.php
+++ b/src/pocketmine/event/server/NetworkInterfaceEvent.php
@@ -29,16 +29,10 @@ class NetworkInterfaceEvent extends ServerEvent{
 	/** @var SourceInterface */
 	protected $interface;
 
-	/**
-	 * @param SourceInterface $interface
-	 */
 	public function __construct(SourceInterface $interface){
 		$this->interface = $interface;
 	}
 
-	/**
-	 * @return SourceInterface
-	 */
 	public function getInterface() : SourceInterface{
 		return $this->interface;
 	}

--- a/src/pocketmine/event/server/QueryRegenerateEvent.php
+++ b/src/pocketmine/event/server/QueryRegenerateEvent.php
@@ -71,10 +71,6 @@ class QueryRegenerateEvent extends ServerEvent{
 	/** @var string|null */
 	private $shortQueryCache = null;
 
-
-	/**
-	 * @param Server $server
-	 */
 	public function __construct(Server $server){
 		$this->serverName = $server->getMotd();
 		$this->listPlugins = $server->getProperty("settings.query-plugins", true);
@@ -100,8 +96,6 @@ class QueryRegenerateEvent extends ServerEvent{
 
 	/**
 	 * @deprecated
-	 *
-	 * @return int
 	 */
 	public function getTimeout() : int{
 		return 0;
@@ -109,7 +103,6 @@ class QueryRegenerateEvent extends ServerEvent{
 
 	/**
 	 * @deprecated
-	 * @param int $timeout
 	 */
 	public function setTimeout(int $timeout) : void{
 
@@ -120,31 +113,19 @@ class QueryRegenerateEvent extends ServerEvent{
 		$this->shortQueryCache = null;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getServerName() : string{
 		return $this->serverName;
 	}
 
-	/**
-	 * @param string $serverName
-	 */
 	public function setServerName(string $serverName) : void{
 		$this->serverName = $serverName;
 		$this->destroyCache();
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function canListPlugins() : bool{
 		return $this->listPlugins;
 	}
 
-	/**
-	 * @param bool $value
-	 */
 	public function setListPlugins(bool $value) : void{
 		$this->listPlugins = $value;
 		$this->destroyCache();
@@ -180,46 +161,28 @@ class QueryRegenerateEvent extends ServerEvent{
 		$this->destroyCache();
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getPlayerCount() : int{
 		return $this->numPlayers;
 	}
 
-	/**
-	 * @param int $count
-	 */
 	public function setPlayerCount(int $count) : void{
 		$this->numPlayers = $count;
 		$this->destroyCache();
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getMaxPlayerCount() : int{
 		return $this->maxPlayers;
 	}
 
-	/**
-	 * @param int $count
-	 */
 	public function setMaxPlayerCount(int $count) : void{
 		$this->maxPlayers = $count;
 		$this->destroyCache();
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getWorld() : string{
 		return $this->map;
 	}
 
-	/**
-	 * @param string $world
-	 */
 	public function setWorld(string $world) : void{
 		$this->map = $world;
 		$this->destroyCache();
@@ -227,24 +190,16 @@ class QueryRegenerateEvent extends ServerEvent{
 
 	/**
 	 * Returns the extra Query data in key => value form
-	 *
-	 * @return array
 	 */
 	public function getExtraData() : array{
 		return $this->extraData;
 	}
 
-	/**
-	 * @param array $extraData
-	 */
 	public function setExtraData(array $extraData) : void{
 		$this->extraData = $extraData;
 		$this->destroyCache();
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getLongQuery() : string{
 		if($this->longQueryCache !== null){
 			return $this->longQueryCache;
@@ -294,9 +249,6 @@ class QueryRegenerateEvent extends ServerEvent{
 		return $this->longQueryCache = $query;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getShortQuery() : string{
 		return $this->shortQueryCache ?? ($this->shortQueryCache = $this->serverName . "\x00" . $this->gametype . "\x00" . $this->map . "\x00" . $this->numPlayers . "\x00" . $this->maxPlayers . "\x00" . Binary::writeLShort($this->port) . $this->ip . "\x00");
 	}

--- a/src/pocketmine/event/server/RemoteServerCommandEvent.php
+++ b/src/pocketmine/event/server/RemoteServerCommandEvent.php
@@ -32,10 +32,6 @@ use pocketmine\command\CommandSender;
  */
 class RemoteServerCommandEvent extends ServerCommandEvent{
 
-	/**
-	 * @param CommandSender $sender
-	 * @param string        $command
-	 */
 	public function __construct(CommandSender $sender, string $command){
 		parent::__construct($sender, $command);
 	}

--- a/src/pocketmine/event/server/ServerCommandEvent.php
+++ b/src/pocketmine/event/server/ServerCommandEvent.php
@@ -43,32 +43,19 @@ class ServerCommandEvent extends ServerEvent implements Cancellable{
 	/** @var CommandSender */
 	protected $sender;
 
-	/**
-	 * @param CommandSender $sender
-	 * @param string        $command
-	 */
 	public function __construct(CommandSender $sender, string $command){
 		$this->sender = $sender;
 		$this->command = $command;
 	}
 
-	/**
-	 * @return CommandSender
-	 */
 	public function getSender() : CommandSender{
 		return $this->sender;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getCommand() : string{
 		return $this->command;
 	}
 
-	/**
-	 * @param string $command
-	 */
 	public function setCommand(string $command) : void{
 		$this->command = $command;
 	}

--- a/src/pocketmine/form/Form.php
+++ b/src/pocketmine/form/Form.php
@@ -34,7 +34,6 @@ interface Form extends \JsonSerializable{
 	/**
 	 * Handles a form response from a player.
 	 *
-	 * @param Player $player
 	 * @param mixed  $data
 	 *
 	 * @throws FormValidationException if the data could not be processed

--- a/src/pocketmine/inventory/BaseInventory.php
+++ b/src/pocketmine/inventory/BaseInventory.php
@@ -73,7 +73,6 @@ abstract class BaseInventory implements Inventory{
 
 	/**
 	 * Returns the size of the inventory.
-	 * @return int
 	 */
 	public function getSize() : int{
 		return $this->slots->getSize();
@@ -82,8 +81,6 @@ abstract class BaseInventory implements Inventory{
 	/**
 	 * Sets the new size of the inventory.
 	 * WARNING: If the size is smaller, any items past the new size will be lost.
-	 *
-	 * @param int $size
 	 *
 	 * @return void
 	 */
@@ -102,8 +99,6 @@ abstract class BaseInventory implements Inventory{
 	}
 
 	/**
-	 * @param bool $includeEmpty
-	 *
 	 * @return Item[]
 	 */
 	public function getContents(bool $includeEmpty = false) : array{
@@ -123,7 +118,6 @@ abstract class BaseInventory implements Inventory{
 
 	/**
 	 * @param Item[] $items
-	 * @param bool   $send
 	 */
 	public function setContents(array $items, bool $send = true) : void{
 		if(count($items) > $this->getSize()){
@@ -150,9 +144,6 @@ abstract class BaseInventory implements Inventory{
 	/**
 	 * Drops the contents of the inventory into the specified Level at the specified position and clears the inventory
 	 * contents.
-	 *
-	 * @param Level   $level
-	 * @param Vector3 $position
 	 */
 	public function dropContents(Level $level, Vector3 $position) : void{
 		foreach($this->getContents() as $item){
@@ -455,7 +446,6 @@ abstract class BaseInventory implements Inventory{
 	}
 
 	/**
-	 * @param int             $index
 	 * @param Player|Player[] $target
 	 */
 	public function sendSlot(int $index, $target) : void{

--- a/src/pocketmine/inventory/BaseInventory.php
+++ b/src/pocketmine/inventory/BaseInventory.php
@@ -55,8 +55,6 @@ abstract class BaseInventory implements Inventory{
 
 	/**
 	 * @param Item[] $items
-	 * @param int    $size
-	 * @param string $title
 	 */
 	public function __construct(array $items = [], int $size = null, string $title = null){
 		$this->slots = new \SplFixedArray($size ?? $this->getDefaultSize());

--- a/src/pocketmine/inventory/ChestInventory.php
+++ b/src/pocketmine/inventory/ChestInventory.php
@@ -35,9 +35,6 @@ class ChestInventory extends ContainerInventory{
 	/** @var Chest */
 	protected $holder;
 
-	/**
-	 * @param Chest $tile
-	 */
 	public function __construct(Chest $tile){
 		parent::__construct($tile);
 	}

--- a/src/pocketmine/inventory/ContainerInventory.php
+++ b/src/pocketmine/inventory/ContainerInventory.php
@@ -70,7 +70,6 @@ abstract class ContainerInventory extends BaseInventory{
 
 	/**
 	 * Returns the Minecraft PE inventory type used to show the inventory window to clients.
-	 * @return int
 	 */
 	abstract public function getNetworkType() : int;
 

--- a/src/pocketmine/inventory/CraftingGrid.php
+++ b/src/pocketmine/inventory/CraftingGrid.php
@@ -129,11 +129,6 @@ class CraftingGrid extends BaseInventory{
 
 	/**
 	 * Returns the item at offset x,y, offset by where the starts of the recipe rectangle are.
-	 *
-	 * @param int $x
-	 * @param int $y
-	 *
-	 * @return Item
 	 */
 	public function getIngredient(int $x, int $y) : Item{
 		if($this->startX !== null and $this->startY !== null){
@@ -145,8 +140,6 @@ class CraftingGrid extends BaseInventory{
 
 	/**
 	 * Returns the width of the recipe we're trying to craft, based on items currently in the grid.
-	 *
-	 * @return int
 	 */
 	public function getRecipeWidth() : int{
 		return $this->xLen ?? 0;
@@ -154,7 +147,6 @@ class CraftingGrid extends BaseInventory{
 
 	/**
 	 * Returns the height of the recipe we're trying to craft, based on items currently in the grid.
-	 * @return int
 	 */
 	public function getRecipeHeight() : int{
 		return $this->yLen ?? 0;

--- a/src/pocketmine/inventory/CraftingManager.php
+++ b/src/pocketmine/inventory/CraftingManager.php
@@ -128,8 +128,6 @@ class CraftingManager{
 
 	/**
 	 * Returns a pre-compressed CraftingDataPacket for sending to players. Rebuilds the cache if it is not found.
-	 *
-	 * @return BatchPacket
 	 */
 	public function getCraftingDataPacket() : BatchPacket{
 		if($this->craftingDataCache === null){
@@ -141,9 +139,6 @@ class CraftingManager{
 
 	/**
 	 * Function used to arrange Shapeless Recipe ingredient lists into a consistent order.
-	 *
-	 * @param Item $i1
-	 * @param Item $i2
 	 *
 	 * @return int
 	 */
@@ -210,27 +205,18 @@ class CraftingManager{
 		return $this->furnaceRecipes;
 	}
 
-	/**
-	 * @param ShapedRecipe $recipe
-	 */
 	public function registerShapedRecipe(ShapedRecipe $recipe) : void{
 		$this->shapedRecipes[self::hashOutputs($recipe->getResults())][] = $recipe;
 
 		$this->craftingDataCache = null;
 	}
 
-	/**
-	 * @param ShapelessRecipe $recipe
-	 */
 	public function registerShapelessRecipe(ShapelessRecipe $recipe) : void{
 		$this->shapelessRecipes[self::hashOutputs($recipe->getResults())][] = $recipe;
 
 		$this->craftingDataCache = null;
 	}
 
-	/**
-	 * @param FurnaceRecipe $recipe
-	 */
 	public function registerFurnaceRecipe(FurnaceRecipe $recipe) : void{
 		$input = $recipe->getInput();
 		$this->furnaceRecipes[$input->getId() . ":" . ($input->hasAnyDamageValue() ? "?" : $input->getDamage())] = $recipe;
@@ -238,10 +224,7 @@ class CraftingManager{
 	}
 
 	/**
-	 * @param CraftingGrid $grid
 	 * @param Item[]       $outputs
-	 *
-	 * @return CraftingRecipe|null
 	 */
 	public function matchRecipe(CraftingGrid $grid, array $outputs) : ?CraftingRecipe{
 		//TODO: try to match special recipes before anything else (first they need to be implemented!)
@@ -290,18 +273,10 @@ class CraftingManager{
 		}
 	}
 
-	/**
-	 * @param Item $input
-	 *
-	 * @return FurnaceRecipe|null
-	 */
 	public function matchFurnaceRecipe(Item $input) : ?FurnaceRecipe{
 		return $this->furnaceRecipes[$input->getId() . ":" . $input->getDamage()] ?? $this->furnaceRecipes[$input->getId() . ":?"] ?? null;
 	}
 
-	/**
-	 * @param Recipe $recipe
-	 */
 	public function registerRecipe(Recipe $recipe) : void{
 		$recipe->registerToCraftingManager($this);
 	}

--- a/src/pocketmine/inventory/CraftingRecipe.php
+++ b/src/pocketmine/inventory/CraftingRecipe.php
@@ -36,18 +36,12 @@ interface CraftingRecipe extends Recipe{
 	/**
 	 * Returns a list of results this recipe will produce when the inputs in the given crafting grid are consumed.
 	 *
-	 * @param CraftingGrid $grid
-	 *
 	 * @return Item[]
 	 */
 	public function getResultsFor(CraftingGrid $grid) : array;
 
 	/**
 	 * Returns whether the given crafting grid meets the requirements to craft this recipe.
-	 *
-	 * @param CraftingGrid $grid
-	 *
-	 * @return bool
 	 */
 	public function matchesCraftingGrid(CraftingGrid $grid) : bool;
 }

--- a/src/pocketmine/inventory/DoubleChestInventory.php
+++ b/src/pocketmine/inventory/DoubleChestInventory.php
@@ -88,7 +88,6 @@ class DoubleChestInventory extends ChestInventory implements InventoryHolder{
 
 	/**
 	 * @param Item[] $items
-	 * @param bool   $send
 	 */
 	public function setContents(array $items, bool $send = true) : void{
 		$size = $this->getSize();
@@ -128,16 +127,10 @@ class DoubleChestInventory extends ChestInventory implements InventoryHolder{
 		parent::onClose($who);
 	}
 
-	/**
-	 * @return ChestInventory
-	 */
 	public function getLeftSide() : ChestInventory{
 		return $this->left;
 	}
 
-	/**
-	 * @return ChestInventory
-	 */
 	public function getRightSide() : ChestInventory{
 		return $this->right;
 	}

--- a/src/pocketmine/inventory/EnderChestInventory.php
+++ b/src/pocketmine/inventory/EnderChestInventory.php
@@ -52,8 +52,6 @@ class EnderChestInventory extends ChestInventory{
 	/**
 	 * Set the holder's position to that of a tile
 	 *
-	 * @param EnderChest $enderChest
-	 *
 	 * @return void
 	 */
 	public function setHolderPosition(EnderChest $enderChest){

--- a/src/pocketmine/inventory/FurnaceInventory.php
+++ b/src/pocketmine/inventory/FurnaceInventory.php
@@ -55,50 +55,26 @@ class FurnaceInventory extends ContainerInventory{
 		return $this->holder;
 	}
 
-	/**
-	 * @return Item
-	 */
 	public function getResult() : Item{
 		return $this->getItem(2);
 	}
 
-	/**
-	 * @return Item
-	 */
 	public function getFuel() : Item{
 		return $this->getItem(1);
 	}
 
-	/**
-	 * @return Item
-	 */
 	public function getSmelting() : Item{
 		return $this->getItem(0);
 	}
 
-	/**
-	 * @param Item $item
-	 *
-	 * @return bool
-	 */
 	public function setResult(Item $item) : bool{
 		return $this->setItem(2, $item);
 	}
 
-	/**
-	 * @param Item $item
-	 *
-	 * @return bool
-	 */
 	public function setFuel(Item $item) : bool{
 		return $this->setItem(1, $item);
 	}
 
-	/**
-	 * @param Item $item
-	 *
-	 * @return bool
-	 */
 	public function setSmelting(Item $item) : bool{
 		return $this->setItem(0, $item);
 	}

--- a/src/pocketmine/inventory/FurnaceRecipe.php
+++ b/src/pocketmine/inventory/FurnaceRecipe.php
@@ -33,34 +33,22 @@ class FurnaceRecipe implements Recipe{
 	/** @var Item */
 	private $ingredient;
 
-	/**
-	 * @param Item $result
-	 * @param Item $ingredient
-	 */
 	public function __construct(Item $result, Item $ingredient){
 		$this->output = clone $result;
 		$this->ingredient = clone $ingredient;
 	}
 
 	/**
-	 * @param Item $item
-	 *
 	 * @return void
 	 */
 	public function setInput(Item $item){
 		$this->ingredient = clone $item;
 	}
 
-	/**
-	 * @return Item
-	 */
 	public function getInput() : Item{
 		return clone $this->ingredient;
 	}
 
-	/**
-	 * @return Item
-	 */
 	public function getResult() : Item{
 		return clone $this->output;
 	}

--- a/src/pocketmine/inventory/Inventory.php
+++ b/src/pocketmine/inventory/Inventory.php
@@ -34,47 +34,21 @@ use pocketmine\Player;
 interface Inventory{
 	public const MAX_STACK = 64;
 
-	/**
-	 * @return int
-	 */
 	public function getSize() : int;
 
-	/**
-	 * @return int
-	 */
 	public function getMaxStackSize() : int;
 
-	/**
-	 * @param int $size
-	 */
 	public function setMaxStackSize(int $size) : void;
 
-	/**
-	 * @return string
-	 */
 	public function getName() : string;
 
-	/**
-	 * @return string
-	 */
 	public function getTitle() : string;
 
-	/**
-	 * @param int $index
-	 *
-	 * @return Item
-	 */
 	public function getItem(int $index) : Item;
 
 	/**
 	 * Puts an Item in a slot.
 	 * If a plugin refuses the update or $index is invalid, it'll return false
-	 *
-	 * @param int  $index
-	 * @param Item $item
-	 * @param bool $send
-	 *
-	 * @return bool
 	 */
 	public function setItem(int $index, Item $item, bool $send = true) : bool;
 
@@ -92,10 +66,6 @@ interface Inventory{
 
 	/**
 	 * Checks if a given Item can be added to the inventory
-	 *
-	 * @param Item $item
-	 *
-	 * @return bool
 	 */
 	public function canAddItem(Item $item) : bool;
 
@@ -110,24 +80,18 @@ interface Inventory{
 	public function removeItem(Item ...$slots) : array;
 
 	/**
-	 * @param bool $includeEmpty
-	 *
 	 * @return Item[]
 	 */
 	public function getContents(bool $includeEmpty = false) : array;
 
 	/**
 	 * @param Item[] $items
-	 * @param bool   $send
 	 */
 	public function setContents(array $items, bool $send = true) : void;
 
 	/**
 	 * Drops the contents of the inventory into the specified Level at the specified position and clears the inventory
 	 * contents.
-	 *
-	 * @param Level   $level
-	 * @param Vector3 $position
 	 */
 	public function dropContents(Level $level, Vector3 $position) : void;
 
@@ -137,7 +101,6 @@ interface Inventory{
 	public function sendContents($target) : void;
 
 	/**
-	 * @param int             $index
 	 * @param Player|Player[] $target
 	 */
 	public function sendSlot(int $index, $target) : void;
@@ -145,18 +108,12 @@ interface Inventory{
 	/**
 	 * Checks if the inventory contains any Item with the same material data.
 	 * It will check id, amount, and metadata (if not null)
-	 *
-	 * @param Item $item
-	 *
-	 * @return bool
 	 */
 	public function contains(Item $item) : bool;
 
 	/**
 	 * Will return all the Items that has the same id and metadata (if not null).
 	 * Won't check amount
-	 *
-	 * @param Item $item
 	 *
 	 * @return Item[]
 	 */
@@ -167,51 +124,31 @@ interface Inventory{
 	 * and count >= to the count of the specified item stack.
 	 *
 	 * If $exact is true, only items with equal ID, damage, NBT and count will match.
-	 *
-	 * @param Item $item
-	 * @param bool $exact
-	 *
-	 * @return int
 	 */
 	public function first(Item $item, bool $exact = false) : int;
 
 	/**
 	 * Returns the first empty slot, or -1 if not found
-	 *
-	 * @return int
 	 */
 	public function firstEmpty() : int;
 
 	/**
 	 * Returns whether the given slot is empty.
-	 *
-	 * @param int $index
-	 *
-	 * @return bool
 	 */
 	public function isSlotEmpty(int $index) : bool;
 
 	/**
 	 * Will remove all the Items that has the same id and metadata (if not null)
-	 *
-	 * @param Item $item
 	 */
 	public function remove(Item $item) : void;
 
 	/**
 	 * Will clear a specific slot
-	 *
-	 * @param int  $index
-	 * @param bool $send
-	 *
-	 * @return bool
 	 */
 	public function clear(int $index, bool $send = true) : bool;
 
 	/**
 	 * Clears all the slots
-	 *
-	 * @param bool $send
 	 */
 	public function clearAll(bool $send = true) : void;
 
@@ -223,50 +160,25 @@ interface Inventory{
 	 */
 	public function getViewers() : array;
 
-	/**
-	 * @param Player $who
-	 */
 	public function onOpen(Player $who) : void;
 
 	/**
 	 * Tries to open the inventory to a player
-	 *
-	 * @param Player $who
-	 *
-	 * @return bool
 	 */
 	public function open(Player $who) : bool;
 
 	public function close(Player $who) : void;
 
-	/**
-	 * @param Player $who
-	 */
 	public function onClose(Player $who) : void;
 
-	/**
-	 * @param int  $index
-	 * @param Item $before
-	 * @param bool $send
-	 */
 	public function onSlotChange(int $index, Item $before, bool $send) : void;
 
 	/**
 	 * Returns whether the specified slot exists in the inventory.
-	 *
-	 * @param int $slot
-	 *
-	 * @return bool
 	 */
 	public function slotExists(int $slot) : bool;
 
-	/**
-	 * @return null|InventoryEventProcessor
-	 */
 	public function getEventProcessor() : ?InventoryEventProcessor;
 
-	/**
-	 * @param null|InventoryEventProcessor $eventProcessor
-	 */
 	public function setEventProcessor(?InventoryEventProcessor $eventProcessor) : void;
 }

--- a/src/pocketmine/inventory/InventoryEventProcessor.php
+++ b/src/pocketmine/inventory/InventoryEventProcessor.php
@@ -37,11 +37,6 @@ interface InventoryEventProcessor{
 	 * Called prior to a slot in the given inventory changing. This is called by inventories that this listener is
 	 * attached to.
 	 *
-	 * @param Inventory $inventory
-	 * @param int       $slot
-	 * @param Item      $oldItem
-	 * @param Item      $newItem
-	 *
 	 * @return Item|null that should be used in place of $newItem, or null if the slot change should not proceed.
 	 */
 	public function onSlotChange(Inventory $inventory, int $slot, Item $oldItem, Item $newItem) : ?Item;

--- a/src/pocketmine/inventory/PlayerInventory.php
+++ b/src/pocketmine/inventory/PlayerInventory.php
@@ -41,9 +41,6 @@ class PlayerInventory extends BaseInventory{
 	/** @var int */
 	protected $itemInHandIndex = 0;
 
-	/**
-	 * @param Human $player
-	 */
 	public function __construct(Human $player){
 		$this->holder = $player;
 		parent::__construct();
@@ -93,8 +90,6 @@ class PlayerInventory extends BaseInventory{
 	}
 
 	/**
-	 * @param int $slot
-	 *
 	 * @throws \InvalidArgumentException
 	 */
 	private function throwIfNotHotbarSlot(int $slot) : void{
@@ -106,10 +101,6 @@ class PlayerInventory extends BaseInventory{
 	/**
 	 * Returns the item in the specified hotbar slot.
 	 *
-	 * @param int $hotbarSlot
-	 *
-	 * @return Item
-	 *
 	 * @throws \InvalidArgumentException if the hotbar slot index is out of range
 	 */
 	public function getHotbarSlotItem(int $hotbarSlot) : Item{
@@ -119,7 +110,6 @@ class PlayerInventory extends BaseInventory{
 
 	/**
 	 * Returns the hotbar slot number the holder is currently holding.
-	 * @return int
 	 */
 	public function getHeldItemIndex() : int{
 		return $this->itemInHandIndex;
@@ -149,8 +139,6 @@ class PlayerInventory extends BaseInventory{
 
 	/**
 	 * Returns the currently-held item.
-	 *
-	 * @return Item
 	 */
 	public function getItemInHand() : Item{
 		return $this->getHotbarSlotItem($this->itemInHandIndex);
@@ -158,10 +146,6 @@ class PlayerInventory extends BaseInventory{
 
 	/**
 	 * Sets the item in the currently-held slot to the specified item.
-	 *
-	 * @param Item $item
-	 *
-	 * @return bool
 	 */
 	public function setItemInHand(Item $item) : bool{
 		return $this->setItem($this->getHeldItemIndex(), $item);
@@ -198,7 +182,6 @@ class PlayerInventory extends BaseInventory{
 
 	/**
 	 * Returns the number of slots in the hotbar.
-	 * @return int
 	 */
 	public function getHotbarSize() : int{
 		return 9;

--- a/src/pocketmine/inventory/ShapedRecipe.php
+++ b/src/pocketmine/inventory/ShapedRecipe.php
@@ -110,8 +110,6 @@ class ShapedRecipe implements CraftingRecipe{
 	}
 
 	/**
-	 * @param CraftingGrid $grid
-	 *
 	 * @return Item[]
 	 */
 	public function getResultsFor(CraftingGrid $grid) : array{
@@ -119,9 +117,6 @@ class ShapedRecipe implements CraftingRecipe{
 	}
 
 	/**
-	 * @param string $key
-	 * @param Item   $item
-	 *
 	 * @return $this
 	 * @throws \InvalidArgumentException
 	 */
@@ -168,12 +163,6 @@ class ShapedRecipe implements CraftingRecipe{
 		return $ingredients;
 	}
 
-	/**
-	 * @param int $x
-	 * @param int $y
-	 *
-	 * @return Item
-	 */
 	public function getIngredient(int $x, int $y) : Item{
 		$exists = $this->ingredientList[$this->shape[$y]{$x}] ?? null;
 		return $exists !== null ? clone $exists : ItemFactory::get(Item::AIR, 0, 0);
@@ -191,12 +180,6 @@ class ShapedRecipe implements CraftingRecipe{
 		$manager->registerShapedRecipe($this);
 	}
 
-	/**
-	 * @param CraftingGrid $grid
-	 * @param bool         $reverse
-	 *
-	 * @return bool
-	 */
 	private function matchInputMap(CraftingGrid $grid, bool $reverse) : bool{
 		for($y = 0; $y < $this->height; ++$y){
 			for($x = 0; $x < $this->width; ++$x){
@@ -212,11 +195,6 @@ class ShapedRecipe implements CraftingRecipe{
 		return true;
 	}
 
-	/**
-	 * @param CraftingGrid $grid
-	 *
-	 * @return bool
-	 */
 	public function matchesCraftingGrid(CraftingGrid $grid) : bool{
 		if($this->width !== $grid->getRecipeWidth() or $this->height !== $grid->getRecipeHeight()){
 			return false;

--- a/src/pocketmine/inventory/ShapelessRecipe.php
+++ b/src/pocketmine/inventory/ShapelessRecipe.php
@@ -55,10 +55,6 @@ class ShapelessRecipe implements CraftingRecipe{
 	}
 
 	/**
-	 * @param Item $item
-	 *
-	 * @return ShapelessRecipe
-	 *
 	 * @throws \InvalidArgumentException
 	 */
 	public function addIngredient(Item $item) : ShapelessRecipe{
@@ -74,8 +70,6 @@ class ShapelessRecipe implements CraftingRecipe{
 	}
 
 	/**
-	 * @param Item $item
-	 *
 	 * @return $this
 	 */
 	public function removeIngredient(Item $item){
@@ -99,9 +93,6 @@ class ShapelessRecipe implements CraftingRecipe{
 		return array_map(function(Item $item) : Item{ return clone $item; }, $this->ingredients);
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getIngredientCount() : int{
 		$count = 0;
 		foreach($this->ingredients as $ingredient){
@@ -115,11 +106,6 @@ class ShapelessRecipe implements CraftingRecipe{
 		$manager->registerShapelessRecipe($this);
 	}
 
-	/**
-	 * @param CraftingGrid $grid
-	 *
-	 * @return bool
-	 */
 	public function matchesCraftingGrid(CraftingGrid $grid) : bool{
 		//don't pack the ingredients - shapeless recipes require that each ingredient be in a separate slot
 		$input = $grid->getContents();

--- a/src/pocketmine/inventory/transaction/CraftingTransaction.php
+++ b/src/pocketmine/inventory/transaction/CraftingTransaction.php
@@ -61,10 +61,7 @@ class CraftingTransaction extends InventoryTransaction{
 	/**
 	 * @param Item[] $txItems
 	 * @param Item[] $recipeItems
-	 * @param bool   $wildcards
-	 * @param int    $iterations
 	 *
-	 * @return int
 	 * @throws TransactionValidationException
 	 */
 	protected function matchRecipeItems(array $txItems, array $recipeItems, bool $wildcards, int $iterations = 0) : int{

--- a/src/pocketmine/inventory/transaction/InventoryTransaction.php
+++ b/src/pocketmine/inventory/transaction/InventoryTransaction.php
@@ -65,7 +65,6 @@ class InventoryTransaction{
 	protected $actions = [];
 
 	/**
-	 * @param Player            $source
 	 * @param InventoryAction[] $actions
 	 */
 	public function __construct(Player $source, array $actions = []){
@@ -75,9 +74,6 @@ class InventoryTransaction{
 		}
 	}
 
-	/**
-	 * @return Player
-	 */
 	public function getSource() : Player{
 		return $this->source;
 	}
@@ -101,9 +97,6 @@ class InventoryTransaction{
 		return $this->actions;
 	}
 
-	/**
-	 * @param InventoryAction $action
-	 */
 	public function addAction(InventoryAction $action) : void{
 		if(!isset($this->actions[$hash = spl_object_hash($action)])){
 			$this->actions[$hash] = $action;
@@ -129,8 +122,6 @@ class InventoryTransaction{
 	/**
 	 * @internal This method should not be used by plugins, it's used to add tracked inventories for InventoryActions
 	 * involving inventories.
-	 *
-	 * @param Inventory $inventory
 	 */
 	public function addInventory(Inventory $inventory) : void{
 		if(!isset($this->inventories[$hash = spl_object_hash($inventory)])){
@@ -232,10 +223,7 @@ class InventoryTransaction{
 	}
 
 	/**
-	 * @param Item               $needOrigin
 	 * @param SlotChangeAction[] $possibleActions
-	 *
-	 * @return null|Item
 	 */
 	protected function findResultItem(Item $needOrigin, array $possibleActions) : ?Item{
 		assert(count($possibleActions) > 0);
@@ -294,7 +282,6 @@ class InventoryTransaction{
 
 	/**
 	 * Executes the group of actions, returning whether the transaction executed successfully or not.
-	 * @return bool
 	 *
 	 * @throws TransactionValidationException
 	 */
@@ -333,9 +320,6 @@ class InventoryTransaction{
 		return true;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function hasExecuted() : bool{
 		return $this->hasExecuted;
 	}

--- a/src/pocketmine/inventory/transaction/action/CreativeInventoryAction.php
+++ b/src/pocketmine/inventory/transaction/action/CreativeInventoryAction.php
@@ -47,10 +47,6 @@ class CreativeInventoryAction extends InventoryAction{
 
 	/**
 	 * Checks that the player is in creative, and (if creating an item) that the item exists in the creative inventory.
-	 *
-	 * @param Player $source
-	 *
-	 * @return bool
 	 */
 	public function isValid(Player $source) : bool{
 		return $source->isCreative(true) and
@@ -66,10 +62,6 @@ class CreativeInventoryAction extends InventoryAction{
 
 	/**
 	 * No need to do anything extra here: this type just provides a place for items to disappear or appear from.
-	 *
-	 * @param Player $source
-	 *
-	 * @return bool
 	 */
 	public function execute(Player $source) : bool{
 		return true;

--- a/src/pocketmine/inventory/transaction/action/DropItemAction.php
+++ b/src/pocketmine/inventory/transaction/action/DropItemAction.php
@@ -53,10 +53,6 @@ class DropItemAction extends InventoryAction{
 
 	/**
 	 * Drops the target item in front of the player.
-	 *
-	 * @param Player $source
-	 *
-	 * @return bool
 	 */
 	public function execute(Player $source) : bool{
 		return $source->dropItem($this->targetItem);

--- a/src/pocketmine/inventory/transaction/action/InventoryAction.php
+++ b/src/pocketmine/inventory/transaction/action/InventoryAction.php
@@ -43,7 +43,6 @@ abstract class InventoryAction{
 
 	/**
 	 * Returns the item that was present before the action took place.
-	 * @return Item
 	 */
 	public function getSourceItem() : Item{
 		return clone $this->sourceItem;
@@ -51,7 +50,6 @@ abstract class InventoryAction{
 
 	/**
 	 * Returns the item that the action attempted to replace the source item with.
-	 * @return Item
 	 */
 	public function getTargetItem() : Item{
 		return clone $this->targetItem;
@@ -59,17 +57,11 @@ abstract class InventoryAction{
 
 	/**
 	 * Returns whether this action is currently valid. This should perform any necessary sanity checks.
-	 *
-	 * @param Player $source
-	 *
-	 * @return bool
 	 */
 	abstract public function isValid(Player $source) : bool;
 
 	/**
 	 * Called when the action is added to the specified InventoryTransaction.
-	 *
-	 * @param InventoryTransaction $transaction
 	 */
 	public function onAddToTransaction(InventoryTransaction $transaction) : void{
 
@@ -78,10 +70,6 @@ abstract class InventoryAction{
 	/**
 	 * Called by inventory transactions before any actions are processed. If this returns false, the transaction will
 	 * be cancelled.
-	 *
-	 * @param Player $source
-	 *
-	 * @return bool
 	 */
 	public function onPreExecute(Player $source) : bool{
 		return true;
@@ -91,24 +79,16 @@ abstract class InventoryAction{
 	 * Performs actions needed to complete the inventory-action server-side. Returns if it was successful. Will return
 	 * false if plugins cancelled events. This will only be called if the transaction which it is part of is considered
 	 * valid.
-	 *
-	 * @param Player $source
-	 *
-	 * @return bool
 	 */
 	abstract public function execute(Player $source) : bool;
 
 	/**
 	 * Performs additional actions when this inventory-action completed successfully.
-	 *
-	 * @param Player $source
 	 */
 	abstract public function onExecuteSuccess(Player $source) : void;
 
 	/**
 	 * Performs additional actions when this inventory-action did not complete successfully.
-	 *
-	 * @param Player $source
 	 */
 	abstract public function onExecuteFail(Player $source) : void;
 

--- a/src/pocketmine/inventory/transaction/action/SlotChangeAction.php
+++ b/src/pocketmine/inventory/transaction/action/SlotChangeAction.php
@@ -39,12 +39,6 @@ class SlotChangeAction extends InventoryAction{
 	/** @var int */
 	private $inventorySlot;
 
-	/**
-	 * @param Inventory $inventory
-	 * @param int       $inventorySlot
-	 * @param Item      $sourceItem
-	 * @param Item      $targetItem
-	 */
 	public function __construct(Inventory $inventory, int $inventorySlot, Item $sourceItem, Item $targetItem){
 		parent::__construct($sourceItem, $targetItem);
 		$this->inventory = $inventory;
@@ -53,8 +47,6 @@ class SlotChangeAction extends InventoryAction{
 
 	/**
 	 * Returns the inventory involved in this action.
-	 *
-	 * @return Inventory
 	 */
 	public function getInventory() : Inventory{
 		return $this->inventory;
@@ -62,7 +54,6 @@ class SlotChangeAction extends InventoryAction{
 
 	/**
 	 * Returns the slot in the inventory which this action modified.
-	 * @return int
 	 */
 	public function getSlot() : int{
 		return $this->inventorySlot;
@@ -70,10 +61,6 @@ class SlotChangeAction extends InventoryAction{
 
 	/**
 	 * Checks if the item in the inventory at the specified slot is the same as this action's source item.
-	 *
-	 * @param Player $source
-	 *
-	 * @return bool
 	 */
 	public function isValid(Player $source) : bool{
 		return (
@@ -84,9 +71,6 @@ class SlotChangeAction extends InventoryAction{
 
 	/**
 	 * Adds this action's target inventory to the transaction's inventory list.
-	 *
-	 * @param InventoryTransaction $transaction
-	 *
 	 */
 	public function onAddToTransaction(InventoryTransaction $transaction) : void{
 		$transaction->addInventory($this->inventory);
@@ -94,10 +78,6 @@ class SlotChangeAction extends InventoryAction{
 
 	/**
 	 * Sets the item into the target inventory.
-	 *
-	 * @param Player $source
-	 *
-	 * @return bool
 	 */
 	public function execute(Player $source) : bool{
 		return $this->inventory->setItem($this->inventorySlot, $this->targetItem, false);
@@ -105,8 +85,6 @@ class SlotChangeAction extends InventoryAction{
 
 	/**
 	 * Sends slot changes to other viewers of the inventory. This will not send any change back to the source Player.
-	 *
-	 * @param Player $source
 	 */
 	public function onExecuteSuccess(Player $source) : void{
 		$viewers = $this->inventory->getViewers();
@@ -116,8 +94,6 @@ class SlotChangeAction extends InventoryAction{
 
 	/**
 	 * Sends the original slot contents to the source player to revert the action.
-	 *
-	 * @param Player $source
 	 */
 	public function onExecuteFail(Player $source) : void{
 		$this->inventory->sendSlot($this->inventorySlot, $source);

--- a/src/pocketmine/item/Armor.php
+++ b/src/pocketmine/item/Armor.php
@@ -43,7 +43,6 @@ abstract class Armor extends Durable{
 
 	/**
 	 * Returns the dyed colour of this armour piece. This generally only applies to leather armour.
-	 * @return Color|null
 	 */
 	public function getCustomColor() : ?Color{
 		if($this->getNamedTag()->hasTag(self::TAG_CUSTOM_COLOR, IntTag::class)){
@@ -55,8 +54,6 @@ abstract class Armor extends Durable{
 
 	/**
 	 * Sets the dyed colour of this armour piece. This generally only applies to leather armour.
-	 *
-	 * @param Color $color
 	 */
 	public function setCustomColor(Color $color) : void{
 		$this->setNamedTagEntry(new IntTag(self::TAG_CUSTOM_COLOR, Binary::signInt($color->toARGB())));
@@ -65,10 +62,6 @@ abstract class Armor extends Durable{
 	/**
 	 * Returns the total enchantment protection factor this armour piece offers from all applicable protection
 	 * enchantments on the item.
-	 *
-	 * @param EntityDamageEvent $event
-	 *
-	 * @return int
 	 */
 	public function getEnchantmentProtectionFactor(EntityDamageEvent $event) : int{
 		$epf = 0;

--- a/src/pocketmine/item/Banner.php
+++ b/src/pocketmine/item/Banner.php
@@ -52,8 +52,6 @@ class Banner extends Item{
 
 	/**
 	 * Returns the color of the banner base.
-	 *
-	 * @return int
 	 */
 	public function getBaseColor() : int{
 		return $this->getNamedTag()->getInt(self::TAG_BASE, 0);
@@ -62,8 +60,6 @@ class Banner extends Item{
 	/**
 	 * Sets the color of the banner base.
 	 * Banner items have to be resent to see the changes in the inventory.
-	 *
-	 * @param int $color
 	 */
 	public function setBaseColor(int $color) : void{
 		$namedTag = $this->getNamedTag();
@@ -74,9 +70,6 @@ class Banner extends Item{
 	/**
 	 * Applies a new pattern on the banner with the given color.
 	 * Banner items have to be resent to see the changes in the inventory.
-	 *
-	 * @param string $pattern
-	 * @param int    $color
 	 *
 	 * @return int ID of pattern.
 	 */
@@ -96,10 +89,6 @@ class Banner extends Item{
 
 	/**
 	 * Returns whether a pattern with the given ID exists on the banner or not.
-	 *
-	 * @param int $patternId
-	 *
-	 * @return bool
 	 */
 	public function patternExists(int $patternId) : bool{
 		$this->correctNBT();
@@ -108,10 +97,6 @@ class Banner extends Item{
 
 	/**
 	 * Returns the data of a pattern with the given ID.
-	 *
-	 * @param int $patternId
-	 *
-	 * @return array
 	 */
 	public function getPatternData(int $patternId) : array{
 		if(!$this->patternExists($patternId)){
@@ -132,10 +117,6 @@ class Banner extends Item{
 	/**
 	 * Changes the pattern of a previously existing pattern.
 	 * Banner items have to be resent to see the changes in the inventory.
-	 *
-	 * @param int    $patternId
-	 * @param string $pattern
-	 * @param int    $color
 	 *
 	 * @return bool indicating success.
 	 */
@@ -159,8 +140,6 @@ class Banner extends Item{
 	/**
 	 * Deletes a pattern from the banner with the given ID.
 	 * Banner items have to be resent to see the changes in the inventory.
-	 *
-	 * @param int $patternId
 	 *
 	 * @return bool indicating whether the pattern existed or not.
 	 */
@@ -200,8 +179,6 @@ class Banner extends Item{
 
 	/**
 	 * Returns the total count of patterns on this banner.
-	 *
-	 * @return int
 	 */
 	public function getPatternCount() : int{
 		return $this->getNamedTag()->getListTag(self::TAG_PATTERNS)->count();

--- a/src/pocketmine/item/Consumable.php
+++ b/src/pocketmine/item/Consumable.php
@@ -48,8 +48,6 @@ interface Consumable{
 	/**
 	 * Called when this Consumable is consumed by mob, after standard resulting effects have been applied.
 	 *
-	 * @param Living $consumer
-	 *
 	 * @return void
 	 */
 	public function onConsume(Living $consumer);

--- a/src/pocketmine/item/Durable.php
+++ b/src/pocketmine/item/Durable.php
@@ -32,7 +32,6 @@ abstract class Durable extends Item{
 
 	/**
 	 * Returns whether this item will take damage when used.
-	 * @return bool
 	 */
 	public function isUnbreakable() : bool{
 		return $this->getNamedTag()->getByte("Unbreakable", 0) !== 0;
@@ -40,8 +39,6 @@ abstract class Durable extends Item{
 
 	/**
 	 * Sets whether the item will take damage when used.
-	 *
-	 * @param bool $value
 	 *
 	 * @return void
 	 */
@@ -51,8 +48,6 @@ abstract class Durable extends Item{
 
 	/**
 	 * Applies damage to the item.
-	 *
-	 * @param int $amount
 	 *
 	 * @return bool if any damage was applied to the item
 	 */
@@ -97,14 +92,11 @@ abstract class Durable extends Item{
 
 	/**
 	 * Returns the maximum amount of damage this item can take before it breaks.
-	 *
-	 * @return int
 	 */
 	abstract public function getMaxDurability() : int;
 
 	/**
 	 * Returns whether the item is broken.
-	 * @return bool
 	 */
 	public function isBroken() : bool{
 		return $this->meta >= $this->getMaxDurability();

--- a/src/pocketmine/item/FoodSource.php
+++ b/src/pocketmine/item/FoodSource.php
@@ -34,7 +34,6 @@ interface FoodSource extends Consumable{
 
 	/**
 	 * Returns whether a Human eating this FoodSource must have a non-full hunger bar.
-	 * @return bool
 	 */
 	public function requiresHunger() : bool;
 }

--- a/src/pocketmine/item/Item.php
+++ b/src/pocketmine/item/Item.php
@@ -94,12 +94,7 @@ class Item implements ItemIds, \JsonSerializable{
 	 *
 	 * This function redirects to {@link ItemFactory#get}.
 	 *
-	 * @param int                $id
-	 * @param int                $meta
-	 * @param int                $count
 	 * @param CompoundTag|string $tags
-	 *
-	 * @return Item
 	 */
 	public static function get(int $id, int $meta = 0, int $count = 1, $tags = "") : Item{
 		return ItemFactory::get($id, $meta, $count, $tags);
@@ -109,9 +104,6 @@ class Item implements ItemIds, \JsonSerializable{
 	 * Tries to parse the specified string into Item ID/meta identifiers, and returns Item instances it created.
 	 *
 	 * This function redirects to {@link ItemFactory#fromString}.
-	 *
-	 * @param string $str
-	 * @param bool   $multiple
 	 *
 	 * @return Item[]|Item
 	 */
@@ -158,8 +150,6 @@ class Item implements ItemIds, \JsonSerializable{
 	 * Adds an item to the creative menu.
 	 * Note: Players who are already online when this is called will not see this change.
 	 *
-	 * @param Item $item
-	 *
 	 * @return void
 	 */
 	public static function addCreativeItem(Item $item){
@@ -169,8 +159,6 @@ class Item implements ItemIds, \JsonSerializable{
 	/**
 	 * Removes an item from the creative menu.
 	 * Note: Players who are already online when this is called will not see this change.
-	 *
-	 * @param Item $item
 	 *
 	 * @return void
 	 */
@@ -186,8 +174,6 @@ class Item implements ItemIds, \JsonSerializable{
 	}
 
 	/**
-	 * @param int $index
-	 *
 	 * @return Item|null
 	 */
 	public static function getCreativeItem(int $index){
@@ -223,10 +209,6 @@ class Item implements ItemIds, \JsonSerializable{
 	 *
 	 * NOTE: This should NOT BE USED for creating items to set into an inventory. Use {@link ItemFactory#get} for that
 	 * purpose.
-	 *
-	 * @param int    $id
-	 * @param int    $meta
-	 * @param string $name
 	 */
 	public function __construct(int $id, int $meta = 0, string $name = "Unknown"){
 		if($id < -0x8000 or $id > 0x7fff){ //signed short range
@@ -260,7 +242,6 @@ class Item implements ItemIds, \JsonSerializable{
 	 * @see Item::getNamedTag()
 	 *
 	 * Returns the serialized NBT of the Item
-	 * @return string
 	 */
 	public function getCompoundTag() : string{
 		return $this->tags;
@@ -268,15 +249,11 @@ class Item implements ItemIds, \JsonSerializable{
 
 	/**
 	 * Returns whether this Item has a non-empty NBT.
-	 * @return bool
 	 */
 	public function hasCompoundTag() : bool{
 		return $this->tags !== "";
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function hasCustomBlockData() : bool{
 		return $this->getNamedTagEntry(self::TAG_BLOCK_ENTITY_TAG) instanceof CompoundTag;
 	}
@@ -290,8 +267,6 @@ class Item implements ItemIds, \JsonSerializable{
 	}
 
 	/**
-	 * @param CompoundTag $compound
-	 *
 	 * @return $this
 	 */
 	public function setCustomBlockData(CompoundTag $compound) : Item{
@@ -302,27 +277,15 @@ class Item implements ItemIds, \JsonSerializable{
 		return $this;
 	}
 
-	/**
-	 * @return CompoundTag|null
-	 */
 	public function getCustomBlockData() : ?CompoundTag{
 		$tag = $this->getNamedTagEntry(self::TAG_BLOCK_ENTITY_TAG);
 		return $tag instanceof CompoundTag ? $tag : null;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function hasEnchantments() : bool{
 		return $this->getNamedTagEntry(self::TAG_ENCH) instanceof ListTag;
 	}
 
-	/**
-	 * @param int $id
-	 * @param int $level
-	 *
-	 * @return bool
-	 */
 	public function hasEnchantment(int $id, int $level = -1) : bool{
 		$ench = $this->getNamedTagEntry(self::TAG_ENCH);
 		if(!($ench instanceof ListTag)){
@@ -339,11 +302,6 @@ class Item implements ItemIds, \JsonSerializable{
 		return false;
 	}
 
-	/**
-	 * @param int $id
-	 *
-	 * @return EnchantmentInstance|null
-	 */
 	public function getEnchantment(int $id) : ?EnchantmentInstance{
 		$ench = $this->getNamedTagEntry(self::TAG_ENCH);
 		if(!($ench instanceof ListTag)){
@@ -363,10 +321,6 @@ class Item implements ItemIds, \JsonSerializable{
 		return null;
 	}
 
-	/**
-	 * @param int $id
-	 * @param int $level
-	 */
 	public function removeEnchantment(int $id, int $level = -1) : void{
 		$ench = $this->getNamedTagEntry(self::TAG_ENCH);
 		if(!($ench instanceof ListTag)){
@@ -388,9 +342,6 @@ class Item implements ItemIds, \JsonSerializable{
 		$this->removeNamedTagEntry(self::TAG_ENCH);
 	}
 
-	/**
-	 * @param EnchantmentInstance $enchantment
-	 */
 	public function addEnchantment(EnchantmentInstance $enchantment) : void{
 		$found = false;
 
@@ -445,10 +396,6 @@ class Item implements ItemIds, \JsonSerializable{
 	/**
 	 * Returns the level of the enchantment on this item with the specified ID, or 0 if the item does not have the
 	 * enchantment.
-	 *
-	 * @param int $enchantmentId
-	 *
-	 * @return int
 	 */
 	public function getEnchantmentLevel(int $enchantmentId) : int{
 		$ench = $this->getNamedTag()->getListTag(self::TAG_ENCH);
@@ -464,9 +411,6 @@ class Item implements ItemIds, \JsonSerializable{
 		return 0;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function hasCustomName() : bool{
 		$display = $this->getNamedTagEntry(self::TAG_DISPLAY);
 		if($display instanceof CompoundTag){
@@ -476,9 +420,6 @@ class Item implements ItemIds, \JsonSerializable{
 		return false;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getCustomName() : string{
 		$display = $this->getNamedTagEntry(self::TAG_DISPLAY);
 		if($display instanceof CompoundTag){
@@ -489,8 +430,6 @@ class Item implements ItemIds, \JsonSerializable{
 	}
 
 	/**
-	 * @param string $name
-	 *
 	 * @return $this
 	 */
 	public function setCustomName(string $name) : Item{
@@ -560,11 +499,6 @@ class Item implements ItemIds, \JsonSerializable{
 		return $this;
 	}
 
-	/**
-	 * @param string $name
-	 *
-	 * @return NamedTag|null
-	 */
 	public function getNamedTagEntry(string $name) : ?NamedTag{
 		return $this->getNamedTag()->getTag($name);
 	}
@@ -584,8 +518,6 @@ class Item implements ItemIds, \JsonSerializable{
 	/**
 	 * Returns a tree of Tag objects representing the Item's NBT. If the item does not have any NBT, an empty CompoundTag
 	 * object is returned to allow the caller to manipulate and apply back to the item.
-	 *
-	 * @return CompoundTag
 	 */
 	public function getNamedTag() : CompoundTag{
 		if(!$this->hasCompoundTag() and $this->cachedNBT === null){
@@ -597,8 +529,6 @@ class Item implements ItemIds, \JsonSerializable{
 
 	/**
 	 * Sets the Item's NBT from the supplied CompoundTag object.
-	 *
-	 * @param CompoundTag $tag
 	 *
 	 * @return $this
 	 */
@@ -621,16 +551,11 @@ class Item implements ItemIds, \JsonSerializable{
 		return $this->setCompoundTag("");
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getCount() : int{
 		return $this->count;
 	}
 
 	/**
-	 * @param int $count
-	 *
 	 * @return $this
 	 */
 	public function setCount(int $count) : Item{
@@ -641,8 +566,6 @@ class Item implements ItemIds, \JsonSerializable{
 
 	/**
 	 * Pops an item from the stack and returns it, decreasing the stack count of this item stack by one.
-	 *
-	 * @param int $count
 	 *
 	 * @return $this
 	 * @throws \InvalidArgumentException if trying to pop more items than are on the stack
@@ -666,7 +589,6 @@ class Item implements ItemIds, \JsonSerializable{
 
 	/**
 	 * Returns the name of the item, or the custom name if it is set.
-	 * @return string
 	 */
 	final public function getName() : string{
 		return $this->hasCustomName() ? $this->getCustomName() : $this->getVanillaName();
@@ -674,44 +596,31 @@ class Item implements ItemIds, \JsonSerializable{
 
 	/**
 	 * Returns the vanilla name of the item, disregarding custom names.
-	 * @return string
 	 */
 	public function getVanillaName() : string{
 		return $this->name;
 	}
 
-	/**
-	 * @return bool
-	 */
 	final public function canBePlaced() : bool{
 		return $this->getBlock()->canBePlaced();
 	}
 
 	/**
 	 * Returns the block corresponding to this Item.
-	 * @return Block
 	 */
 	public function getBlock() : Block{
 		return BlockFactory::get(self::AIR);
 	}
 
-	/**
-	 * @return int
-	 */
 	final public function getId() : int{
 		return $this->id;
 	}
 
-	/**
-	 * @return int
-	 */
 	final public function getDamage() : int{
 		return $this->meta;
 	}
 
 	/**
-	 * @param int $meta
-	 *
 	 * @return $this
 	 */
 	public function setDamage(int $meta) : Item{
@@ -723,8 +632,6 @@ class Item implements ItemIds, \JsonSerializable{
 	/**
 	 * Returns whether this item can match any item with an equivalent ID with any meta value.
 	 * Used in crafting recipes which accept multiple variants of the same item, for example crafting tables recipes.
-	 *
-	 * @return bool
 	 */
 	public function hasAnyDamageValue() : bool{
 		return $this->meta === -1;
@@ -732,7 +639,6 @@ class Item implements ItemIds, \JsonSerializable{
 
 	/**
 	 * Returns the highest amount of this item which will fit into one inventory slot.
-	 * @return int
 	 */
 	public function getMaxStackSize() : int{
 		return 64;
@@ -740,7 +646,6 @@ class Item implements ItemIds, \JsonSerializable{
 
 	/**
 	 * Returns the time in ticks which the item will fuel a furnace for.
-	 * @return int
 	 */
 	public function getFuelTime() : int{
 		return 0;
@@ -748,7 +653,6 @@ class Item implements ItemIds, \JsonSerializable{
 
 	/**
 	 * Returns how many points of damage this item will deal to an entity when used as a weapon.
-	 * @return int
 	 */
 	public function getAttackPoints() : int{
 		return 1;
@@ -756,7 +660,6 @@ class Item implements ItemIds, \JsonSerializable{
 
 	/**
 	 * Returns how many armor points can be gained by wearing this item.
-	 * @return int
 	 */
 	public function getDefensePoints() : int{
 		return 0;
@@ -765,8 +668,6 @@ class Item implements ItemIds, \JsonSerializable{
 	/**
 	 * Returns what type of block-breaking tool this is. Blocks requiring the same tool type as the item will break
 	 * faster (except for blocks requiring no tool, which break at the same speed regardless of the tool used)
-	 *
-	 * @return int
 	 */
 	public function getBlockToolType() : int{
 		return BlockToolType::TYPE_NONE;
@@ -778,8 +679,6 @@ class Item implements ItemIds, \JsonSerializable{
 	 * This should return 1 for non-tiered tools, and the tool tier for tiered tools.
 	 *
 	 * @see Block::getToolHarvestLevel()
-	 *
-	 * @return int
 	 */
 	public function getBlockToolHarvestLevel() : int{
 		return 0;
@@ -791,14 +690,6 @@ class Item implements ItemIds, \JsonSerializable{
 
 	/**
 	 * Called when a player uses this item on a block.
-	 *
-	 * @param Player  $player
-	 * @param Block   $blockReplace
-	 * @param Block   $blockClicked
-	 * @param int     $face
-	 * @param Vector3 $clickVector
-	 *
-	 * @return bool
 	 */
 	public function onActivate(Player $player, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector) : bool{
 		return false;
@@ -807,11 +698,6 @@ class Item implements ItemIds, \JsonSerializable{
 	/**
 	 * Called when a player uses the item on air, for example throwing a projectile.
 	 * Returns whether the item was changed, for example count decrease or durability change.
-	 *
-	 * @param Player  $player
-	 * @param Vector3 $directionVector
-	 *
-	 * @return bool
 	 */
 	public function onClickAir(Player $player, Vector3 $directionVector) : bool{
 		return false;
@@ -820,10 +706,6 @@ class Item implements ItemIds, \JsonSerializable{
 	/**
 	 * Called when a player is using this item and releases it. Used to handle bow shoot actions.
 	 * Returns whether the item was changed, for example count decrease or durability change.
-	 *
-	 * @param Player $player
-	 *
-	 * @return bool
 	 */
 	public function onReleaseUsing(Player $player) : bool{
 		return false;
@@ -831,10 +713,6 @@ class Item implements ItemIds, \JsonSerializable{
 
 	/**
 	 * Called when this item is used to destroy a block. Usually used to update durability.
-	 *
-	 * @param Block $block
-	 *
-	 * @return bool
 	 */
 	public function onDestroyBlock(Block $block) : bool{
 		return false;
@@ -842,10 +720,6 @@ class Item implements ItemIds, \JsonSerializable{
 
 	/**
 	 * Called when this item is used to attack an entity. Usually used to update durability.
-	 *
-	 * @param Entity $victim
-	 *
-	 * @return bool
 	 */
 	public function onAttackEntity(Entity $victim) : bool{
 		return false;
@@ -853,8 +727,6 @@ class Item implements ItemIds, \JsonSerializable{
 
 	/**
 	 * Returns the number of ticks a player must wait before activating this item again.
-	 *
-	 * @return int
 	 */
 	public function getCooldownTicks() : int{
 		return 0;
@@ -863,11 +735,8 @@ class Item implements ItemIds, \JsonSerializable{
 	/**
 	 * Compares an Item to this Item and check if they match.
 	 *
-	 * @param Item $item
 	 * @param bool $checkDamage Whether to verify that the damage values match.
 	 * @param bool $checkCompound Whether to verify that the items' NBT match.
-	 *
-	 * @return bool
 	 */
 	final public function equals(Item $item, bool $checkDamage = true, bool $checkCompound = true) : bool{
 		if($this->id === $item->getId() and (!$checkDamage or $this->getDamage() === $item->getDamage())){
@@ -888,26 +757,17 @@ class Item implements ItemIds, \JsonSerializable{
 
 	/**
 	 * Returns whether the specified item stack has the same ID, damage, NBT and count as this item stack.
-	 *
-	 * @param Item $other
-	 *
-	 * @return bool
 	 */
 	final public function equalsExact(Item $other) : bool{
 		return $this->equals($other, true, true) and $this->count === $other->count;
 	}
 
-	/**
-	 * @return string
-	 */
 	final public function __toString() : string{
 		return "Item " . $this->name . " (" . $this->id . ":" . ($this->hasAnyDamageValue() ? "?" : $this->meta) . ")x" . $this->count . ($this->hasCompoundTag() ? " tags:" . base64_encode($this->getCompoundTag()) : "");
 	}
 
 	/**
 	 * Returns an array of item stack properties that can be serialized to json.
-	 *
-	 * @return array
 	 */
 	final public function jsonSerialize() : array{
 		$data = [
@@ -931,10 +791,6 @@ class Item implements ItemIds, \JsonSerializable{
 
 	/**
 	 * Returns an Item from properties created in an array by {@link Item#jsonSerialize}
-	 *
-	 * @param array $data
-	 *
-	 * @return Item
 	 */
 	final public static function jsonDeserialize(array $data) : Item{
 		$nbt = "";
@@ -960,8 +816,6 @@ class Item implements ItemIds, \JsonSerializable{
 	 *
 	 * @param int    $slot optional, the inventory slot of the item
 	 * @param string $tagName the name to assign to the CompoundTag object
-	 *
-	 * @return CompoundTag
 	 */
 	public function nbtSerialize(int $slot = -1, string $tagName = "") : CompoundTag{
 		$result = new CompoundTag($tagName, [
@@ -985,10 +839,6 @@ class Item implements ItemIds, \JsonSerializable{
 
 	/**
 	 * Deserializes an Item from an NBT CompoundTag
-	 *
-	 * @param CompoundTag $tag
-	 *
-	 * @return Item
 	 */
 	public static function nbtDeserialize(CompoundTag $tag) : Item{
 		if(!$tag->hasTag("id") or !$tag->hasTag("Count")){

--- a/src/pocketmine/item/ItemBlock.php
+++ b/src/pocketmine/item/ItemBlock.php
@@ -34,9 +34,7 @@ class ItemBlock extends Item{
 	protected $blockId;
 
 	/**
-	 * @param int      $blockId
 	 * @param int      $meta usually 0-15 (placed blocks may only have meta values 0-15)
-	 * @param int|null $itemId
 	 */
 	public function __construct(int $blockId, int $meta = 0, int $itemId = null){
 		$this->blockId = $blockId;

--- a/src/pocketmine/item/ItemFactory.php
+++ b/src/pocketmine/item/ItemFactory.php
@@ -285,9 +285,6 @@ class ItemFactory{
 	 * NOTE: If you are registering a new item type, you will need to add it to the creative inventory yourself - it
 	 * will not automatically appear there.
 	 *
-	 * @param Item $item
-	 * @param bool $override
-	 *
 	 * @return void
 	 * @throws \RuntimeException if something attempted to override an already-registered item without specifying the
 	 * $override parameter.
@@ -304,12 +301,8 @@ class ItemFactory{
 	/**
 	 * Returns an instance of the Item with the specified id, meta, count and NBT.
 	 *
-	 * @param int                     $id
-	 * @param int                     $meta
-	 * @param int                     $count
 	 * @param CompoundTag|string|null $tags
 	 *
-	 * @return Item
 	 * @throws \TypeError
 	 */
 	public static function get(int $id, int $meta = 0, int $count = 1, $tags = null) : Item{
@@ -350,9 +343,6 @@ class ItemFactory{
 	 * If multiple item instances are to be created, their identifiers must be comma-separated, for example:
 	 * `diamond_pickaxe,wooden_shovel:18,iron_ingot`
 	 *
-	 * @param string $str
-	 * @param bool   $multiple
-	 *
 	 * @return Item[]|Item
 	 *
 	 * @throws \InvalidArgumentException if the given string cannot be parsed as an item identifier
@@ -389,9 +379,6 @@ class ItemFactory{
 
 	/**
 	 * Returns whether the specified item ID is already registered in the item factory.
-	 *
-	 * @param int $id
-	 * @return bool
 	 */
 	public static function isRegistered(int $id) : bool{
 		if($id < 256){

--- a/src/pocketmine/item/Potion.php
+++ b/src/pocketmine/item/Potion.php
@@ -70,8 +70,6 @@ class Potion extends Item implements Consumable{
 	/**
 	 * Returns a list of effects applied by potions with the specified ID.
 	 *
-	 * @param int $id
-	 *
 	 * @return EffectInstance[]
 	 */
 	public static function getPotionEffectsById(int $id) : array{

--- a/src/pocketmine/item/ProjectileItem.php
+++ b/src/pocketmine/item/ProjectileItem.php
@@ -40,8 +40,6 @@ abstract class ProjectileItem extends Item{
 
 	/**
 	 * Helper function to apply extra NBT tags to pass to the created projectile.
-	 *
-	 * @param CompoundTag $tag
 	 */
 	protected function addExtraTags(CompoundTag $tag) : void{
 

--- a/src/pocketmine/item/WritableBook.php
+++ b/src/pocketmine/item/WritableBook.php
@@ -40,10 +40,6 @@ class WritableBook extends Item{
 
 	/**
 	 * Returns whether the given page exists in this book.
-	 *
-	 * @param int $pageId
-	 *
-	 * @return bool
 	 */
 	public function pageExists(int $pageId) : bool{
 		return $this->getPagesTag()->isset($pageId);
@@ -51,10 +47,6 @@ class WritableBook extends Item{
 
 	/**
 	 * Returns a string containing the content of a page (which could be empty), or null if the page doesn't exist.
-	 *
-	 * @param int $pageId
-	 *
-	 * @return string|null
 	 */
 	public function getPageText(int $pageId) : ?string{
 		$pages = $this->getNamedTag()->getListTag(self::TAG_PAGES);
@@ -72,9 +64,6 @@ class WritableBook extends Item{
 
 	/**
 	 * Sets the text of a page in the book. Adds the page if the page does not yet exist.
-	 *
-	 * @param int    $pageId
-	 * @param string $pageText
 	 *
 	 * @return bool indicating whether the page was created or not.
 	 */
@@ -99,8 +88,6 @@ class WritableBook extends Item{
 	/**
 	 * Adds a new page with the given page ID.
 	 * Creates a new page for every page between the given ID and existing pages that doesn't yet exist.
-	 *
-	 * @param int $pageId
 	 */
 	public function addPage(int $pageId) : void{
 		if($pageId < 0){
@@ -122,8 +109,6 @@ class WritableBook extends Item{
 	/**
 	 * Deletes an existing page with the given page ID.
 	 *
-	 * @param int $pageId
-	 *
 	 * @return bool indicating success
 	 */
 	public function deletePage(int $pageId) : bool{
@@ -136,9 +121,6 @@ class WritableBook extends Item{
 
 	/**
 	 * Inserts a new page with the given text and moves other pages upwards.
-	 *
-	 * @param int    $pageId
-	 * @param string $pageText
 	 *
 	 * @return bool indicating success
 	 */
@@ -157,9 +139,6 @@ class WritableBook extends Item{
 
 	/**
 	 * Switches the text of two pages with each other.
-	 *
-	 * @param int $pageId1
-	 * @param int $pageId2
 	 *
 	 * @return bool indicating success
 	 */

--- a/src/pocketmine/item/WrittenBook.php
+++ b/src/pocketmine/item/WrittenBook.php
@@ -45,8 +45,6 @@ class WrittenBook extends WritableBook{
 	/**
 	 * Returns the generation of the book.
 	 * Generations higher than 1 can not be copied.
-	 *
-	 * @return int
 	 */
 	public function getGeneration() : int{
 		return $this->getNamedTag()->getInt(self::TAG_GENERATION, -1);
@@ -54,8 +52,6 @@ class WrittenBook extends WritableBook{
 
 	/**
 	 * Sets the generation of a book.
-	 *
-	 * @param int $generation
 	 */
 	public function setGeneration(int $generation) : void{
 		if($generation < 0 or $generation > 3){
@@ -70,8 +66,6 @@ class WrittenBook extends WritableBook{
 	 * Returns the author of this book.
 	 * This is not a reliable way to get the name of the player who signed this book.
 	 * The author can be set to anything when signing a book.
-	 *
-	 * @return string
 	 */
 	public function getAuthor() : string{
 		return $this->getNamedTag()->getString(self::TAG_AUTHOR, "");
@@ -79,8 +73,6 @@ class WrittenBook extends WritableBook{
 
 	/**
 	 * Sets the author of this book.
-	 *
-	 * @param string $authorName
 	 */
 	public function setAuthor(string $authorName) : void{
 		$namedTag = $this->getNamedTag();
@@ -90,8 +82,6 @@ class WrittenBook extends WritableBook{
 
 	/**
 	 * Returns the title of this book.
-	 *
-	 * @return string
 	 */
 	public function getTitle() : string{
 		return $this->getNamedTag()->getString(self::TAG_TITLE, "");
@@ -99,8 +89,6 @@ class WrittenBook extends WritableBook{
 
 	/**
 	 * Sets the author of this book.
-	 *
-	 * @param string $title
 	 */
 	public function setTitle(string $title) : void{
 		$namedTag = $this->getNamedTag();

--- a/src/pocketmine/item/enchantment/Enchantment.php
+++ b/src/pocketmine/item/enchantment/Enchantment.php
@@ -142,18 +142,11 @@ class Enchantment{
 
 	/**
 	 * Registers an enchantment type.
-	 *
-	 * @param Enchantment $enchantment
 	 */
 	public static function registerEnchantment(Enchantment $enchantment) : void{
 		self::$enchantments[$enchantment->getId()] = clone $enchantment;
 	}
 
-	/**
-	 * @param int $id
-	 *
-	 * @return Enchantment|null
-	 */
 	public static function getEnchantment(int $id) : ?Enchantment{
 		if($id < 0 or $id >= self::$enchantments->getSize()){
 			return null;
@@ -161,11 +154,6 @@ class Enchantment{
 		return self::$enchantments[$id] ?? null;
 	}
 
-	/**
-	 * @param string $name
-	 *
-	 * @return Enchantment|null
-	 */
 	public static function getEnchantmentByName(string $name) : ?Enchantment{
 		$const = Enchantment::class . "::" . strtoupper($name);
 		if(defined($const)){
@@ -187,14 +175,6 @@ class Enchantment{
 	/** @var int */
 	private $maxLevel;
 
-	/**
-	 * @param int    $id
-	 * @param string $name
-	 * @param int    $rarity
-	 * @param int    $primaryItemFlags
-	 * @param int    $secondaryItemFlags
-	 * @param int    $maxLevel
-	 */
 	public function __construct(int $id, string $name, int $rarity, int $primaryItemFlags, int $secondaryItemFlags, int $maxLevel){
 		$this->id = $id;
 		$this->name = $name;
@@ -206,7 +186,6 @@ class Enchantment{
 
 	/**
 	 * Returns the ID of this enchantment as per Minecraft PE
-	 * @return int
 	 */
 	public function getId() : int{
 		return $this->id;
@@ -214,7 +193,6 @@ class Enchantment{
 
 	/**
 	 * Returns a translation key for this enchantment's name.
-	 * @return string
 	 */
 	public function getName() : string{
 		return $this->name;
@@ -222,7 +200,6 @@ class Enchantment{
 
 	/**
 	 * Returns an int constant indicating how rare this enchantment type is.
-	 * @return int
 	 */
 	public function getRarity() : int{
 		return $this->rarity;
@@ -230,8 +207,6 @@ class Enchantment{
 
 	/**
 	 * Returns a bitset indicating what item types can have this item applied from an enchanting table.
-	 *
-	 * @return int
 	 */
 	public function getPrimaryItemFlags() : int{
 		return $this->primaryItemFlags;
@@ -240,8 +215,6 @@ class Enchantment{
 	/**
 	 * Returns a bitset indicating what item types cannot have this item applied from an enchanting table, but can from
 	 * an anvil.
-	 *
-	 * @return int
 	 */
 	public function getSecondaryItemFlags() : int{
 		return $this->secondaryItemFlags;
@@ -249,10 +222,6 @@ class Enchantment{
 
 	/**
 	 * Returns whether this enchantment can apply to the item type from an enchanting table.
-	 *
-	 * @param int $flag
-	 *
-	 * @return bool
 	 */
 	public function hasPrimaryItemType(int $flag) : bool{
 		return ($this->primaryItemFlags & $flag) !== 0;
@@ -260,10 +229,6 @@ class Enchantment{
 
 	/**
 	 * Returns whether this enchantment can apply to the item type from an anvil, if it is not a primary item.
-	 *
-	 * @param int $flag
-	 *
-	 * @return bool
 	 */
 	public function hasSecondaryItemType(int $flag) : bool{
 		return ($this->secondaryItemFlags & $flag) !== 0;
@@ -271,7 +236,6 @@ class Enchantment{
 
 	/**
 	 * Returns the maximum level of this enchantment that can be found on an enchantment table.
-	 * @return int
 	 */
 	public function getMaxLevel() : int{
 		return $this->maxLevel;

--- a/src/pocketmine/item/enchantment/EnchantmentEntry.php
+++ b/src/pocketmine/item/enchantment/EnchantmentEntry.php
@@ -35,8 +35,6 @@ class EnchantmentEntry{
 
 	/**
 	 * @param Enchantment[] $enchantments
-	 * @param int           $cost
-	 * @param string        $randomName
 	 */
 	public function __construct(array $enchantments, int $cost, string $randomName){
 		$this->enchantments = $enchantments;

--- a/src/pocketmine/item/enchantment/EnchantmentInstance.php
+++ b/src/pocketmine/item/enchantment/EnchantmentInstance.php
@@ -45,7 +45,6 @@ class EnchantmentInstance{
 
 	/**
 	 * Returns the type of this enchantment.
-	 * @return Enchantment
 	 */
 	public function getType() : Enchantment{
 		return $this->enchantment;
@@ -53,7 +52,6 @@ class EnchantmentInstance{
 
 	/**
 	 * Returns the type identifier of this enchantment instance.
-	 * @return int
 	 */
 	public function getId() : int{
 		return $this->enchantment->getId();
@@ -61,7 +59,6 @@ class EnchantmentInstance{
 
 	/**
 	 * Returns the level of the enchantment.
-	 * @return int
 	 */
 	public function getLevel() : int{
 		return $this->level;
@@ -69,8 +66,6 @@ class EnchantmentInstance{
 
 	/**
 	 * Sets the level of the enchantment.
-	 *
-	 * @param int $level
 	 *
 	 * @return $this
 	 */

--- a/src/pocketmine/item/enchantment/EnchantmentList.php
+++ b/src/pocketmine/item/enchantment/EnchantmentList.php
@@ -33,19 +33,10 @@ class EnchantmentList{
 		$this->enchantments = new \SplFixedArray($size);
 	}
 
-	/**
-	 * @param int              $slot
-	 * @param EnchantmentEntry $entry
-	 */
 	public function setSlot(int $slot, EnchantmentEntry $entry) : void{
 		$this->enchantments[$slot] = $entry;
 	}
 
-	/**
-	 * @param int $slot
-	 *
-	 * @return EnchantmentEntry
-	 */
 	public function getSlot(int $slot) : EnchantmentEntry{
 		return $this->enchantments[$slot];
 	}

--- a/src/pocketmine/item/enchantment/MeleeWeaponEnchantment.php
+++ b/src/pocketmine/item/enchantment/MeleeWeaponEnchantment.php
@@ -34,28 +34,16 @@ abstract class MeleeWeaponEnchantment extends Enchantment{
 	/**
 	 * Returns whether this melee enchantment has an effect on the target entity. For example, Smite only applies to
 	 * undead mobs.
-	 *
-	 * @param Entity $victim
-	 *
-	 * @return bool
 	 */
 	abstract public function isApplicableTo(Entity $victim) : bool;
 
 	/**
 	 * Returns the amount of additional damage caused by this enchantment to applicable targets.
-	 *
-	 * @param int $enchantmentLevel
-	 *
-	 * @return float
 	 */
 	abstract public function getDamageBonus(int $enchantmentLevel) : float;
 
 	/**
 	 * Called after damaging the entity to apply any post damage effects to the target.
-	 *
-	 * @param Entity $attacker
-	 * @param Entity $victim
-	 * @param int    $enchantmentLevel
 	 */
 	public function onPostAttack(Entity $attacker, Entity $victim, int $enchantmentLevel) : void{
 

--- a/src/pocketmine/item/enchantment/ProtectionEnchantment.php
+++ b/src/pocketmine/item/enchantment/ProtectionEnchantment.php
@@ -36,13 +36,6 @@ class ProtectionEnchantment extends Enchantment{
 	/**
 	 * ProtectionEnchantment constructor.
 	 *
-	 * @param int        $id
-	 * @param string     $name
-	 * @param int        $rarity
-	 * @param int        $primaryItemFlags
-	 * @param int        $secondaryItemFlags
-	 * @param int        $maxLevel
-	 * @param float      $typeModifier
 	 * @param int[]|null $applicableDamageTypes EntityDamageEvent::CAUSE_* constants which this enchantment type applies to, or null if it applies to all types of damage.
 	 */
 	public function __construct(int $id, string $name, int $rarity, int $primaryItemFlags, int $secondaryItemFlags, int $maxLevel, float $typeModifier, ?array $applicableDamageTypes){
@@ -56,7 +49,6 @@ class ProtectionEnchantment extends Enchantment{
 
 	/**
 	 * Returns the multiplier by which this enchantment type's EPF increases with each enchantment level.
-	 * @return float
 	 */
 	public function getTypeModifier() : float{
 		return $this->typeModifier;
@@ -64,10 +56,6 @@ class ProtectionEnchantment extends Enchantment{
 
 	/**
 	 * Returns the base EPF this enchantment type offers for the given enchantment level.
-	 *
-	 * @param int $level
-	 *
-	 * @return int
 	 */
 	public function getProtectionFactor(int $level) : int{
 		return (int) floor((6 + $level ** 2) * $this->typeModifier / 3);
@@ -75,10 +63,6 @@ class ProtectionEnchantment extends Enchantment{
 
 	/**
 	 * Returns whether this enchantment type offers protection from the specified damage source's cause.
-	 *
-	 * @param EntityDamageEvent $event
-	 *
-	 * @return bool
 	 */
 	public function isApplicable(EntityDamageEvent $event) : bool{
 		return $this->applicableDamageTypes === null or isset($this->applicableDamageTypes[$event->getCause()]);

--- a/src/pocketmine/lang/BaseLang.php
+++ b/src/pocketmine/lang/BaseLang.php
@@ -106,7 +106,6 @@ class BaseLang{
 	}
 
 	/**
-	 * @param string   $path
 	 * @param string[] $d reference parameter
 	 *
 	 * @return bool
@@ -121,11 +120,7 @@ class BaseLang{
 	}
 
 	/**
-	 * @param string               $str
 	 * @param (float|int|string)[] $params
-	 * @param string|null          $onlyPrefix
-	 *
-	 * @return string
 	 */
 	public function translateString(string $str, array $params = [], string $onlyPrefix = null) : string{
 		$baseText = $this->get($str);
@@ -139,8 +134,6 @@ class BaseLang{
 	}
 
 	/**
-	 * @param TextContainer $c
-	 *
 	 * @return string
 	 */
 	public function translate(TextContainer $c){
@@ -159,8 +152,6 @@ class BaseLang{
 	}
 
 	/**
-	 * @param string $id
-	 *
 	 * @return string|null
 	 */
 	public function internalGet(string $id){
@@ -173,11 +164,6 @@ class BaseLang{
 		return null;
 	}
 
-	/**
-	 * @param string $id
-	 *
-	 * @return string
-	 */
 	public function get(string $id) : string{
 		if(isset($this->lang[$id])){
 			return $this->lang[$id];
@@ -188,12 +174,6 @@ class BaseLang{
 		return $id;
 	}
 
-	/**
-	 * @param string      $text
-	 * @param string|null $onlyPrefix
-	 *
-	 * @return string
-	 */
 	protected function parseTranslation(string $text, string $onlyPrefix = null) : string{
 		$newString = "";
 

--- a/src/pocketmine/lang/TextContainer.php
+++ b/src/pocketmine/lang/TextContainer.php
@@ -28,32 +28,21 @@ class TextContainer{
 	/** @var string $text */
 	protected $text;
 
-	/**
-	 * @param string $text
-	 */
 	public function __construct(string $text){
 		$this->text = $text;
 	}
 
 	/**
-	 * @param string $text
-	 *
 	 * @return void
 	 */
 	public function setText(string $text){
 		$this->text = $text;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getText() : string{
 		return $this->text;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function __toString() : string{
 		return $this->getText();
 	}

--- a/src/pocketmine/lang/TranslationContainer.php
+++ b/src/pocketmine/lang/TranslationContainer.php
@@ -31,7 +31,6 @@ class TranslationContainer extends TextContainer{
 	protected $params = [];
 
 	/**
-	 * @param string               $text
 	 * @param (float|int|string)[] $params
 	 */
 	public function __construct(string $text, array $params = []){
@@ -48,8 +47,6 @@ class TranslationContainer extends TextContainer{
 	}
 
 	/**
-	 * @param int $i
-	 *
 	 * @return string|null
 	 */
 	public function getParameter(int $i){
@@ -57,9 +54,6 @@ class TranslationContainer extends TextContainer{
 	}
 
 	/**
-	 * @param int    $i
-	 * @param string $str
-	 *
 	 * @return void
 	 */
 	public function setParameter(int $i, string $str){

--- a/src/pocketmine/level/ChunkLoader.php
+++ b/src/pocketmine/level/ChunkLoader.php
@@ -42,15 +42,11 @@ interface ChunkLoader{
 	/**
 	 * Returns the ChunkLoader id.
 	 * Call Level::generateChunkLoaderId($this) to generate and save it
-	 *
-	 * @return int
 	 */
 	public function getLoaderId() : int;
 
 	/**
 	 * Returns if the chunk loader is currently active
-	 *
-	 * @return bool
 	 */
 	public function isLoaderActive() : bool;
 
@@ -77,8 +73,6 @@ interface ChunkLoader{
 	/**
 	 * This method will be called when a Chunk is replaced by a new one
 	 *
-	 * @param Chunk $chunk
-	 *
 	 * @return void
 	 */
 	public function onChunkChanged(Chunk $chunk);
@@ -86,17 +80,12 @@ interface ChunkLoader{
 	/**
 	 * This method will be called when a registered chunk is loaded
 	 *
-	 * @param Chunk $chunk
-	 *
 	 * @return void
 	 */
 	public function onChunkLoaded(Chunk $chunk);
 
-
 	/**
 	 * This method will be called when a registered chunk is unloaded
-	 *
-	 * @param Chunk $chunk
 	 *
 	 * @return void
 	 */
@@ -105,8 +94,6 @@ interface ChunkLoader{
 	/**
 	 * This method will be called when a registered chunk is populated
 	 * Usually it'll be sent with another call to onChunkChanged()
-	 *
-	 * @param Chunk $chunk
 	 *
 	 * @return void
 	 */

--- a/src/pocketmine/level/ChunkManager.php
+++ b/src/pocketmine/level/ChunkManager.php
@@ -29,10 +29,6 @@ interface ChunkManager{
 	/**
 	 * Gets the raw block id.
 	 *
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 *
 	 * @return int 0-255
 	 */
 	public function getBlockIdAt(int $x, int $y, int $z) : int;
@@ -40,9 +36,6 @@ interface ChunkManager{
 	/**
 	 * Sets the raw block id.
 	 *
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
 	 * @param int $id 0-255
 	 *
 	 * @return void
@@ -52,10 +45,6 @@ interface ChunkManager{
 	/**
 	 * Gets the raw block metadata
 	 *
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 *
 	 * @return int 0-15
 	 */
 	public function getBlockDataAt(int $x, int $y, int $z) : int;
@@ -63,9 +52,6 @@ interface ChunkManager{
 	/**
 	 * Sets the raw block metadata.
 	 *
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
 	 * @param int $data 0-15
 	 *
 	 * @return void
@@ -74,22 +60,11 @@ interface ChunkManager{
 
 	/**
 	 * Returns the raw block light level
-	 *
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 *
-	 * @return int
 	 */
 	public function getBlockLightAt(int $x, int $y, int $z) : int;
 
 	/**
 	 * Sets the raw block light level
-	 *
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 * @param int $level
 	 *
 	 * @return void
 	 */
@@ -97,66 +72,39 @@ interface ChunkManager{
 
 	/**
 	 * Returns the highest amount of sky light can reach the specified coordinates.
-	 *
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 *
-	 * @return int
 	 */
 	public function getBlockSkyLightAt(int $x, int $y, int $z) : int;
 
 	/**
 	 * Sets the raw block sky light level.
 	 *
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 * @param int $level
-	 *
 	 * @return void
 	 */
 	public function setBlockSkyLightAt(int $x, int $y, int $z, int $level);
 
 	/**
-	 * @param int $chunkX
-	 * @param int $chunkZ
-	 *
 	 * @return Chunk|null
 	 */
 	public function getChunk(int $chunkX, int $chunkZ);
 
 	/**
-	 * @param int        $chunkX
-	 * @param int        $chunkZ
-	 * @param Chunk|null $chunk
-	 *
 	 * @return void
 	 */
 	public function setChunk(int $chunkX, int $chunkZ, Chunk $chunk = null);
 
 	/**
 	 * Gets the level seed
-	 *
-	 * @return int
 	 */
 	public function getSeed() : int;
 
 	/**
 	 * Returns the height of the world
-	 * @return int
 	 */
 	public function getWorldHeight() : int;
 
 	/**
 	 * Returns whether the specified coordinates are within the valid world boundaries, taking world format limitations
 	 * into account.
-	 *
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 *
-	 * @return bool
 	 */
 	public function isInWorld(int $x, int $y, int $z) : bool;
 }

--- a/src/pocketmine/level/Explosion.php
+++ b/src/pocketmine/level/Explosion.php
@@ -67,8 +67,6 @@ class Explosion{
 	private $subChunkHandler;
 
 	/**
-	 * @param Position     $center
-	 * @param float        $size
 	 * @param Entity|Block $what
 	 */
 	public function __construct(Position $center, float $size, $what = null){
@@ -90,8 +88,6 @@ class Explosion{
 	/**
 	 * Calculates which blocks will be destroyed by this explosion. If explodeB() is called without calling this, no blocks 
 	 * will be destroyed.
-	 *
-	 * @return bool
 	 */
 	public function explodeA() : bool{
 		if($this->size < 0.1){
@@ -153,8 +149,6 @@ class Explosion{
 	/**
 	 * Executes the explosion's effects on the world. This includes destroying blocks (if any), harming and knocking back entities,
 	 * and creating sounds and particles.
-	 *
-	 * @return bool
 	 */
 	public function explodeB() : bool{
 		$send = [];

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1643,8 +1643,6 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * @param Vector3 $motion
-	 *
 	 * @return ItemEntity|null
 	 */
 	public function dropItem(Vector3 $source, Item $item, Vector3 $motion = null, int $delay = 10){
@@ -1725,7 +1723,6 @@ class Level implements ChunkManager, Metadatable{
 	 * It'll try to lower the durability if Item is a tool, and set it to Air if broken.
 	 *
 	 * @param Item    $item reference parameter (if null, can break anything)
-	 * @param Player  $player
 	 */
 	public function useBreakOn(Vector3 $vector, Item &$item = null, Player $player = null, bool $createParticles = false) : bool{
 		$target = $this->getBlock($vector);
@@ -1994,8 +1991,6 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * Returns the entities near the current one inside the AxisAlignedBB
-	 *
-	 * @param Entity        $entity
 	 *
 	 * @return Entity[]
 	 */

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -302,12 +302,6 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * Computes a small index relative to chunk base from the given coordinates.
-	 *
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 *
-	 * @return int
 	 */
 	public static function chunkBlockHash(int $x, int $y, int $z) : int{
 		return ($y << 8) | (($z & 0xf) << 4) | ($x & 0xf);
@@ -319,11 +313,6 @@ class Level implements ChunkManager, Metadatable{
 		$z = ($hash & 0xFFFFFFF) << 36 >> 36;
 	}
 
-	/**
-	 * @param int      $hash
-	 * @param int|null $x
-	 * @param int|null $z
-	 */
 	public static function getXZ(int $hash, ?int &$x, ?int &$z) : void{
 		$x = $hash >> 32;
 		$z = ($hash & 0xFFFFFFFF) << 32 >> 32;
@@ -337,11 +326,6 @@ class Level implements ChunkManager, Metadatable{
 		}
 	}
 
-	/**
-	 * @param string $str
-	 *
-	 * @return int
-	 */
 	public static function getDifficultyFromString(string $str) : int{
 		switch(strtolower(trim($str))){
 			case "0":
@@ -370,10 +354,6 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * Init the default level data
-	 *
-	 * @param Server        $server
-	 * @param string        $name
-	 * @param LevelProvider $provider
 	 */
 	public function __construct(Server $server, string $name, LevelProvider $provider){
 		$this->blockStates = BlockFactory::getBlockStatesArray();
@@ -422,7 +402,6 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * @deprecated
-	 * @return int
 	 */
 	public function getTickRate() : int{
 		return 1;
@@ -434,7 +413,6 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * @deprecated does nothing
-	 * @param int $tickRate
 	 *
 	 * @return void
 	 */
@@ -509,7 +487,6 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * @param Sound         $sound
 	 * @param Player[]|null $players
 	 *
 	 * @return void
@@ -531,7 +508,6 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * @param Particle      $particle
 	 * @param Player[]|null $players
 	 *
 	 * @return void
@@ -556,8 +532,6 @@ class Level implements ChunkManager, Metadatable{
 	 * Broadcasts a LevelEvent to players in the area. This could be sound, particles, weather changes, etc.
 	 *
 	 * @param Vector3|null $pos If null, broadcasts to every player in the Level
-	 * @param int          $evid
-	 * @param int          $data
 	 *
 	 * @return void
 	 */
@@ -577,11 +551,6 @@ class Level implements ChunkManager, Metadatable{
 	/**
 	 * Broadcasts a LevelSoundEvent to players in the area.
 	 *
-	 * @param Vector3 $pos
-	 * @param int     $soundId
-	 * @param int     $extraData
-	 * @param int     $entityTypeId
-	 * @param bool    $isBabyMob
 	 * @param bool    $disableRelativeVolume If true, all players receiving this sound-event will hear the sound at full volume regardless of distance
 	 *
 	 * @return void
@@ -602,8 +571,6 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * @param bool $value
-	 *
 	 * @return void
 	 */
 	public function setAutoSave(bool $value){
@@ -618,7 +585,6 @@ class Level implements ChunkManager, Metadatable{
 	 *
 	 * @param bool $force default false, force unload of default level
 	 *
-	 * @return bool
 	 * @throws \InvalidStateException if trying to unload a level during level tick
 	 */
 	public function unload(bool $force = false) : bool{
@@ -665,9 +631,6 @@ class Level implements ChunkManager, Metadatable{
 	 *
 	 * Returns a list of players who have the target chunk within their view distance.
 	 *
-	 * @param int $chunkX
-	 * @param int $chunkZ
-	 *
 	 * @return Player[]
 	 */
 	public function getChunkPlayers(int $chunkX, int $chunkZ) : array{
@@ -677,9 +640,6 @@ class Level implements ChunkManager, Metadatable{
 	/**
 	 * Gets the chunk loaders being used in a specific chunk
 	 *
-	 * @param int $chunkX
-	 * @param int $chunkZ
-	 *
 	 * @return ChunkLoader[]
 	 */
 	public function getChunkLoaders(int $chunkX, int $chunkZ) : array{
@@ -688,7 +648,6 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * Returns an array of players who have the target position within their view distance.
-	 * @param Vector3 $pos
 	 *
 	 * @return Player[]
 	 */
@@ -699,10 +658,6 @@ class Level implements ChunkManager, Metadatable{
 	/**
 	 * Queues a DataPacket to be sent to all players using the chunk at the specified X/Z coordinates at the end of the
 	 * current tick.
-	 *
-	 * @param int        $chunkX
-	 * @param int        $chunkZ
-	 * @param DataPacket $packet
 	 *
 	 * @return void
 	 */
@@ -716,9 +671,6 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * Broadcasts a packet to every player who has the target position within their view distance.
-	 *
-	 * @param Vector3    $pos
-	 * @param DataPacket $packet
 	 */
 	public function broadcastPacketToViewers(Vector3 $pos, DataPacket $packet) : void{
 		$this->addChunkPacket($pos->getFloorX() >> 4, $pos->getFloorZ() >> 4, $packet);
@@ -726,8 +678,6 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * Broadcasts a packet to every player in the level.
-	 *
-	 * @param DataPacket $packet
 	 */
 	public function broadcastGlobalPacket(DataPacket $packet) : void{
 		$this->globalPackets[] = $packet;
@@ -736,19 +686,12 @@ class Level implements ChunkManager, Metadatable{
 	/**
 	 * @deprecated
 	 * @see Level::broadcastGlobalPacket()
-	 *
-	 * @param DataPacket $packet
 	 */
 	public function addGlobalPacket(DataPacket $packet) : void{
 		$this->globalPackets[] = $packet;
 	}
 
 	/**
-	 * @param ChunkLoader $loader
-	 * @param int         $chunkX
-	 * @param int         $chunkZ
-	 * @param bool        $autoLoad
-	 *
 	 * @return void
 	 */
 	public function registerChunkLoader(ChunkLoader $loader, int $chunkX, int $chunkZ, bool $autoLoad = true){
@@ -781,10 +724,6 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * @param ChunkLoader $loader
-	 * @param int         $chunkX
-	 * @param int         $chunkZ
-	 *
 	 * @return void
 	 */
 	public function unregisterChunkLoader(ChunkLoader $loader, int $chunkX, int $chunkZ){
@@ -822,8 +761,6 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * @internal
-	 *
-	 * @param int $currentTick
 	 *
 	 * @return void
 	 */
@@ -1014,8 +951,6 @@ class Level implements ChunkManager, Metadatable{
 	/**
 	 * @param Player[]  $target
 	 * @param Vector3[] $blocks
-	 * @param int       $flags
-	 * @param bool      $optimizeRebuilds
 	 *
 	 * @return void
 	 */
@@ -1078,8 +1013,6 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * @param bool $force
-	 *
 	 * @return void
 	 */
 	public function clearCache(bool $force = false){
@@ -1099,9 +1032,6 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * @param int $chunkX
-	 * @param int $chunkZ
-	 *
 	 * @return void
 	 */
 	public function clearChunkCache(int $chunkX, int $chunkZ){
@@ -1113,8 +1043,6 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * @param int $id
-	 *
 	 * @return void
 	 */
 	public function addRandomTickedBlock(int $id){
@@ -1122,8 +1050,6 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * @param int $id
-	 *
 	 * @return void
 	 */
 	public function removeRandomTickedBlock(int $id){
@@ -1216,11 +1142,6 @@ class Level implements ChunkManager, Metadatable{
 		return [];
 	}
 
-	/**
-	 * @param bool $force
-	 *
-	 * @return bool
-	 */
 	public function save(bool $force = false) : bool{
 
 		if(!$this->getAutoSave() and !$force){
@@ -1259,9 +1180,6 @@ class Level implements ChunkManager, Metadatable{
 	 * Schedules a block update to be executed after the specified number of ticks.
 	 * Blocks will be updated with the scheduled update type.
 	 *
-	 * @param Vector3 $pos
-	 * @param int     $delay
-	 *
 	 * @return void
 	 */
 	public function scheduleDelayedBlockUpdate(Vector3 $pos, int $delay){
@@ -1279,8 +1197,6 @@ class Level implements ChunkManager, Metadatable{
 	 * Schedules the blocks around the specified position to be updated at the end of this tick.
 	 * Blocks will be updated with the normal update type.
 	 *
-	 * @param Vector3 $pos
-	 *
 	 * @return void
 	 */
 	public function scheduleNeighbourBlockUpdates(Vector3 $pos){
@@ -1295,9 +1211,6 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * @param AxisAlignedBB $bb
-	 * @param bool          $targetFirst
-	 *
 	 * @return Block[]
 	 */
 	public function getCollisionBlocks(AxisAlignedBB $bb, bool $targetFirst = false) : array{
@@ -1338,11 +1251,6 @@ class Level implements ChunkManager, Metadatable{
 		return $collides;
 	}
 
-	/**
-	 * @param Vector3 $pos
-	 *
-	 * @return bool
-	 */
 	public function isFullBlock(Vector3 $pos) : bool{
 		if($pos instanceof Block){
 			if($pos->isSolid()){
@@ -1357,10 +1265,6 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * @param Entity        $entity
-	 * @param AxisAlignedBB $bb
-	 * @param bool          $entities
-	 *
 	 * @return AxisAlignedBB[]
 	 */
 	public function getCollisionCubes(Entity $entity, AxisAlignedBB $bb, bool $entities = true) : array{
@@ -1413,8 +1317,6 @@ class Level implements ChunkManager, Metadatable{
 	/**
 	 * Computes the percentage of a circle away from noon the sun is currently at. This can be multiplied by 2 * M_PI to
 	 * get an angle in radians, or by 360 to get an angle in degrees.
-	 *
-	 * @return float
 	 */
 	public function computeSunAnglePercentage() : float{
 		$timeProgress = ($this->time % 24000) / 24000;
@@ -1431,7 +1333,6 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * Returns the percentage of a circle away from noon the sun is currently at.
-	 * @return float
 	 */
 	public function getSunAnglePercentage() : float{
 		return $this->sunAnglePercentage;
@@ -1439,7 +1340,6 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * Returns the current sun angle in radians.
-	 * @return float
 	 */
 	public function getSunAngleRadians() : float{
 		return $this->sunAnglePercentage * 2 * M_PI;
@@ -1447,7 +1347,6 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * Returns the current sun angle in degrees.
-	 * @return float
 	 */
 	public function getSunAngleDegrees() : float{
 		return $this->sunAnglePercentage * 360.0;
@@ -1456,8 +1355,6 @@ class Level implements ChunkManager, Metadatable{
 	/**
 	 * Computes how many points of sky light is subtracted based on the current time. Used to offset raw chunk sky light
 	 * to get a real light value.
-	 *
-	 * @return int
 	 */
 	public function computeSkyLightReduction() : int{
 		$percentage = max(0, min(1, -(cos($this->getSunAngleRadians()) * 2 - 0.5)));
@@ -1469,7 +1366,6 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * Returns how many points of sky light is subtracted based on the current time.
-	 * @return int
 	 */
 	public function getSkyLightReduction() : int{
 		return $this->skyLightReduction;
@@ -1477,10 +1373,6 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * Returns the sky light level at the specified coordinates, offset by the current time and weather.
-	 *
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
 	 *
 	 * @return int 0-15
 	 */
@@ -1490,10 +1382,6 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 *
 	 * @return int bitmap, (id << 4) | data
 	 */
 	public function getFullBlock(int $x, int $y, int $z) : int{
@@ -1515,11 +1403,8 @@ class Level implements ChunkManager, Metadatable{
 	 * Note: If you're using this for performance-sensitive code, and you're guaranteed to be supplying ints in the
 	 * specified vector, consider using {@link getBlockAt} instead for better performance.
 	 *
-	 * @param Vector3 $pos
 	 * @param bool    $cached Whether to use the block cache for getting the block (faster, but may be inaccurate)
 	 * @param bool    $addToCache Whether to cache the block object created by this method call.
-	 *
-	 * @return Block
 	 */
 	public function getBlock(Vector3 $pos, bool $cached = true, bool $addToCache = true) : Block{
 		return $this->getBlockAt((int) floor($pos->x), (int) floor($pos->y), (int) floor($pos->z), $cached, $addToCache);
@@ -1531,13 +1416,8 @@ class Level implements ChunkManager, Metadatable{
 	 * Note for plugin developers: If you are using this method a lot (thousands of times for many positions for
 	 * example), you may want to set addToCache to false to avoid using excessive amounts of memory.
 	 *
-	 * @param int  $x
-	 * @param int  $y
-	 * @param int  $z
 	 * @param bool $cached Whether to use the block cache for getting the block (faster, but may be inaccurate)
 	 * @param bool $addToCache Whether to cache the block object created by this method call.
-	 *
-	 * @return Block
 	 */
 	public function getBlockAt(int $x, int $y, int $z, bool $cached = true, bool $addToCache = true) : Block{
 		$fullState = 0;
@@ -1574,8 +1454,6 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * @param Vector3 $pos
-	 *
 	 * @return void
 	 */
 	public function updateAllLight(Vector3 $pos){
@@ -1585,12 +1463,6 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * Returns the highest block light level available in the positions adjacent to the specified block coordinates.
-	 *
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 *
-	 * @return int
 	 */
 	public function getHighestAdjacentBlockSkyLight(int $x, int $y, int $z) : int{
 		return max([
@@ -1604,10 +1476,6 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 *
 	 * @return void
 	 */
 	public function updateBlockSkyLight(int $x, int $y, int $z){
@@ -1652,12 +1520,6 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * Returns the highest block light level available in the positions adjacent to the specified block coordinates.
-	 *
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 *
-	 * @return int
 	 */
 	public function getHighestAdjacentBlockLight(int $x, int $y, int $z) : int{
 		return max([
@@ -1671,10 +1533,6 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 *
 	 * @return void
 	 */
 	public function updateBlockLight(int $x, int $y, int $z){
@@ -1718,10 +1576,7 @@ class Level implements ChunkManager, Metadatable{
 	 * If $update is true, it'll get the neighbour blocks (6 sides) and update them.
 	 * If you are doing big changes, you might want to set this to false, then update manually.
 	 *
-	 * @param Vector3 $pos
-	 * @param Block   $block
 	 * @param bool    $direct @deprecated
-	 * @param bool    $update
 	 *
 	 * @return bool Whether the block has been updated or not
 	 */
@@ -1788,10 +1643,7 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * @param Vector3 $source
-	 * @param Item    $item
 	 * @param Vector3 $motion
-	 * @param int     $delay
 	 *
 	 * @return ItemEntity|null
 	 */
@@ -1818,9 +1670,6 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * Drops XP orbs into the world for the specified amount, splitting the amount into several orbs if necessary.
-	 *
-	 * @param Vector3 $pos
-	 * @param int     $amount
 	 *
 	 * @return ExperienceOrb[]
 	 */
@@ -1855,9 +1704,6 @@ class Level implements ChunkManager, Metadatable{
 	 * Checks if the level spawn protection radius will prevent the player from using items or building at the specified
 	 * Vector3 position.
 	 *
-	 * @param Player  $player
-	 * @param Vector3 $vector
-	 *
 	 * @return bool true if spawn protection cancelled the action, false if not.
 	 */
 	public function checkSpawnProtection(Player $player, Vector3 $vector) : bool{
@@ -1878,12 +1724,8 @@ class Level implements ChunkManager, Metadatable{
 	 * Tries to break a block using a item, including Player time checks if available
 	 * It'll try to lower the durability if Item is a tool, and set it to Air if broken.
 	 *
-	 * @param Vector3 $vector
 	 * @param Item    $item reference parameter (if null, can break anything)
 	 * @param Player  $player
-	 * @param bool    $createParticles
-	 *
-	 * @return bool
 	 */
 	public function useBreakOn(Vector3 $vector, Item &$item = null, Player $player = null, bool $createParticles = false) : bool{
 		$target = $this->getBlock($vector);
@@ -1988,14 +1830,8 @@ class Level implements ChunkManager, Metadatable{
 	/**
 	 * Uses a item on a position and face, placing it or activating the block
 	 *
-	 * @param Vector3      $vector
-	 * @param Item         $item
-	 * @param int          $face
-	 * @param Vector3|null $clickVector
 	 * @param Player|null  $player default null
 	 * @param bool         $playSound Whether to play a block-place sound if the block was placed successfully.
-	 *
-	 * @return bool
 	 */
 	public function useItemOn(Vector3 $vector, Item &$item, int $face, Vector3 $clickVector = null, Player $player = null, bool $playSound = false) : bool{
 		$blockClicked = $this->getBlock($vector);
@@ -2112,8 +1948,6 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * @param int $entityId
-	 *
 	 * @return Entity|null
 	 */
 	public function getEntity(int $entityId){
@@ -2131,9 +1965,6 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * Returns the entities colliding the current one inside the AxisAlignedBB
-	 *
-	 * @param AxisAlignedBB $bb
-	 * @param Entity|null   $entity
 	 *
 	 * @return Entity[]
 	 */
@@ -2164,7 +1995,6 @@ class Level implements ChunkManager, Metadatable{
 	/**
 	 * Returns the entities near the current one inside the AxisAlignedBB
 	 *
-	 * @param AxisAlignedBB $bb
 	 * @param Entity        $entity
 	 *
 	 * @return Entity[]
@@ -2193,8 +2023,6 @@ class Level implements ChunkManager, Metadatable{
 	/**
 	 * Returns the closest Entity to the specified position, within the given radius.
 	 *
-	 * @param Vector3 $pos
-	 * @param float   $maxDistance
 	 * @param string  $entityType Class of entity to use for instanceof
 	 * @param bool    $includeDead Whether to include entitites which are dead
 	 *
@@ -2242,8 +2070,6 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * @param int $tileId
-	 *
 	 * @return Tile|null
 	 */
 	public function getTileById(int $tileId){
@@ -2271,10 +2097,6 @@ class Level implements ChunkManager, Metadatable{
 	 *
 	 * Note: This method wraps getTileAt(). If you're guaranteed to be passing integers, and you're using this method
 	 * in performance-sensitive code, consider using getTileAt() instead of this method for better performance.
-	 *
-	 * @param Vector3 $pos
-	 *
-	 * @return Tile|null
 	 */
 	public function getTile(Vector3 $pos) : ?Tile{
 		return $this->getTileAt((int) floor($pos->x), (int) floor($pos->y), (int) floor($pos->z));
@@ -2282,12 +2104,6 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * Returns the tile at the specified x,y,z coordinates, or null if it does not exist.
-	 *
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 *
-	 * @return Tile|null
 	 */
 	public function getTileAt(int $x, int $y, int $z) : ?Tile{
 		$chunk = $this->getChunk($x >> 4, $z >> 4);
@@ -2302,9 +2118,6 @@ class Level implements ChunkManager, Metadatable{
 	/**
 	 * Returns a list of the entities on a given chunk
 	 *
-	 * @param int $X
-	 * @param int $Z
-	 *
 	 * @return Entity[]
 	 */
 	public function getChunkEntities(int $X, int $Z) : array{
@@ -2313,9 +2126,6 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * Gives a list of the Tile entities on a given chunk
-	 *
-	 * @param int $X
-	 * @param int $Z
 	 *
 	 * @return Tile[]
 	 */
@@ -2326,10 +2136,6 @@ class Level implements ChunkManager, Metadatable{
 	/**
 	 * Gets the raw block id.
 	 *
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 *
 	 * @return int 0-255
 	 */
 	public function getBlockIdAt(int $x, int $y, int $z) : int{
@@ -2339,9 +2145,6 @@ class Level implements ChunkManager, Metadatable{
 	/**
 	 * Sets the raw block id.
 	 *
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
 	 * @param int $id 0-255
 	 *
 	 * @return void
@@ -2367,10 +2170,6 @@ class Level implements ChunkManager, Metadatable{
 	/**
 	 * Gets the raw block metadata
 	 *
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 *
 	 * @return int 0-15
 	 */
 	public function getBlockDataAt(int $x, int $y, int $z) : int{
@@ -2380,9 +2179,6 @@ class Level implements ChunkManager, Metadatable{
 	/**
 	 * Sets the raw block metadata.
 	 *
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
 	 * @param int $data 0-15
 	 *
 	 * @return void
@@ -2409,10 +2205,6 @@ class Level implements ChunkManager, Metadatable{
 	/**
 	 * Gets the raw block skylight level
 	 *
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 *
 	 * @return int 0-15
 	 */
 	public function getBlockSkyLightAt(int $x, int $y, int $z) : int{
@@ -2422,9 +2214,6 @@ class Level implements ChunkManager, Metadatable{
 	/**
 	 * Sets the raw block skylight level.
 	 *
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
 	 * @param int $level 0-15
 	 *
 	 * @return void
@@ -2436,10 +2225,6 @@ class Level implements ChunkManager, Metadatable{
 	/**
 	 * Gets the raw block light level
 	 *
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 *
 	 * @return int 0-15
 	 */
 	public function getBlockLightAt(int $x, int $y, int $z) : int{
@@ -2449,9 +2234,6 @@ class Level implements ChunkManager, Metadatable{
 	/**
 	 * Sets the raw block light level.
 	 *
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
 	 * @param int $level 0-15
 	 *
 	 * @return void
@@ -2460,52 +2242,26 @@ class Level implements ChunkManager, Metadatable{
 		$this->getChunk($x >> 4, $z >> 4, true)->setBlockLight($x & 0x0f, $y, $z & 0x0f, $level & 0x0f);
 	}
 
-	/**
-	 * @param int $x
-	 * @param int $z
-	 *
-	 * @return int
-	 */
 	public function getBiomeId(int $x, int $z) : int{
 		return $this->getChunk($x >> 4, $z >> 4, true)->getBiomeId($x & 0x0f, $z & 0x0f);
 	}
 
-	/**
-	 * @param int $x
-	 * @param int $z
-	 *
-	 * @return Biome
-	 */
 	public function getBiome(int $x, int $z) : Biome{
 		return Biome::getBiome($this->getBiomeId($x, $z));
 	}
 
 	/**
-	 * @param int $x
-	 * @param int $z
-	 * @param int $biomeId
-	 *
 	 * @return void
 	 */
 	public function setBiomeId(int $x, int $z, int $biomeId){
 		$this->getChunk($x >> 4, $z >> 4, true)->setBiomeId($x & 0x0f, $z & 0x0f, $biomeId);
 	}
 
-	/**
-	 * @param int $x
-	 * @param int $z
-	 *
-	 * @return int
-	 */
 	public function getHeightMap(int $x, int $z) : int{
 		return $this->getChunk($x >> 4, $z >> 4, true)->getHeightMap($x & 0x0f, $z & 0x0f);
 	}
 
 	/**
-	 * @param int $x
-	 * @param int $z
-	 * @param int $value
-	 *
 	 * @return void
 	 */
 	public function setHeightMap(int $x, int $z, int $value){
@@ -2523,8 +2279,6 @@ class Level implements ChunkManager, Metadatable{
 	 * Returns the chunk at the specified X/Z coordinates. If the chunk is not loaded, attempts to (synchronously!!!)
 	 * load it.
 	 *
-	 * @param int  $x
-	 * @param int  $z
 	 * @param bool $create Whether to create an empty chunk as a placeholder if the chunk does not exist
 	 *
 	 * @return Chunk|null
@@ -2541,11 +2295,6 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * Returns the chunk containing the given Vector3 position.
-	 *
-	 * @param Vector3 $pos
-	 * @param bool    $create
-	 *
-	 * @return null|Chunk
 	 */
 	public function getChunkAtPosition(Vector3 $pos, bool $create = false) : ?Chunk{
 		return $this->getChunk($pos->getFloorX() >> 4, $pos->getFloorZ() >> 4, $create);
@@ -2553,9 +2302,6 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * Returns the chunks adjacent to the specified chunk.
-	 *
-	 * @param int $x
-	 * @param int $z
 	 *
 	 * @return (Chunk|null)[]
 	 */
@@ -2575,10 +2321,6 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * @param int        $x
-	 * @param int        $z
-	 * @param Chunk|null $chunk
-	 *
 	 * @return void
 	 */
 	public function generateChunkCallback(int $x, int $z, ?Chunk $chunk){
@@ -2614,9 +2356,6 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * @param int        $chunkX
-	 * @param int        $chunkZ
-	 * @param Chunk|null $chunk
 	 * @param bool       $deleteEntitiesAndTiles Whether to delete entities and tiles on the old chunk, or transfer them to the new one
 	 *
 	 * @return void
@@ -2680,9 +2419,6 @@ class Level implements ChunkManager, Metadatable{
 	/**
 	 * Gets the highest block Y value at a specific $x and $z
 	 *
-	 * @param int $x
-	 * @param int $z
-	 *
 	 * @return int 0-255
 	 */
 	public function getHighestBlockAt(int $x, int $z) : int{
@@ -2691,42 +2427,20 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * Returns whether the given position is in a loaded area of terrain.
-	 *
-	 * @param Vector3 $pos
-	 *
-	 * @return bool
 	 */
 	public function isInLoadedTerrain(Vector3 $pos) : bool{
 		return $this->isChunkLoaded($pos->getFloorX() >> 4, $pos->getFloorZ() >> 4);
 	}
 
-	/**
-	 * @param int $x
-	 * @param int $z
-	 *
-	 * @return bool
-	 */
 	public function isChunkLoaded(int $x, int $z) : bool{
 		return isset($this->chunks[Level::chunkHash($x, $z)]);
 	}
 
-	/**
-	 * @param int $x
-	 * @param int $z
-	 *
-	 * @return bool
-	 */
 	public function isChunkGenerated(int $x, int $z) : bool{
 		$chunk = $this->getChunk($x, $z);
 		return $chunk !== null ? $chunk->isGenerated() : false;
 	}
 
-	/**
-	 * @param int $x
-	 * @param int $z
-	 *
-	 * @return bool
-	 */
 	public function isChunkPopulated(int $x, int $z) : bool{
 		$chunk = $this->getChunk($x, $z);
 		return $chunk !== null ? $chunk->isPopulated() : false;
@@ -2734,8 +2448,6 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * Returns a Position pointing to the spawn
-	 *
-	 * @return Position
 	 */
 	public function getSpawnLocation() : Position{
 		return Position::fromObject($this->provider->getSpawn(), $this);
@@ -2743,8 +2455,6 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * Sets the level spawn location
-	 *
-	 * @param Vector3 $pos
 	 *
 	 * @return void
 	 */
@@ -2755,10 +2465,6 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * @param int    $x
-	 * @param int    $z
-	 * @param Player $player
-	 *
 	 * @return void
 	 */
 	public function requestChunk(int $x, int $z, Player $player){
@@ -2821,10 +2527,6 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * @param int         $x
-	 * @param int         $z
-	 * @param BatchPacket $payload
-	 *
 	 * @return void
 	 */
 	public function chunkRequestCallback(int $x, int $z, BatchPacket $payload){
@@ -2843,8 +2545,6 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * @param Entity $entity
-	 *
 	 * @return void
 	 * @throws LevelException
 	 */
@@ -2865,8 +2565,6 @@ class Level implements ChunkManager, Metadatable{
 	/**
 	 * Removes the entity from the level index
 	 *
-	 * @param Entity $entity
-	 *
 	 * @return void
 	 * @throws LevelException
 	 */
@@ -2885,8 +2583,6 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * @param Tile $tile
-	 *
 	 * @return void
 	 * @throws LevelException
 	 */
@@ -2912,8 +2608,6 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * @param Tile $tile
-	 *
 	 * @return void
 	 * @throws LevelException
 	 */
@@ -2933,12 +2627,6 @@ class Level implements ChunkManager, Metadatable{
 		$this->clearChunkCache($chunkX, $chunkZ);
 	}
 
-	/**
-	 * @param int $x
-	 * @param int $z
-	 *
-	 * @return bool
-	 */
 	public function isChunkInUse(int $x, int $z) : bool{
 		return isset($this->chunkLoaders[$index = Level::chunkHash($x, $z)]) and count($this->chunkLoaders[$index]) > 0;
 	}
@@ -2946,8 +2634,6 @@ class Level implements ChunkManager, Metadatable{
 	/**
 	 * Attempts to load a chunk from the level provider (if not already loaded).
 	 *
-	 * @param int  $x
-	 * @param int  $z
 	 * @param bool $create Whether to create an empty chunk to load if the chunk cannot be loaded from disk.
 	 *
 	 * @return bool if loading the chunk was successful
@@ -3016,10 +2702,6 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * @param int  $x
-	 * @param int  $z
-	 * @param bool $safe
-	 *
 	 * @return bool
 	 */
 	public function unloadChunkRequest(int $x, int $z, bool $safe = true){
@@ -3033,9 +2715,6 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * @param int $x
-	 * @param int $z
-	 *
 	 * @return void
 	 */
 	public function cancelUnloadChunkRequest(int $x, int $z){
@@ -3099,11 +2778,6 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * Returns whether the chunk at the specified coordinates is a spawn chunk
-	 *
-	 * @param int $X
-	 * @param int $Z
-	 *
-	 * @return bool
 	 */
 	public function isSpawnChunk(int $X, int $Z) : bool{
 		$spawn = $this->provider->getSpawn();
@@ -3113,11 +2787,6 @@ class Level implements ChunkManager, Metadatable{
 		return abs($X - $spawnX) <= 1 and abs($Z - $spawnZ) <= 1;
 	}
 
-	/**
-	 * @param Vector3|null $spawn
-	 *
-	 * @return Position
-	 */
 	public function getSafeSpawn(?Vector3 $spawn = null) : Position{
 		if(!($spawn instanceof Vector3) or $spawn->y < 1){
 			$spawn = $this->getSpawnLocation();
@@ -3160,8 +2829,6 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * Gets the current time
-	 *
-	 * @return int
 	 */
 	public function getTime() : int{
 		return $this->time;
@@ -3169,8 +2836,6 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * Returns the Level name
-	 *
-	 * @return string
 	 */
 	public function getName() : string{
 		return $this->displayName;
@@ -3178,8 +2843,6 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * Returns the Level folder name
-	 *
-	 * @return string
 	 */
 	public function getFolderName() : string{
 		return $this->folderName;
@@ -3187,8 +2850,6 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * Sets the current time on the level
-	 *
-	 * @param int $time
 	 *
 	 * @return void
 	 */
@@ -3219,8 +2880,6 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * Gets the level seed
-	 *
-	 * @return int
 	 */
 	public function getSeed() : int{
 		return $this->provider->getSeed();
@@ -3228,8 +2887,6 @@ class Level implements ChunkManager, Metadatable{
 
 	/**
 	 * Sets the seed for the level
-	 *
-	 * @param int $seed
 	 *
 	 * @return void
 	 */
@@ -3241,16 +2898,11 @@ class Level implements ChunkManager, Metadatable{
 		return $this->worldHeight;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getDifficulty() : int{
 		return $this->provider->getDifficulty();
 	}
 
 	/**
-	 * @param int $difficulty
-	 *
 	 * @return void
 	 */
 	public function setDifficulty(int $difficulty){
@@ -3336,8 +2988,6 @@ class Level implements ChunkManager, Metadatable{
 	}
 
 	/**
-	 * @param bool $force
-	 *
 	 * @return void
 	 */
 	public function unloadChunks(bool $force = false){

--- a/src/pocketmine/level/Location.php
+++ b/src/pocketmine/level/Location.php
@@ -47,12 +47,9 @@ class Location extends Position{
 	}
 
 	/**
-	 * @param Vector3    $pos
 	 * @param Level|null $level default null
 	 * @param float      $yaw   default 0.0
 	 * @param float      $pitch default 0.0
-	 *
-	 * @return Location
 	 */
 	public static function fromObject(Vector3 $pos, Level $level = null, $yaw = 0.0, $pitch = 0.0) : Location{
 		return new Location($pos->x, $pos->y, $pos->z, $yaw, $pitch, $level ?? (($pos instanceof Position) ? $pos->level : null));
@@ -60,8 +57,6 @@ class Location extends Position{
 
 	/**
 	 * Return a Location instance
-	 *
-	 * @return Location
 	 */
 	public function asLocation() : Location{
 		return new Location($this->x, $this->y, $this->z, $this->yaw, $this->pitch, $this->level);

--- a/src/pocketmine/level/Location.php
+++ b/src/pocketmine/level/Location.php
@@ -38,7 +38,6 @@ class Location extends Position{
 	 * @param float|int $z
 	 * @param float     $yaw
 	 * @param float     $pitch
-	 * @param Level     $level
 	 */
 	public function __construct($x = 0, $y = 0, $z = 0, $yaw = 0.0, $pitch = 0.0, Level $level = null){
 		$this->yaw = $yaw;
@@ -47,7 +46,6 @@ class Location extends Position{
 	}
 
 	/**
-	 * @param Level|null $level default null
 	 * @param float      $yaw   default 0.0
 	 * @param float      $pitch default 0.0
 	 */

--- a/src/pocketmine/level/Position.php
+++ b/src/pocketmine/level/Position.php
@@ -36,7 +36,6 @@ class Position extends Vector3{
 	 * @param float|int $x
 	 * @param float|int $y
 	 * @param float|int $z
-	 * @param Level     $level
 	 */
 	public function __construct($x = 0, $y = 0, $z = 0, Level $level = null){
 		parent::__construct($x, $y, $z);

--- a/src/pocketmine/level/Position.php
+++ b/src/pocketmine/level/Position.php
@@ -44,9 +44,6 @@ class Position extends Vector3{
 	}
 
 	/**
-	 * @param Vector3    $pos
-	 * @param Level|null $level
-	 *
 	 * @return Position
 	 */
 	public static function fromObject(Vector3 $pos, Level $level = null){
@@ -55,8 +52,6 @@ class Position extends Vector3{
 
 	/**
 	 * Return a Position instance
-	 *
-	 * @return Position
 	 */
 	public function asPosition() : Position{
 		return new Position($this->x, $this->y, $this->z, $this->level);
@@ -80,8 +75,6 @@ class Position extends Vector3{
 	/**
 	 * Sets the target Level of the position.
 	 *
-	 * @param Level|null $level
-	 *
 	 * @return $this
 	 *
 	 * @throws \InvalidArgumentException if the specified Level has been closed
@@ -97,8 +90,6 @@ class Position extends Vector3{
 
 	/**
 	 * Checks if this object has a valid reference to a loaded Level
-	 *
-	 * @return bool
 	 */
 	public function isValid() : bool{
 		if($this->level !== null and $this->level->isClosed()){
@@ -112,9 +103,6 @@ class Position extends Vector3{
 
 	/**
 	 * Returns a side Vector
-	 *
-	 * @param int $side
-	 * @param int $step
 	 *
 	 * @return Position
 	 */

--- a/src/pocketmine/level/SimpleChunkManager.php
+++ b/src/pocketmine/level/SimpleChunkManager.php
@@ -39,9 +39,6 @@ class SimpleChunkManager implements ChunkManager{
 
 	/**
 	 * SimpleChunkManager constructor.
-	 *
-	 * @param int $seed
-	 * @param int $worldHeight
 	 */
 	public function __construct(int $seed, int $worldHeight = Level::Y_MAX){
 		$this->seed = $seed;
@@ -50,10 +47,6 @@ class SimpleChunkManager implements ChunkManager{
 
 	/**
 	 * Gets the raw block id.
-	 *
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
 	 *
 	 * @return int 0-255
 	 */
@@ -67,9 +60,6 @@ class SimpleChunkManager implements ChunkManager{
 	/**
 	 * Sets the raw block id.
 	 *
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
 	 * @param int $id 0-255
 	 *
 	 * @return void
@@ -83,10 +73,6 @@ class SimpleChunkManager implements ChunkManager{
 	/**
 	 * Gets the raw block metadata
 	 *
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 *
 	 * @return int 0-15
 	 */
 	public function getBlockDataAt(int $x, int $y, int $z) : int{
@@ -99,9 +85,6 @@ class SimpleChunkManager implements ChunkManager{
 	/**
 	 * Sets the raw block metadata.
 	 *
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
 	 * @param int $data 0-15
 	 *
 	 * @return void
@@ -141,9 +124,6 @@ class SimpleChunkManager implements ChunkManager{
 	}
 
 	/**
-	 * @param int $chunkX
-	 * @param int $chunkZ
-	 *
 	 * @return Chunk|null
 	 */
 	public function getChunk(int $chunkX, int $chunkZ){
@@ -151,10 +131,6 @@ class SimpleChunkManager implements ChunkManager{
 	}
 
 	/**
-	 * @param int        $chunkX
-	 * @param int        $chunkZ
-	 * @param Chunk|null $chunk
-	 *
 	 * @return void
 	 */
 	public function setChunk(int $chunkX, int $chunkZ, Chunk $chunk = null){
@@ -174,8 +150,6 @@ class SimpleChunkManager implements ChunkManager{
 
 	/**
 	 * Gets the level seed
-	 *
-	 * @return int
 	 */
 	public function getSeed() : int{
 		return $this->seed;

--- a/src/pocketmine/level/biome/Biome.php
+++ b/src/pocketmine/level/biome/Biome.php
@@ -77,9 +77,6 @@ abstract class Biome{
 	protected $temperature = 0.5;
 
 	/**
-	 * @param int   $id
-	 * @param Biome $biome
-	 *
 	 * @return void
 	 */
 	protected static function register(int $id, Biome $biome){
@@ -110,11 +107,6 @@ abstract class Biome{
 		self::register(self::BIRCH_FOREST, new ForestBiome(ForestBiome::TYPE_BIRCH));
 	}
 
-	/**
-	 * @param int $id
-	 *
-	 * @return Biome
-	 */
 	public static function getBiome(int $id) : Biome{
 		if(self::$biomes[$id] === null){
 			self::register($id, new UnknownBiome());
@@ -130,8 +122,6 @@ abstract class Biome{
 	}
 
 	/**
-	 * @param Populator $populator
-	 *
 	 * @return void
 	 */
 	public function addPopulator(Populator $populator){
@@ -139,11 +129,6 @@ abstract class Biome{
 	}
 
 	/**
-	 * @param ChunkManager $level
-	 * @param int          $chunkX
-	 * @param int          $chunkZ
-	 * @param Random       $random
-	 *
 	 * @return void
 	 */
 	public function populateChunk(ChunkManager $level, int $chunkX, int $chunkZ, Random $random){
@@ -160,8 +145,6 @@ abstract class Biome{
 	}
 
 	/**
-	 * @param int $id
-	 *
 	 * @return void
 	 */
 	public function setId(int $id){
@@ -186,9 +169,6 @@ abstract class Biome{
 	}
 
 	/**
-	 * @param int $min
-	 * @param int $max
-	 *
 	 * @return void
 	 */
 	public function setElevation(int $min, int $max){

--- a/src/pocketmine/level/format/Chunk.php
+++ b/src/pocketmine/level/format/Chunk.php
@@ -99,12 +99,9 @@ class Chunk{
 	protected $NBTentities = [];
 
 	/**
-	 * @param int                 $chunkX
-	 * @param int                 $chunkZ
 	 * @param SubChunkInterface[] $subChunks
 	 * @param CompoundTag[]       $entities
 	 * @param CompoundTag[]       $tiles
-	 * @param string              $biomeIds
 	 * @param int[]               $heightMap
 	 */
 	public function __construct(int $chunkX, int $chunkZ, array $subChunks = [], array $entities = [], array $tiles = [], string $biomeIds = "", array $heightMap = []){
@@ -139,23 +136,15 @@ class Chunk{
 		$this->NBTentities = $entities;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getX() : int{
 		return $this->x;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getZ() : int{
 		return $this->z;
 	}
 
 	/**
-	 * @param int $x
-	 *
 	 * @return void
 	 */
 	public function setX(int $x){
@@ -163,8 +152,6 @@ class Chunk{
 	}
 
 	/**
-	 * @param int $z
-	 *
 	 * @return void
 	 */
 	public function setZ(int $z){
@@ -173,8 +160,6 @@ class Chunk{
 
 	/**
 	 * Returns the chunk height in count of subchunks.
-	 *
-	 * @return int
 	 */
 	public function getHeight() : int{
 		return $this->height;
@@ -201,8 +186,6 @@ class Chunk{
 	 * @param int      $z 0-15
 	 * @param int|null $blockId 0-255 if null, does not change
 	 * @param int|null $meta 0-15 if null, does not change
-	 *
-	 * @return bool
 	 */
 	public function setBlock(int $x, int $y, int $z, ?int $blockId = null, ?int $meta = null) : bool{
 		if($this->getSubChunk($y >> 4, true)->setBlock($x, $y & 0x0f, $z, $blockId !== null ? ($blockId & 0xff) : null, $meta !== null ? ($meta & 0x0f) : null)){
@@ -300,8 +283,6 @@ class Chunk{
 	}
 
 	/**
-	 * @param int $level
-	 *
 	 * @return void
 	 */
 	public function setAllBlockSkyLight(int $level){
@@ -342,8 +323,6 @@ class Chunk{
 	}
 
 	/**
-	 * @param int $level
-	 *
 	 * @return void
 	 */
 	public function setAllBlockLight(int $level){
@@ -387,8 +366,6 @@ class Chunk{
 	 *
 	 * @param int $x 0-15
 	 * @param int $z 0-15
-	 *
-	 * @return int
 	 */
 	public function getHeightMap(int $x, int $z) : int{
 		return $this->heightMap[($z << 4) | $x];
@@ -399,7 +376,6 @@ class Chunk{
 	 *
 	 * @param int $x 0-15
 	 * @param int $z 0-15
-	 * @param int $value
 	 *
 	 * @return void
 	 */
@@ -507,8 +483,6 @@ class Chunk{
 	 *
 	 * @param int $x 0-15
 	 * @param int $z 0-15
-	 *
-	 * @return string
 	 */
 	public function getBlockIdColumn(int $x, int $z) : string{
 		$result = "";
@@ -524,8 +498,6 @@ class Chunk{
 	 *
 	 * @param int $x 0-15
 	 * @param int $z 0-15
-	 *
-	 * @return string
 	 */
 	public function getBlockDataColumn(int $x, int $z) : string{
 		$result = "";
@@ -540,8 +512,6 @@ class Chunk{
 	 *
 	 * @param int $x 0-15
 	 * @param int $z 0-15
-	 *
-	 * @return string
 	 */
 	public function getBlockSkyLightColumn(int $x, int $z) : string{
 		$result = "";
@@ -556,8 +526,6 @@ class Chunk{
 	 *
 	 * @param int $x 0-15
 	 * @param int $z 0-15
-	 *
-	 * @return string
 	 */
 	public function getBlockLightColumn(int $x, int $z) : string{
 		$result = "";
@@ -567,48 +535,33 @@ class Chunk{
 		return $result;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isLightPopulated() : bool{
 		return $this->lightPopulated;
 	}
 
 	/**
-	 * @param bool $value
-	 *
 	 * @return void
 	 */
 	public function setLightPopulated(bool $value = true){
 		$this->lightPopulated = $value;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isPopulated() : bool{
 		return $this->terrainPopulated;
 	}
 
 	/**
-	 * @param bool $value
-	 *
 	 * @return void
 	 */
 	public function setPopulated(bool $value = true){
 		$this->terrainPopulated = $value;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isGenerated() : bool{
 		return $this->terrainGenerated;
 	}
 
 	/**
-	 * @param bool $value
-	 *
 	 * @return void
 	 */
 	public function setGenerated(bool $value = true){
@@ -616,8 +569,6 @@ class Chunk{
 	}
 
 	/**
-	 * @param Entity $entity
-	 *
 	 * @return void
 	 */
 	public function addEntity(Entity $entity){
@@ -631,8 +582,6 @@ class Chunk{
 	}
 
 	/**
-	 * @param Entity $entity
-	 *
 	 * @return void
 	 */
 	public function removeEntity(Entity $entity){
@@ -643,8 +592,6 @@ class Chunk{
 	}
 
 	/**
-	 * @param Tile $tile
-	 *
 	 * @return void
 	 */
 	public function addTile(Tile $tile){
@@ -662,8 +609,6 @@ class Chunk{
 	}
 
 	/**
-	 * @param Tile $tile
-	 *
 	 * @return void
 	 */
 	public function removeTile(Tile $tile){
@@ -730,8 +675,6 @@ class Chunk{
 	/**
 	 * Deserializes tiles and entities from NBT
 	 *
-	 * @param Level $level
-	 *
 	 * @return void
 	 */
 	public function initChunk(Level $level){
@@ -786,9 +729,6 @@ class Chunk{
 		}
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getBiomeIdArray() : string{
 		return $this->biomeIds;
 	}
@@ -800,16 +740,11 @@ class Chunk{
 		return $this->heightMap->toArray();
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function hasChanged() : bool{
 		return $this->hasChanged;
 	}
 
 	/**
-	 * @param bool $value
-	 *
 	 * @return void
 	 */
 	public function setChanged(bool $value = true){
@@ -819,10 +754,7 @@ class Chunk{
 	/**
 	 * Returns the subchunk at the specified subchunk Y coordinate, or an empty, unmodifiable stub if it does not exist or the coordinate is out of range.
 	 *
-	 * @param int  $y
 	 * @param bool $generateNew Whether to create a new, modifiable subchunk if there is not one in place
-	 *
-	 * @return SubChunkInterface
 	 */
 	public function getSubChunk(int $y, bool $generateNew = false) : SubChunkInterface{
 		if($y < 0 or $y >= $this->height){
@@ -837,11 +769,7 @@ class Chunk{
 	/**
 	 * Sets a subchunk in the chunk index
 	 *
-	 * @param int                    $y
-	 * @param SubChunkInterface|null $subChunk
 	 * @param bool                   $allowEmpty Whether to check if the chunk is empty, and if so replace it with an empty stub
-	 *
-	 * @return bool
 	 */
 	public function setSubChunk(int $y, SubChunkInterface $subChunk = null, bool $allowEmpty = false) : bool{
 		if($y < 0 or $y >= $this->height){
@@ -865,8 +793,6 @@ class Chunk{
 
 	/**
 	 * Returns the Y coordinate of the highest non-empty subchunk in this chunk.
-	 *
-	 * @return int
 	 */
 	public function getHighestSubChunkIndex() : int{
 		for($y = $this->subChunks->count() - 1; $y >= 0; --$y){
@@ -882,8 +808,6 @@ class Chunk{
 
 	/**
 	 * Returns the count of subchunks that need sending to players
-	 *
-	 * @return int
 	 */
 	public function getSubChunkSendCount() : int{
 		return $this->getHighestSubChunkIndex() + 1;
@@ -906,8 +830,6 @@ class Chunk{
 
 	/**
 	 * Serializes the chunk for sending to players
-	 *
-	 * @return string
 	 */
 	public function networkSerialize() : string{
 		$result = "";
@@ -930,8 +852,6 @@ class Chunk{
 	/**
 	 * Fast-serializes the chunk for passing between threads
 	 * TODO: tiles and entities
-	 *
-	 * @return string
 	 */
 	public function fastSerialize() : string{
 		$stream = new BinaryStream();
@@ -967,10 +887,6 @@ class Chunk{
 
 	/**
 	 * Deserializes a fast-serialized chunk
-	 *
-	 * @param string $data
-	 *
-	 * @return Chunk
 	 */
 	public static function fastDeserialize(string $data) : Chunk{
 		$stream = new BinaryStream($data);

--- a/src/pocketmine/level/format/SubChunkInterface.php
+++ b/src/pocketmine/level/format/SubChunkInterface.php
@@ -25,185 +25,55 @@ namespace pocketmine\level\format;
 
 interface SubChunkInterface{
 
-	/**
-	 * @param bool $checkLight
-	 *
-	 * @return bool
-	 */
 	public function isEmpty(bool $checkLight = true) : bool;
 
-	/**
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 *
-	 * @return int
-	 */
 	public function getBlockId(int $x, int $y, int $z) : int;
 
-	/**
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 * @param int $id
-	 *
-	 * @return bool
-	 */
 	public function setBlockId(int $x, int $y, int $z, int $id) : bool;
 
-	/**
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 *
-	 * @return int
-	 */
 	public function getBlockData(int $x, int $y, int $z) : int;
 
-	/**
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 * @param int $data
-	 *
-	 * @return bool
-	 */
 	public function setBlockData(int $x, int $y, int $z, int $data) : bool;
 
-	/**
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 *
-	 * @return int
-	 */
 	public function getFullBlock(int $x, int $y, int $z) : int;
 
-	/**
-	 * @param int      $x
-	 * @param int      $y
-	 * @param int      $z
-	 * @param int|null $id
-	 * @param int|null $data
-	 *
-	 * @return bool
-	 */
 	public function setBlock(int $x, int $y, int $z, ?int $id = null, ?int $data = null) : bool;
 
-	/**
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 *
-	 * @return int
-	 */
 	public function getBlockLight(int $x, int $y, int $z) : int;
 
-	/**
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 * @param int $level
-	 *
-	 * @return bool
-	 */
 	public function setBlockLight(int $x, int $y, int $z, int $level) : bool;
 
-	/**
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 *
-	 * @return int
-	 */
 	public function getBlockSkyLight(int $x, int $y, int $z) : int;
 
-	/**
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 * @param int $level
-	 *
-	 * @return bool
-	 */
 	public function setBlockSkyLight(int $x, int $y, int $z, int $level) : bool;
 
-	/**
-	 * @param int $x
-	 * @param int $z
-	 *
-	 * @return int
-	 */
 	public function getHighestBlockAt(int $x, int $z) : int;
 
-	/**
-	 * @param int $x
-	 * @param int $z
-	 *
-	 * @return string
-	 */
 	public function getBlockIdColumn(int $x, int $z) : string;
 
-	/**
-	 * @param int $x
-	 * @param int $z
-	 *
-	 * @return string
-	 */
 	public function getBlockDataColumn(int $x, int $z) : string;
 
-	/**
-	 * @param int $x
-	 * @param int $z
-	 *
-	 * @return string
-	 */
 	public function getBlockLightColumn(int $x, int $z) : string;
 
-	/**
-	 * @param int $x
-	 * @param int $z
-	 *
-	 * @return string
-	 */
 	public function getBlockSkyLightColumn(int $x, int $z) : string;
 
-	/**
-	 * @return string
-	 */
 	public function getBlockIdArray() : string;
 
-	/**
-	 * @return string
-	 */
 	public function getBlockDataArray() : string;
 
-	/**
-	 * @return string
-	 */
 	public function getBlockSkyLightArray() : string;
 
 	/**
-	 * @param string $data
-	 *
 	 * @return void
 	 */
 	public function setBlockSkyLightArray(string $data);
 
-	/**
-	 * @return string
-	 */
 	public function getBlockLightArray() : string;
 
 	/**
-	 * @param string $data
-	 *
 	 * @return void
 	 */
 	public function setBlockLightArray(string $data);
 
-	/**
-	 * @return string
-	 */
 	public function networkSerialize() : string;
 }

--- a/src/pocketmine/level/format/io/BaseLevelProvider.php
+++ b/src/pocketmine/level/format/io/BaseLevelProvider.php
@@ -143,9 +143,6 @@ abstract class BaseLevelProvider implements LevelProvider{
 
 	}
 
-	/**
-	 * @return CompoundTag
-	 */
 	public function getLevelData() : CompoundTag{
 		return $this->levelData;
 	}
@@ -162,10 +159,6 @@ abstract class BaseLevelProvider implements LevelProvider{
 	}
 
 	/**
-	 * @param int $chunkX
-	 * @param int $chunkZ
-	 *
-	 * @return Chunk|null
 	 * @throws CorruptedChunkException
 	 * @throws UnsupportedChunkFormatException
 	 */
@@ -181,10 +174,6 @@ abstract class BaseLevelProvider implements LevelProvider{
 	}
 
 	/**
-	 * @param int $chunkX
-	 * @param int $chunkZ
-	 *
-	 * @return Chunk|null
 	 * @throws UnsupportedChunkFormatException
 	 * @throws CorruptedChunkException
 	 */

--- a/src/pocketmine/level/format/io/ChunkUtils.php
+++ b/src/pocketmine/level/format/io/ChunkUtils.php
@@ -98,8 +98,6 @@ if(!extension_loaded('pocketmine_chunkutils')){
 		 * Converts pre-MCPE-1.0 biome color array to biome ID array.
 		 *
 		 * @param int[] $array of biome color values
-		 *
-		 * @return string
 		 */
 		public static function convertBiomeColors(array $array) : string{
 			$result = str_repeat("\x00", 256);

--- a/src/pocketmine/level/format/io/LevelProvider.php
+++ b/src/pocketmine/level/format/io/LevelProvider.php
@@ -30,48 +30,28 @@ use pocketmine\math\Vector3;
 
 interface LevelProvider{
 
-	/**
-	 * @param string $path
-	 */
 	public function __construct(string $path);
 
 	/**
 	 * Returns the full provider name, like "anvil" or "mcregion", will be used to find the correct format.
-	 *
-	 * @return string
 	 */
 	public static function getProviderName() : string;
 
 	/**
 	 * Gets the build height limit of this world
-	 *
-	 * @return int
 	 */
 	public function getWorldHeight() : int;
 
-	/**
-	 * @return string
-	 */
 	public function getPath() : string;
 
 	/**
 	 * Tells if the path is a valid level.
 	 * This must tell if the current format supports opening the files in the directory
-	 *
-	 * @param string $path
-	 *
-	 * @return bool
 	 */
 	public static function isValid(string $path) : bool;
 
 	/**
 	 * Generate the needed files in the path given
-	 *
-	 * @param string  $path
-	 * @param string  $name
-	 * @param int     $seed
-	 * @param string  $generator
-	 * @param array   $options
 	 *
 	 * @return void
 	 */
@@ -79,87 +59,54 @@ interface LevelProvider{
 
 	/**
 	 * Returns the generator name
-	 *
-	 * @return string
 	 */
 	public function getGenerator() : string;
 
-	/**
-	 * @return array
-	 */
 	public function getGeneratorOptions() : array;
 
 	/**
 	 * Saves a chunk (usually to disk).
-	 *
-	 * @param Chunk $chunk
 	 */
 	public function saveChunk(Chunk $chunk) : void;
 
 	/**
 	 * Loads a chunk (usually from disk storage) and returns it. If the chunk does not exist, null is returned.
 	 *
-	 * @param int $chunkX
-	 * @param int $chunkZ
-	 *
-	 * @return null|Chunk
-	 *
 	 * @throws CorruptedChunkException
 	 * @throws UnsupportedChunkFormatException
 	 */
 	public function loadChunk(int $chunkX, int $chunkZ) : ?Chunk;
 
-	/**
-	 * @return string
-	 */
 	public function getName() : string;
 
-	/**
-	 * @return int
-	 */
 	public function getTime() : int;
 
 	/**
-	 * @param int $value
-	 *
 	 * @return void
 	 */
 	public function setTime(int $value);
 
-	/**
-	 * @return int
-	 */
 	public function getSeed() : int;
 
 	/**
-	 * @param int $value
-	 *
 	 * @return void
 	 */
 	public function setSeed(int $value);
 
-	/**
-	 * @return Vector3
-	 */
 	public function getSpawn() : Vector3;
 
 	/**
-	 * @param Vector3 $pos
-	 *
 	 * @return void
 	 */
 	public function setSpawn(Vector3 $pos);
 
 	/**
 	 * Returns the world difficulty. This will be one of the Level constants.
-	 * @return int
 	 */
 	public function getDifficulty() : int;
 
 	/**
 	 * Sets the world difficulty.
-	 *
-	 * @param int $difficulty
 	 *
 	 * @return void
 	 */

--- a/src/pocketmine/level/format/io/LevelProviderManager.php
+++ b/src/pocketmine/level/format/io/LevelProviderManager.php
@@ -42,8 +42,6 @@ abstract class LevelProviderManager{
 	}
 
 	/**
-	 * @param string $class
-	 *
 	 * @return void
 	 * @throws \InvalidArgumentException
 	 */
@@ -67,8 +65,6 @@ abstract class LevelProviderManager{
 	/**
 	 * Returns a LevelProvider class for this path, or null
 	 *
-	 * @param string $path
-	 *
 	 * @return string|null
 	 */
 	public static function getProvider(string $path){
@@ -84,8 +80,6 @@ abstract class LevelProviderManager{
 
 	/**
 	 * Returns a LevelProvider by name, or null if not found
-	 *
-	 * @param string $name
 	 *
 	 * @return string|null
 	 */

--- a/src/pocketmine/level/format/io/leveldb/LevelDB.php
+++ b/src/pocketmine/level/format/io/leveldb/LevelDB.php
@@ -297,10 +297,6 @@ class LevelDB extends BaseLevelProvider{
 	}
 
 	/**
-	 * @param int $chunkX
-	 * @param int $chunkZ
-	 *
-	 * @return Chunk|null
 	 * @throws UnsupportedChunkFormatException
 	 */
 	protected function readChunk(int $chunkX, int $chunkZ) : ?Chunk{
@@ -521,7 +517,6 @@ class LevelDB extends BaseLevelProvider{
 
 	/**
 	 * @param CompoundTag[] $targets
-	 * @param string        $index
 	 */
 	private function writeTags(array $targets, string $index) : void{
 		if(count($targets) > 0){
@@ -532,9 +527,6 @@ class LevelDB extends BaseLevelProvider{
 		}
 	}
 
-	/**
-	 * @return \LevelDB
-	 */
 	public function getDatabase() : \LevelDB{
 		return $this->db;
 	}

--- a/src/pocketmine/level/format/io/region/McRegion.php
+++ b/src/pocketmine/level/format/io/region/McRegion.php
@@ -67,11 +67,6 @@ class McRegion extends BaseLevelProvider{
 	/** @var RegionLoader[] */
 	protected $regions = [];
 
-	/**
-	 * @param Chunk $chunk
-	 *
-	 * @return string
-	 */
 	protected function nbtSerialize(Chunk $chunk) : string{
 		$nbt = new CompoundTag("Level", []);
 		$nbt->setInt("xPos", $chunk->getX());
@@ -127,9 +122,6 @@ class McRegion extends BaseLevelProvider{
 	}
 
 	/**
-	 * @param string $data
-	 *
-	 * @return Chunk
 	 * @throws CorruptedChunkException
 	 */
 	protected function nbtDeserialize(string $data) : Chunk{
@@ -206,9 +198,6 @@ class McRegion extends BaseLevelProvider{
 	}
 
 	/**
-	 * @param string $context
-	 * @param ListTag $list
-	 *
 	 * @return CompoundTag[]
 	 * @throws CorruptedChunkException
 	 */
@@ -236,7 +225,6 @@ class McRegion extends BaseLevelProvider{
 
 	/**
 	 * Returns the storage version as per Minecraft PC world formats.
-	 * @return int
 	 */
 	public static function getPcWorldFormatVersion() : int{
 		return 19132; //mcregion
@@ -329,8 +317,6 @@ class McRegion extends BaseLevelProvider{
 	}
 
 	/**
-	 * @param int $chunkX
-	 * @param int $chunkZ
 	 * @param int $regionX reference parameter
 	 * @param int $regionZ reference parameter
 	 *
@@ -342,9 +328,6 @@ class McRegion extends BaseLevelProvider{
 	}
 
 	/**
-	 * @param int $regionX
-	 * @param int $regionZ
-	 *
 	 * @return RegionLoader|null
 	 */
 	protected function getRegion(int $regionX, int $regionZ){
@@ -353,20 +336,12 @@ class McRegion extends BaseLevelProvider{
 
 	/**
 	 * Returns the path to a specific region file based on its X/Z coordinates
-	 *
-	 * @param int $regionX
-	 * @param int $regionZ
-	 *
-	 * @return string
 	 */
 	protected function pathToRegion(int $regionX, int $regionZ) : string{
 		return $this->path . "region/r.$regionX.$regionZ." . static::REGION_FILE_EXTENSION;
 	}
 
 	/**
-	 * @param int $regionX
-	 * @param int $regionZ
-	 *
 	 * @return void
 	 */
 	protected function loadRegion(int $regionX, int $regionZ){
@@ -402,11 +377,6 @@ class McRegion extends BaseLevelProvider{
 	}
 
 	/**
-	 * @param int $chunkX
-	 * @param int $chunkZ
-	 *
-	 * @return Chunk|null
-	 *
 	 * @throws CorruptedChunkException
 	 */
 	protected function readChunk(int $chunkX, int $chunkZ) : ?Chunk{

--- a/src/pocketmine/level/format/io/region/RegionLoader.php
+++ b/src/pocketmine/level/format/io/region/RegionLoader.php
@@ -122,10 +122,6 @@ class RegionLoader{
 	}
 
 	/**
-	 * @param int $x
-	 * @param int $z
-	 *
-	 * @return null|string
 	 * @throws \InvalidArgumentException if invalid coordinates are given
 	 * @throws CorruptedChunkException if chunk corruption is detected
 	 */
@@ -174,10 +170,6 @@ class RegionLoader{
 	}
 
 	/**
-	 * @param int $x
-	 * @param int $z
-	 *
-	 * @return bool
 	 * @throws \InvalidArgumentException
 	 */
 	public function chunkExists(int $x, int $z) : bool{
@@ -185,10 +177,6 @@ class RegionLoader{
 	}
 
 	/**
-	 * @param int    $x
-	 * @param int    $z
-	 * @param string $chunkData
-	 *
 	 * @return void
 	 * @throws ChunkException
 	 * @throws \InvalidArgumentException
@@ -219,9 +207,6 @@ class RegionLoader{
 	}
 
 	/**
-	 * @param int $x
-	 * @param int $z
-	 *
 	 * @return void
 	 * @throws \InvalidArgumentException
 	 */
@@ -232,10 +217,6 @@ class RegionLoader{
 	}
 
 	/**
-	 * @param int $x
-	 * @param int $z
-	 *
-	 * @return int
 	 * @throws \InvalidArgumentException
 	 */
 	protected static function getChunkOffset(int $x, int $z) : int{
@@ -246,7 +227,6 @@ class RegionLoader{
 	}
 
 	/**
-	 * @param int $offset
 	 * @param int $x reference parameter
 	 * @param int $z reference parameter
 	 */
@@ -257,8 +237,6 @@ class RegionLoader{
 
 	/**
 	 * Writes the region header and closes the file
-	 *
-	 * @param bool $writeHeader
 	 *
 	 * @return void
 	 */

--- a/src/pocketmine/level/format/io/region/RegionLocationTableEntry.php
+++ b/src/pocketmine/level/format/io/region/RegionLocationTableEntry.php
@@ -35,10 +35,6 @@ class RegionLocationTableEntry{
 	private $timestamp;
 
 	/**
-	 * @param int $firstSector
-	 * @param int $sectorCount
-	 * @param int $timestamp
-	 *
 	 * @throws \InvalidArgumentException
 	 */
 	public function __construct(int $firstSector, int $sectorCount, int $timestamp){
@@ -53,16 +49,10 @@ class RegionLocationTableEntry{
 		$this->timestamp = $timestamp;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getFirstSector() : int{
 		return $this->firstSector;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getLastSector() : int{
 		return $this->firstSector + $this->sectorCount - 1;
 	}
@@ -75,23 +65,14 @@ class RegionLocationTableEntry{
 		return range($this->getFirstSector(), $this->getLastSector());
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getSectorCount() : int{
 		return $this->sectorCount;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getTimestamp() : int{
 		return $this->timestamp;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isNull() : bool{
 		return $this->firstSector === 0 or $this->sectorCount === 0;
 	}

--- a/src/pocketmine/level/generator/Flat.php
+++ b/src/pocketmine/level/generator/Flat.php
@@ -64,8 +64,6 @@ class Flat extends Generator{
 	}
 
 	/**
-	 * @param array $options
-	 *
 	 * @throws InvalidGeneratorOptionsException
 	 */
 	public function __construct(array $options = []){
@@ -96,8 +94,6 @@ class Flat extends Generator{
 	}
 
 	/**
-	 * @param string $layers
-	 *
 	 * @return int[][]
 	 * @throws InvalidGeneratorOptionsException
 	 */

--- a/src/pocketmine/level/generator/Generator.php
+++ b/src/pocketmine/level/generator/Generator.php
@@ -36,10 +36,6 @@ abstract class Generator{
 
 	/**
 	 * Converts a string level seed into an integer for use by the generator.
-	 *
-	 * @param string $seed
-	 *
-	 * @return int|null
 	 */
 	public static function convertSeed(string $seed) : ?int{
 		if($seed === ""){ //empty seed should cause a random seed to be selected - can't use 0 here because 0 is a valid seed
@@ -59,8 +55,6 @@ abstract class Generator{
 	protected $random;
 
 	/**
-	 * @param array $settings
-	 *
 	 * @throws InvalidGeneratorOptionsException
 	 */
 	abstract public function __construct(array $settings = []);

--- a/src/pocketmine/level/generator/GeneratorManager.php
+++ b/src/pocketmine/level/generator/GeneratorManager.php
@@ -73,7 +73,6 @@ final class GeneratorManager{
 	/**
 	 * Returns a class name of a registered Generator matching the given name.
 	 *
-	 * @param string $name
 	 * @param bool   $throwOnMissing @deprecated this is for backwards compatibility only
 	 *
 	 * @return string|Generator Name of class that extends Generator (not an actual Generator object)
@@ -94,8 +93,6 @@ final class GeneratorManager{
 	 * Returns the registered name of the given Generator class.
 	 *
 	 * @param string $class Fully qualified name of class that extends \pocketmine\level\generator\Generator
-	 *
-	 * @return string
 	 */
 	public static function getGeneratorName(string $class) : string{
 		foreach(self::$list as $name => $c){

--- a/src/pocketmine/level/generator/biome/BiomeSelector.php
+++ b/src/pocketmine/level/generator/biome/BiomeSelector.php
@@ -45,9 +45,6 @@ abstract class BiomeSelector{
 	/**
 	 * Lookup function called by recalculate() to determine the biome to use for this temperature and rainfall.
 	 *
-	 * @param float $temperature
-	 * @param float $rainfall
-	 *
 	 * @return int biome ID 0-255
 	 */
 	abstract protected function lookup(float $temperature, float $rainfall) : int;
@@ -92,8 +89,6 @@ abstract class BiomeSelector{
 	/**
 	 * @param int $x
 	 * @param int $z
-	 *
-	 * @return Biome
 	 */
 	public function pickBiome($x, $z) : Biome{
 		$temperature = (int) ($this->getTemperature($x, $z) * 63);

--- a/src/pocketmine/level/generator/hell/Nether.php
+++ b/src/pocketmine/level/generator/hell/Nether.php
@@ -53,8 +53,6 @@ class Nether extends Generator{
 	private $noiseBase;
 
 	/**
-	 * @param array $options
-	 *
 	 * @throws InvalidGeneratorOptionsException
 	 */
 	public function __construct(array $options = []){

--- a/src/pocketmine/level/generator/noise/Noise.php
+++ b/src/pocketmine/level/generator/noise/Noise.php
@@ -48,8 +48,6 @@ abstract class Noise{
 
 	/**
 	 * @param float $x
-	 *
-	 * @return int
 	 */
 	public static function floor($x) : int{
 		return $x >= 0 ? (int) $x : (int) ($x - 1);
@@ -250,16 +248,6 @@ abstract class Noise{
 		return $result;
 	}
 
-
-	/**
-	 * @param int $xSize
-	 * @param int $samplingRate
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 *
-	 * @return \SplFixedArray
-	 */
 	public function getFastNoise1D(int $xSize, int $samplingRate, int $x, int $y, int $z) : \SplFixedArray{
 		if($samplingRate === 0){
 			throw new \InvalidArgumentException("samplingRate cannot be 0");
@@ -284,16 +272,6 @@ abstract class Noise{
 		return $noiseArray;
 	}
 
-	/**
-	 * @param int $xSize
-	 * @param int $zSize
-	 * @param int $samplingRate
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 *
-	 * @return \SplFixedArray
-	 */
 	public function getFastNoise2D(int $xSize, int $zSize, int $samplingRate, int $x, int $y, int $z) : \SplFixedArray{
 		assert($samplingRate !== 0, new \InvalidArgumentException("samplingRate cannot be 0"));
 
@@ -330,19 +308,6 @@ abstract class Noise{
 		return $noiseArray;
 	}
 
-	/**
-	 * @param int $xSize
-	 * @param int $ySize
-	 * @param int $zSize
-	 * @param int $xSamplingRate
-	 * @param int $ySamplingRate
-	 * @param int $zSamplingRate
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 *
-	 * @return array
-	 */
 	public function getFastNoise3D(int $xSize, int $ySize, int $zSize, int $xSamplingRate, int $ySamplingRate, int $zSamplingRate, int $x, int $y, int $z) : array{
 
 		assert($xSamplingRate !== 0, new \InvalidArgumentException("xSamplingRate cannot be 0"));

--- a/src/pocketmine/level/generator/noise/Perlin.php
+++ b/src/pocketmine/level/generator/noise/Perlin.php
@@ -35,7 +35,6 @@ class Perlin extends Noise{
 
 
 	/**
-	 * @param Random $random
 	 * @param int    $octaves
 	 * @param float  $persistence
 	 * @param float  $expansion

--- a/src/pocketmine/level/generator/noise/Simplex.php
+++ b/src/pocketmine/level/generator/noise/Simplex.php
@@ -84,7 +84,6 @@ class Simplex extends Perlin{
 
 
 	/**
-	 * @param Random $random
 	 * @param int    $octaves
 	 * @param float  $persistence
 	 * @param float  $expansion

--- a/src/pocketmine/level/generator/normal/Normal.php
+++ b/src/pocketmine/level/generator/normal/Normal.php
@@ -61,8 +61,6 @@ class Normal extends Generator{
 	private static $SMOOTH_SIZE = 2;
 
 	/**
-	 * @param array $options
-	 *
 	 * @throws InvalidGeneratorOptionsException
 	 */
 	public function __construct(array $options = []){

--- a/src/pocketmine/level/generator/object/BigTree.php
+++ b/src/pocketmine/level/generator/object/BigTree.php
@@ -36,12 +36,6 @@ class BigTree extends Tree{
 	}
 
 	/**
-	 * @param ChunkManager $level
-	 * @param int          $x
-	 * @param int          $y
-	 * @param int          $z
-	 * @param Random       $random
-	 *
 	 * @return void
 	 */
 	public function placeObject(ChunkManager $level, int $x, int $y, int $z, Random $random){

--- a/src/pocketmine/level/generator/object/BirchTree.php
+++ b/src/pocketmine/level/generator/object/BirchTree.php
@@ -41,12 +41,6 @@ class BirchTree extends Tree{
 	}
 
 	/**
-	 * @param ChunkManager $level
-	 * @param int          $x
-	 * @param int          $y
-	 * @param int          $z
-	 * @param Random       $random
-	 *
 	 * @return void
 	 */
 	public function placeObject(ChunkManager $level, int $x, int $y, int $z, Random $random){

--- a/src/pocketmine/level/generator/object/OakTree.php
+++ b/src/pocketmine/level/generator/object/OakTree.php
@@ -37,12 +37,6 @@ class OakTree extends Tree{
 	}
 
 	/**
-	 * @param ChunkManager $level
-	 * @param int          $x
-	 * @param int          $y
-	 * @param int          $z
-	 * @param Random       $random
-	 *
 	 * @return void
 	 */
 	public function placeObject(ChunkManager $level, int $x, int $y, int $z, Random $random){

--- a/src/pocketmine/level/generator/object/Ore.php
+++ b/src/pocketmine/level/generator/object/Ore.php
@@ -50,11 +50,6 @@ class Ore{
 	}
 
 	/**
-	 * @param ChunkManager $level
-	 * @param int          $x
-	 * @param int          $y
-	 * @param int          $z
-	 *
 	 * @return void
 	 */
 	public function placeObject(ChunkManager $level, int $x, int $y, int $z){

--- a/src/pocketmine/level/generator/object/Pond.php
+++ b/src/pocketmine/level/generator/object/Pond.php
@@ -44,9 +44,6 @@ class Pond{
 	}
 
 	/**
-	 * @param ChunkManager $level
-	 * @param Vector3      $pos
-	 *
 	 * @return void
 	 */
 	public function placeObject(ChunkManager $level, Vector3 $pos){

--- a/src/pocketmine/level/generator/object/SpruceTree.php
+++ b/src/pocketmine/level/generator/object/SpruceTree.php
@@ -40,12 +40,6 @@ class SpruceTree extends Tree{
 	}
 
 	/**
-	 * @param ChunkManager $level
-	 * @param int          $x
-	 * @param int          $y
-	 * @param int          $z
-	 * @param Random       $random
-	 *
 	 * @return void
 	 */
 	public function placeObject(ChunkManager $level, int $x, int $y, int $z, Random $random){

--- a/src/pocketmine/level/generator/object/TallGrass.php
+++ b/src/pocketmine/level/generator/object/TallGrass.php
@@ -32,12 +32,6 @@ use function count;
 class TallGrass{
 
 	/**
-	 * @param ChunkManager $level
-	 * @param Vector3      $pos
-	 * @param Random       $random
-	 * @param int          $count
-	 * @param int          $radius
-	 *
 	 * @return void
 	 */
 	public static function growGrass(ChunkManager $level, Vector3 $pos, Random $random, int $count = 15, int $radius = 10){

--- a/src/pocketmine/level/generator/object/Tree.php
+++ b/src/pocketmine/level/generator/object/Tree.php
@@ -50,13 +50,6 @@ abstract class Tree{
 	public $treeHeight = 7;
 
 	/**
-	 * @param ChunkManager $level
-	 * @param int          $x
-	 * @param int          $y
-	 * @param int          $z
-	 * @param Random       $random
-	 * @param int          $type
-	 *
 	 * @return void
 	 */
 	public static function growTree(ChunkManager $level, int $x, int $y, int $z, Random $random, int $type = 0){
@@ -111,12 +104,6 @@ abstract class Tree{
 	}
 
 	/**
-	 * @param ChunkManager $level
-	 * @param int          $x
-	 * @param int          $y
-	 * @param int          $z
-	 * @param Random       $random
-	 *
 	 * @return void
 	 */
 	public function placeObject(ChunkManager $level, int $x, int $y, int $z, Random $random){
@@ -143,13 +130,6 @@ abstract class Tree{
 	}
 
 	/**
-	 * @param ChunkManager $level
-	 * @param int          $x
-	 * @param int          $y
-	 * @param int          $z
-	 * @param Random       $random
-	 * @param int          $trunkHeight
-	 *
 	 * @return void
 	 */
 	protected function placeTrunk(ChunkManager $level, int $x, int $y, int $z, Random $random, int $trunkHeight){

--- a/src/pocketmine/level/generator/populator/Pond.php
+++ b/src/pocketmine/level/generator/populator/Pond.php
@@ -50,8 +50,6 @@ class Pond extends Populator{
 	}
 
 	/**
-	 * @param int $waterOdd
-	 *
 	 * @return void
 	 */
 	public function setWaterOdd(int $waterOdd){
@@ -59,8 +57,6 @@ class Pond extends Populator{
 	}
 
 	/**
-	 * @param int $lavaOdd
-	 *
 	 * @return void
 	 */
 	public function setLavaOdd(int $lavaOdd){
@@ -68,8 +64,6 @@ class Pond extends Populator{
 	}
 
 	/**
-	 * @param int $lavaSurfaceOdd
-	 *
 	 * @return void
 	 */
 	public function setLavaSurfaceOdd(int $lavaSurfaceOdd){

--- a/src/pocketmine/level/generator/populator/Populator.php
+++ b/src/pocketmine/level/generator/populator/Populator.php
@@ -32,11 +32,6 @@ use pocketmine\utils\Random;
 abstract class Populator{
 
 	/**
-	 * @param ChunkManager $level
-	 * @param int          $chunkX
-	 * @param int          $chunkZ
-	 * @param Random       $random
-	 *
 	 * @return mixed
 	 */
 	abstract public function populate(ChunkManager $level, int $chunkX, int $chunkZ, Random $random);

--- a/src/pocketmine/level/light/LightUpdate.php
+++ b/src/pocketmine/level/light/LightUpdate.php
@@ -60,21 +60,11 @@ abstract class LightUpdate{
 	abstract protected function getLight(int $x, int $y, int $z) : int;
 
 	/**
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 * @param int $level
-	 *
 	 * @return void
 	 */
 	abstract protected function setLight(int $x, int $y, int $z, int $level);
 
 	/**
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 * @param int $newLevel
-	 *
 	 * @return void
 	 */
 	public function setAndUpdateLight(int $x, int $y, int $z, int $newLevel){
@@ -157,11 +147,6 @@ abstract class LightUpdate{
 	}
 
 	/**
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 * @param int $oldAdjacentLevel
-	 *
 	 * @return void
 	 */
 	protected function computeRemoveLight(int $x, int $y, int $z, int $oldAdjacentLevel){
@@ -185,11 +170,6 @@ abstract class LightUpdate{
 	}
 
 	/**
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
-	 * @param int $newAdjacentLevel
-	 *
 	 * @return void
 	 */
 	protected function computeSpreadLight(int $x, int $y, int $z, int $newAdjacentLevel){

--- a/src/pocketmine/level/particle/FloatingTextParticle.php
+++ b/src/pocketmine/level/particle/FloatingTextParticle.php
@@ -48,11 +48,6 @@ class FloatingTextParticle extends Particle{
 	/** @var bool */
 	protected $invisible = false;
 
-	/**
-	 * @param Vector3 $pos
-	 * @param string  $text
-	 * @param string  $title
-	 */
 	public function __construct(Vector3 $pos, string $text, string $title = ""){
 		parent::__construct($pos->x, $pos->y, $pos->z);
 		$this->text = $text;

--- a/src/pocketmine/metadata/BlockMetadataStore.php
+++ b/src/pocketmine/metadata/BlockMetadataStore.php
@@ -43,9 +43,6 @@ class BlockMetadataStore extends MetadataStore{
 	}
 
 	/**
-	 * @param Block  $subject
-	 * @param string $metadataKey
-	 *
 	 * @return MetadataValue[]
 	 */
 	public function getMetadata(Block $subject, string $metadataKey){
@@ -57,10 +54,6 @@ class BlockMetadataStore extends MetadataStore{
 	}
 
 	/**
-	 * @param Block  $subject
-	 * @param string $metadataKey
-	 * @param Plugin $owningPlugin
-	 *
 	 * @return void
 	 */
 	public function removeMetadata(Block $subject, string $metadataKey, Plugin $owningPlugin){
@@ -68,10 +61,6 @@ class BlockMetadataStore extends MetadataStore{
 	}
 
 	/**
-	 * @param Block         $subject
-	 * @param string        $metadataKey
-	 * @param MetadataValue $newMetadataValue
-	 *
 	 * @return void
 	 */
 	public function setMetadata(Block $subject, string $metadataKey, MetadataValue $newMetadataValue){

--- a/src/pocketmine/metadata/EntityMetadataStore.php
+++ b/src/pocketmine/metadata/EntityMetadataStore.php
@@ -33,9 +33,6 @@ class EntityMetadataStore extends MetadataStore{
 	}
 
 	/**
-	 * @param Entity $subject
-	 * @param string $metadataKey
-	 *
 	 * @return MetadataValue[]
 	 */
 	public function getMetadata(Entity $subject, string $metadataKey){
@@ -47,10 +44,6 @@ class EntityMetadataStore extends MetadataStore{
 	}
 
 	/**
-	 * @param Entity $subject
-	 * @param string $metadataKey
-	 * @param Plugin $owningPlugin
-	 *
 	 * @return void
 	 */
 	public function removeMetadata(Entity $subject, string $metadataKey, Plugin $owningPlugin){
@@ -58,10 +51,6 @@ class EntityMetadataStore extends MetadataStore{
 	}
 
 	/**
-	 * @param Entity        $subject
-	 * @param string        $metadataKey
-	 * @param MetadataValue $newMetadataValue
-	 *
 	 * @return void
 	 */
 	public function setMetadata(Entity $subject, string $metadataKey, MetadataValue $newMetadataValue){

--- a/src/pocketmine/metadata/LevelMetadataStore.php
+++ b/src/pocketmine/metadata/LevelMetadataStore.php
@@ -34,9 +34,6 @@ class LevelMetadataStore extends MetadataStore{
 	}
 
 	/**
-	 * @param Level  $subject
-	 * @param string $metadataKey
-	 *
 	 * @return MetadataValue[]
 	 */
 	public function getMetadata(Level $subject, string $metadataKey){
@@ -48,10 +45,6 @@ class LevelMetadataStore extends MetadataStore{
 	}
 
 	/**
-	 * @param Level  $subject
-	 * @param string $metadataKey
-	 * @param Plugin $owningPlugin
-	 *
 	 * @return void
 	 */
 	public function removeMetadata(Level $subject, string $metadataKey, Plugin $owningPlugin){
@@ -59,10 +52,6 @@ class LevelMetadataStore extends MetadataStore{
 	}
 
 	/**
-	 * @param Level         $subject
-	 * @param string        $metadataKey
-	 * @param MetadataValue $newMetadataValue
-	 *
 	 * @return void
 	 */
 	public function setMetadata(Level $subject, string $metadataKey, MetadataValue $newMetadataValue){

--- a/src/pocketmine/metadata/MetadataStore.php
+++ b/src/pocketmine/metadata/MetadataStore.php
@@ -35,9 +35,6 @@ abstract class MetadataStore{
 	/**
 	 * Adds a metadata value to an object.
 	 *
-	 * @param string        $key
-	 * @param MetadataValue $newMetadataValue
-	 *
 	 * @return void
 	 */
 	protected function setMetadataInternal(string $key, MetadataValue $newMetadataValue){
@@ -56,8 +53,6 @@ abstract class MetadataStore{
 	 * Returns all metadata values attached to an object. If multiple
 	 * have attached metadata, each will value will be included.
 	 *
-	 * @param string $key
-	 *
 	 * @return MetadataValue[]
 	 */
 	protected function getMetadataInternal(string $key){
@@ -70,10 +65,6 @@ abstract class MetadataStore{
 
 	/**
 	 * Tests to see if a metadata attribute has been set on an object.
-	 *
-	 * @param string $key
-	 *
-	 * @return bool
 	 */
 	protected function hasMetadataInternal(string $key) : bool{
 		return isset($this->metadataMap[$key]);
@@ -81,9 +72,6 @@ abstract class MetadataStore{
 
 	/**
 	 * Removes a metadata item owned by a plugin from a subject.
-	 *
-	 * @param string $key
-	 * @param Plugin $owningPlugin
 	 *
 	 * @return void
 	 */
@@ -100,8 +88,6 @@ abstract class MetadataStore{
 	 * Invalidates all metadata in the metadata store that originates from the
 	 * given plugin. Doing this will force each invalidated metadata item to
 	 * be recalculated the next time it is accessed.
-	 *
-	 * @param Plugin $owningPlugin
 	 *
 	 * @return void
 	 */

--- a/src/pocketmine/metadata/Metadatable.php
+++ b/src/pocketmine/metadata/Metadatable.php
@@ -30,9 +30,6 @@ interface Metadatable{
 	/**
 	 * Sets a metadata value in the implementing object's metadata store.
 	 *
-	 * @param string        $metadataKey
-	 * @param MetadataValue $newMetadataValue
-	 *
 	 * @return void
 	 */
 	public function setMetadata(string $metadataKey, MetadataValue $newMetadataValue);
@@ -41,8 +38,6 @@ interface Metadatable{
 	 * Returns a list of previously set metadata values from the implementing
 	 * object's metadata store.
 	 *
-	 * @param string $metadataKey
-	 *
 	 * @return MetadataValue[]
 	 */
 	public function getMetadata(string $metadataKey);
@@ -50,19 +45,12 @@ interface Metadatable{
 	/**
 	 * Tests to see whether the implementing object contains the given
 	 * metadata value in its metadata store.
-	 *
-	 * @param string $metadataKey
-	 *
-	 * @return bool
 	 */
 	public function hasMetadata(string $metadataKey) : bool;
 
 	/**
 	 * Removes the given metadata value from the implementing object's
 	 * metadata store.
-	 *
-	 * @param string $metadataKey
-	 * @param Plugin $owningPlugin
 	 *
 	 * @return void
 	 */

--- a/src/pocketmine/metadata/PlayerMetadataStore.php
+++ b/src/pocketmine/metadata/PlayerMetadataStore.php
@@ -34,9 +34,6 @@ class PlayerMetadataStore extends MetadataStore{
 	}
 
 	/**
-	 * @param IPlayer $subject
-	 * @param string  $metadataKey
-	 *
 	 * @return MetadataValue[]
 	 */
 	public function getMetadata(IPlayer $subject, string $metadataKey){
@@ -48,10 +45,6 @@ class PlayerMetadataStore extends MetadataStore{
 	}
 
 	/**
-	 * @param IPlayer $subject
-	 * @param string  $metadataKey
-	 * @param Plugin  $owningPlugin
-	 *
 	 * @return void
 	 */
 	public function removeMetadata(IPlayer $subject, string $metadataKey, Plugin $owningPlugin){
@@ -59,10 +52,6 @@ class PlayerMetadataStore extends MetadataStore{
 	}
 
 	/**
-	 * @param IPlayer       $subject
-	 * @param string        $metadataKey
-	 * @param MetadataValue $newMetadataValue
-	 *
 	 * @return void
 	 */
 	public function setMetadata(IPlayer $subject, string $metadataKey, MetadataValue $newMetadataValue){

--- a/src/pocketmine/network/AdvancedSourceInterface.php
+++ b/src/pocketmine/network/AdvancedSourceInterface.php
@@ -35,7 +35,6 @@ interface AdvancedSourceInterface extends SourceInterface{
 	/**
 	 * Prevents packets received from the IP address getting processed for the given timeout.
 	 *
-	 * @param string $address
 	 * @param int    $timeout Seconds
 	 *
 	 * @return void
@@ -45,25 +44,17 @@ interface AdvancedSourceInterface extends SourceInterface{
 	/**
 	 * Unblocks a previously-blocked address.
 	 *
-	 * @param string $address
-	 *
 	 * @return void
 	 */
 	public function unblockAddress(string $address);
 
 	/**
-	 * @param Network $network
-	 *
 	 * @return void
 	 */
 	public function setNetwork(Network $network);
 
 	/**
 	 * Sends a raw payload to the network interface, bypassing any sessions.
-	 *
-	 * @param string $address
-	 * @param int    $port
-	 * @param string $payload
 	 *
 	 * @return void
 	 */

--- a/src/pocketmine/network/CompressBatchedTask.php
+++ b/src/pocketmine/network/CompressBatchedTask.php
@@ -36,7 +36,6 @@ class CompressBatchedTask extends AsyncTask{
 	public $data;
 
 	/**
-	 * @param BatchPacket $batch
 	 * @param Player[]    $targets
 	 */
 	public function __construct(BatchPacket $batch, array $targets){

--- a/src/pocketmine/network/Network.php
+++ b/src/pocketmine/network/Network.php
@@ -112,17 +112,12 @@ class Network{
 
 	/**
 	 * @deprecated
-	 * @param SourceInterface $interface
-	 *
-	 * @return void
 	 */
 	public function processInterface(SourceInterface $interface) : void{
 		$interface->process();
 	}
 
 	/**
-	 * @param SourceInterface $interface
-	 *
 	 * @return void
 	 */
 	public function registerInterface(SourceInterface $interface){
@@ -140,8 +135,6 @@ class Network{
 	}
 
 	/**
-	 * @param SourceInterface $interface
-	 *
 	 * @return void
 	 */
 	public function unregisterInterface(SourceInterface $interface){
@@ -152,8 +145,6 @@ class Network{
 	/**
 	 * Sets the server name shown on each interface Query
 	 *
-	 * @param string $name
-	 *
 	 * @return void
 	 */
 	public function setName(string $name){
@@ -163,9 +154,6 @@ class Network{
 		}
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getName() : string{
 		return $this->name;
 	}
@@ -179,18 +167,11 @@ class Network{
 		}
 	}
 
-	/**
-	 * @return Server
-	 */
 	public function getServer() : Server{
 		return $this->server;
 	}
 
 	/**
-	 * @param string $address
-	 * @param int    $port
-	 * @param string $payload
-	 *
 	 * @return void
 	 */
 	public function sendPacket(string $address, int $port, string $payload){
@@ -202,9 +183,6 @@ class Network{
 	/**
 	 * Blocks an IP address from the main interface. Setting timeout to -1 will block it forever
 	 *
-	 * @param string $address
-	 * @param int    $timeout
-	 *
 	 * @return void
 	 */
 	public function blockAddress(string $address, int $timeout = 300){
@@ -214,8 +192,6 @@ class Network{
 	}
 
 	/**
-	 * @param string $address
-	 *
 	 * @return void
 	 */
 	public function unblockAddress(string $address){

--- a/src/pocketmine/network/SourceInterface.php
+++ b/src/pocketmine/network/SourceInterface.php
@@ -44,11 +44,6 @@ interface SourceInterface{
 	/**
 	 * Sends a DataPacket to the interface, returns an unique identifier for the packet if $needACK is true
 	 *
-	 * @param Player     $player
-	 * @param DataPacket $packet
-	 * @param bool       $needACK
-	 * @param bool       $immediate
-	 *
 	 * @return int|null
 	 */
 	public function putPacket(Player $player, DataPacket $packet, bool $needACK = false, bool $immediate = true);
@@ -56,16 +51,11 @@ interface SourceInterface{
 	/**
 	 * Terminates the connection
 	 *
-	 * @param Player $player
-	 * @param string $reason
-	 *
 	 * @return void
 	 */
 	public function close(Player $player, string $reason = "unknown reason");
 
 	/**
-	 * @param string $name
-	 *
 	 * @return void
 	 */
 	public function setName(string $name);

--- a/src/pocketmine/network/mcpe/NetworkBinaryStream.php
+++ b/src/pocketmine/network/mcpe/NetworkBinaryStream.php
@@ -104,8 +104,6 @@ class NetworkBinaryStream extends BinaryStream{
 	}
 
 	/**
-	 * @param SkinData $skin
-	 *
 	 * @return void
 	 */
 	public function putSkin(SkinData $skin){
@@ -275,8 +273,6 @@ class NetworkBinaryStream extends BinaryStream{
 	 * Decodes entity metadata from the stream.
 	 *
 	 * @param bool $types Whether to include metadata types along with values in the returned array
-	 *
-	 * @return array
 	 */
 	public function getEntityMetadata(bool $types = true) : array{
 		$count = $this->getUnsignedVarInt();
@@ -329,8 +325,6 @@ class NetworkBinaryStream extends BinaryStream{
 
 	/**
 	 * Writes entity metadata to the packet buffer.
-	 *
-	 * @param array $metadata
 	 */
 	public function putEntityMetadata(array $metadata) : void{
 		$this->putUnsignedVarInt(count($metadata));
@@ -427,7 +421,6 @@ class NetworkBinaryStream extends BinaryStream{
 
 	/**
 	 * Reads and returns an EntityUniqueID
-	 * @return int
 	 */
 	public function getEntityUniqueId() : int{
 		return $this->getVarLong();
@@ -435,8 +428,6 @@ class NetworkBinaryStream extends BinaryStream{
 
 	/**
 	 * Writes an EntityUniqueID
-	 *
-	 * @param int $eid
 	 */
 	public function putEntityUniqueId(int $eid) : void{
 		$this->putVarLong($eid);
@@ -444,7 +435,6 @@ class NetworkBinaryStream extends BinaryStream{
 
 	/**
 	 * Reads and returns an EntityRuntimeID
-	 * @return int
 	 */
 	public function getEntityRuntimeId() : int{
 		return $this->getUnsignedVarLong();
@@ -452,8 +442,6 @@ class NetworkBinaryStream extends BinaryStream{
 
 	/**
 	 * Writes an EntityRuntimeID
-	 *
-	 * @param int $eid
 	 */
 	public function putEntityRuntimeId(int $eid) : void{
 		$this->putUnsignedVarLong($eid);
@@ -474,10 +462,6 @@ class NetworkBinaryStream extends BinaryStream{
 
 	/**
 	 * Writes a block position with unsigned Y coordinate.
-	 *
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
 	 */
 	public function putBlockPosition(int $x, int $y, int $z) : void{
 		$this->putVarInt($x);
@@ -500,10 +484,6 @@ class NetworkBinaryStream extends BinaryStream{
 
 	/**
 	 * Writes a block position with a signed Y coordinate.
-	 *
-	 * @param int $x
-	 * @param int $y
-	 * @param int $z
 	 */
 	public function putSignedBlockPosition(int $x, int $y, int $z) : void{
 		$this->putVarInt($x);
@@ -513,8 +493,6 @@ class NetworkBinaryStream extends BinaryStream{
 
 	/**
 	 * Reads a floating-point Vector3 object with coordinates rounded to 4 decimal places.
-	 *
-	 * @return Vector3
 	 */
 	public function getVector3() : Vector3{
 		return new Vector3(
@@ -531,8 +509,6 @@ class NetworkBinaryStream extends BinaryStream{
 	 * For all other purposes, use the non-nullable version.
 	 *
 	 * @see NetworkBinaryStream::putVector3()
-	 *
-	 * @param Vector3|null $vector
 	 */
 	public function putVector3Nullable(?Vector3 $vector) : void{
 		if($vector){
@@ -546,8 +522,6 @@ class NetworkBinaryStream extends BinaryStream{
 
 	/**
 	 * Writes a floating-point Vector3 object
-	 *
-	 * @param Vector3 $vector
 	 */
 	public function putVector3(Vector3 $vector) : void{
 		$this->putLFloat($vector->x);
@@ -597,8 +571,6 @@ class NetworkBinaryStream extends BinaryStream{
 	/**
 	 * Writes a gamerule array, members should be in the structure [name => [type, value]]
 	 * TODO: implement this properly
-	 *
-	 * @param array $rules
 	 */
 	public function putGameRules(array $rules) : void{
 		$this->putUnsignedVarInt(count($rules));
@@ -619,9 +591,6 @@ class NetworkBinaryStream extends BinaryStream{
 		}
 	}
 
-	/**
-	 * @return EntityLink
-	 */
 	protected function getEntityLink() : EntityLink{
 		$link = new EntityLink();
 
@@ -633,9 +602,6 @@ class NetworkBinaryStream extends BinaryStream{
 		return $link;
 	}
 
-	/**
-	 * @param EntityLink $link
-	 */
 	protected function putEntityLink(EntityLink $link) : void{
 		$this->putEntityUniqueId($link->fromEntityUniqueId);
 		$this->putEntityUniqueId($link->toEntityUniqueId);

--- a/src/pocketmine/network/mcpe/NetworkSession.php
+++ b/src/pocketmine/network/mcpe/NetworkSession.php
@@ -170,8 +170,6 @@ use pocketmine\network\mcpe\protocol\VideoStreamConnectPacket;
 abstract class NetworkSession{
 
 	/**
-	 * @param DataPacket $packet
-	 *
 	 * @return void
 	 */
 	abstract public function handleDataPacket(DataPacket $packet);

--- a/src/pocketmine/network/mcpe/PlayerNetworkSessionAdapter.php
+++ b/src/pocketmine/network/mcpe/PlayerNetworkSessionAdapter.php
@@ -268,9 +268,6 @@ class PlayerNetworkSessionAdapter extends NetworkSession{
 	/**
 	 * Hack to work around a stupid bug in Minecraft W10 which causes empty strings to be sent unquoted in form responses.
 	 *
-	 * @param string $json
-	 * @param bool   $assoc
-	 *
 	 * @return mixed
 	 */
 	private static function stupid_json_decode(string $json, bool $assoc = false){

--- a/src/pocketmine/network/mcpe/VerifyLoginTask.php
+++ b/src/pocketmine/network/mcpe/VerifyLoginTask.php
@@ -92,10 +92,6 @@ class VerifyLoginTask extends AsyncTask{
 	}
 
 	/**
-	 * @param string      $jwt
-	 * @param null|string $currentPublicKey
-	 * @param bool        $first
-	 *
 	 * @throws VerifyLoginException if errors are encountered
 	 */
 	private function validateToken(string $jwt, ?string &$currentPublicKey, bool $first = false) : void{

--- a/src/pocketmine/network/mcpe/protocol/AddEntityPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/AddEntityPacket.php
@@ -39,9 +39,6 @@ class AddEntityPacket extends DataPacket/* implements ClientboundPacket*/{
 		return $result;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getUvarint1() : int{
 		return $this->uvarint1;
 	}

--- a/src/pocketmine/network/mcpe/protocol/AdventureSettingsPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/AdventureSettingsPacket.php
@@ -103,9 +103,6 @@ class AdventureSettingsPacket extends DataPacket{
 	}
 
 	/**
-	 * @param int  $flag
-	 * @param bool $value
-	 *
 	 * @return void
 	 */
 	public function setFlag(int $flag, bool $value){

--- a/src/pocketmine/network/mcpe/protocol/AvailableCommandsPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/AvailableCommandsPacket.php
@@ -149,7 +149,6 @@ class AvailableCommandsPacket extends DataPacket{
 	/**
 	 * @param string[] $enumValueList
 	 *
-	 * @return CommandEnum
 	 * @throws \UnexpectedValueException
 	 * @throws BinaryDataException
 	 */
@@ -184,7 +183,6 @@ class AvailableCommandsPacket extends DataPacket{
 	}
 
 	/**
-	 * @param CommandEnum $enum
 	 * @param int[]       $enumValueMap string enum name -> int index
 	 */
 	protected function putEnum(CommandEnum $enum, array $enumValueMap) : void{
@@ -211,9 +209,6 @@ class AvailableCommandsPacket extends DataPacket{
 	}
 
 	/**
-	 * @param int $valueCount
-	 *
-	 * @return int
 	 * @throws BinaryDataException
 	 */
 	protected function getEnumValueIndex(int $valueCount) : int{
@@ -239,8 +234,6 @@ class AvailableCommandsPacket extends DataPacket{
 	/**
 	 * @param CommandEnum[] $enums
 	 * @param string[]      $enumValues
-	 *
-	 * @return CommandEnumConstraint
 	 */
 	protected function getEnumConstraint(array $enums, array $enumValues) : CommandEnumConstraint{
 		//wtf, what was wrong with an offset inside the enum? :(
@@ -267,7 +260,6 @@ class AvailableCommandsPacket extends DataPacket{
 	}
 
 	/**
-	 * @param CommandEnumConstraint $constraint
 	 * @param int[]                 $enumIndexes string enum name -> int index
 	 * @param int[]                 $enumValueIndexes string value -> int index
 	 */
@@ -284,7 +276,6 @@ class AvailableCommandsPacket extends DataPacket{
 	 * @param CommandEnum[] $enums
 	 * @param string[]      $postfixes
 	 *
-	 * @return CommandData
 	 * @throws \UnexpectedValueException
 	 * @throws BinaryDataException
 	 */
@@ -329,7 +320,6 @@ class AvailableCommandsPacket extends DataPacket{
 	}
 
 	/**
-	 * @param CommandData $data
 	 * @param int[]       $enumIndexes string enum name -> int index
 	 * @param int[]       $postfixIndexes
 	 */

--- a/src/pocketmine/network/mcpe/protocol/BatchPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/BatchPacket.php
@@ -76,8 +76,6 @@ class BatchPacket extends DataPacket{
 	}
 
 	/**
-	 * @param DataPacket $packet
-	 *
 	 * @return void
 	 */
 	public function addPacket(DataPacket $packet){
@@ -110,8 +108,6 @@ class BatchPacket extends DataPacket{
 	}
 
 	/**
-	 * @param int $level
-	 *
 	 * @return void
 	 */
 	public function setCompressionLevel(int $level){

--- a/src/pocketmine/network/mcpe/protocol/ClientCacheBlobStatusPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/ClientCacheBlobStatusPacket.php
@@ -39,8 +39,6 @@ class ClientCacheBlobStatusPacket extends DataPacket/* implements ServerboundPac
 	/**
 	 * @param int[] $hitHashes
 	 * @param int[] $missHashes
-	 *
-	 * @return self
 	 */
 	public static function create(array $hitHashes, array $missHashes) : self{
 		//type checks

--- a/src/pocketmine/network/mcpe/protocol/ClientCacheMissResponsePacket.php
+++ b/src/pocketmine/network/mcpe/protocol/ClientCacheMissResponsePacket.php
@@ -37,8 +37,6 @@ class ClientCacheMissResponsePacket extends DataPacket/* implements ClientboundP
 
 	/**
 	 * @param ChunkCacheBlob[] $blobs
-	 *
-	 * @return self
 	 */
 	public static function create(array $blobs) : self{
 		//type check

--- a/src/pocketmine/network/mcpe/protocol/ClientCacheStatusPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/ClientCacheStatusPacket.php
@@ -39,9 +39,6 @@ class ClientCacheStatusPacket extends DataPacket/* implements ServerboundPacket*
 		return $result;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isEnabled() : bool{
 		return $this->enabled;
 	}

--- a/src/pocketmine/network/mcpe/protocol/CommandOutputPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/CommandOutputPacket.php
@@ -87,8 +87,6 @@ class CommandOutputPacket extends DataPacket{
 	}
 
 	/**
-	 * @param CommandOutputMessage $message
-	 *
 	 * @return void
 	 */
 	protected function putCommandMessage(CommandOutputMessage $message){

--- a/src/pocketmine/network/mcpe/protocol/CraftingDataPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/CraftingDataPacket.php
@@ -164,10 +164,6 @@ class CraftingDataPacket extends DataPacket{
 
 	/**
 	 * @param object              $entry
-	 * @param NetworkBinaryStream $stream
-	 * @param int                 $pos
-	 *
-	 * @return int
 	 */
 	private static function writeEntry($entry, NetworkBinaryStream $stream, int $pos) : int{
 		if($entry instanceof ShapelessRecipe){
@@ -239,8 +235,6 @@ class CraftingDataPacket extends DataPacket{
 	}
 
 	/**
-	 * @param ShapelessRecipe $recipe
-	 *
 	 * @return void
 	 */
 	public function addShapelessRecipe(ShapelessRecipe $recipe){
@@ -248,8 +242,6 @@ class CraftingDataPacket extends DataPacket{
 	}
 
 	/**
-	 * @param ShapedRecipe $recipe
-	 *
 	 * @return void
 	 */
 	public function addShapedRecipe(ShapedRecipe $recipe){
@@ -257,8 +249,6 @@ class CraftingDataPacket extends DataPacket{
 	}
 
 	/**
-	 * @param FurnaceRecipe $recipe
-	 *
 	 * @return void
 	 */
 	public function addFurnaceRecipe(FurnaceRecipe $recipe){

--- a/src/pocketmine/network/mcpe/protocol/DataPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/DataPacket.php
@@ -70,7 +70,6 @@ abstract class DataPacket extends NetworkBinaryStream{
 
 	/**
 	 * Returns whether the packet may legally have unread bytes left in the buffer.
-	 * @return bool
 	 */
 	public function mayHaveUnreadBytes() : bool{
 		return false;
@@ -141,8 +140,6 @@ abstract class DataPacket extends NetworkBinaryStream{
 	 *
 	 * This method returns a bool to indicate whether the packet was handled or not. If the packet was unhandled, a debug message will be logged with a hexdump of the packet.
 	 * Typically this method returns the return value of the handler in the supplied NetworkSession. See other packets for examples how to implement this.
-	 *
-	 * @param NetworkSession $session
 	 *
 	 * @return bool true if the packet was handled successfully, false if not.
 	 */

--- a/src/pocketmine/network/mcpe/protocol/EmotePacket.php
+++ b/src/pocketmine/network/mcpe/protocol/EmotePacket.php
@@ -49,7 +49,6 @@ class EmotePacket extends DataPacket/* implements ClientboundPacket, Serverbound
 
 	/**
 	 * TODO: we can't call this getEntityRuntimeId() because of base class collision (crap architecture, thanks Shoghi)
-	 * @return int
 	 */
 	public function getEntityRuntimeIdField() : int{
 		return $this->entityRuntimeId;

--- a/src/pocketmine/network/mcpe/protocol/LevelChunkPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/LevelChunkPacket.php
@@ -70,30 +70,18 @@ class LevelChunkPacket extends DataPacket/* implements ClientboundPacket*/{
 		return $result;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getChunkX() : int{
 		return $this->chunkX;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getChunkZ() : int{
 		return $this->chunkZ;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getSubChunkCount() : int{
 		return $this->subChunkCount;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isCacheEnabled() : bool{
 		return $this->cacheEnabled;
 	}
@@ -105,9 +93,6 @@ class LevelChunkPacket extends DataPacket/* implements ClientboundPacket*/{
 		return $this->usedBlobHashes;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getExtraPayload() : string{
 		return $this->extraPayload;
 	}

--- a/src/pocketmine/network/mcpe/protocol/LevelEventGenericPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/LevelEventGenericPacket.php
@@ -44,16 +44,10 @@ class LevelEventGenericPacket extends DataPacket/* implements ClientboundPacket*
 		return $result;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getEventId() : int{
 		return $this->eventId;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getEventData() : string{
 		return $this->eventData;
 	}

--- a/src/pocketmine/network/mcpe/protocol/PacketPool.php
+++ b/src/pocketmine/network/mcpe/protocol/PacketPool.php
@@ -181,27 +181,17 @@ class PacketPool{
 	}
 
 	/**
-	 * @param DataPacket $packet
-	 *
 	 * @return void
 	 */
 	public static function registerPacket(DataPacket $packet){
 		static::$pool[$packet->pid()] = clone $packet;
 	}
 
-	/**
-	 * @param int $pid
-	 *
-	 * @return DataPacket
-	 */
 	public static function getPacketById(int $pid) : DataPacket{
 		return isset(static::$pool[$pid]) ? clone static::$pool[$pid] : new UnknownPacket();
 	}
 
 	/**
-	 * @param string $buffer
-	 *
-	 * @return DataPacket
 	 * @throws BinaryDataException
 	 */
 	public static function getPacket(string $buffer) : DataPacket{

--- a/src/pocketmine/network/mcpe/protocol/PlayerAuthInputPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/PlayerAuthInputPacket.php
@@ -56,18 +56,9 @@ class PlayerAuthInputPacket extends DataPacket/* implements ServerboundPacket*/{
 	private $vrGazeDirection = null;
 
 	/**
-	 * @param Vector3      $position
-	 * @param float        $pitch
-	 * @param float        $yaw
-	 * @param float        $headYaw
-	 * @param float        $moveVecX
-	 * @param float        $moveVecZ
-	 * @param int          $inputFlags
 	 * @param int          $inputMode @see InputMode
 	 * @param int          $playMode @see PlayMode
 	 * @param Vector3|null $vrGazeDirection only used when PlayMode::VR
-	 *
-	 * @return self
 	 */
 	public static function create(Vector3 $position, float $pitch, float $yaw, float $headYaw, float $moveVecX, float $moveVecZ, int $inputFlags, int $inputMode, int $playMode, ?Vector3 $vrGazeDirection = null) : self{
 		if($playMode === PlayMode::VR and $vrGazeDirection === null){
@@ -120,7 +111,6 @@ class PlayerAuthInputPacket extends DataPacket/* implements ServerboundPacket*/{
 
 	/**
 	 * @see InputMode
-	 * @return int
 	 */
 	public function getInputMode() : int{
 		return $this->inputMode;
@@ -128,7 +118,6 @@ class PlayerAuthInputPacket extends DataPacket/* implements ServerboundPacket*/{
 
 	/**
 	 * @see PlayMode
-	 * @return int
 	 */
 	public function getPlayMode() : int{
 		return $this->playMode;

--- a/src/pocketmine/network/mcpe/protocol/RemoveEntityPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/RemoveEntityPacket.php
@@ -39,9 +39,6 @@ class RemoveEntityPacket extends DataPacket/* implements ClientboundPacket*/{
 		return $result;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getUvarint1() : int{
 		return $this->uvarint1;
 	}

--- a/src/pocketmine/network/mcpe/protocol/types/ChunkCacheBlob.php
+++ b/src/pocketmine/network/mcpe/protocol/types/ChunkCacheBlob.php
@@ -31,25 +31,16 @@ class ChunkCacheBlob{
 
 	/**
 	 * ChunkCacheBlob constructor.
-	 *
-	 * @param int    $hash
-	 * @param string $payload
 	 */
 	public function __construct(int $hash, string $payload){
 		$this->hash = $hash;
 		$this->payload = $payload;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getHash() : int{
 		return $this->hash;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getPayload() : string{
 		return $this->payload;
 	}

--- a/src/pocketmine/network/mcpe/protocol/types/CommandEnumConstraint.php
+++ b/src/pocketmine/network/mcpe/protocol/types/CommandEnumConstraint.php
@@ -32,8 +32,6 @@ class CommandEnumConstraint{
 	private $constraints; //TODO: find constants
 
 	/**
-	 * @param CommandEnum $enum
-	 * @param int         $valueOffset
 	 * @param int[]       $constraints
 	 */
 	public function __construct(CommandEnum $enum, int $valueOffset, array $constraints){

--- a/src/pocketmine/network/mcpe/protocol/types/NetworkInventoryAction.php
+++ b/src/pocketmine/network/mcpe/protocol/types/NetworkInventoryAction.php
@@ -83,8 +83,6 @@ class NetworkInventoryAction{
 	public $newItem;
 
 	/**
-	 * @param InventoryTransactionPacket $packet
-	 *
 	 * @return $this
 	 */
 	public function read(InventoryTransactionPacket $packet){
@@ -114,7 +112,6 @@ class NetworkInventoryAction{
 	}
 
 	/**
-	 * @param InventoryTransactionPacket $packet
 	 * @return void
 	 */
 	public function write(InventoryTransactionPacket $packet){
@@ -142,8 +139,6 @@ class NetworkInventoryAction{
 	}
 
 	/**
-	 * @param Player $player
-	 *
 	 * @return InventoryAction|null
 	 *
 	 * @throws \UnexpectedValueException

--- a/src/pocketmine/network/mcpe/protocol/types/RuntimeBlockMapping.php
+++ b/src/pocketmine/network/mcpe/protocol/types/RuntimeBlockMapping.php
@@ -129,12 +129,6 @@ final class RuntimeBlockMapping{
 		return $table;
 	}
 
-	/**
-	 * @param int $id
-	 * @param int $meta
-	 *
-	 * @return int
-	 */
 	public static function toStaticRuntimeId(int $id, int $meta = 0) : int{
 		self::lazyInit();
 		/*
@@ -146,8 +140,6 @@ final class RuntimeBlockMapping{
 	}
 
 	/**
-	 * @param int $runtimeId
-	 *
 	 * @return int[] [id, meta]
 	 */
 	public static function fromStaticRuntimeId(int $runtimeId) : array{

--- a/src/pocketmine/network/mcpe/protocol/types/SkinAdapter.php
+++ b/src/pocketmine/network/mcpe/protocol/types/SkinAdapter.php
@@ -32,17 +32,11 @@ interface SkinAdapter{
 
 	/**
 	 * Allows you to convert a skin entity to skin data.
-	 *
-	 * @param Skin $skin
-	 * @return SkinData
 	 */
 	public function toSkinData(Skin $skin) : SkinData;
 
 	/**
 	 * Allows you to convert skin data to a skin entity.
-	 *
-	 * @param SkinData $data
-	 * @return Skin
 	 */
 	public function fromSkinData(SkinData $data) : Skin;
 }

--- a/src/pocketmine/network/mcpe/protocol/types/SkinAnimation.php
+++ b/src/pocketmine/network/mcpe/protocol/types/SkinAnimation.php
@@ -44,8 +44,6 @@ class SkinAnimation{
 
 	/**
 	 * Image of the animation.
-	 *
-	 * @return SkinImage
 	 */
 	public function getImage() : SkinImage{
 		return $this->image;
@@ -53,8 +51,6 @@ class SkinAnimation{
 
 	/**
 	 * The type of animation you are applying.
-	 *
-	 * @return int
 	 */
 	public function getType() : int{
 		return $this->type;
@@ -62,8 +58,6 @@ class SkinAnimation{
 
 	/**
 	 * The total amount of frames in an animation.
-	 *
-	 * @return float
 	 */
 	public function getFrames() : float{
 		return $this->frames;

--- a/src/pocketmine/network/mcpe/protocol/types/SkinData.php
+++ b/src/pocketmine/network/mcpe/protocol/types/SkinData.php
@@ -49,17 +49,7 @@ class SkinData{
 	private $capeId;
 
 	/**
-	 * @param string          $skinId
-	 * @param string          $resourcePatch
-	 * @param SkinImage       $skinImage
 	 * @param SkinAnimation[] $animations
-	 * @param SkinImage|null  $capeImage
-	 * @param string          $geometryData
-	 * @param string          $animationData
-	 * @param bool            $premium
-	 * @param bool            $persona
-	 * @param bool            $personaCapeOnClassic
-	 * @param string          $capeId
 	 */
 	public function __construct(string $skinId, string $resourcePatch, SkinImage $skinImage, array $animations = [], SkinImage $capeImage = null, string $geometryData = "", string $animationData = "", bool $premium = false, bool $persona = false, bool $personaCapeOnClassic = false, string $capeId = ""){
 		$this->skinId = $skinId;
@@ -75,23 +65,14 @@ class SkinData{
 		$this->capeId = $capeId;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getSkinId() : string{
 		return $this->skinId;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getResourcePatch() : string{
 		return $this->resourcePatch;
 	}
 
-	/**
-	 * @return SkinImage
-	 */
 	public function getSkinImage() : SkinImage{
 		return $this->skinImage;
 	}
@@ -103,51 +84,30 @@ class SkinData{
 		return $this->animations;
 	}
 
-	/**
-	 * @return SkinImage
-	 */
 	public function getCapeImage() : SkinImage{
 		return $this->capeImage;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getGeometryData() : string{
 		return $this->geometryData;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getAnimationData() : string{
 		return $this->animationData;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isPersona() : bool{
 		return $this->persona;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isPremium() : bool{
 		return $this->premium;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isPersonaCapeOnClassic() : bool{
 		return $this->personaCapeOnClassic;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getCapeId() : string{
 		return $this->capeId;
 	}

--- a/src/pocketmine/network/query/QueryHandler.php
+++ b/src/pocketmine/network/query/QueryHandler.php
@@ -96,11 +96,6 @@ class QueryHandler{
 	}
 
 	/**
-	 * @param AdvancedSourceInterface $interface
-	 * @param string                  $address
-	 * @param int                     $port
-	 * @param string                  $packet
-	 *
 	 * @return void
 	 */
 	public function handle(AdvancedSourceInterface $interface, string $address, int $port, string $packet){

--- a/src/pocketmine/network/rcon/RCONInstance.php
+++ b/src/pocketmine/network/rcon/RCONInstance.php
@@ -75,11 +75,7 @@ class RCONInstance extends Thread{
 
 	/**
 	 * @param resource             $socket
-	 * @param string               $password
-	 * @param int                  $maxClients
-	 * @param \ThreadedLogger      $logger
 	 * @param resource             $ipcSocket
-	 * @param null|SleeperNotifier $notifier
 	 */
 	public function __construct($socket, string $password, int $maxClients = 50, \ThreadedLogger $logger, $ipcSocket, ?SleeperNotifier $notifier){
 		$this->stop = false;
@@ -97,9 +93,6 @@ class RCONInstance extends Thread{
 
 	/**
 	 * @param resource $client
-	 * @param int      $requestID
-	 * @param int      $packetType
-	 * @param string   $payload
 	 *
 	 * @return int|false
 	 */

--- a/src/pocketmine/permission/BanEntry.php
+++ b/src/pocketmine/permission/BanEntry.php
@@ -62,8 +62,6 @@ class BanEntry{
 	}
 
 	/**
-	 * @param \DateTime $date
-	 *
 	 * @return void
 	 */
 	public function setCreated(\DateTime $date){
@@ -76,8 +74,6 @@ class BanEntry{
 	}
 
 	/**
-	 * @param string $source
-	 *
 	 * @return void
 	 */
 	public function setSource(string $source){
@@ -92,8 +88,6 @@ class BanEntry{
 	}
 
 	/**
-	 * @param \DateTime|null $date
-	 *
 	 * @return void
 	 */
 	public function setExpires(\DateTime $date = null){
@@ -114,8 +108,6 @@ class BanEntry{
 	}
 
 	/**
-	 * @param string $reason
-	 *
 	 * @return void
 	 */
 	public function setReason(string $reason){
@@ -143,8 +135,6 @@ class BanEntry{
 	 *
 	 * @link https://bugs.php.net/bug.php?id=75992
 	 *
-	 * @param \DateTime $dateTime
-	 *
 	 * @throws \RuntimeException if the argument can't be parsed from a formatted date string
 	 */
 	private static function validateDate(\DateTime $dateTime) : void{
@@ -152,9 +142,6 @@ class BanEntry{
 	}
 
 	/**
-	 * @param string $date
-	 *
-	 * @return \DateTime
 	 * @throws \RuntimeException
 	 */
 	private static function parseDate(string $date) : \DateTime{
@@ -167,9 +154,6 @@ class BanEntry{
 	}
 
 	/**
-	 * @param string $str
-	 *
-	 * @return BanEntry|null
 	 * @throws \RuntimeException
 	 */
 	public static function fromString(string $str) : ?BanEntry{

--- a/src/pocketmine/permission/BanList.php
+++ b/src/pocketmine/permission/BanList.php
@@ -94,11 +94,6 @@ class BanList{
 		$this->save();
 	}
 
-	/**
-	 * @param string    $reason
-	 * @param \DateTime $expires
-	 * @param string    $source
-	 */
 	public function addBan(string $target, string $reason = null, \DateTime $expires = null, string $source = null) : BanEntry{
 		$entry = new BanEntry($target);
 		$entry->setSource($source ?? $entry->getSource());

--- a/src/pocketmine/permission/BanList.php
+++ b/src/pocketmine/permission/BanList.php
@@ -45,34 +45,21 @@ class BanList{
 	/** @var bool */
 	private $enabled = true;
 
-	/**
-	 * @param string $file
-	 */
 	public function __construct(string $file){
 		$this->file = $file;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isEnabled() : bool{
 		return $this->enabled;
 	}
 
 	/**
-	 * @param bool $flag
-	 *
 	 * @return void
 	 */
 	public function setEnabled(bool $flag){
 		$this->enabled = $flag;
 	}
 
-	/**
-	 * @param string $name
-	 *
-	 * @return BanEntry|null
-	 */
 	public function getEntry(string $name) : ?BanEntry{
 		$this->removeExpired();
 
@@ -88,11 +75,6 @@ class BanList{
 		return $this->list;
 	}
 
-	/**
-	 * @param string $name
-	 *
-	 * @return bool
-	 */
 	public function isBanned(string $name) : bool{
 		$name = strtolower($name);
 		if(!$this->isEnabled()){
@@ -105,8 +87,6 @@ class BanList{
 	}
 
 	/**
-	 * @param BanEntry $entry
-	 *
 	 * @return void
 	 */
 	public function add(BanEntry $entry){
@@ -115,12 +95,9 @@ class BanList{
 	}
 
 	/**
-	 * @param string    $target
 	 * @param string    $reason
 	 * @param \DateTime $expires
 	 * @param string    $source
-	 *
-	 * @return BanEntry
 	 */
 	public function addBan(string $target, string $reason = null, \DateTime $expires = null, string $source = null) : BanEntry{
 		$entry = new BanEntry($target);
@@ -135,8 +112,6 @@ class BanList{
 	}
 
 	/**
-	 * @param string $name
-	 *
 	 * @return void
 	 */
 	public function remove(string $name){
@@ -186,8 +161,6 @@ class BanList{
 	}
 
 	/**
-	 * @param bool $writeHeader
-	 *
 	 * @return void
 	 */
 	public function save(bool $writeHeader = true){

--- a/src/pocketmine/permission/DefaultPermissions.php
+++ b/src/pocketmine/permission/DefaultPermissions.php
@@ -26,9 +26,6 @@ namespace pocketmine\permission;
 abstract class DefaultPermissions{
 	public const ROOT = "pocketmine";
 
-	/**
-	 * @param Permission $parent
-	 */
 	public static function registerPermission(Permission $perm, Permission $parent = null) : Permission{
 		if($parent instanceof Permission){
 			$parent->getChildren()[$perm->getName()] = true;

--- a/src/pocketmine/permission/DefaultPermissions.php
+++ b/src/pocketmine/permission/DefaultPermissions.php
@@ -27,10 +27,7 @@ abstract class DefaultPermissions{
 	public const ROOT = "pocketmine";
 
 	/**
-	 * @param Permission $perm
 	 * @param Permission $parent
-	 *
-	 * @return Permission
 	 */
 	public static function registerPermission(Permission $perm, Permission $parent = null) : Permission{
 		if($parent instanceof Permission){

--- a/src/pocketmine/permission/Permissible.php
+++ b/src/pocketmine/permission/Permissible.php
@@ -41,10 +41,6 @@ interface Permissible extends ServerOperator{
 	 */
 	public function hasPermission($name) : bool;
 
-	/**
-	 * @param string $name
-	 * @param bool   $value
-	 */
 	public function addAttachment(Plugin $plugin, string $name = null, bool $value = null) : PermissionAttachment;
 
 	/**

--- a/src/pocketmine/permission/Permissible.php
+++ b/src/pocketmine/permission/Permissible.php
@@ -31,8 +31,6 @@ interface Permissible extends ServerOperator{
 	 * Checks if this instance has a permission overridden
 	 *
 	 * @param string|Permission $name
-	 *
-	 * @return bool
 	 */
 	public function isPermissionSet($name) : bool;
 
@@ -40,23 +38,16 @@ interface Permissible extends ServerOperator{
 	 * Returns the permission value if overridden, or the default value if not
 	 *
 	 * @param string|Permission $name
-	 *
-	 * @return bool
 	 */
 	public function hasPermission($name) : bool;
 
 	/**
-	 * @param Plugin $plugin
 	 * @param string $name
 	 * @param bool   $value
-	 *
-	 * @return PermissionAttachment
 	 */
 	public function addAttachment(Plugin $plugin, string $name = null, bool $value = null) : PermissionAttachment;
 
 	/**
-	 * @param PermissionAttachment $attachment
-	 *
 	 * @return void
 	 */
 	public function removeAttachment(PermissionAttachment $attachment);

--- a/src/pocketmine/permission/PermissibleBase.php
+++ b/src/pocketmine/permission/PermissibleBase.php
@@ -85,9 +85,6 @@ class PermissibleBase implements Permissible{
 
 	/**
 	 * //TODO: tick scheduled attachments
-	 *
-	 * @param string $name
-	 * @param bool   $value
 	 */
 	public function addAttachment(Plugin $plugin, string $name = null, bool $value = null) : PermissionAttachment{
 		if(!$plugin->isEnabled()){

--- a/src/pocketmine/permission/PermissibleBase.php
+++ b/src/pocketmine/permission/PermissibleBase.php
@@ -45,9 +45,6 @@ class PermissibleBase implements Permissible{
 	 */
 	private $permissions = [];
 
-	/**
-	 * @param ServerOperator $opable
-	 */
 	public function __construct(ServerOperator $opable){
 		$this->opable = $opable;
 		if($opable instanceof Permissible){
@@ -89,11 +86,8 @@ class PermissibleBase implements Permissible{
 	/**
 	 * //TODO: tick scheduled attachments
 	 *
-	 * @param Plugin $plugin
 	 * @param string $name
 	 * @param bool   $value
-	 *
-	 * @return PermissionAttachment
 	 */
 	public function addAttachment(Plugin $plugin, string $name = null, bool $value = null) : PermissionAttachment{
 		if(!$plugin->isEnabled()){
@@ -161,8 +155,6 @@ class PermissibleBase implements Permissible{
 
 	/**
 	 * @param bool[]                    $children
-	 * @param bool                      $invert
-	 * @param PermissionAttachment|null $attachment
 	 */
 	private function calculateChildPermissions(array $children, bool $invert, ?PermissionAttachment $attachment) : void{
 		$permManager = PermissionManager::getInstance();

--- a/src/pocketmine/permission/Permission.php
+++ b/src/pocketmine/permission/Permission.php
@@ -46,8 +46,6 @@ class Permission{
 	/**
 	 * @param bool|string $value
 	 *
-	 * @return string
-	 *
 	 * @throws \InvalidArgumentException
 	 */
 	public static function getByName($value) : string{
@@ -85,9 +83,6 @@ class Permission{
 	}
 
 	/**
-	 * @param array  $data
-	 * @param string $default
-	 *
 	 * @return Permission[]
 	 */
 	public static function loadPermissions(array $data, string $default = self::DEFAULT_OP) : array{
@@ -100,13 +95,6 @@ class Permission{
 	}
 
 	/**
-	 * @param string $name
-	 * @param array  $data
-	 * @param string $default
-	 * @param array  $output
-	 *
-	 * @return Permission
-	 *
 	 * @throws \Exception
 	 */
 	public static function loadPermission(string $name, array $data, string $default = self::DEFAULT_OP, array &$output = []) : Permission{
@@ -155,7 +143,6 @@ class Permission{
 	/**
 	 * Creates a new Permission object to be attached to Permissible objects
 	 *
-	 * @param string $name
 	 * @param string $description
 	 * @param string $defaultValue
 	 * @param bool[] $children
@@ -169,9 +156,6 @@ class Permission{
 		$this->recalculatePermissibles();
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getName() : string{
 		return $this->name;
 	}
@@ -183,16 +167,11 @@ class Permission{
 		return $this->children;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getDefault() : string{
 		return $this->defaultValue;
 	}
 
 	/**
-	 * @param string $value
-	 *
 	 * @return void
 	 */
 	public function setDefault(string $value){
@@ -202,16 +181,11 @@ class Permission{
 		}
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getDescription() : string{
 		return $this->description;
 	}
 
 	/**
-	 * @param string $value
-	 *
 	 * @return void
 	 */
 	public function setDescription(string $value){
@@ -241,7 +215,6 @@ class Permission{
 
 	/**
 	 * @param string|Permission $name
-	 * @param bool              $value
 	 *
 	 * @return Permission|null Permission if $name is a string, null if it's a Permission
 	 */

--- a/src/pocketmine/permission/Permission.php
+++ b/src/pocketmine/permission/Permission.php
@@ -143,8 +143,6 @@ class Permission{
 	/**
 	 * Creates a new Permission object to be attached to Permissible objects
 	 *
-	 * @param string $description
-	 * @param string $defaultValue
 	 * @param bool[] $children
 	 */
 	public function __construct(string $name, string $description = null, string $defaultValue = null, array $children = []){

--- a/src/pocketmine/permission/PermissionAttachment.php
+++ b/src/pocketmine/permission/PermissionAttachment.php
@@ -42,9 +42,6 @@ class PermissionAttachment{
 	private $plugin;
 
 	/**
-	 * @param Plugin      $plugin
-	 * @param Permissible $permissible
-	 *
 	 * @throws PluginException
 	 */
 	public function __construct(Plugin $plugin, Permissible $permissible){
@@ -56,16 +53,11 @@ class PermissionAttachment{
 		$this->plugin = $plugin;
 	}
 
-	/**
-	 * @return Plugin
-	 */
 	public function getPlugin() : Plugin{
 		return $this->plugin;
 	}
 
 	/**
-	 * @param PermissionRemovedExecutor $ex
-	 *
 	 * @return void
 	 */
 	public function setRemovalCallback(PermissionRemovedExecutor $ex){
@@ -79,9 +71,6 @@ class PermissionAttachment{
 		return $this->removed;
 	}
 
-	/**
-	 * @return Permissible
-	 */
 	public function getPermissible() : Permissible{
 		return $this->permissible;
 	}
@@ -127,7 +116,6 @@ class PermissionAttachment{
 
 	/**
 	 * @param string|Permission $name
-	 * @param bool              $value
 	 *
 	 * @return void
 	 */

--- a/src/pocketmine/permission/PermissionAttachmentInfo.php
+++ b/src/pocketmine/permission/PermissionAttachmentInfo.php
@@ -38,11 +38,6 @@ class PermissionAttachmentInfo{
 	private $value;
 
 	/**
-	 * @param Permissible               $permissible
-	 * @param string                    $permission
-	 * @param PermissionAttachment|null $attachment
-	 * @param bool                      $value
-	 *
 	 * @throws \InvalidStateException
 	 */
 	public function __construct(Permissible $permissible, string $permission, PermissionAttachment $attachment = null, bool $value){
@@ -52,16 +47,10 @@ class PermissionAttachmentInfo{
 		$this->value = $value;
 	}
 
-	/**
-	 * @return Permissible
-	 */
 	public function getPermissible() : Permissible{
 		return $this->permissible;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getPermission() : string{
 		return $this->permission;
 	}
@@ -73,9 +62,6 @@ class PermissionAttachmentInfo{
 		return $this->attachment;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function getValue() : bool{
 		return $this->value;
 	}

--- a/src/pocketmine/permission/PermissionManager.php
+++ b/src/pocketmine/permission/PermissionManager.php
@@ -53,19 +53,12 @@ class PermissionManager{
 	protected $defSubsOp = [];
 
 	/**
-	 * @param string $name
-	 *
 	 * @return null|Permission
 	 */
 	public function getPermission(string $name){
 		return $this->permissions[$name] ?? null;
 	}
 
-	/**
-	 * @param Permission $permission
-	 *
-	 * @return bool
-	 */
 	public function addPermission(Permission $permission) : bool{
 		if(!isset($this->permissions[$permission->getName()])){
 			$this->permissions[$permission->getName()] = $permission;
@@ -91,8 +84,6 @@ class PermissionManager{
 	}
 
 	/**
-	 * @param bool $op
-	 *
 	 * @return Permission[]
 	 */
 	public function getDefaultPermissions(bool $op) : array{
@@ -104,8 +95,6 @@ class PermissionManager{
 	}
 
 	/**
-	 * @param Permission $permission
-	 *
 	 * @return void
 	 */
 	public function recalculatePermissionDefaults(Permission $permission){
@@ -116,9 +105,6 @@ class PermissionManager{
 		}
 	}
 
-	/**
-	 * @param Permission $permission
-	 */
 	private function calculatePermissionDefault(Permission $permission) : void{
 		Timings::$permissionDefaultTimer->startTiming();
 		if($permission->getDefault() === Permission::DEFAULT_OP or $permission->getDefault() === Permission::DEFAULT_TRUE){
@@ -133,9 +119,6 @@ class PermissionManager{
 		Timings::$permissionDefaultTimer->startTiming();
 	}
 
-	/**
-	 * @param bool $op
-	 */
 	private function dirtyPermissibles(bool $op) : void{
 		foreach($this->getDefaultPermSubscriptions($op) as $p){
 			$p->recalculatePermissions();
@@ -143,9 +126,6 @@ class PermissionManager{
 	}
 
 	/**
-	 * @param string      $permission
-	 * @param Permissible $permissible
-	 *
 	 * @return void
 	 */
 	public function subscribeToPermission(string $permission, Permissible $permissible){
@@ -156,9 +136,6 @@ class PermissionManager{
 	}
 
 	/**
-	 * @param string      $permission
-	 * @param Permissible $permissible
-	 *
 	 * @return void
 	 */
 	public function unsubscribeFromPermission(string $permission, Permissible $permissible){
@@ -170,9 +147,6 @@ class PermissionManager{
 		}
 	}
 
-	/**
-	 * @param Permissible $permissible
-	 */
 	public function unsubscribeFromAllPermissions(Permissible $permissible) : void{
 		foreach($this->permSubs as $permission => &$subs){
 			unset($subs[spl_object_hash($permissible)]);
@@ -183,8 +157,6 @@ class PermissionManager{
 	}
 
 	/**
-	 * @param string $permission
-	 *
 	 * @return array|Permissible[]
 	 */
 	public function getPermissionSubscriptions(string $permission) : array{
@@ -192,9 +164,6 @@ class PermissionManager{
 	}
 
 	/**
-	 * @param bool        $op
-	 * @param Permissible $permissible
-	 *
 	 * @return void
 	 */
 	public function subscribeToDefaultPerms(bool $op, Permissible $permissible){
@@ -206,9 +175,6 @@ class PermissionManager{
 	}
 
 	/**
-	 * @param bool        $op
-	 * @param Permissible $permissible
-	 *
 	 * @return void
 	 */
 	public function unsubscribeFromDefaultPerms(bool $op, Permissible $permissible){
@@ -220,8 +186,6 @@ class PermissionManager{
 	}
 
 	/**
-	 * @param bool $op
-	 *
 	 * @return Permissible[]
 	 */
 	public function getDefaultPermSubscriptions(bool $op) : array{

--- a/src/pocketmine/permission/PermissionRemovedExecutor.php
+++ b/src/pocketmine/permission/PermissionRemovedExecutor.php
@@ -27,8 +27,6 @@ namespace pocketmine\permission;
 interface PermissionRemovedExecutor{
 
 	/**
-	 * @param PermissionAttachment $attachment
-	 *
 	 * @return void
 	 */
 	public function attachmentRemoved(PermissionAttachment $attachment);

--- a/src/pocketmine/permission/ServerOperator.php
+++ b/src/pocketmine/permission/ServerOperator.php
@@ -27,15 +27,11 @@ namespace pocketmine\permission;
 interface ServerOperator{
 	/**
 	 * Checks if the current object has operator permissions
-	 *
-	 * @return bool
 	 */
 	public function isOp() : bool;
 
 	/**
 	 * Sets the operator permission for the current object
-	 *
-	 * @param bool $value
 	 *
 	 * @return void
 	 */

--- a/src/pocketmine/plugin/EventExecutor.php
+++ b/src/pocketmine/plugin/EventExecutor.php
@@ -29,9 +29,6 @@ use pocketmine\event\Listener;
 interface EventExecutor{
 
 	/**
-	 * @param Listener $listener
-	 * @param Event    $event
-	 *
 	 * @return void
 	 */
 	public function execute(Listener $listener, Event $event);

--- a/src/pocketmine/plugin/PharPluginLoader.php
+++ b/src/pocketmine/plugin/PharPluginLoader.php
@@ -46,8 +46,6 @@ class PharPluginLoader implements PluginLoader{
 
 	/**
 	 * Loads the plugin contained in $file
-	 *
-	 * @param string $file
 	 */
 	public function loadPlugin(string $file) : void{
 		$this->loader->addPath("$file/src");
@@ -55,10 +53,6 @@ class PharPluginLoader implements PluginLoader{
 
 	/**
 	 * Gets the PluginDescription from the file
-	 *
-	 * @param string $file
-	 *
-	 * @return null|PluginDescription
 	 */
 	public function getPluginDescription(string $file) : ?PluginDescription{
 		$phar = new \Phar($file);

--- a/src/pocketmine/plugin/Plugin.php
+++ b/src/pocketmine/plugin/Plugin.php
@@ -53,9 +53,6 @@ interface Plugin extends CommandExecutor{
 	 */
 	public function onEnable();
 
-	/**
-	 * @return bool
-	 */
 	public function isEnabled() : bool;
 
 	/**
@@ -64,8 +61,6 @@ interface Plugin extends CommandExecutor{
 	 * @internal This is intended for core use only and should not be used by plugins
 	 * @see PluginManager::enablePlugin()
 	 * @see PluginManager::disablePlugin()
-	 *
-	 * @param bool $enabled
 	 */
 	public function setEnabled(bool $enabled = true) : void;
 
@@ -77,28 +72,18 @@ interface Plugin extends CommandExecutor{
 	 */
 	public function onDisable();
 
-	/**
-	 * @return bool
-	 */
 	public function isDisabled() : bool;
 
 	/**
 	 * Gets the plugin's data folder to save files and configuration.
 	 * This directory name has a trailing slash.
-	 *
-	 * @return string
 	 */
 	public function getDataFolder() : string;
 
-	/**
-	 * @return PluginDescription
-	 */
 	public function getDescription() : PluginDescription;
 
 	/**
 	 * Gets an embedded resource in the plugin file.
-	 *
-	 * @param string $filename
 	 *
 	 * @return null|resource Resource data, or null
 	 */
@@ -106,11 +91,6 @@ interface Plugin extends CommandExecutor{
 
 	/**
 	 * Saves an embedded resource to its relative location in the data folder
-	 *
-	 * @param string $filename
-	 * @param bool   $replace
-	 *
-	 * @return bool
 	 */
 	public function saveResource(string $filename, bool $replace = false) : bool;
 
@@ -121,9 +101,6 @@ interface Plugin extends CommandExecutor{
 	 */
 	public function getResources() : array;
 
-	/**
-	 * @return Config
-	 */
 	public function getConfig() : Config;
 
 	/**
@@ -131,9 +108,6 @@ interface Plugin extends CommandExecutor{
 	 */
 	public function saveConfig();
 
-	/**
-	 * @return bool
-	 */
 	public function saveDefaultConfig() : bool;
 
 	/**
@@ -141,19 +115,10 @@ interface Plugin extends CommandExecutor{
 	 */
 	public function reloadConfig();
 
-	/**
-	 * @return Server
-	 */
 	public function getServer() : Server;
 
-	/**
-	 * @return string
-	 */
 	public function getName() : string;
 
-	/**
-	 * @return PluginLogger
-	 */
 	public function getLogger() : PluginLogger;
 
 	/**
@@ -161,9 +126,6 @@ interface Plugin extends CommandExecutor{
 	 */
 	public function getPluginLoader();
 
-	/**
-	 * @return TaskScheduler
-	 */
 	public function getScheduler() : TaskScheduler;
 
 }

--- a/src/pocketmine/plugin/PluginBase.php
+++ b/src/pocketmine/plugin/PluginBase.php
@@ -97,9 +97,6 @@ abstract class PluginBase implements Plugin{
 
 	}
 
-	/**
-	 * @return bool
-	 */
 	final public function isEnabled() : bool{
 		return $this->isEnabled;
 	}
@@ -110,8 +107,6 @@ abstract class PluginBase implements Plugin{
 	 * @internal This is intended for core use only and should not be used by plugins
 	 * @see PluginManager::enablePlugin()
 	 * @see PluginManager::disablePlugin()
-	 *
-	 * @param bool $enabled
 	 */
 	final public function setEnabled(bool $enabled = true) : void{
 		if($this->isEnabled !== $enabled){
@@ -124,9 +119,6 @@ abstract class PluginBase implements Plugin{
 		}
 	}
 
-	/**
-	 * @return bool
-	 */
 	final public function isDisabled() : bool{
 		return !$this->isEnabled;
 	}
@@ -139,16 +131,11 @@ abstract class PluginBase implements Plugin{
 		return $this->description;
 	}
 
-	/**
-	 * @return PluginLogger
-	 */
 	public function getLogger() : PluginLogger{
 		return $this->logger;
 	}
 
 	/**
-	 * @param string $name
-	 *
 	 * @return Command|PluginIdentifiableCommand|null
 	 */
 	public function getCommand(string $name){
@@ -165,20 +152,12 @@ abstract class PluginBase implements Plugin{
 	}
 
 	/**
-	 * @param CommandSender $sender
-	 * @param Command       $command
-	 * @param string        $label
 	 * @param string[]      $args
-	 *
-	 * @return bool
 	 */
 	public function onCommand(CommandSender $sender, Command $command, string $label, array $args) : bool{
 		return false;
 	}
 
-	/**
-	 * @return bool
-	 */
 	protected function isPhar() : bool{
 		return strpos($this->file, "phar://") === 0;
 	}
@@ -186,8 +165,6 @@ abstract class PluginBase implements Plugin{
 	/**
 	 * Gets an embedded resource on the plugin file.
 	 * WARNING: You must close the resource given using fclose()
-	 *
-	 * @param string $filename
 	 *
 	 * @return null|resource Resource data, or null
 	 */
@@ -200,12 +177,6 @@ abstract class PluginBase implements Plugin{
 		return null;
 	}
 
-	/**
-	 * @param string $filename
-	 * @param bool   $replace
-	 *
-	 * @return bool
-	 */
 	public function saveResource(string $filename, bool $replace = false) : bool{
 		if(trim($filename) === ""){
 			return false;
@@ -249,9 +220,6 @@ abstract class PluginBase implements Plugin{
 		return $resources;
 	}
 
-	/**
-	 * @return Config
-	 */
 	public function getConfig() : Config{
 		if($this->config === null){
 			$this->reloadConfig();
@@ -278,30 +246,18 @@ abstract class PluginBase implements Plugin{
 		$this->config = new Config($this->configFile);
 	}
 
-	/**
-	 * @return Server
-	 */
 	final public function getServer() : Server{
 		return $this->server;
 	}
 
-	/**
-	 * @return string
-	 */
 	final public function getName() : string{
 		return $this->description->getName();
 	}
 
-	/**
-	 * @return string
-	 */
 	final public function getFullName() : string{
 		return $this->description->getFullName();
 	}
 
-	/**
-	 * @return string
-	 */
 	protected function getFile() : string{
 		return $this->file;
 	}
@@ -313,9 +269,6 @@ abstract class PluginBase implements Plugin{
 		return $this->loader;
 	}
 
-	/**
-	 * @return TaskScheduler
-	 */
 	public function getScheduler() : TaskScheduler{
 		return $this->scheduler;
 	}

--- a/src/pocketmine/plugin/PluginDescription.php
+++ b/src/pocketmine/plugin/PluginDescription.php
@@ -88,8 +88,6 @@ class PluginDescription{
 	}
 
 	/**
-	 * @param array $plugin
-	 *
 	 * @throws PluginException
 	 */
 	private function loadMap(array $plugin) : void{
@@ -161,16 +159,10 @@ class PluginDescription{
 		}
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getFullName() : string{
 		return $this->name . " v" . $this->version;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function getCompatibleApis() : array{
 		return $this->api;
 	}
@@ -189,16 +181,10 @@ class PluginDescription{
 		return $this->authors;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getPrefix() : string{
 		return $this->prefix;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function getCommands() : array{
 		return $this->commands;
 	}
@@ -245,44 +231,26 @@ class PluginDescription{
 		}
 	}
 
-	/**
-	 * @return array
-	 */
 	public function getDepend() : array{
 		return $this->depend;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getDescription() : string{
 		return $this->description;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function getLoadBefore() : array{
 		return $this->loadBefore;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getMain() : string{
 		return $this->main;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getName() : string{
 		return $this->name;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getOrder() : int{
 		return $this->order;
 	}
@@ -294,23 +262,14 @@ class PluginDescription{
 		return $this->permissions;
 	}
 
-	/**
-	 * @return array
-	 */
 	public function getSoftDepend() : array{
 		return $this->softDepend;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getVersion() : string{
 		return $this->version;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getWebsite() : string{
 		return $this->website;
 	}

--- a/src/pocketmine/plugin/PluginLoader.php
+++ b/src/pocketmine/plugin/PluginLoader.php
@@ -30,33 +30,21 @@ interface PluginLoader{
 
 	/**
 	 * Returns whether this PluginLoader can load the plugin in the given path.
-	 *
-	 * @param string $path
-	 *
-	 * @return bool
 	 */
 	public function canLoadPlugin(string $path) : bool;
 
 	/**
 	 * Loads the plugin contained in $file
-	 *
-	 * @param string $file
 	 */
 	public function loadPlugin(string $file) : void;
 
 	/**
 	 * Gets the PluginDescription from the file
-	 *
-	 * @param string $file
-	 *
-	 * @return null|PluginDescription
 	 */
 	public function getPluginDescription(string $file) : ?PluginDescription;
 
 	/**
 	 * Returns the protocol prefix used to access files in this plugin, e.g. file://, phar://
-	 *
-	 * @return string
 	 */
 	public function getAccessProtocol() : string;
 }

--- a/src/pocketmine/plugin/PluginLogger.php
+++ b/src/pocketmine/plugin/PluginLogger.php
@@ -51,9 +51,6 @@ class PluginLogger implements \AttachableLogger{
 		return $this->attachments;
 	}
 
-	/**
-	 * @param Plugin $context
-	 */
 	public function __construct(Plugin $context){
 		$prefix = $context->getDescription()->getPrefix();
 		$this->pluginName = $prefix != null ? "[$prefix] " : "[" . $context->getDescription()->getName() . "] ";

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -94,11 +94,6 @@ class PluginManager{
 	/** @var string|null */
 	private $pluginDataDirectory;
 
-	/**
-	 * @param Server           $server
-	 * @param SimpleCommandMap $commandMap
-	 * @param null|string      $pluginDataDirectory
-	 */
 	public function __construct(Server $server, SimpleCommandMap $commandMap, ?string $pluginDataDirectory){
 		$this->server = $server;
 		$this->commandMap = $commandMap;
@@ -113,8 +108,6 @@ class PluginManager{
 	}
 
 	/**
-	 * @param string $name
-	 *
 	 * @return null|Plugin
 	 */
 	public function getPlugin(string $name){
@@ -125,9 +118,6 @@ class PluginManager{
 		return null;
 	}
 
-	/**
-	 * @param PluginLoader $loader
-	 */
 	public function registerInterface(PluginLoader $loader) : void{
 		$this->fileAssociations[get_class($loader)] = $loader;
 	}
@@ -147,10 +137,7 @@ class PluginManager{
 	}
 
 	/**
-	 * @param string         $path
 	 * @param PluginLoader[] $loaders
-	 *
-	 * @return Plugin|null
 	 */
 	public function loadPlugin(string $path, array $loaders = null) : ?Plugin{
 		foreach($loaders ?? $this->fileAssociations as $loader){
@@ -215,7 +202,6 @@ class PluginManager{
 	}
 
 	/**
-	 * @param string $directory
 	 * @param array  $newLoaders
 	 *
 	 * @return Plugin[]
@@ -373,8 +359,6 @@ class PluginManager{
 	 * Returns whether a specified API version string is considered compatible with the server's API version.
 	 *
 	 * @param string ...$versions
-	 *
-	 * @return bool
 	 */
 	public function isCompatibleApi(string ...$versions) : bool{
 		$serverString = $this->server->getApiVersion();
@@ -416,8 +400,6 @@ class PluginManager{
 	 * @deprecated
 	 * @see PermissionManager::getPermission()
 	 *
-	 * @param string $name
-	 *
 	 * @return null|Permission
 	 */
 	public function getPermission(string $name){
@@ -427,10 +409,6 @@ class PluginManager{
 	/**
 	 * @deprecated
 	 * @see PermissionManager::addPermission()
-	 *
-	 * @param Permission $permission
-	 *
-	 * @return bool
 	 */
 	public function addPermission(Permission $permission) : bool{
 		return PermissionManager::getInstance()->addPermission($permission);
@@ -452,8 +430,6 @@ class PluginManager{
 	 * @deprecated
 	 * @see PermissionManager::getDefaultPermissions()
 	 *
-	 * @param bool $op
-	 *
 	 * @return Permission[]
 	 */
 	public function getDefaultPermissions(bool $op) : array{
@@ -463,8 +439,6 @@ class PluginManager{
 	/**
 	 * @deprecated
 	 * @see PermissionManager::recalculatePermissionDefaults()
-	 *
-	 * @param Permission $permission
 	 *
 	 * @return void
 	 */
@@ -476,9 +450,6 @@ class PluginManager{
 	 * @deprecated
 	 * @see PermissionManager::subscribeToPermission()
 	 *
-	 * @param string      $permission
-	 * @param Permissible $permissible
-	 *
 	 * @return void
 	 */
 	public function subscribeToPermission(string $permission, Permissible $permissible){
@@ -489,9 +460,6 @@ class PluginManager{
 	 * @deprecated
 	 * @see PermissionManager::unsubscribeFromPermission()
 	 *
-	 * @param string      $permission
-	 * @param Permissible $permissible
-	 *
 	 * @return void
 	 */
 	public function unsubscribeFromPermission(string $permission, Permissible $permissible){
@@ -501,10 +469,6 @@ class PluginManager{
 	/**
 	 * @deprecated
 	 * @see PermissionManager::unsubscribeFromAllPermissions()
-	 *
-	 * @param Permissible $permissible
-	 *
-	 * @return void
 	 */
 	public function unsubscribeFromAllPermissions(Permissible $permissible) : void{
 		PermissionManager::getInstance()->unsubscribeFromAllPermissions($permissible);
@@ -513,8 +477,6 @@ class PluginManager{
 	/**
 	 * @deprecated
 	 * @see PermissionManager::getPermissionSubscriptions()
-	 *
-	 * @param string $permission
 	 *
 	 * @return array|Permissible[]
 	 */
@@ -526,9 +488,6 @@ class PluginManager{
 	 * @deprecated
 	 * @see PermissionManager::subscribeToDefaultPerms()
 	 *
-	 * @param bool        $op
-	 * @param Permissible $permissible
-	 *
 	 * @return void
 	 */
 	public function subscribeToDefaultPerms(bool $op, Permissible $permissible){
@@ -539,9 +498,6 @@ class PluginManager{
 	 * @deprecated
 	 * @see PermissionManager::unsubscribeFromDefaultPerms()
 	 *
-	 * @param bool        $op
-	 * @param Permissible $permissible
-	 *
 	 * @return void
 	 */
 	public function unsubscribeFromDefaultPerms(bool $op, Permissible $permissible){
@@ -551,8 +507,6 @@ class PluginManager{
 	/**
 	 * @deprecated
 	 * @see PermissionManager::getDefaultPermSubscriptions()
-	 *
-	 * @param bool $op
 	 *
 	 * @return Permissible[]
 	 */
@@ -570,18 +524,11 @@ class PluginManager{
 		return PermissionManager::getInstance()->getPermissions();
 	}
 
-	/**
-	 * @param Plugin $plugin
-	 *
-	 * @return bool
-	 */
 	public function isPluginEnabled(Plugin $plugin) : bool{
 		return isset($this->plugins[$plugin->getDescription()->getName()]) and $plugin->isEnabled();
 	}
 
 	/**
-	 * @param Plugin $plugin
-	 *
 	 * @return void
 	 */
 	public function enablePlugin(Plugin $plugin){
@@ -607,8 +554,6 @@ class PluginManager{
 	}
 
 	/**
-	 * @param Plugin $plugin
-	 *
 	 * @return PluginCommand[]
 	 */
 	protected function parseYamlCommands(Plugin $plugin) : array{
@@ -673,8 +618,6 @@ class PluginManager{
 	}
 
 	/**
-	 * @param Plugin $plugin
-	 *
 	 * @return void
 	 */
 	public function disablePlugin(Plugin $plugin){
@@ -720,8 +663,6 @@ class PluginManager{
 	 * @deprecated
 	 * @see Event::call()
 	 *
-	 * @param Event $event
-	 *
 	 * @return void
 	 */
 	public function callEvent(Event $event){
@@ -730,9 +671,6 @@ class PluginManager{
 
 	/**
 	 * Registers all the events in the given Listener class
-	 *
-	 * @param Listener $listener
-	 * @param Plugin   $plugin
 	 *
 	 * @throws PluginException
 	 */
@@ -798,11 +736,6 @@ class PluginManager{
 
 	/**
 	 * @param string        $event Class name that extends Event
-	 * @param Listener      $listener
-	 * @param int           $priority
-	 * @param EventExecutor $executor
-	 * @param Plugin        $plugin
-	 * @param bool          $ignoreCancelled
 	 *
 	 * @throws PluginException
 	 */
@@ -830,11 +763,6 @@ class PluginManager{
 		$this->getEventListeners($event)->register(new RegisteredListener($listener, $executor, $priority, $plugin, $ignoreCancelled, $timings));
 	}
 
-	/**
-	 * @param string $event
-	 *
-	 * @return HandlerList
-	 */
 	private function getEventListeners(string $event) : HandlerList{
 		$list = HandlerList::getHandlerListFor($event);
 		if($list === null){

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -202,8 +202,6 @@ class PluginManager{
 	}
 
 	/**
-	 * @param array  $newLoaders
-	 *
 	 * @return Plugin[]
 	 */
 	public function loadPlugins(string $directory, array $newLoaders = null){

--- a/src/pocketmine/plugin/RegisteredListener.php
+++ b/src/pocketmine/plugin/RegisteredListener.php
@@ -48,15 +48,6 @@ class RegisteredListener{
 	/** @var TimingsHandler */
 	private $timings;
 
-
-	/**
-	 * @param Listener       $listener
-	 * @param EventExecutor  $executor
-	 * @param int            $priority
-	 * @param Plugin         $plugin
-	 * @param bool           $ignoreCancelled
-	 * @param TimingsHandler $timings
-	 */
 	public function __construct(Listener $listener, EventExecutor $executor, int $priority, Plugin $plugin, bool $ignoreCancelled, TimingsHandler $timings){
 		$this->listener = $listener;
 		$this->priority = $priority;
@@ -66,30 +57,19 @@ class RegisteredListener{
 		$this->timings = $timings;
 	}
 
-	/**
-	 * @return Listener
-	 */
 	public function getListener() : Listener{
 		return $this->listener;
 	}
 
-	/**
-	 * @return Plugin
-	 */
 	public function getPlugin() : Plugin{
 		return $this->plugin;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getPriority() : int{
 		return $this->priority;
 	}
 
 	/**
-	 * @param Event $event
-	 *
 	 * @return void
 	 */
 	public function callEvent(Event $event){
@@ -105,9 +85,6 @@ class RegisteredListener{
 		$this->timings->remove();
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isIgnoringCancelled() : bool{
 		return $this->ignoreCancelled;
 	}

--- a/src/pocketmine/plugin/ScriptPluginLoader.php
+++ b/src/pocketmine/plugin/ScriptPluginLoader.php
@@ -46,8 +46,6 @@ class ScriptPluginLoader implements PluginLoader{
 
 	/**
 	 * Loads the plugin contained in $file
-	 *
-	 * @param string $file
 	 */
 	public function loadPlugin(string $file) : void{
 		include_once $file;
@@ -55,10 +53,6 @@ class ScriptPluginLoader implements PluginLoader{
 
 	/**
 	 * Gets the PluginDescription from the file
-	 *
-	 * @param string $file
-	 *
-	 * @return null|PluginDescription
 	 */
 	public function getPluginDescription(string $file) : ?PluginDescription{
 		$content = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);

--- a/src/pocketmine/resourcepacks/ResourcePack.php
+++ b/src/pocketmine/resourcepacks/ResourcePack.php
@@ -29,31 +29,26 @@ interface ResourcePack{
 
 	/**
 	 * Returns the path to the resource pack. This might be a file or a directory, depending on the type of pack.
-	 * @return string
 	 */
 	public function getPath() : string;
 
 	/**
 	 * Returns the human-readable name of the resource pack
-	 * @return string
 	 */
 	public function getPackName() : string;
 
 	/**
 	 * Returns the pack's UUID as a human-readable string
-	 * @return string
 	 */
 	public function getPackId() : string;
 
 	/**
 	 * Returns the size of the pack on disk in bytes.
-	 * @return int
 	 */
 	public function getPackSize() : int;
 
 	/**
 	 * Returns a version number for the pack in the format major.minor.patch
-	 * @return string
 	 */
 	public function getPackVersion() : string;
 

--- a/src/pocketmine/resourcepacks/ResourcePackManager.php
+++ b/src/pocketmine/resourcepacks/ResourcePackManager.php
@@ -52,7 +52,6 @@ class ResourcePackManager{
 
 	/**
 	 * @param string  $path Path to resource-packs directory.
-	 * @param \Logger $logger
 	 */
 	public function __construct(string $path, \Logger $logger){
 		$this->path = $path;
@@ -122,7 +121,6 @@ class ResourcePackManager{
 
 	/**
 	 * Returns the directory which resource packs are loaded from.
-	 * @return string
 	 */
 	public function getPath() : string{
 		return $this->path;
@@ -130,7 +128,6 @@ class ResourcePackManager{
 
 	/**
 	 * Returns whether players must accept resource packs in order to join.
-	 * @return bool
 	 */
 	public function resourcePacksRequired() : bool{
 		return $this->serverForceResources;
@@ -146,8 +143,6 @@ class ResourcePackManager{
 
 	/**
 	 * Returns the resource pack matching the specified UUID string, or null if the ID was not recognized.
-	 *
-	 * @param string $id
 	 *
 	 * @return ResourcePack|null
 	 */

--- a/src/pocketmine/resourcepacks/ZippedResourcePack.php
+++ b/src/pocketmine/resourcepacks/ZippedResourcePack.php
@@ -43,10 +43,6 @@ class ZippedResourcePack implements ResourcePack{
 	/**
 	 * Performs basic validation checks on a resource pack's manifest.json.
 	 * TODO: add more manifest validation
-	 *
-	 * @param \stdClass $manifest
-	 *
-	 * @return bool
 	 */
 	public static function verifyManifest(\stdClass $manifest) : bool{
 		if(!isset($manifest->format_version) or !isset($manifest->header) or !isset($manifest->modules)){

--- a/src/pocketmine/scheduler/AsyncPool.php
+++ b/src/pocketmine/scheduler/AsyncPool.php
@@ -81,8 +81,6 @@ class AsyncPool{
 
 	/**
 	 * Returns the maximum size of the pool. Note that there may be less active workers than this number.
-	 *
-	 * @return int
 	 */
 	public function getSize() : int{
 		return $this->size;
@@ -90,8 +88,6 @@ class AsyncPool{
 
 	/**
 	 * Increases the maximum size of the pool to the specified amount. This does not immediately start new workers.
-	 *
-	 * @param int $newSize
 	 */
 	public function increaseSize(int $newSize) : void{
 		if($newSize > $this->size){
@@ -104,8 +100,6 @@ class AsyncPool{
 	 * The signature should be `function(int $worker) : void`
 	 *
 	 * This function will call the hook for every already-running worker.
-	 *
-	 * @param \Closure $hook
 	 */
 	public function addWorkerStartHook(\Closure $hook) : void{
 		Utils::validateCallableSignature(function(int $worker) : void{}, $hook);
@@ -117,8 +111,6 @@ class AsyncPool{
 
 	/**
 	 * Removes a previously-registered callback listening for workers being started.
-	 *
-	 * @param \Closure $hook
 	 */
 	public function removeWorkerStartHook(\Closure $hook) : void{
 		unset($this->workerStartHooks[spl_object_hash($hook)]);
@@ -136,10 +128,6 @@ class AsyncPool{
 	/**
 	 * Fetches the worker with the specified ID, starting it if it does not exist, and firing any registered worker
 	 * start hooks.
-	 *
-	 * @param int $worker
-	 *
-	 * @return AsyncWorker
 	 */
 	private function getWorker(int $worker) : AsyncWorker{
 		if(!isset($this->workers[$worker])){
@@ -158,9 +146,6 @@ class AsyncPool{
 
 	/**
 	 * Submits an AsyncTask to an arbitrary worker.
-	 *
-	 * @param AsyncTask $task
-	 * @param int       $worker
 	 */
 	public function submitTaskToWorker(AsyncTask $task, int $worker) : void{
 		if($worker < 0 or $worker >= $this->size){
@@ -187,8 +172,6 @@ class AsyncPool{
 	 * - if an idle worker is found, it will be selected
 	 * - else, if the worker pool is not full, a new worker will be selected
 	 * - else, the worker with the smallest backlog is chosen.
-	 *
-	 * @return int
 	 */
 	public function selectWorker() : int{
 		$worker = null;
@@ -219,10 +202,6 @@ class AsyncPool{
 	/**
 	 * Submits an AsyncTask to the worker with the least load. If all workers are busy and the pool is not full, a new
 	 * worker may be started.
-	 *
-	 * @param AsyncTask $task
-	 *
-	 * @return int
 	 */
 	public function submitTask(AsyncTask $task) : int{
 		if($task->getTaskId() !== null){
@@ -236,9 +215,6 @@ class AsyncPool{
 
 	/**
 	 * Removes a completed or crashed task from the pool.
-	 *
-	 * @param AsyncTask $task
-	 * @param bool      $force
 	 */
 	private function removeTask(AsyncTask $task, bool $force = false) : void{
 		if(isset($this->taskWorkers[$task->getTaskId()])){

--- a/src/pocketmine/scheduler/AsyncTask.php
+++ b/src/pocketmine/scheduler/AsyncTask.php
@@ -111,9 +111,6 @@ abstract class AsyncTask extends Collectable{
 		return $this->cancelRun;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function hasResult() : bool{
 		return $this->result !== null;
 	}
@@ -128,8 +125,6 @@ abstract class AsyncTask extends Collectable{
 	}
 
 	/**
-	 * @param int $taskId
-	 *
 	 * @return void
 	 */
 	public function setTaskId(int $taskId){
@@ -146,8 +141,6 @@ abstract class AsyncTask extends Collectable{
 	/**
 	 * @see AsyncWorker::getFromThreadStore()
 	 *
-	 * @param string $identifier
-	 *
 	 * @return mixed
 	 */
 	public function getFromThreadStore(string $identifier){
@@ -160,7 +153,6 @@ abstract class AsyncTask extends Collectable{
 	/**
 	 * @see AsyncWorker::saveToThreadStore()
 	 *
-	 * @param string $identifier
 	 * @param mixed  $value
 	 *
 	 * @return void
@@ -174,10 +166,6 @@ abstract class AsyncTask extends Collectable{
 
 	/**
 	 * @see AsyncWorker::removeFromThreadStore()
-	 *
-	 * @param string $identifier
-	 *
-	 * @return void
 	 */
 	public function removeFromThreadStore(string $identifier) : void{
 		if($this->worker === null or $this->isGarbage()){
@@ -196,8 +184,6 @@ abstract class AsyncTask extends Collectable{
 	/**
 	 * Actions to execute when completed (on main thread)
 	 * Implement this if you want to handle the data in your AsyncTask after it has been processed
-	 *
-	 * @param Server $server
 	 *
 	 * @return void
 	 */
@@ -220,8 +206,6 @@ abstract class AsyncTask extends Collectable{
 	/**
 	 * @internal Only call from AsyncPool.php on the main thread
 	 *
-	 * @param Server $server
-	 *
 	 * @return void
 	 */
 	public function checkProgressUpdates(Server $server){
@@ -236,7 +220,6 @@ abstract class AsyncTask extends Collectable{
 	 * All {@link AsyncTask::publishProgress} calls should result in {@link AsyncTask::onProgressUpdate} calls before
 	 * {@link AsyncTask::onCompletion} is called.
 	 *
-	 * @param Server $server
 	 * @param mixed  $progress The parameter passed to {@link AsyncTask::publishProgress}. It is serialize()'ed
 	 *                         and then unserialize()'ed, as if it has been cloned.
 	 *
@@ -336,7 +319,6 @@ abstract class AsyncTask extends Collectable{
 
 	/**
 	 * @internal Called by the AsyncPool to destroy any leftover stored objects that this task failed to retrieve.
-	 * @return bool
 	 */
 	public function removeDanglingStoredObjects() : bool{
 		if(self::$localObjectStorage !== null and isset(self::$localObjectStorage[$this])){

--- a/src/pocketmine/scheduler/AsyncWorker.php
+++ b/src/pocketmine/scheduler/AsyncWorker.php
@@ -98,7 +98,6 @@ class AsyncWorker extends Worker{
 	 * Saves mixed data into the worker's thread-local object store. This can be used to store objects which you
 	 * want to use on this worker thread from multiple AsyncTasks.
 	 *
-	 * @param string $identifier
 	 * @param mixed  $value
 	 */
 	public function saveToThreadStore(string $identifier, $value) : void{
@@ -113,8 +112,6 @@ class AsyncWorker extends Worker{
 	 *
 	 * Objects stored in this storage may ONLY be retrieved while the task is running.
 	 *
-	 * @param string $identifier
-	 *
 	 * @return mixed
 	 */
 	public function getFromThreadStore(string $identifier){
@@ -123,8 +120,6 @@ class AsyncWorker extends Worker{
 
 	/**
 	 * Removes previously-stored mixed data from the worker's thread-local object store.
-	 *
-	 * @param string $identifier
 	 */
 	public function removeFromThreadStore(string $identifier) : void{
 		unset(self::$store[$identifier]);

--- a/src/pocketmine/scheduler/BulkCurlTask.php
+++ b/src/pocketmine/scheduler/BulkCurlTask.php
@@ -44,7 +44,6 @@ class BulkCurlTask extends AsyncTask{
 	 * "timeout", "extraHeaders" and "extraOpts". Documentation of these options are same as those in
 	 * {@link Utils::simpleCurl}.
 	 *
-	 * @param array      $operations
 	 * @param mixed|null $complexData
 	 */
 	public function __construct(array $operations, $complexData = null){

--- a/src/pocketmine/scheduler/DumpWorkerMemoryTask.php
+++ b/src/pocketmine/scheduler/DumpWorkerMemoryTask.php
@@ -37,11 +37,6 @@ class DumpWorkerMemoryTask extends AsyncTask{
 	/** @var int */
 	private $maxStringSize;
 
-	/**
-	 * @param string $outputFolder
-	 * @param int    $maxNesting
-	 * @param int    $maxStringSize
-	 */
 	public function __construct(string $outputFolder, int $maxNesting, int $maxStringSize){
 		$this->outputFolder = $outputFolder;
 		$this->maxNesting = $maxNesting;

--- a/src/pocketmine/scheduler/FileWriteTask.php
+++ b/src/pocketmine/scheduler/FileWriteTask.php
@@ -35,9 +35,7 @@ class FileWriteTask extends AsyncTask{
 	private $flags;
 
 	/**
-	 * @param string $path
 	 * @param mixed  $contents
-	 * @param int    $flags
 	 */
 	public function __construct(string $path, $contents, int $flags = 0){
 		$this->path = $path;

--- a/src/pocketmine/scheduler/SendUsageTask.php
+++ b/src/pocketmine/scheduler/SendUsageTask.php
@@ -49,11 +49,6 @@ class SendUsageTask extends AsyncTask{
 	/** @var string */
 	public $data;
 
-	/**
-	 * @param Server $server
-	 * @param int    $type
-	 * @param array  $playerList
-	 */
 	public function __construct(Server $server, int $type, array $playerList = []){
 		$endpoint = "http://" . $server->getProperty("anonymous-statistics.host", "stats.pocketmine.net") . "/";
 

--- a/src/pocketmine/scheduler/Task.php
+++ b/src/pocketmine/scheduler/Task.php
@@ -37,9 +37,6 @@ abstract class Task{
 		return $this->taskHandler;
 	}
 
-	/**
-	 * @return int
-	 */
 	final public function getTaskId() : int{
 		if($this->taskHandler !== null){
 			return $this->taskHandler->getTaskId();
@@ -53,8 +50,6 @@ abstract class Task{
 	}
 
 	/**
-	 * @param TaskHandler|null $taskHandler
-	 *
 	 * @return void
 	 */
 	final public function setHandler(TaskHandler $taskHandler = null){
@@ -65,8 +60,6 @@ abstract class Task{
 
 	/**
 	 * Actions to execute when run
-	 *
-	 * @param int $currentTick
 	 *
 	 * @return void
 	 */

--- a/src/pocketmine/scheduler/TaskHandler.php
+++ b/src/pocketmine/scheduler/TaskHandler.php
@@ -54,13 +54,6 @@ class TaskHandler{
 	/** @var string */
 	private $ownerName;
 
-	/**
-	 * @param Task        $task
-	 * @param int         $taskId
-	 * @param int         $delay
-	 * @param int         $period
-	 * @param string|null $ownerName
-	 */
 	public function __construct(Task $task, int $taskId, int $delay = -1, int $period = -1, ?string $ownerName = null){
 		$this->task = $task;
 		$this->taskId = $taskId;
@@ -72,67 +65,41 @@ class TaskHandler{
 		$this->task->setHandler($this);
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isCancelled() : bool{
 		return $this->cancelled;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getNextRun() : int{
 		return $this->nextRun;
 	}
 
 	/**
-	 * @param int $ticks
-	 *
 	 * @return void
 	 */
 	public function setNextRun(int $ticks){
 		$this->nextRun = $ticks;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getTaskId() : int{
 		return $this->taskId;
 	}
 
-	/**
-	 * @return Task
-	 */
 	public function getTask() : Task{
 		return $this->task;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getDelay() : int{
 		return $this->delay;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isDelayed() : bool{
 		return $this->delay > 0;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function isRepeating() : bool{
 		return $this->period > 0;
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getPeriod() : int{
 		return $this->period;
 	}
@@ -159,8 +126,6 @@ class TaskHandler{
 	}
 
 	/**
-	 * @param int $currentTick
-	 *
 	 * @return void
 	 */
 	public function run(int $currentTick){
@@ -172,9 +137,6 @@ class TaskHandler{
 		}
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getTaskName() : string{
 		return $this->taskName;
 	}

--- a/src/pocketmine/scheduler/TaskScheduler.php
+++ b/src/pocketmine/scheduler/TaskScheduler.php
@@ -54,7 +54,6 @@ class TaskScheduler{
 
 	/**
 	 * @param \Logger     $logger @deprecated
-	 * @param null|string $owner
 	 */
 	public function __construct(\Logger $logger, ?string $owner = null){
 		$this->owner = $owner;
@@ -62,8 +61,6 @@ class TaskScheduler{
 	}
 
 	/**
-	 * @param Task $task
-	 *
 	 * @return TaskHandler
 	 */
 	public function scheduleTask(Task $task){
@@ -71,9 +68,6 @@ class TaskScheduler{
 	}
 
 	/**
-	 * @param Task $task
-	 * @param int  $delay
-	 *
 	 * @return TaskHandler
 	 */
 	public function scheduleDelayedTask(Task $task, int $delay){
@@ -81,9 +75,6 @@ class TaskScheduler{
 	}
 
 	/**
-	 * @param Task $task
-	 * @param int  $period
-	 *
 	 * @return TaskHandler
 	 */
 	public function scheduleRepeatingTask(Task $task, int $period){
@@ -91,10 +82,6 @@ class TaskScheduler{
 	}
 
 	/**
-	 * @param Task $task
-	 * @param int  $delay
-	 * @param int  $period
-	 *
 	 * @return TaskHandler
 	 */
 	public function scheduleDelayedRepeatingTask(Task $task, int $delay, int $period){
@@ -102,8 +89,6 @@ class TaskScheduler{
 	}
 
 	/**
-	 * @param int $taskId
-	 *
 	 * @return void
 	 */
 	public function cancelTask(int $taskId){
@@ -130,20 +115,11 @@ class TaskScheduler{
 		$this->ids = 1;
 	}
 
-	/**
-	 * @param int $taskId
-	 *
-	 * @return bool
-	 */
 	public function isQueued(int $taskId) : bool{
 		return isset($this->tasks[$taskId]);
 	}
 
 	/**
-	 * @param Task $task
-	 * @param int  $delay
-	 * @param int  $period
-	 *
 	 * @return TaskHandler
 	 *
 	 * @throws \InvalidStateException
@@ -190,8 +166,6 @@ class TaskScheduler{
 	}
 
 	/**
-	 * @param int $currentTick
-	 *
 	 * @return void
 	 */
 	public function mainThreadHeartbeat(int $currentTick){
@@ -218,9 +192,6 @@ class TaskScheduler{
 		return !$this->queue->isEmpty() and $this->queue->current()->getNextRun() <= $currentTick;
 	}
 
-	/**
-	 * @return int
-	 */
 	private function nextId() : int{
 		return $this->ids++;
 	}

--- a/src/pocketmine/tile/Banner.php
+++ b/src/pocketmine/tile/Banner.php
@@ -127,8 +127,6 @@ class Banner extends Spawnable implements Nameable{
 
 	/**
 	 * Returns the color of the banner base.
-	 *
-	 * @return int
 	 */
 	public function getBaseColor() : int{
 		return $this->baseColor;
@@ -136,8 +134,6 @@ class Banner extends Spawnable implements Nameable{
 
 	/**
 	 * Sets the color of the banner base.
-	 *
-	 * @param int $color
 	 */
 	public function setBaseColor(int $color) : void{
 		$this->baseColor = $color;
@@ -146,9 +142,6 @@ class Banner extends Spawnable implements Nameable{
 
 	/**
 	 * Applies a new pattern on the banner with the given color.
-	 *
-	 * @param string $pattern
-	 * @param int    $color
 	 *
 	 * @return int ID of pattern.
 	 */
@@ -164,10 +157,6 @@ class Banner extends Spawnable implements Nameable{
 
 	/**
 	 * Returns whether a pattern with the given ID exists on the banner or not.
-	 *
-	 * @param int $patternId
-	 *
-	 * @return bool
 	 */
 	public function patternExists(int $patternId) : bool{
 		return $this->patterns->isset($patternId);
@@ -175,10 +164,6 @@ class Banner extends Spawnable implements Nameable{
 
 	/**
 	 * Returns the data of a pattern with the given ID.
-	 *
-	 * @param int $patternId
-	 *
-	 * @return array
 	 */
 	public function getPatternData(int $patternId) : array{
 		if(!$this->patternExists($patternId)){
@@ -196,10 +181,6 @@ class Banner extends Spawnable implements Nameable{
 
 	/**
 	 * Changes the pattern of a previously existing pattern.
-	 *
-	 * @param int    $patternId
-	 * @param string $pattern
-	 * @param int    $color
 	 *
 	 * @return bool indicating success.
 	 */
@@ -219,8 +200,6 @@ class Banner extends Spawnable implements Nameable{
 
 	/**
 	 * Deletes a pattern from the banner with the given ID.
-	 *
-	 * @param int $patternId
 	 *
 	 * @return bool indicating whether the pattern existed or not.
 	 */
@@ -255,16 +234,11 @@ class Banner extends Spawnable implements Nameable{
 
 	/**
 	 * Returns the total count of patterns on this banner.
-	 *
-	 * @return int
 	 */
 	public function getPatternCount() : int{
 		return $this->patterns->count();
 	}
 
-	/**
-	 * @return ListTag
-	 */
 	public function getPatterns() : ListTag{
 		return $this->patterns;
 	}

--- a/src/pocketmine/tile/Chest.php
+++ b/src/pocketmine/tile/Chest.php
@@ -147,9 +147,6 @@ class Chest extends Spawnable implements InventoryHolder, Container, Nameable{
 		}
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getDefaultName() : string{
 		return "Chest";
 	}
@@ -161,9 +158,6 @@ class Chest extends Spawnable implements InventoryHolder, Container, Nameable{
 		return $this->pairX !== null and $this->pairZ !== null;
 	}
 
-	/**
-	 * @return Chest|null
-	 */
 	public function getPair() : ?Chest{
 		if($this->isPaired()){
 			$tile = $this->getLevel()->getTileAt($this->pairX, $this->y, $this->pairZ);

--- a/src/pocketmine/tile/Container.php
+++ b/src/pocketmine/tile/Container.php
@@ -41,10 +41,6 @@ interface Container{
 
 	/**
 	 * Returns whether this container can be opened by an item with the given custom name.
-	 *
-	 * @param string $key
-	 *
-	 * @return bool
 	 */
 	public function canOpenWith(string $key) : bool;
 }

--- a/src/pocketmine/tile/ContainerTrait.php
+++ b/src/pocketmine/tile/ContainerTrait.php
@@ -73,10 +73,6 @@ trait ContainerTrait{
 
 	/**
 	 * @see Container::canOpenWith()
-	 *
-	 * @param string $key
-	 *
-	 * @return bool
 	 */
 	public function canOpenWith(string $key) : bool{
 		return $this->lock === null or $this->lock === $key;

--- a/src/pocketmine/tile/EnchantTable.php
+++ b/src/pocketmine/tile/EnchantTable.php
@@ -29,9 +29,6 @@ class EnchantTable extends Spawnable implements Nameable{
 		saveName as writeSaveData;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getDefaultName() : string{
 		return "Enchanting Table";
 	}

--- a/src/pocketmine/tile/FlowerPot.php
+++ b/src/pocketmine/tile/FlowerPot.php
@@ -71,8 +71,6 @@ class FlowerPot extends Spawnable{
 	}
 
 	/**
-	 * @param Item $item
-	 *
 	 * @return void
 	 */
 	public function setItem(Item $item){

--- a/src/pocketmine/tile/Furnace.php
+++ b/src/pocketmine/tile/Furnace.php
@@ -108,9 +108,6 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 		$this->saveItems($nbt);
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getDefaultName() : string{
 		return "Furnace";
 	}
@@ -139,8 +136,6 @@ class Furnace extends Spawnable implements InventoryHolder, Container, Nameable{
 	}
 
 	/**
-	 * @param Item $fuel
-	 *
 	 * @return void
 	 */
 	protected function checkFuel(Item $fuel){

--- a/src/pocketmine/tile/ItemFrame.php
+++ b/src/pocketmine/tile/ItemFrame.php
@@ -64,8 +64,6 @@ class ItemFrame extends Spawnable{
 	}
 
 	/**
-	 * @param Item|null $item
-	 *
 	 * @return void
 	 */
 	public function setItem(Item $item = null){
@@ -82,8 +80,6 @@ class ItemFrame extends Spawnable{
 	}
 
 	/**
-	 * @param int $rotation
-	 *
 	 * @return void
 	 */
 	public function setItemRotation(int $rotation){
@@ -96,8 +92,6 @@ class ItemFrame extends Spawnable{
 	}
 
 	/**
-	 * @param float $chance
-	 *
 	 * @return void
 	 */
 	public function setItemDropChance(float $chance){

--- a/src/pocketmine/tile/Nameable.php
+++ b/src/pocketmine/tile/Nameable.php
@@ -26,25 +26,14 @@ namespace pocketmine\tile;
 interface Nameable{
 	public const TAG_CUSTOM_NAME = "CustomName";
 
-	/**
-	 * @return string
-	 */
 	public function getDefaultName() : string;
 
-	/**
-	 * @return string
-	 */
 	public function getName() : string;
 
 	/**
-	 * @param string $str
-	 *
 	 * @return void
 	 */
 	public function setName(string $str);
 
-	/**
-	 * @return bool
-	 */
 	public function hasName() : bool;
 }

--- a/src/pocketmine/tile/NameableTrait.php
+++ b/src/pocketmine/tile/NameableTrait.php
@@ -36,21 +36,12 @@ trait NameableTrait{
 	/** @var string|null */
 	private $customName;
 
-	/**
-	 * @return string
-	 */
 	abstract public function getDefaultName() : string;
 
-	/**
-	 * @return string
-	 */
 	public function getName() : string{
 		return $this->customName ?? $this->getDefaultName();
 	}
 
-	/**
-	 * @param string $name
-	 */
 	public function setName(string $name) : void{
 		if($name === ""){
 			$this->customName = null;
@@ -59,9 +50,6 @@ trait NameableTrait{
 		}
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function hasName() : bool{
 		return $this->customName !== null;
 	}

--- a/src/pocketmine/tile/Sign.php
+++ b/src/pocketmine/tile/Sign.php
@@ -77,11 +77,6 @@ class Sign extends Spawnable{
 	/**
 	 * Changes contents of the specific lines to the string provided.
 	 * Leaves contents of the specific lines as is if null is provided.
-	 *
-	 * @param null|string $line1
-	 * @param null|string $line2
-	 * @param null|string $line3
-	 * @param null|string $line4
 	 */
 	public function setText(?string $line1 = "", ?string $line2 = "", ?string $line3 = "", ?string $line4 = "") : void{
 		if($line1 !== null){
@@ -102,8 +97,6 @@ class Sign extends Spawnable{
 
 	/**
 	 * @param int    $index 0-3
-	 * @param string $line
-	 * @param bool   $update
 	 */
 	public function setLine(int $index, string $line, bool $update = true) : void{
 		if($index < 0 or $index > 3){
@@ -121,8 +114,6 @@ class Sign extends Spawnable{
 
 	/**
 	 * @param int $index 0-3
-	 *
-	 * @return string
 	 */
 	public function getLine(int $index) : string{
 		if($index < 0 or $index > 3){

--- a/src/pocketmine/tile/Skull.php
+++ b/src/pocketmine/tile/Skull.php
@@ -58,8 +58,6 @@ class Skull extends Spawnable{
 	}
 
 	/**
-	 * @param int $type
-	 *
 	 * @return void
 	 */
 	public function setType(int $type){

--- a/src/pocketmine/tile/Spawnable.php
+++ b/src/pocketmine/tile/Spawnable.php
@@ -102,9 +102,6 @@ abstract class Spawnable extends Tile{
 		return $this->spawnCompoundCache;
 	}
 
-	/**
-	 * @return CompoundTag
-	 */
 	final public function getSpawnCompound() : CompoundTag{
 		$nbt = new CompoundTag("", [
 			new StringTag(self::TAG_ID, static::getSaveId()),
@@ -119,17 +116,12 @@ abstract class Spawnable extends Tile{
 	/**
 	 * An extension to getSpawnCompound() for
 	 * further modifying the generic tile NBT.
-	 *
-	 * @param CompoundTag $nbt
 	 */
 	abstract protected function addAdditionalSpawnData(CompoundTag $nbt) : void;
 
 	/**
 	 * Called when a player updates a block entity's NBT data
 	 * for example when writing on a sign.
-	 *
-	 * @param CompoundTag $nbt
-	 * @param Player      $player
 	 *
 	 * @return bool indication of success, will respawn the tile to the player if false.
 	 */

--- a/src/pocketmine/tile/Tile.php
+++ b/src/pocketmine/tile/Tile.php
@@ -102,11 +102,7 @@ abstract class Tile extends Position{
 
 	/**
 	 * @param string      $type
-	 * @param Level       $level
-	 * @param CompoundTag $nbt
 	 * @param mixed       ...$args
-	 *
-	 * @return Tile|null
 	 */
 	public static function createTile($type, Level $level, CompoundTag $nbt, ...$args) : ?Tile{
 		if(isset(self::$knownTiles[$type])){
@@ -119,10 +115,6 @@ abstract class Tile extends Position{
 	}
 
 	/**
-	 * @param string $className
-	 * @param array  $saveNames
-	 *
-	 * @return bool
 	 * @throws \ReflectionException
 	 */
 	public static function registerTile(string $className, array $saveNames = []) : bool{
@@ -148,7 +140,6 @@ abstract class Tile extends Position{
 
 	/**
 	 * Returns the short save name
-	 * @return string
 	 */
 	public static function getSaveId() : string{
 		if(!isset(self::$saveNames[static::class])){
@@ -178,15 +169,11 @@ abstract class Tile extends Position{
 
 	/**
 	 * Reads additional data from the CompoundTag on tile creation.
-	 *
-	 * @param CompoundTag $nbt
 	 */
 	abstract protected function readSaveData(CompoundTag $nbt) : void;
 
 	/**
 	 * Writes additional save data to a CompoundTag, not including generic things like ID and coordinates.
-	 *
-	 * @param CompoundTag $nbt
 	 */
 	abstract protected function writeSaveData(CompoundTag $nbt) : void;
 
@@ -208,13 +195,6 @@ abstract class Tile extends Position{
 
 	/**
 	 * Creates and returns a CompoundTag containing the necessary information to spawn a tile of this type.
-	 *
-	 * @param Vector3     $pos
-	 * @param int|null    $face
-	 * @param Item|null   $item
-	 * @param Player|null $player
-	 *
-	 * @return CompoundTag
 	 */
 	public static function createNBT(Vector3 $pos, ?int $face = null, ?Item $item = null, ?Player $player = null) : CompoundTag{
 		if(static::class === self::class){
@@ -243,27 +223,15 @@ abstract class Tile extends Position{
 
 	/**
 	 * Called by createNBT() to allow descendent classes to add their own base NBT using the parameters provided.
-	 *
-	 * @param CompoundTag $nbt
-	 * @param Vector3     $pos
-	 * @param int|null    $face
-	 * @param Item|null   $item
-	 * @param Player|null $player
 	 */
 	protected static function createAdditionalNBT(CompoundTag $nbt, Vector3 $pos, ?int $face = null, ?Item $item = null, ?Player $player = null) : void{
 
 	}
 
-	/**
-	 * @return Block
-	 */
 	public function getBlock() : Block{
 		return $this->level->getBlockAt($this->x, $this->y, $this->z);
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function onUpdate() : bool{
 		return false;
 	}

--- a/src/pocketmine/timings/Timings.php
+++ b/src/pocketmine/timings/Timings.php
@@ -148,12 +148,6 @@ abstract class Timings{
 
 	}
 
-	/**
-	 * @param TaskHandler $task
-	 * @param int         $period
-	 *
-	 * @return TimingsHandler
-	 */
 	public static function getScheduledTaskTimings(TaskHandler $task, int $period) : TimingsHandler{
 		$name = "Task: " . ($task->getOwnerName() ?? "Unknown") . " Runnable: " . $task->getTaskName();
 
@@ -170,11 +164,6 @@ abstract class Timings{
 		return self::$pluginTaskTimingMap[$name];
 	}
 
-	/**
-	 * @param Entity $entity
-	 *
-	 * @return TimingsHandler
-	 */
 	public static function getEntityTimings(Entity $entity) : TimingsHandler{
 		$entityType = (new \ReflectionClass($entity))->getShortName();
 		if(!isset(self::$entityTypeTimingMap[$entityType])){
@@ -188,11 +177,6 @@ abstract class Timings{
 		return self::$entityTypeTimingMap[$entityType];
 	}
 
-	/**
-	 * @param Tile $tile
-	 *
-	 * @return TimingsHandler
-	 */
 	public static function getTileEntityTimings(Tile $tile) : TimingsHandler{
 		$tileType = (new \ReflectionClass($tile))->getShortName();
 		if(!isset(self::$tileEntityTypeTimingMap[$tileType])){
@@ -202,11 +186,6 @@ abstract class Timings{
 		return self::$tileEntityTypeTimingMap[$tileType];
 	}
 
-	/**
-	 * @param DataPacket $pk
-	 *
-	 * @return TimingsHandler
-	 */
 	public static function getReceiveDataPacketTimings(DataPacket $pk) : TimingsHandler{
 		if(!isset(self::$packetReceiveTimingMap[$pk::NETWORK_ID])){
 			$pkName = (new \ReflectionClass($pk))->getShortName();
@@ -216,12 +195,6 @@ abstract class Timings{
 		return self::$packetReceiveTimingMap[$pk::NETWORK_ID];
 	}
 
-
-	/**
-	 * @param DataPacket $pk
-	 *
-	 * @return TimingsHandler
-	 */
 	public static function getSendDataPacketTimings(DataPacket $pk) : TimingsHandler{
 		if(!isset(self::$packetSendTimingMap[$pk::NETWORK_ID])){
 			$pkName = (new \ReflectionClass($pk))->getShortName();

--- a/src/pocketmine/timings/TimingsHandler.php
+++ b/src/pocketmine/timings/TimingsHandler.php
@@ -154,9 +154,6 @@ class TimingsHandler{
 	/** @var int */
 	private $violations = 0;
 
-	/**
-	 * @param TimingsHandler $parent
-	 */
 	public function __construct(string $name, TimingsHandler $parent = null){
 		$this->name = $name;
 		$this->parent = $parent;

--- a/src/pocketmine/timings/TimingsHandler.php
+++ b/src/pocketmine/timings/TimingsHandler.php
@@ -108,8 +108,6 @@ class TimingsHandler{
 	}
 
 	/**
-	 * @param bool $measure
-	 *
 	 * @return void
 	 */
 	public static function tick(bool $measure = true){
@@ -157,7 +155,6 @@ class TimingsHandler{
 	private $violations = 0;
 
 	/**
-	 * @param string         $name
 	 * @param TimingsHandler $parent
 	 */
 	public function __construct(string $name, TimingsHandler $parent = null){

--- a/src/pocketmine/updater/AutoUpdater.php
+++ b/src/pocketmine/updater/AutoUpdater.php
@@ -46,10 +46,6 @@ class AutoUpdater{
 	/** @var VersionString|null */
 	protected $newVersion;
 
-	/**
-	 * @param Server $server
-	 * @param string $endpoint
-	 */
 	public function __construct(Server $server, string $endpoint){
 		$this->server = $server;
 		$this->endpoint = "http://$endpoint/api/";
@@ -61,8 +57,6 @@ class AutoUpdater{
 
 	/**
 	 * Callback used at the end of the update checking task
-	 *
-	 * @param array $updateInfo
 	 *
 	 * @return void
 	 */
@@ -85,8 +79,6 @@ class AutoUpdater{
 
 	/**
 	 * Returns whether there is an update available.
-	 *
-	 * @return bool
 	 */
 	public function hasUpdate() : bool{
 		return $this->newVersion !== null;
@@ -111,8 +103,6 @@ class AutoUpdater{
 
 	/**
 	 * Shows a warning to a player to tell them there is an update available
-	 *
-	 * @param Player $player
 	 *
 	 * @return void
 	 */
@@ -198,8 +188,6 @@ class AutoUpdater{
 
 	/**
 	 * Returns the channel used for update checking (stable, beta, dev)
-	 *
-	 * @return string
 	 */
 	public function getChannel() : string{
 		$channel = strtolower($this->server->getProperty("auto-updater.preferred-channel", "stable"));
@@ -212,8 +200,6 @@ class AutoUpdater{
 
 	/**
 	 * Returns the host used for update checks.
-	 *
-	 * @return string
 	 */
 	public function getEndpoint() : string{
 		return $this->endpoint;

--- a/src/pocketmine/utils/Color.php
+++ b/src/pocketmine/utils/Color.php
@@ -47,7 +47,6 @@ class Color{
 
 	/**
 	 * Returns the alpha (opacity) value of this colour.
-	 * @return int
 	 */
 	public function getA() : int{
 		return $this->a;
@@ -55,8 +54,6 @@ class Color{
 
 	/**
 	 * Sets the alpha (opacity) value of this colour, lower = more transparent
-	 *
-	 * @param int $a
 	 *
 	 * @return void
 	 */
@@ -66,7 +63,6 @@ class Color{
 
 	/**
 	 * Retuns the red value of this colour.
-	 * @return int
 	 */
 	public function getR() : int{
 		return $this->r;
@@ -74,8 +70,6 @@ class Color{
 
 	/**
 	 * Sets the red value of this colour.
-	 *
-	 * @param int $r
 	 *
 	 * @return void
 	 */
@@ -85,7 +79,6 @@ class Color{
 
 	/**
 	 * Returns the green value of this colour.
-	 * @return int
 	 */
 	public function getG() : int{
 		return $this->g;
@@ -93,8 +86,6 @@ class Color{
 
 	/**
 	 * Sets the green value of this colour.
-	 *
-	 * @param int $g
 	 *
 	 * @return void
 	 */
@@ -104,7 +95,6 @@ class Color{
 
 	/**
 	 * Returns the blue value of this colour.
-	 * @return int
 	 */
 	public function getB() : int{
 		return $this->b;
@@ -112,8 +102,6 @@ class Color{
 
 	/**
 	 * Sets the blue value of this colour.
-	 *
-	 * @param int $b
 	 *
 	 * @return void
 	 */
@@ -125,8 +113,6 @@ class Color{
 	 * Mixes the supplied list of colours together to produce a result colour.
 	 *
 	 * @param Color ...$colors
-	 *
-	 * @return Color
 	 */
 	public static function mix(Color ...$colors) : Color{
 		$count = count($colors);
@@ -149,8 +135,6 @@ class Color{
 	/**
 	 * Returns a Color from the supplied RGB colour code (24-bit)
 	 *
-	 * @param int $code
-	 *
 	 * @return Color
 	 */
 	public static function fromRGB(int $code){
@@ -160,8 +144,6 @@ class Color{
 	/**
 	 * Returns a Color from the supplied ARGB colour code (32-bit)
 	 *
-	 * @param int $code
-	 *
 	 * @return Color
 	 */
 	public static function fromARGB(int $code){
@@ -170,7 +152,6 @@ class Color{
 
 	/**
 	 * Returns an ARGB 32-bit colour value.
-	 * @return int
 	 */
 	public function toARGB() : int{
 		return ($this->a << 24) | ($this->r << 16) | ($this->g << 8) | $this->b;
@@ -178,7 +159,6 @@ class Color{
 
 	/**
 	 * Returns a little-endian ARGB 32-bit colour value.
-	 * @return int
 	 */
 	public function toBGRA() : int{
 		return ($this->b << 24) | ($this->g << 16) | ($this->r << 8) | $this->a;
@@ -186,7 +166,6 @@ class Color{
 
 	/**
 	 * Returns an RGBA 32-bit colour value.
-	 * @return int
 	 */
 	public function toRGBA() : int{
 		return ($this->r << 24) | ($this->g << 16) | ($this->b << 8) | $this->a;
@@ -194,15 +173,12 @@ class Color{
 
 	/**
 	 * Returns a little-endian RGBA colour value.
-	 * @return int
 	 */
 	public function toABGR() : int{
 		return ($this->a << 24) | ($this->b << 16) | ($this->g << 8) | $this->r;
 	}
 
 	/**
-	 * @param int $code
-	 *
 	 * @return Color
 	 */
 	public static function fromABGR(int $code){

--- a/src/pocketmine/utils/Config.php
+++ b/src/pocketmine/utils/Config.php
@@ -136,22 +136,10 @@ class Config{
 		$this->changed = $changed;
 	}
 
-	/**
-	 * @param string $str
-	 *
-	 * @return string
-	 */
 	public static function fixYAMLIndexes(string $str) : string{
 		return preg_replace("#^( *)(y|Y|yes|Yes|YES|n|N|no|No|NO|true|True|TRUE|false|False|FALSE|on|On|ON|off|Off|OFF)( *)\:#m", "$1\"$2\"$3:", $str);
 	}
 
-	/**
-	 * @param string $file
-	 * @param int    $type
-	 * @param array  $default
-	 *
-	 * @return bool
-	 */
 	public function load(string $file, int $type = Config::DETECT, array $default = []) : bool{
 		$this->correct = true;
 		$this->file = $file;
@@ -209,16 +197,10 @@ class Config{
 		return true;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function check() : bool{
 		return $this->correct;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function save() : bool{
 		if($this->correct){
 			$content = null;
@@ -255,8 +237,6 @@ class Config{
 	/**
 	 * Sets the options for the JSON encoding when saving
 	 *
-	 * @param int $options
-	 *
 	 * @return Config $this
 	 * @throws \RuntimeException if the Config is not in JSON
 	 * @see json_encode
@@ -273,8 +253,6 @@ class Config{
 
 	/**
 	 * Enables the given option in addition to the currently set JSON options
-	 *
-	 * @param int $option
 	 *
 	 * @return Config $this
 	 * @throws \RuntimeException if the Config is not in JSON
@@ -293,8 +271,6 @@ class Config{
 	/**
 	 * Disables the given option for the JSON encoding when saving
 	 *
-	 * @param int $option
-	 *
 	 * @return Config $this
 	 * @throws \RuntimeException if the Config is not in JSON
 	 * @see json_encode
@@ -312,7 +288,6 @@ class Config{
 	/**
 	 * Returns the options for the JSON encoding when saving
 	 *
-	 * @return int
 	 * @throws \RuntimeException if the Config is not in JSON
 	 * @see json_encode
 	 */
@@ -466,8 +441,6 @@ class Config{
 	}
 
 	/**
-	 * @param array $v
-	 *
 	 * @return void
 	 */
 	public function setAll(array $v){
@@ -478,8 +451,6 @@ class Config{
 	/**
 	 * @param string $k
 	 * @param bool   $lowercase If set, searches Config in single-case / lowercase.
-	 *
-	 * @return bool
 	 */
 	public function exists($k, bool $lowercase = false) : bool{
 		if($lowercase){
@@ -501,18 +472,11 @@ class Config{
 		$this->changed = true;
 	}
 
-	/**
-	 * @param bool $keys
-	 *
-	 * @return array
-	 */
 	public function getAll(bool $keys = false) : array{
 		return ($keys ? array_keys($this->config) : $this->config);
 	}
 
 	/**
-	 * @param array $defaults
-	 *
 	 * @return void
 	 */
 	public function setDefaults(array $defaults){
@@ -520,10 +484,7 @@ class Config{
 	}
 
 	/**
-	 * @param array $default
 	 * @param array $data reference parameter
-	 *
-	 * @return int
 	 */
 	private function fillDefaults(array $default, &$data) : int{
 		$changed = 0;
@@ -546,9 +507,6 @@ class Config{
 		return $changed;
 	}
 
-	/**
-	 * @param string $content
-	 */
 	private function parseList(string $content) : void{
 		foreach(explode("\n", trim(str_replace("\r\n", "\n", $content))) as $v){
 			$v = trim($v);
@@ -559,9 +517,6 @@ class Config{
 		}
 	}
 
-	/**
-	 * @return string
-	 */
 	private function writeProperties() : string{
 		$content = "#Properties Config file\r\n#" . date("D M j H:i:s T Y") . "\r\n";
 		foreach($this->config as $k => $v){
@@ -576,9 +531,6 @@ class Config{
 		return $content;
 	}
 
-	/**
-	 * @param string $content
-	 */
 	private function parseProperties(string $content) : void{
 		if(preg_match_all('/^\s*([a-zA-Z0-9\-_\.]+)[ \t]*=([^\r\n]*)/um', $content, $matches) > 0){ //false or 0 matches
 			foreach($matches[1] as $i => $k){

--- a/src/pocketmine/utils/Git.php
+++ b/src/pocketmine/utils/Git.php
@@ -36,10 +36,7 @@ final class Git{
 	/**
 	 * Returns the git hash of the currently checked out head of the given repository, or null on failure.
 	 *
-	 * @param string $dir
 	 * @param bool   $dirty reference parameter, set to whether the repo has local changes
-	 *
-	 * @return string|null
 	 */
 	public static function getRepositoryState(string $dir, bool &$dirty) : ?string{
 		if(Utils::execute("git -C \"$dir\" rev-parse HEAD", $out) === 0 and $out !== false and strlen($out = trim($out)) === 40){
@@ -54,10 +51,6 @@ final class Git{
 	/**
 	 * Infallible, returns a string representing git state, or a string of zeros on failure.
 	 * If the repo is dirty, a "-dirty" suffix is added.
-	 *
-	 * @param string $dir
-	 *
-	 * @return string
 	 */
 	public static function getRepositoryStatePretty(string $dir) : string{
 		$dirty = false;

--- a/src/pocketmine/utils/Internet.php
+++ b/src/pocketmine/utils/Internet.php
@@ -113,7 +113,6 @@ class Internet{
 	 * Returns the machine's internal network IP address. If the machine is not behind a router, this may be the same
 	 * as the external IP.
 	 *
-	 * @return string
 	 * @throws InternetException
 	 */
 	public static function getInternalIP() : string{
@@ -135,9 +134,7 @@ class Internet{
 	 * GETs an URL using cURL
 	 * NOTE: This is a blocking operation and can take a significant amount of time. It is inadvisable to use this method on the main thread.
 	 *
-	 * @param string  $page
 	 * @param int     $timeout default 10
-	 * @param array   $extraHeaders
 	 * @param string  $err reference parameter, will be set to the output of curl_error(). Use this to retrieve errors that occured during the operation.
 	 * @param array[] $headers reference parameter
 	 * @param int     $httpCode reference parameter
@@ -158,10 +155,7 @@ class Internet{
 	 * POSTs data to an URL
 	 * NOTE: This is a blocking operation and can take a significant amount of time. It is inadvisable to use this method on the main thread.
 	 *
-	 * @param string       $page
 	 * @param array|string $args
-	 * @param int          $timeout
-	 * @param array        $extraHeaders
 	 * @param string       $err reference parameter, will be set to the output of curl_error(). Use this to retrieve errors that occured during the operation.
 	 * @param array[]      $headers reference parameter
 	 * @param int          $httpCode reference parameter
@@ -185,7 +179,6 @@ class Internet{
 	 * General cURL shorthand function.
 	 * NOTE: This is a blocking operation and can take a significant amount of time. It is inadvisable to use this method on the main thread.
 	 *
-	 * @param string        $page
 	 * @param float|int     $timeout      The maximum connect timeout and timeout in seconds, correct to ms.
 	 * @param string[]      $extraHeaders extra headers to send as a plain string array
 	 * @param array         $extraOpts    extra CURLOPT_* to set as an [opt => value] map

--- a/src/pocketmine/utils/MainLogger.php
+++ b/src/pocketmine/utils/MainLogger.php
@@ -79,9 +79,6 @@ class MainLogger extends \AttachableThreadedLogger{
 	private $timezone;
 
 	/**
-	 * @param string $logFile
-	 * @param bool   $logDebug
-	 *
 	 * @throws \RuntimeException
 	 */
 	public function __construct(string $logFile, bool $logDebug = false){
@@ -101,16 +98,12 @@ class MainLogger extends \AttachableThreadedLogger{
 		$this->start(PTHREADS_INHERIT_NONE);
 	}
 
-	/**
-	 * @return MainLogger
-	 */
 	public static function getLogger() : MainLogger{
 		return static::$logger;
 	}
 
 	/**
 	 * Returns whether a MainLogger instance is statically registered on this thread.
-	 * @return bool
 	 */
 	public static function isRegisteredStatic() : bool{
 		return static::$logger !== null;
@@ -132,8 +125,6 @@ class MainLogger extends \AttachableThreadedLogger{
 
 	/**
 	 * Returns the current logger format used for console output.
-	 *
-	 * @return string
 	 */
 	public function getFormat() : string{
 		return $this->format;
@@ -149,8 +140,6 @@ class MainLogger extends \AttachableThreadedLogger{
 	 * - message
 	 *
 	 * @see http://php.net/manual/en/function.sprintf.php
-	 *
-	 * @param string $format
 	 */
 	public function setFormat(string $format) : void{
 		$this->format = $format;
@@ -192,8 +181,6 @@ class MainLogger extends \AttachableThreadedLogger{
 	}
 
 	/**
-	 * @param bool $logDebug
-	 *
 	 * @return void
 	 */
 	public function setLogDebug(bool $logDebug){
@@ -201,7 +188,6 @@ class MainLogger extends \AttachableThreadedLogger{
 	}
 
 	/**
-	 * @param \Throwable $e
 	 * @param array|null $trace
 	 *
 	 * @return void

--- a/src/pocketmine/utils/Random.php
+++ b/src/pocketmine/utils/Random.php
@@ -88,8 +88,6 @@ class Random{
 
 	/**
 	 * Returns an 31-bit integer (not signed)
-	 *
-	 * @return int
 	 */
 	public function nextInt() : int{
 		return $this->nextSignedInt() & 0x7fffffff;
@@ -97,8 +95,6 @@ class Random{
 
 	/**
 	 * Returns a 32-bit integer (signed)
-	 *
-	 * @return int
 	 */
 	public function nextSignedInt() : int{
 		$t = ($this->x ^ ($this->x << 11)) & 0xffffffff;
@@ -114,8 +110,6 @@ class Random{
 
 	/**
 	 * Returns a float between 0.0 and 1.0 (inclusive)
-	 *
-	 * @return float
 	 */
 	public function nextFloat() : float{
 		return $this->nextInt() / 0x7fffffff;
@@ -123,8 +117,6 @@ class Random{
 
 	/**
 	 * Returns a float between -1.0 and 1.0 (inclusive)
-	 *
-	 * @return float
 	 */
 	public function nextSignedFloat() : float{
 		return $this->nextSignedInt() / 0x7fffffff;
@@ -132,8 +124,6 @@ class Random{
 
 	/**
 	 * Returns a random boolean
-	 *
-	 * @return bool
 	 */
 	public function nextBoolean() : bool{
 		return ($this->nextSignedInt() & 0x01) === 0;
@@ -144,8 +134,6 @@ class Random{
 	 *
 	 * @param int $start default 0
 	 * @param int $end default 0x7fffffff
-	 *
-	 * @return int
 	 */
 	public function nextRange(int $start = 0, int $end = 0x7fffffff) : int{
 		return $start + ($this->nextInt() % ($end + 1 - $start));

--- a/src/pocketmine/utils/Terminal.php
+++ b/src/pocketmine/utils/Terminal.php
@@ -204,8 +204,6 @@ abstract class Terminal{
 	 * Note that this is platform-dependent and might produce different results depending on the terminal type and/or OS.
 	 *
 	 * @param string|array $string
-	 *
-	 * @return string
 	 */
 	public static function toANSI($string) : string{
 		if(!is_array($string)){

--- a/src/pocketmine/utils/TextFormat.php
+++ b/src/pocketmine/utils/TextFormat.php
@@ -68,10 +68,6 @@ abstract class TextFormat{
 
 	/**
 	 * Splits the string by Format tokens
-	 *
-	 * @param string $string
-	 *
-	 * @return array
 	 */
 	public static function tokenize(string $string) : array{
 		return preg_split("/(" . TextFormat::ESCAPE . "[0-9a-fk-or])/u", $string, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
@@ -79,9 +75,6 @@ abstract class TextFormat{
 
 	/**
 	 * Cleans the string from Minecraft codes, ANSI Escape Codes and invalid UTF-8 characters
-	 *
-	 * @param string $string
-	 * @param bool   $removeFormat
 	 *
 	 * @return string valid clean UTF-8
 	 */
@@ -97,10 +90,7 @@ abstract class TextFormat{
 	/**
 	 * Replaces placeholders of § with the correct character. Only valid codes (as in the constants of the TextFormat class) will be converted.
 	 *
-	 * @param string $string
 	 * @param string $placeholder default "&"
-	 *
-	 * @return string
 	 */
 	public static function colorize(string $string, string $placeholder = "&") : string{
 		return preg_replace('/' . preg_quote($placeholder, "/") . '([0-9a-fk-or])/u', TextFormat::ESCAPE . '$1', $string);
@@ -110,8 +100,6 @@ abstract class TextFormat{
 	 * Returns an JSON-formatted string with colors/markup
 	 *
 	 * @param string|array $string
-	 *
-	 * @return string
 	 */
 	public static function toJSON($string) : string{
 		if(!is_array($string)){
@@ -298,8 +286,6 @@ abstract class TextFormat{
 	 * Returns an HTML-formatted string with colors/markup
 	 *
 	 * @param string|array $string
-	 *
-	 * @return string
 	 */
 	public static function toHTML($string) : string{
 		if(!is_array($string)){

--- a/src/pocketmine/utils/UUID.php
+++ b/src/pocketmine/utils/UUID.php
@@ -60,10 +60,7 @@ class UUID{
 	/**
 	 * Creates an UUID from an hexadecimal representation
 	 *
-	 * @param string $uuid
 	 * @param int    $version
-	 *
-	 * @return UUID
 	 */
 	public static function fromString(string $uuid, int $version = null) : UUID{
 		return self::fromBinary(hex2bin(str_replace("-", "", trim($uuid))), $version);
@@ -72,10 +69,7 @@ class UUID{
 	/**
 	 * Creates an UUID from a binary representation
 	 *
-	 * @param string $uuid
 	 * @param int    $version
-	 *
-	 * @return UUID
 	 *
 	 * @throws \InvalidArgumentException
 	 */
@@ -91,8 +85,6 @@ class UUID{
 	 * Creates an UUIDv3 from binary data or list of binary data
 	 *
 	 * @param string ...$data
-	 *
-	 * @return UUID
 	 */
 	public static function fromData(string ...$data) : UUID{
 		$hash = hash("md5", implode($data), true);
@@ -120,8 +112,6 @@ class UUID{
 	}
 
 	/**
-	 * @param int $partNumber
-	 *
 	 * @return int
 	 * @throws \InvalidArgumentException
 	 */

--- a/src/pocketmine/utils/UUID.php
+++ b/src/pocketmine/utils/UUID.php
@@ -59,8 +59,6 @@ class UUID{
 
 	/**
 	 * Creates an UUID from an hexadecimal representation
-	 *
-	 * @param int    $version
 	 */
 	public static function fromString(string $uuid, int $version = null) : UUID{
 		return self::fromBinary(hex2bin(str_replace("-", "", trim($uuid))), $version);
@@ -68,8 +66,6 @@ class UUID{
 
 	/**
 	 * Creates an UUID from a binary representation
-	 *
-	 * @param int    $version
 	 *
 	 * @throws \InvalidArgumentException
 	 */

--- a/src/pocketmine/utils/Utils.php
+++ b/src/pocketmine/utils/Utils.php
@@ -108,8 +108,6 @@ class Utils{
 	/**
 	 * Generates an unique identifier to a callable
 	 *
-	 * @param callable $variable
-	 *
 	 * @return string
 	 */
 	public static function getCallableIdentifier(callable $variable){
@@ -123,9 +121,6 @@ class Utils{
 	/**
 	 * Returns a readable identifier for the given Closure, including file and line.
 	 *
-	 * @param \Closure $closure
-	 *
-	 * @return string
 	 * @throws \ReflectionException
 	 */
 	public static function getNiceClosureName(\Closure $closure) : string{
@@ -151,9 +146,6 @@ class Utils{
 	/**
 	 * Returns a readable identifier for the class of the given object. Sanitizes class names for anonymous classes.
 	 *
-	 * @param object $obj
-	 *
-	 * @return string
 	 * @throws \ReflectionException
 	 */
 	public static function getNiceClassName(object $obj) : string{
@@ -172,8 +164,6 @@ class Utils{
 	 * The rest of the hash will change depending on other factors.
 	 *
 	 * @param string $extra optional, additional data to identify the machine
-	 *
-	 * @return UUID
 	 */
 	public static function getMachineUniqueId(string $extra = "") : UUID{
 		if(self::$serverUniqueId !== null and $extra === ""){
@@ -254,10 +244,6 @@ class Utils{
 	 * Linux => Linux
 	 * BSD => bsd
 	 * Other => other
-	 *
-	 * @param bool $recalculate
-	 *
-	 * @return string
 	 */
 	public static function getOS(bool $recalculate = false) : string{
 		if(self::$os === null or $recalculate){
@@ -310,8 +296,6 @@ class Utils{
 	}
 
 	/**
-	 * @param bool $advanced
-	 *
 	 * @return int[]|int
 	 */
 	public static function getMemoryUsage(bool $advanced = false){
@@ -357,11 +341,6 @@ class Utils{
 		return count(ThreadManager::getInstance()->getAll()) + 3; //RakLib + MainLogger + Main Thread
 	}
 
-	/**
-	 * @param bool $recalculate
-	 *
-	 * @return int
-	 */
 	public static function getCoreCount(bool $recalculate = false) : int{
 		static $processors = 0;
 
@@ -399,10 +378,6 @@ class Utils{
 
 	/**
 	 * Returns a prettified hexdump
-	 *
-	 * @param string $bin
-	 *
-	 * @return string
 	 */
 	public static function hexdump(string $bin) : string{
 		$output = "";
@@ -416,13 +391,10 @@ class Utils{
 		return $output;
 	}
 
-
 	/**
 	 * Returns a string that can be printed, replaces non-printable characters
 	 *
 	 * @param mixed $str
-	 *
-	 * @return string
 	 */
 	public static function printable($str) : string{
 		if(!is_string($str)){
@@ -448,9 +420,7 @@ class Utils{
 	 * @deprecated
 	 * @see Internet::getURL()
 	 *
-	 * @param string  $page
 	 * @param int     $timeout default 10
-	 * @param array   $extraHeaders
 	 * @param string  $err reference parameter, will be set to the output of curl_error(). Use this to retrieve errors that occured during the operation.
 	 * @param array[] $headers reference parameter
 	 * @param int     $httpCode reference parameter
@@ -465,10 +435,7 @@ class Utils{
 	 * @deprecated
 	 * @see Internet::postURL()
 	 *
-	 * @param string       $page
 	 * @param array|string $args
-	 * @param int          $timeout
-	 * @param array        $extraHeaders
 	 * @param string       $err reference parameter, will be set to the output of curl_error(). Use this to retrieve errors that occured during the operation.
 	 * @param array[]      $headers reference parameter
 	 * @param int          $httpCode reference parameter
@@ -483,7 +450,6 @@ class Utils{
 	 * @deprecated
 	 * @see Internet::simpleCurl()
 	 *
-	 * @param string        $page
 	 * @param float|int     $timeout      The maximum connect timeout and timeout in seconds, correct to ms.
 	 * @param string[]      $extraHeaders extra headers to send as a plain string array
 	 * @param array         $extraOpts    extra CURLOPT_* to set as an [opt => value] map
@@ -578,7 +544,6 @@ class Utils{
 
 	/**
 	 * @param object $value
-	 * @param bool   $includeCurrent
 	 *
 	 * @return int
 	 */
@@ -594,12 +559,6 @@ class Utils{
 		return -1;
 	}
 
-	/**
-	 * @param array $trace
-	 * @param int   $maxStringLength
-	 *
-	 * @return array
-	 */
 	public static function printableTrace(array $trace, int $maxStringLength = 80) : array{
 		$messages = [];
 		for($i = 0; isset($trace[$i]); ++$i){
@@ -629,11 +588,6 @@ class Utils{
 		return $messages;
 	}
 
-	/**
-	 * @param int $skipFrames
-	 *
-	 * @return array
-	 */
 	public static function currentTrace(int $skipFrames = 0) : array{
 		++$skipFrames; //omit this frame from trace, in addition to other skipped frames
 		if(function_exists("xdebug_get_function_stack")){
@@ -648,11 +602,6 @@ class Utils{
 		return array_values($trace);
 	}
 
-	/**
-	 * @param int $skipFrames
-	 *
-	 * @return array
-	 */
 	public static function printableCurrentTrace(int $skipFrames = 0) : array{
 		return self::printableTrace(self::currentTrace(++$skipFrames));
 	}
@@ -683,8 +632,6 @@ class Utils{
 	/**
 	 * Extracts one-line tags from the doc-comment
 	 *
-	 * @param string $docComment
-	 *
 	 * @return string[] an array of tagName => tag value. If the tag has no value, an empty string is used as the value.
 	 */
 	public static function parseDocComment(string $docComment) : array{
@@ -694,12 +641,6 @@ class Utils{
 	}
 
 	/**
-	 * @param int    $severity
-	 * @param string $message
-	 * @param string $file
-	 * @param int    $line
-	 *
-	 * @return bool
 	 * @throws \ErrorException
 	 */
 	public static function errorExceptionHandler(int $severity, string $message, string $file, int $line) : bool{

--- a/src/pocketmine/utils/VersionString.php
+++ b/src/pocketmine/utils/VersionString.php
@@ -48,11 +48,6 @@ class VersionString{
 	/** @var bool */
 	private $development = false;
 
-	/**
-	 * @param string $baseVersion
-	 * @param bool   $isDevBuild
-	 * @param int    $buildNumber
-	 */
 	public function __construct(string $baseVersion, bool $isDevBuild = false, int $buildNumber = 0){
 		$this->baseVersion = $baseVersion;
 		$this->development = $isDevBuild;
@@ -117,12 +112,6 @@ class VersionString{
 		return $this->getFullVersion();
 	}
 
-	/**
-	 * @param VersionString $target
-	 * @param bool          $diff
-	 *
-	 * @return int
-	 */
 	public function compare(VersionString $target, bool $diff = false) : int{
 		$number = $this->getNumber();
 		$tNumber = $target->getNumber();


### PR DESCRIPTION
## Introduction
As PHP has grown more and more typed over the years, the necessity for @param and @return annotations has decreased, because the types are able to be specified using language-level types.

This PR strips all @param and @return annotations which do not provide any additional useful information about the parameter they describe. This means that a type annotation is not necessary if the native type provides all the information.

The following are exempt from removal:
- Annotations which contain additional descriptions about the parameter or return
- Annotations providing extra information about their target, e.g. specifying the type of an array `T[]` for a native type `array`
- Annotations describing union types
- Annotations describing types which are not currently native due to BC constraints (e.g. `@return void`)

## Motivation
- Reducing the amount of work needed to add documentation. Now, only things which require detail need to be specified.
- Improved readability: many useless LOC are gone, and more useful code can fit on the screen.
- Reduced conflicts between branches during merges. Function signature changes often produce conflicts when merging changes, and they have to be fixed in 2 places. This change will reduce that to 1 for most cases.

## Tests
This only affects PHPDoc and does not affect any functionality; therefore no tests are required. PHPStan should fail the build if any changes were made incorrectly.