### PR TITLE
Change Level::TIME_ constants to match client

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -128,9 +128,11 @@ class Level implements ChunkManager, Metadatable{
 	public const Y_MASK = 0xFF;
 	public const Y_MAX = 0x100; //256
 
-	public const TIME_DAY = 0;
+	public const TIME_DAY = 1000;
+	public const TIME_NOON = 6000;
 	public const TIME_SUNSET = 12000;
-	public const TIME_NIGHT = 14000;
+	public const TIME_NIGHT = 13000;
+	public const TIME_MIDNIGHT = 18000;
 	public const TIME_SUNRISE = 23000;
 
 	public const TIME_FULL = 24000;


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
The constants in `Level.php` do not match the clients representation of the vanilla `/time set` command arguments

In Minecraft Java 1.7 there was a change in values
- Day from 0 to 1000
- Night from 12500 to 13000
See: https://minecraft.gamepedia.com/Commands/time and https://minecraft.gamepedia.com/Java_Edition_1.7

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
- Added new Level::TIME_ constants
- Match Level::TIME_ constants with client values

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
- Probably, because i.e. `TIME_DAY` was changed from 0 to 1000, some plugins might depend on the value `0`

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
- Ran PMMP from source
- Tried accessing the new constants
- Returned proper time
- Tried locking level time to MIDNIGHT and NOON, functions well.
- Watched the sun. The sun angle now matches the client for i.e. TIME_DAY (world already bright, no more sunrise)