### PR TITLE
Added the new dark yellow color code

### DIFF
--- a/src/pocketmine/utils/Terminal.php
+++ b/src/pocketmine/utils/Terminal.php
@@ -77,6 +77,8 @@ abstract class Terminal{
 	public static $COLOR_YELLOW = "";
 	/** @var string */
 	public static $COLOR_WHITE = "";
+	/** @var string */
+	public static $COLOR_DARK_YELLOW = "";
 
 	/** @var bool|null */
 	private static $formattingCodes = null;
@@ -129,6 +131,7 @@ abstract class Terminal{
 		self::$COLOR_LIGHT_PURPLE = "\x1b[38;5;207m";
 		self::$COLOR_YELLOW = "\x1b[38;5;227m";
 		self::$COLOR_WHITE = "\x1b[38;5;231m";
+		self::$COLOR_DARK_YELLOW = "\x1b[38;5;226m";
 	}
 
 	/**
@@ -161,11 +164,12 @@ abstract class Terminal{
 			self::$COLOR_LIGHT_PURPLE = $colors >= 256 ? `tput setaf 207` : `tput setaf 13`;
 			self::$COLOR_YELLOW = $colors >= 256 ? `tput setaf 227` : `tput setaf 11`;
 			self::$COLOR_WHITE = $colors >= 256 ? `tput setaf 231` : `tput setaf 15`;
+			self::$COLOR_DARK_YELLOW = $colors >= 256 ? `tput setaf 178` : `tput setaf 11`;
 		}else{
 			self::$COLOR_BLACK = self::$COLOR_DARK_GRAY = `tput setaf 0`;
 			self::$COLOR_RED = self::$COLOR_DARK_RED = `tput setaf 1`;
 			self::$COLOR_GREEN = self::$COLOR_DARK_GREEN = `tput setaf 2`;
-			self::$COLOR_YELLOW = self::$COLOR_GOLD = `tput setaf 3`;
+			self::$COLOR_YELLOW = self::$COLOR_GOLD = self::$COLOR_DARK_YELLOW = `tput setaf 3`;
 			self::$COLOR_BLUE = self::$COLOR_DARK_BLUE = `tput setaf 4`;
 			self::$COLOR_LIGHT_PURPLE = self::$COLOR_PURPLE = `tput setaf 5`;
 			self::$COLOR_AQUA = self::$COLOR_DARK_AQUA = `tput setaf 6`;

--- a/src/pocketmine/utils/Terminal.php
+++ b/src/pocketmine/utils/Terminal.php
@@ -285,6 +285,9 @@ abstract class Terminal{
 				case TextFormat::WHITE:
 					$newString .= Terminal::$COLOR_WHITE;
 					break;
+				case TextFormat::DARK_YELLOW:
+					$newString .= Terminal::$COLOR_DARK_YELLOW;
+					break;
 				default:
 					$newString .= $token;
 					break;

--- a/src/pocketmine/utils/Terminal.php
+++ b/src/pocketmine/utils/Terminal.php
@@ -164,7 +164,7 @@ abstract class Terminal{
 			self::$COLOR_LIGHT_PURPLE = $colors >= 256 ? `tput setaf 207` : `tput setaf 13`;
 			self::$COLOR_YELLOW = $colors >= 256 ? `tput setaf 227` : `tput setaf 11`;
 			self::$COLOR_WHITE = $colors >= 256 ? `tput setaf 231` : `tput setaf 15`;
-			self::$COLOR_DARK_YELLOW = $colors >= 256 ? `tput setaf 178` : `tput setaf 11`;
+			self::$COLOR_DARK_YELLOW = $colors >= 256 ? `tput setaf 226` : `tput setaf 11`;
 		}else{
 			self::$COLOR_BLACK = self::$COLOR_DARK_GRAY = `tput setaf 0`;
 			self::$COLOR_RED = self::$COLOR_DARK_RED = `tput setaf 1`;

--- a/src/pocketmine/utils/TextFormat.php
+++ b/src/pocketmine/utils/TextFormat.php
@@ -58,6 +58,7 @@ abstract class TextFormat{
 	public const LIGHT_PURPLE = TextFormat::ESCAPE . "d";
 	public const YELLOW = TextFormat::ESCAPE . "e";
 	public const WHITE = TextFormat::ESCAPE . "f";
+	public const DARK_YELLOW = TextFormat::ESCAPE . "g";
 
 	public const OBFUSCATED = TextFormat::ESCAPE . "k";
 	public const BOLD = TextFormat::ESCAPE . "l";
@@ -72,7 +73,7 @@ abstract class TextFormat{
 	 * @return string[]
 	 */
 	public static function tokenize(string $string) : array{
-		return preg_split("/(" . TextFormat::ESCAPE . "[0-9a-fk-or])/u", $string, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
+		return preg_split("/(" . TextFormat::ESCAPE . "[0-9a-gk-or])/u", $string, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
 	}
 
 	/**
@@ -84,7 +85,7 @@ abstract class TextFormat{
 		$string = mb_scrub($string, 'UTF-8');
 		$string = preg_replace("/[\x{E000}-\x{F8FF}]/u", "", $string); //remove unicode private-use-area characters (they might break the console)
 		if($removeFormat){
-			$string = str_replace(TextFormat::ESCAPE, "", preg_replace("/" . TextFormat::ESCAPE . "[0-9a-fk-or]/u", "", $string));
+			$string = str_replace(TextFormat::ESCAPE, "", preg_replace("/" . TextFormat::ESCAPE . "[0-9a-gk-or]/u", "", $string));
 		}
 		return str_replace("\x1b", "", preg_replace("/\x1b[\\(\\][[0-9;\\[\\(]+[Bm]/u", "", $string));
 	}
@@ -95,7 +96,7 @@ abstract class TextFormat{
 	 * @param string $placeholder default "&"
 	 */
 	public static function colorize(string $string, string $placeholder = "&") : string{
-		return preg_replace('/' . preg_quote($placeholder, "/") . '([0-9a-fk-or])/u', TextFormat::ESCAPE . '$1', $string);
+		return preg_replace('/' . preg_quote($placeholder, "/") . '([0-9a-gk-or])/u', TextFormat::ESCAPE . '$1', $string);
 	}
 
 	/**
@@ -267,6 +268,10 @@ abstract class TextFormat{
 					$pointer["color"] = "white";
 					$color = "white";
 					break;
+				case TextFormat::DARK_YELLOW:
+					$pointer["color"] = "dark_yellow";
+					$color = "dark_yellow";
+					break;
 				default:
 					$pointer["text"] = $token;
 					break;
@@ -385,6 +390,10 @@ abstract class TextFormat{
 					break;
 				case TextFormat::WHITE:
 					$newString .= "<span style=color:#FFF>";
+					++$tokens;
+					break;
+				case TextFormat::DARK_YELLOW:
+					$newString .= "<span style=color:#DDD605>";
 					++$tokens;
 					break;
 				default:


### PR DESCRIPTION
## Introduction
Minecraft: Bedrock Edition v1.13 introduced a new colour code, which is identified by the letter "g". The colour connected to this code is dark yellow.

## Changes
### API changes
- The constant ``TextFormat::DARK_YELLOW`` has been created with the value ``§g``
- The static property ``Terminal::$COLOR_DARK_YELLOW `` has been created with the following values:
  - Fallback Escape Code: ``\x1b[38;5;226m``
  - Tput colors <= 8: ``tput setaf 3``
  - Tput colors > 8: ``tput setaf 11``
  - Tput colors > 256: ``tput setaf 178``

### Behavioural changes
Any current occurrences of ``§g`` in-game or in a console will start to be displayed as a dark yellow colour

## Tests
```php
use pocketmine\Player;
use pocketmine\utils\TextFormat;

/** @var Player $player */
$player->sendMessage(TextFormat::DARK_YELLOW . "This message is dark yellow!");
```