### PR TITLE
Fix RCON socket lingering

### DIFF
--- a/src/pocketmine/network/rcon/RCON.php
+++ b/src/pocketmine/network/rcon/RCON.php
@@ -41,6 +41,7 @@ use function socket_getsockname;
 use function socket_last_error;
 use function socket_listen;
 use function socket_set_block;
+use function socket_set_option;
 use function socket_strerror;
 use function socket_write;
 use function trim;

--- a/src/pocketmine/network/rcon/RCON.php
+++ b/src/pocketmine/network/rcon/RCON.php
@@ -46,9 +46,11 @@ use function socket_write;
 use function trim;
 use const AF_INET;
 use const AF_UNIX;
+use const SO_REUSEADDR;
 use const SOCK_STREAM;
 use const SOCKET_ENOPROTOOPT;
 use const SOCKET_EPROTONOSUPPORT;
+use const SOL_SOCKET;
 use const SOL_TCP;
 
 class RCON{
@@ -73,6 +75,10 @@ class RCON{
 		}
 
 		$this->socket = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+
+		if(!socket_set_option($this->socket, SOL_SOCKET, SO_REUSEADDR, 1)){
+			throw new \RuntimeException("Unable to set option on socket: " . trim(socket_strerror(socket_last_error())));
+		}
 
 		if($this->socket === false or !@socket_bind($this->socket, $interface, $port) or !@socket_listen($this->socket, 5)){
 			throw new \RuntimeException(trim(socket_strerror(socket_last_error())));


### PR DESCRIPTION
## Introduction
This fixes an issue where RCON is unable to start after being abruptly stopped.

## Tests
1. Start PocketMine-MP server with RCON enabled.
2. Use an RCON client to execute `/stop` on the server.
3. When the server reboots, RCON will be able to bind the socket. Without this PR, RCON will exit with the error below:
![image](https://user-images.githubusercontent.com/17762324/76695684-3e66d480-66bd-11ea-93ae-39a0d89fde7c.png)

