### PR TITLE
Add a `php` directive to plugin.yml

### DIFF
--- a/src/pocketmine/plugin/PluginDescription.php
+++ b/src/pocketmine/plugin/PluginDescription.php
@@ -57,6 +57,8 @@ class PluginDescription{
 	private $compatibleMcpeProtocols = [];
 	/** @var string[] */
 	private $compatibleOperatingSystems = [];
+	/** @var string[] */
+	private $compatiblePhpVersions = [];
 	/**
 	 * @var string[][]
 	 * @phpstan-var array<string, list<mixed>>
@@ -117,6 +119,7 @@ class PluginDescription{
 		$this->api = array_map("\strval", (array) ($plugin["api"] ?? []));
 		$this->compatibleMcpeProtocols = array_map("\intval", (array) ($plugin["mcpe-protocol"] ?? []));
 		$this->compatibleOperatingSystems = array_map("\strval", (array) ($plugin["os"] ?? []));
+		$this->compatiblePhpVersions = array_map("\strval", (array) ($plugin["php"] ?? []));
 
 		if(isset($plugin["commands"]) and is_array($plugin["commands"])){
 			$this->commands = $plugin["commands"];
@@ -193,6 +196,13 @@ class PluginDescription{
 	 */
 	public function getCompatibleOperatingSystems() : array{
 		return $this->compatibleOperatingSystems;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function getCompatiblePhpVersions() : array{
+		return $this->compatiblePhpVersions;
 	}
 
 	/**

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -267,6 +267,16 @@ class PluginManager{
 						continue;
 					}
 
+					$pluginPhpVersions = $description->getCompatiblePhpVersions();
+					preg_match("#^\d+(\.\d+)*#", PHP_VERSION, $matches);
+					if(count($pluginPhpVersions) > 0 and !(in_array($matches[0], $pluginPhpVersions) or in_array(implode(".", array_slice(explode(".", PHP_VERSION), 0, 2)), $pluginPhpVersions))) {
+						$this->server->getLogger()->error($this->server->getLanguage()->translateString("pocketmine.plugin.loadError", [
+							$name,
+							$this->server->getLanguage()->translateString("%pocketmine.plugin.incompatiblePhpVersion", [implode(", ", $pluginPhpVersions)])
+						]));
+						continue;
+					}
+
 					if(count($pluginMcpeProtocols = $description->getCompatibleMcpeProtocols()) > 0){
 						$serverMcpeProtocols = [ProtocolInfo::CURRENT_PROTOCOL];
 						if(count(array_intersect($pluginMcpeProtocols, $serverMcpeProtocols)) === 0){

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -268,8 +268,8 @@ class PluginManager{
 					}
 
 					$pluginPhpVersions = $description->getCompatiblePhpVersions();
-					preg_match("#^\d+(\.\d+)*#", PHP_VERSION, $matches);
-					if(count($pluginPhpVersions) > 0 and !(in_array($matches[0], $pluginPhpVersions, true) or in_array(implode(".", array_slice(explode(".", PHP_VERSION), 0, 2)), $pluginPhpVersions, true))){
+					$pluginCompatiblePhpVersions = array_filter($pluginPhpVersions, function(string $version) : bool{ return Utils::isVersionCompatible($version, PHP_MAJOR_VERSION . "." . PHP_MINOR_VERSION . "." . PHP_RELEASE_VERSION); });
+					if(count($pluginPhpVersions) > 0 and count($pluginCompatiblePhpVersions) < 1){
 						$this->server->getLogger()->error($this->server->getLanguage()->translateString("pocketmine.plugin.loadError", [
 							$name,
 							$this->server->getLanguage()->translateString("%pocketmine.plugin.incompatiblePhpVersion", [implode(", ", $pluginPhpVersions)])

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -269,7 +269,7 @@ class PluginManager{
 
 					$pluginPhpVersions = $description->getCompatiblePhpVersions();
 					preg_match("#^\d+(\.\d+)*#", PHP_VERSION, $matches);
-					if(count($pluginPhpVersions) > 0 and !(in_array($matches[0], $pluginPhpVersions) or in_array(implode(".", array_slice(explode(".", PHP_VERSION), 0, 2)), $pluginPhpVersions))) {
+					if(count($pluginPhpVersions) > 0 and !(in_array($matches[0], $pluginPhpVersions, true) or in_array(implode(".", array_slice(explode(".", PHP_VERSION), 0, 2)), $pluginPhpVersions, true))) {
 						$this->server->getLogger()->error($this->server->getLanguage()->translateString("pocketmine.plugin.loadError", [
 							$name,
 							$this->server->getLanguage()->translateString("%pocketmine.plugin.incompatiblePhpVersion", [implode(", ", $pluginPhpVersions)])

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -269,7 +269,7 @@ class PluginManager{
 
 					$pluginPhpVersions = $description->getCompatiblePhpVersions();
 					preg_match("#^\d+(\.\d+)*#", PHP_VERSION, $matches);
-					if(count($pluginPhpVersions) > 0 and !(in_array($matches[0], $pluginPhpVersions, true) or in_array(implode(".", array_slice(explode(".", PHP_VERSION), 0, 2)), $pluginPhpVersions, true))) {
+					if(count($pluginPhpVersions) > 0 and !(in_array($matches[0], $pluginPhpVersions, true) or in_array(implode(".", array_slice(explode(".", PHP_VERSION), 0, 2)), $pluginPhpVersions, true))){
 						$this->server->getLogger()->error($this->server->getLanguage()->translateString("pocketmine.plugin.loadError", [
 							$name,
 							$this->server->getLanguage()->translateString("%pocketmine.plugin.incompatiblePhpVersion", [implode(", ", $pluginPhpVersions)])

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -268,7 +268,7 @@ class PluginManager{
 					}
 
 					$pluginPhpVersions = $description->getCompatiblePhpVersions();
-					$pluginCompatiblePhpVersions = array_filter($pluginPhpVersions, function(string $version) : bool{ return Utils::isVersionCompatible($version, PHP_MAJOR_VERSION . "." . PHP_MINOR_VERSION . "." . PHP_RELEASE_VERSION); });
+					$pluginCompatiblePhpVersions = array_filter($pluginPhpVersions, function(string $version) : bool{ return Utils::arePhpVersionsCompatible($version, PHP_MAJOR_VERSION . "." . PHP_MINOR_VERSION . "." . PHP_RELEASE_VERSION); });
 					if(count($pluginPhpVersions) > 0 and count($pluginCompatiblePhpVersions) < 1){
 						$this->server->getLogger()->error($this->server->getLanguage()->translateString("pocketmine.plugin.loadError", [
 							$name,

--- a/src/pocketmine/utils/Utils.php
+++ b/src/pocketmine/utils/Utils.php
@@ -333,6 +333,18 @@ class Utils{
 		return $processors;
 	}
 
+	public static function isVersionCompatible(string $version, string $otherVersion) : bool{
+		$parts = explode(".", $version);
+		$otherParts = explode(".", $otherVersion);
+
+		if(count($parts) < 2 or count($otherParts) < 2){
+			throw new \InvalidArgumentException("The versions must include major and minor version!");
+		}
+
+		$sliceLength = (count($parts) > 2 and count($otherParts) > 2) ? 3 : 2;
+		return implode(".", array_slice($parts, 0, $sliceLength)) === implode(".", array_slice($otherParts, 0, $sliceLength));
+	}
+
 	/**
 	 * Returns a prettified hexdump
 	 */

--- a/src/pocketmine/utils/Utils.php
+++ b/src/pocketmine/utils/Utils.php
@@ -333,7 +333,7 @@ class Utils{
 		return $processors;
 	}
 
-	public static function isVersionCompatible(string $version, string $otherVersion) : bool{
+	public static function arePhpVersionsCompatible(string $version, string $otherVersion) : bool{
 		$parts = explode(".", $version);
 		$otherParts = explode(".", $otherVersion);
 


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
It has been mentioned before (#3195) that using features from higher php versions on servers using previous versions is an issue. This PR addresses that issue by adding an optional property "php" to let plugin developers specify the compatible php versions.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
Closes #3195

## Translations

This PR requires translation for `pocketmine.plugin.incompatiblePhpVersion` [(#57)](https://github.com/pmmp/PocketMine-Language/pull/57)

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Adding this property to a plugin manifest is optional, it maintains BC.

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
All of these tests were done using PHP 7.3.14, I added the following properties to the plugin manifest and noted the result:
- `php: 7.3` -> Plugin loads
- `php: 7.3.14` -> Plugin loads
- `php: [7.3.15, 7.3.13]` -> Plugin doesn't load
- `php: 5.4` -> Plugin doesn't load
- `#Not specified` -> Plugin loads