### PR TITLE
Protocol: MultiplayerSettingsPacket can be sent to the player

### DIFF
--- a/src/network/mcpe/protocol/MultiplayerSettingsPacket.php
+++ b/src/network/mcpe/protocol/MultiplayerSettingsPacket.php
@@ -28,7 +28,7 @@ namespace pocketmine\network\mcpe\protocol;
 use pocketmine\network\mcpe\handler\PacketHandler;
 use pocketmine\network\mcpe\serializer\NetworkBinaryStream;
 
-class MultiplayerSettingsPacket extends DataPacket implements ServerboundPacket{ //TODO: this might be clientbound too, but unsure
+class MultiplayerSettingsPacket extends DataPacket implements ClientboundPacket, ServerboundPacket{
 	public const NETWORK_ID = ProtocolInfo::MULTIPLAYER_SETTINGS_PACKET;
 
 	public const ACTION_ENABLE_MULTIPLAYER = 0;


### PR DESCRIPTION
## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Now MultiplayerSettingsPacket can be sent to the player.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
No performance changes.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
This PR contains only protocol-related changes.

## Tests
I can approve that MultiplayerSettingsPacket is ClientboundPacket:
Bedrock Dedicated Server (BDS) sends this packet after successful handling MultiplayerSettingsPacket. This is a screenshot from IDA:
![](https://user-images.githubusercontent.com/25742996/75466697-a1f1c200-599b-11ea-8d06-5caa5660f557.png)
<!--

v24 is MultiplayerSettingsPacket

-->