### PR TITLE
Fix #3336

### DIFF
--- a/src/entity/Entity.php
+++ b/src/entity/Entity.php
@@ -1556,7 +1556,7 @@ abstract class Entity{
 	public function despawnFrom(Player $player, bool $send = true) : void{
 		$id = spl_object_id($player);
 		if(isset($this->hasSpawned[$id])){
-			if($send){
+			if($send and $player->isConnected()){
 				$player->getNetworkSession()->sendDataPacket(RemoveActorPacket::create($this->id));
 			}
 			unset($this->hasSpawned[$id]);


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
An additional check to make sure that the network session exists and is connected before sending the packet. The lack of this check leads to server crashes at times.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #3336 

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
N/A

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
N/A

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
N/A

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
N/A

<!-- Requires translations:
N/A

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result

There is no one clear way to test this, since the crash occurs randomly on its own. Even so, this additional check will clearly allow to avoid sending a packet to a non-existent NetworkSession, since it will make sure that the NetworkSession is connected.

-->
