### PR TITLE
Stop overriding item in hand if it has changed

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2420,7 +2420,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 						if($this->canInteract($blockVector->add(0.5, 0.5, 0.5), $this->isCreative() ? 13 : 7) and $this->level->useBreakOn($blockVector, $item, $this, true)){
 							if($this->isSurvival()){
-								if(!$item->equalsExact($oldItem)){
+								if(!$item->equalsExact($oldItem) and $item->equals($this->inventory->getItemInHand(), false, false)){
 									$this->inventory->setItemInHand($item);
 									$this->inventory->sendHeldItem($this->hasSpawned);
 								}

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2420,7 +2420,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 						if($this->canInteract($blockVector->add(0.5, 0.5, 0.5), $this->isCreative() ? 13 : 7) and $this->level->useBreakOn($blockVector, $item, $this, true)){
 							if($this->isSurvival()){
-								if(!$item->equalsExact($oldItem) and $item->equals($this->inventory->getItemInHand(), false, false)){
+								if(!$item->equalsExact($oldItem) and $oldItem->equalsExact($this->inventory->getItemInHand())){
 									$this->inventory->setItemInHand($item);
 									$this->inventory->sendHeldItem($this->hasSpawned);
 								}


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
When a player in survival mode breaks a block, the item in his hand is immediately overwritten by another one with a different durability. This causes unexpected behavior: if the item the player has in his hand changes during BlockBreakEvent, it will reappear. 
This PR fixes that issue.

### Relevant issues
<!-- List relevant issues here -->
Fixes #2010

## Changes
Checks if the player's item in hand is different before overriding it.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
This PR should maintain backwards compatibility.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
I made a plugin to clean the inventory when BlockBreakEvent was called and then checked if #2010 was still occurring, it wasn't.
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
[![Youtube video](https://img.youtube.com/vi/oL_XSPNikzc/0.jpg)](https://www.youtube.com/watch?v=oL_XSPNikzc)
