### PR TITLE
Async worker init closures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
       "pocketmine/classloader": "dev-master",
       "daverandom/callback-validator": "dev-master",
       "adhocore/json-comment": "^0.1.0",
-      "particle/validator": "^2.3"
+      "particle/validator": "^2.3",
+      "opis/closure": "^3.5"
    },
    "require-dev": {
       "phpstan/phpstan": "^0.12.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bb9233cea6e62cc28ea22863681e066e",
+    "content-hash": "a85ce5a659bb2d131f96167be134ace2",
     "packages": [
         {
             "name": "adhocore/json-comment",
@@ -232,6 +232,67 @@
             "time": "2018-12-03T18:17:01+00:00"
         },
         {
+            "name": "opis/closure",
+            "version": "3.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opis/closure.git",
+                "reference": "93ebc5712cdad8d5f489b500c59d122df2e53969"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opis/closure/zipball/93ebc5712cdad8d5f489b500c59d122df2e53969",
+                "reference": "93ebc5712cdad8d5f489b500c59d122df2e53969",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.4 || ^7.0"
+            },
+            "require-dev": {
+                "jeremeamia/superclosure": "^2.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Opis\\Closure\\": "src/"
+                },
+                "files": [
+                    "functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marius Sarca",
+                    "email": "marius.sarca@gmail.com"
+                },
+                {
+                    "name": "Sorin Sarca",
+                    "email": "sarca_sorin@hotmail.com"
+                }
+            ],
+            "description": "A library that can be used to serialize closures (anonymous functions) and arbitrary objects.",
+            "homepage": "https://opis.io/closure",
+            "keywords": [
+                "anonymous functions",
+                "closure",
+                "function",
+                "serializable",
+                "serialization",
+                "serialize"
+            ],
+            "time": "2019-11-29T22:36:02+00:00"
+        },
+        {
             "name": "particle/validator",
             "version": "v2.3.4",
             "source": {
@@ -277,7 +338,7 @@
                 {
                     "name": "Berry Langerak",
                     "email": "berry@berryllium.nl",
-                    "role": "Developer"
+                    "role": "developer"
                 },
                 {
                     "name": "Rick van der Staaij",
@@ -591,7 +652,7 @@
             "source": {
                 "type": "git",
                 "url": "https://gitlab.irstea.fr/pole-is/tools/phpunit-shim.git",
-                "reference": "39b6155954d6caec1110a9e78582c4816ab247bc"
+                "reference": "8ec63f895972681271191821a36f9081c236b993"
             },
             "require": {
                 "ext-dom": "*",
@@ -613,6 +674,11 @@
                 "phpunit"
             ],
             "type": "library",
+            "autoload": {
+                "exclude-from-classmap": [
+                    "phpunit"
+                ]
+            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
@@ -632,7 +698,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2020-01-09T03:20:20+00:00"
+            "time": "2020-01-23T13:39:47+00:00"
         },
         {
             "name": "phpstan/phpstan",

--- a/src/scheduler/AsyncPool.php
+++ b/src/scheduler/AsyncPool.php
@@ -171,7 +171,8 @@ class AsyncPool{
 				$hook($worker);
 			}
 
-			if(count($this->workerInitHooks) > 0) {
+			// make sure there are hooks so we don't schedule a task for no reason
+			if(count($this->workerInitHooks) > 0){
 				$this->scheduleClosuresForWorker($worker, $this->workerInitHooks);
 			}
 		}

--- a/src/scheduler/AsyncPool.php
+++ b/src/scheduler/AsyncPool.php
@@ -343,12 +343,9 @@ class AsyncPool{
 	private function scheduleClosuresForWorker(int $worker, array $closures) : void{
 		// use an anonymous class so this functionality isn't publicly exposed
 		$task = new class($closures) extends AsyncTask {
-			/** @var string[] */
+			/** @var string */
 			private $closures;
 
-			/**
-			 * @param string[] $closures
-			 */
 			public function __construct(array $closures) {
 				$this->closures = serialize($closures);
 			}

--- a/src/scheduler/AsyncPool.php
+++ b/src/scheduler/AsyncPool.php
@@ -346,6 +346,9 @@ class AsyncPool{
 			/** @var string */
 			private $closures;
 
+			/**
+			 * @param SerializableClosure[] $closures
+			 */
 			public function __construct(array $closures) {
 				$this->closures = serialize($closures);
 			}


### PR DESCRIPTION
## Introduction
Allows registering a closure that is run on async worker threads. Useful for static registries (blocks, items, etc).

## Changes
### API changes
* Added `\pocketmine\scheduler\AsyncPool::addWorkerInitHook(\Closure)` method for registering a closure that is run once on all current workers and any new workers.
* Added `\pocketmine\scheduler\AsyncPool::removeWorkerInitHook(\Closure)` method for removing a closure that has previously been registered as an init hook.

## Backwards compatibility
No BC changes, only API additions.

## Tests
https://gist.github.com/JackNoordhuis/936df0444262d10538239c0e985f7d04
