### PR TITLE
Player: Stop setting held item post entity attack if changed

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2590,7 +2590,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 						if($this->isAlive()){
 							//reactive damage like thorns might cause us to be killed by attacking another mob, which
 							//would mean we'd already have dropped the inventory by the time we reached here
-							if($heldItem->onAttackEntity($target) and $this->isSurvival()){ //always fire the hook, even if we are survival
+							if($heldItem->onAttackEntity($target) and $this->isSurvival() and $heldItem->equalsExact($this->inventory->getItemInHand())){ //always fire the hook, even if we are survival
 								$this->inventory->setItemInHand($heldItem);
 							}
 


### PR DESCRIPTION
## Introduction
This PR goes in the same lane as #3345: It makes sure the held item hasn't changed before setting it back to the inventory, preventing unexpected behavior such as items staying in the inventory when a plugin modified it on EntityDamageByEntityEvent.

## Changes
Fixes #3340 

## Backwards compatibility
This PR maintains BC.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
#3340 can't be reproduced using this patch.
[![IMAGE ALT TEXT HERE](https://img.youtube.com/vi/2MW4CU1KSnQ/0.jpg)](https://www.youtube.com/watch?v=2MW4CU1KSnQ)