### PR TITLE
Fix player interaction when sneaking.

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1862,11 +1862,15 @@ class Level implements ChunkManager, Metadatable{
 
 			$ev->call();
 			if(!$ev->isCancelled()){
-				if(!$player->isSneaking() and $blockClicked->onActivate($item, $player)){
+				if(!$player->isSneaking()){
+					if($blockClicked->onActivate($item, $player)){
+						return true;
+					}elseif($item->onActivate($player, $blockReplace, $blockClicked, $face, $clickVector)){
+						return true;
+					}
+				}elseif($item->getId() === Item::AIR and $blockClicked->onActivate($item, $player)){
 					return true;
-				}
-
-				if(!$player->isSneaking() and $item->onActivate($player, $blockReplace, $blockClicked, $face, $clickVector)){
+				}elseif($item->onActivate($player, $blockReplace, $blockClicked, $face, $clickVector)){
 					return true;
 				}
 			}else{

--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1868,7 +1868,7 @@ class Level implements ChunkManager, Metadatable{
 					}elseif($item->onActivate($player, $blockReplace, $blockClicked, $face, $clickVector)){
 						return true;
 					}
-				}elseif($item->getId() === Item::AIR and $blockClicked->onActivate($item, $player)){
+				}elseif($item->isNull() and $blockClicked->onActivate($item, $player)){
 					return true;
 				}elseif($item->onActivate($player, $blockReplace, $blockClicked, $face, $clickVector)){
 					return true;


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This changes behavior of block interactions and item usage to be more like vanilla behavior when the player is crouched/sneaking.  Things such as using buckets, turning items in item frames, placing paintings, and opening/closing doors should now work properly despite the player's stance.

### Relevant issues
<!-- List relevant issues here -->
* Fixes #3401 (Crouched players can't place certain items)
* Fixes #1904 (Buckets can't be used when sneaking)
* Fixes #2539 (Paintings cannot be placed while sneaking)

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
This does not change API.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
No noticeable performance or behavioral impact was observed other than fixing intended behavior.
## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
This does not impact backwards compatibility.
## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.
Attach scripts or actions to test this pull request, as well as the result
-->
Tested interaction with trapdoors, water buckets, paintings, and item frame. 
https://youtu.be/m8p-KXOfauw