### PR TITLE
Make it easier to prevent an object from being consumed

### DIFF
--- a/src/pocketmine/block/Cake.php
+++ b/src/pocketmine/block/Cake.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\entity\EffectInstance;
+use pocketmine\entity\Human;
 use pocketmine\entity\Living;
 use pocketmine\item\FoodSource;
 use pocketmine\item\Item;
@@ -128,7 +129,19 @@ class Cake extends Transparent implements FoodSource{
 		return [];
 	}
 
+	/**
+	 * This method always receives a Player object
+	 *
+	 * @param Human|Living $consumer
+	 * @return bool
+	 */
+	public function canBeConsumedBy(Living $consumer) : bool{
+		return $consumer->isHungry();
+	}
+
 	public function onConsume(Living $consumer) : void{
+		$consumer->addFood($this->getFoodRestore());
+		$consumer->addSaturation($this->getSaturationRestore());
 		$this->level->setBlock($this, $this->getResidue());
 	}
 }

--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -294,19 +294,6 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 		return $ev->getAmount();
 	}
 
-	public function consumeObject(Consumable $consumable) : bool{
-		if($consumable instanceof FoodSource){
-			if($consumable->requiresHunger() and !$this->isHungry()){
-				return false;
-			}
-
-			$this->addFood($consumable->getFoodRestore());
-			$this->addSaturation($consumable->getSaturationRestore());
-		}
-
-		return parent::consumeObject($consumable);
-	}
-
 	/**
 	 * Returns the player's experience level.
 	 */

--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -359,6 +359,10 @@ abstract class Living extends Entity implements Damageable{
 	 * etc.
 	 */
 	public function consumeObject(Consumable $consumable) : bool{
+		if(!$consumable->canBeConsumedBy($this)){
+			return false;
+		}
+
 		foreach($consumable->getAdditionalEffects() as $effect){
 			$this->addEffect($effect);
 		}

--- a/src/pocketmine/item/Bucket.php
+++ b/src/pocketmine/item/Bucket.php
@@ -107,7 +107,7 @@ class Bucket extends Item implements Consumable{
 		return [];
 	}
 
-	public function canBeConsumed() : bool{
+	public function canBeConsumedBy(Living $consumer) : bool{
 		return $this->meta === 1; //Milk
 	}
 

--- a/src/pocketmine/item/Consumable.php
+++ b/src/pocketmine/item/Consumable.php
@@ -46,6 +46,11 @@ interface Consumable{
 	public function getAdditionalEffects() : array;
 
 	/**
+	 * @return bool
+	 */
+	public function canBeConsumedBy(Living $consumer) : bool;
+
+	/**
 	 * Called when this Consumable is consumed by mob, after standard resulting effects have been applied.
 	 *
 	 * @return void

--- a/src/pocketmine/item/Food.php
+++ b/src/pocketmine/item/Food.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\item;
 
+use pocketmine\entity\Human;
 use pocketmine\entity\Living;
 
 abstract class Food extends Item implements FoodSource{
@@ -41,7 +42,14 @@ abstract class Food extends Item implements FoodSource{
 		return [];
 	}
 
-	public function onConsume(Living $consumer){
+	public function canBeConsumedBy(Living $consumer): bool{
+		return ($this->requiresHunger() and $consumer instanceof Human and !$consumer->isHungry()) ? false : true;
+	}
 
+	public function onConsume(Living $consumer){
+		if($consumer instanceof Human) {
+			$consumer->addFood($this->getFoodRestore());
+			$consumer->addSaturation($this->getSaturationRestore());
+		}
 	}
 }

--- a/src/pocketmine/item/Potion.php
+++ b/src/pocketmine/item/Potion.php
@@ -221,6 +221,10 @@ class Potion extends Item implements Consumable{
 		return 1;
 	}
 
+	public function canBeConsumedBy(Living $consumer) : bool{
+		return true;
+	}
+
 	public function onConsume(Living $consumer){
 
 	}


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
At the moment, to prevent an item from being consumed the function `Living->consumeObject()` has to be overwritten. This PR encapsulates that part into Consumable, making it easier to prevent an object from being consumed or to identify if it can be consumed.

### Relevant issues
<!-- List relevant issues here -->
Fixes #3306 
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Adds `canBeConsumedBy(Living $consumer)` to the interface `Consumable`
```php
	public function canBeConsumedBy(Living $consumer) : bool;
```

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
All classes implementing `Consumable` must be declared abstract or add the function `canBeConsumedBy(Living $consumer)`

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->

- Potions can be consumed.
- All food sources work as expected.
- Water/Lava buckets cannot be consumed anymore.

[![Testing the update](https://img.youtube.com/vi/peaw3k31hPg/0.jpg)](https://www.youtube.com/watch?v=peaw3k31hPg)
