### PR TITLE
Pass old item(s) to inventory change listeners (#3323)

### DIFF
--- a/src/inventory/BaseInventory.php
+++ b/src/inventory/BaseInventory.php
@@ -90,6 +90,8 @@ abstract class BaseInventory implements Inventory{
 			$items = array_slice($items, 0, $this->getSize(), true);
 		}
 
+		$oldContents = $this->slots->toArray();
+
 		$listeners = $this->listeners;
 		$this->listeners = [];
 		$viewers = $this->viewers;
@@ -109,7 +111,7 @@ abstract class BaseInventory implements Inventory{
 		}
 
 		foreach($this->listeners as $listener){
-			$listener->onContentChange($this);
+			$listener->onContentChange($this, $oldContents);
 		}
 
 		foreach($this->getViewers() as $viewer){
@@ -359,7 +361,7 @@ abstract class BaseInventory implements Inventory{
 
 	protected function onSlotChange(int $index, Item $before) : void{
 		foreach($this->listeners as $listener){
-			$listener->onSlotChange($this, $index);
+			$listener->onSlotChange($this, $index, $before);
 		}
 		foreach($this->viewers as $viewer){
 			$viewer->getNetworkSession()->getInvManager()->syncSlot($this, $index);

--- a/src/inventory/CallbackInventoryChangeListener.php
+++ b/src/inventory/CallbackInventoryChangeListener.php
@@ -75,6 +75,10 @@ class CallbackInventoryChangeListener implements InventoryChangeListener{
 		($this->onSlotChangeCallback)($inventory, $slot, $oldItem);
 	}
 
+	/**
+	 * @param Inventory $inventory
+	 * @param Item[] $oldContents
+	 */
 	public function onContentChange(Inventory $inventory, array $oldContents) : void{
 		($this->onContentChangeCallback)($inventory, $oldContents);
 	}

--- a/src/inventory/CallbackInventoryChangeListener.php
+++ b/src/inventory/CallbackInventoryChangeListener.php
@@ -76,7 +76,6 @@ class CallbackInventoryChangeListener implements InventoryChangeListener{
 	}
 
 	/**
-	 * @param Inventory $inventory
 	 * @param Item[] $oldContents
 	 */
 	public function onContentChange(Inventory $inventory, array $oldContents) : void{

--- a/src/inventory/CallbackInventoryChangeListener.php
+++ b/src/inventory/CallbackInventoryChangeListener.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\inventory;
 
+use pocketmine\item\Item;
 use pocketmine\utils\Utils;
 
 class CallbackInventoryChangeListener implements InventoryChangeListener{
@@ -31,25 +32,25 @@ class CallbackInventoryChangeListener implements InventoryChangeListener{
 
 	/**
 	 * @var \Closure|null
-	 * @phpstan-var (\Closure(Inventory, int) : void)|null
+	 * @phpstan-var (\Closure(Inventory, int, Item) : void)|null
 	 */
 	private $onSlotChangeCallback;
 	/**
 	 * @var \Closure|null
-	 * @phpstan-var (\Closure(Inventory) : void)|null
+	 * @phpstan-var (\Closure(Inventory, Item[]) : void)|null
 	 */
 	private $onContentChangeCallback;
 
 	/**
-	 * @phpstan-param (\Closure(Inventory, int) : void)|null $onSlotChange
-	 * @phpstan-param (\Closure(Inventory) : void)|null $onContentChange
+	 * @phpstan-param (\Closure(Inventory, int, Item) : void)|null $onSlotChange
+	 * @phpstan-param (\Closure(Inventory, Item[]) : void)|null $onContentChange
 	 */
 	public function __construct(?\Closure $onSlotChange, ?\Closure $onContentChange){
 		if($onSlotChange !== null){
-			Utils::validateCallableSignature(function(Inventory $inventory, int $slot) : void{}, $onSlotChange);
+			Utils::validateCallableSignature(function(Inventory $inventory, int $slot, Item $oldItem) : void{}, $onSlotChange);
 		}
 		if($onContentChange !== null){
-			Utils::validateCallableSignature(function(Inventory $inventory) : void{}, $onContentChange);
+			Utils::validateCallableSignature(function(Inventory $inventory, array $oldContents) : void{}, $onContentChange);
 		}
 
 		$this->onSlotChangeCallback = $onSlotChange;
@@ -61,20 +62,20 @@ class CallbackInventoryChangeListener implements InventoryChangeListener{
 	 */
 	public static function onAnyChange(\Closure $onChange) : self{
 		return new self(
-			static function(Inventory $inventory, int $unused) use ($onChange) : void{
+			static function(Inventory $inventory, int $unused, Item $unusedB) use ($onChange) : void{
 				$onChange($inventory);
 			},
-			static function(Inventory $inventory) use ($onChange) : void{
+			static function(Inventory $inventory, array $unused) use ($onChange) : void{
 				$onChange($inventory);
 			}
 		);
 	}
 
-	public function onSlotChange(Inventory $inventory, int $slot) : void{
-		($this->onSlotChangeCallback)($inventory, $slot);
+	public function onSlotChange(Inventory $inventory, int $slot, Item $oldItem) : void{
+		($this->onSlotChangeCallback)($inventory, $slot, $oldItem);
 	}
 
-	public function onContentChange(Inventory $inventory) : void{
-		($this->onContentChangeCallback)($inventory);
+	public function onContentChange(Inventory $inventory, array $oldContents) : void{
+		($this->onContentChangeCallback)($inventory, $oldContents);
 	}
 }

--- a/src/inventory/InventoryChangeListener.php
+++ b/src/inventory/InventoryChangeListener.php
@@ -23,6 +23,8 @@ declare(strict_types=1);
 
 namespace pocketmine\inventory;
 
+use pocketmine\item\Item;
+
 /**
  * Classes implementing this interface can be injected into inventories to receive notifications when content changes
  * occur.
@@ -32,7 +34,7 @@ namespace pocketmine\inventory;
  */
 interface InventoryChangeListener{
 
-	public function onSlotChange(Inventory $inventory, int $slot) : void;
+	public function onSlotChange(Inventory $inventory, int $slot, Item $oldItem) : void;
 
-	public function onContentChange(Inventory $inventory) : void;
+	public function onContentChange(Inventory $inventory, array $oldContents) : void;
 }

--- a/src/inventory/InventoryChangeListener.php
+++ b/src/inventory/InventoryChangeListener.php
@@ -37,7 +37,6 @@ interface InventoryChangeListener{
 	public function onSlotChange(Inventory $inventory, int $slot, Item $oldItem) : void;
 
 	/**
-	 * @param Inventory $inventory
 	 * @param Item[] $oldContents
 	 */
 	public function onContentChange(Inventory $inventory, array $oldContents) : void;

--- a/src/inventory/InventoryChangeListener.php
+++ b/src/inventory/InventoryChangeListener.php
@@ -36,5 +36,9 @@ interface InventoryChangeListener{
 
 	public function onSlotChange(Inventory $inventory, int $slot, Item $oldItem) : void;
 
+	/**
+	 * @param Inventory $inventory
+	 * @param Item[] $oldContents
+	 */
 	public function onContentChange(Inventory $inventory, array $oldContents) : void;
 }


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This PR solves the issue discussed in issue #3323 where old items can  not being accessed by inventory change listeners

### Relevant issues
<!-- List relevant issues here -->
* Fixes #3323 

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
* Signatures of InventoryChangeListener::onSlotChange() and InventoryChangeListener::onContentChange() have been changed
* Signatures of callables used by CallbackInventoryChangeListener have also been changed

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
This will break plugins currently using inventory change listeners.

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
```php
    public function onJoin(PlayerJoinEvent $event): void
    {
        $player = $event->getPlayer();
        $player->getInventory()->addChangeListeners(new CallbackInventoryChangeListener(function (Inventory $inventory, int $slot, Item $oldItem) use ($player): void {
            $player->sendMessage("Change in slot " . $slot . " Old Item: " . $oldItem->__toString() . " New Item: " . $inventory->getItem($slot)->__toString());
        }, function (Inventory $inventory, array $oldContents) use ($player): void {
            foreach ($oldContents as $slot => $oldContent) {
                if (!$inventory->getItem($slot)->equals($oldContent)) {
                    $player->sendMessage("[CONTENT CHANGE] Change in slot " . $slot . " Old Item: " . $oldContent->__toString() . " New Item: " . $inventory->getItem($slot)->__toString());
                }
            }
        }));
    }
```

![image](https://user-images.githubusercontent.com/8540562/75736296-aaa30a80-5cb1-11ea-8728-f32db85f89e0.png)
Image shows changes caused by dropping an arrow, picking up the arrow, and placing the arrow in its original slot (5)

![image](https://user-images.githubusercontent.com/8540562/75736355-d7efb880-5cb1-11ea-8813-ca9c2fd684d9.png)
Image shows content changes when dying with an inventory of 1x arrows
