### PR TITLE
add some PHPStan-specific callable prototypes

### DIFF
--- a/src/pocketmine/scheduler/AsyncPool.php
+++ b/src/pocketmine/scheduler/AsyncPool.php
@@ -68,7 +68,10 @@ class AsyncPool{
 	/** @var int[] */
 	private $workerLastUsed = [];
 
-	/** @var \Closure[] */
+	/**
+	 * @var \Closure[]
+	 * @phpstan-var (\Closure(int $workerId) : void)[]
+	 */
 	private $workerStartHooks = [];
 
 	public function __construct(Server $server, int $size, int $workerMemoryLimit, \ClassLoader $classLoader, \ThreadedLogger $logger){
@@ -100,6 +103,8 @@ class AsyncPool{
 	 * The signature should be `function(int $worker) : void`
 	 *
 	 * This function will call the hook for every already-running worker.
+	 *
+	 * @phpstan-param \Closure(int $workerId) : void $hook
 	 */
 	public function addWorkerStartHook(\Closure $hook) : void{
 		Utils::validateCallableSignature(function(int $worker) : void{}, $hook);
@@ -111,6 +116,8 @@ class AsyncPool{
 
 	/**
 	 * Removes a previously-registered callback listening for workers being started.
+	 *
+	 * @phpstan-param \Closure(int $workerId) : void $hook
 	 */
 	public function removeWorkerStartHook(\Closure $hook) : void{
 		unset($this->workerStartHooks[spl_object_hash($hook)]);

--- a/src/pocketmine/scheduler/ClosureTask.php
+++ b/src/pocketmine/scheduler/ClosureTask.php
@@ -38,11 +38,15 @@ use pocketmine\utils\Utils;
  */
 class ClosureTask extends Task{
 
-	/** @var \Closure */
+	/**
+	 * @var \Closure
+	 * @phpstan-var \Closure(int) : void
+	 */
 	private $closure;
 
 	/**
 	 * @param \Closure $closure Must accept only ONE parameter, $currentTick
+	 * @phpstan-param \Closure(int) : void $closure
 	 */
 	public function __construct(\Closure $closure){
 		Utils::validateCallableSignature(function(int $currentTick) : void{}, $closure);

--- a/src/pocketmine/utils/Internet.php
+++ b/src/pocketmine/utils/Internet.php
@@ -183,6 +183,7 @@ class Internet{
 	 * @param string[]      $extraHeaders extra headers to send as a plain string array
 	 * @param array         $extraOpts    extra CURLOPT_* to set as an [opt => value] map
 	 * @param callable|null $onSuccess    function to be called if there is no error. Accepts a resource argument as the cURL handle.
+	 * @phpstan-param (callable(resource) : void)|null $onSuccess
 	 *
 	 * @return array a plain array of three [result body : string, headers : array[], HTTP response code : int]. Headers are grouped by requests with strtolower(header name) as keys and header value as values
 	 *

--- a/src/pocketmine/utils/Utils.php
+++ b/src/pocketmine/utils/Utils.php
@@ -454,6 +454,7 @@ class Utils{
 	 * @param string[]      $extraHeaders extra headers to send as a plain string array
 	 * @param array         $extraOpts    extra CURLOPT_* to set as an [opt => value] map
 	 * @param callable|null $onSuccess    function to be called if there is no error. Accepts a resource argument as the cURL handle.
+	 * @phpstan-param (callable(resource) : void)|null $onSuccess
 	 *
 	 * @return array a plain array of three [result body : string, headers : array[], HTTP response code : int]. Headers are grouped by requests with strtolower(header name) as keys and header value as values
 	 *


### PR DESCRIPTION
## Introduction
This pull requests adds prototype information where callables are used. This is useful for static analysers to detect bugs in code both core and plugin.

Since these annotations are not subject to any code styling standard, the style must be manually maintained; therefore, discussion on the rules to apply on their formatting needs to be had.

### Behavioural changes
PHPStan may detect additional flaws in code relating to closure/callable usage.

## Tests
Since this is a PHPStan focused change, tests are not required, since the CI will do the work.