### PR TITLE
When ClickAir and clear your inventory, the item in your hand remains.

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2498,7 +2498,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 						if($item->onClickAir($this, $directionVector)){
 							$this->resetItemCooldown($item);
-							if($this->isSurvival()){
+							if($this->isSurvival() and $item->equalsExact($this->inventory->getItemInHand())){
 								$this->inventory->setItemInHand($item);
 							}
 						}


### PR DESCRIPTION
This problem refers to https://github.com/pmmp/PocketMine-MP/pull/3345, also related to https://github.com/pmmp/PocketMine-MP/pull/3345 and https://github.com/pmmp/PocketMine-MP/pull/3348

If you clear your inventory while the player is using the item through the air (PlayerItemUseEvent in the pmmp 4.0), the item will remain in your hand