### PR TITLE
1.14.60 support

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -146,6 +146,8 @@ use pocketmine\network\mcpe\protocol\types\CommandEnum;
 use pocketmine\network\mcpe\protocol\types\CommandParameter;
 use pocketmine\network\mcpe\protocol\types\ContainerIds;
 use pocketmine\network\mcpe\protocol\types\DimensionIds;
+use pocketmine\network\mcpe\protocol\types\PersonaPieceTintColor;
+use pocketmine\network\mcpe\protocol\types\PersonaSkinPiece;
 use pocketmine\network\mcpe\protocol\types\PlayerPermissions;
 use pocketmine\network\mcpe\protocol\types\SkinAdapterSingleton;
 use pocketmine\network\mcpe\protocol\types\SkinAnimation;
@@ -1859,6 +1861,16 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 			$animations[] = new SkinAnimation(new SkinImage($animation["ImageHeight"], $animation["ImageWidth"], base64_decode($animation["Image"], true)), $animation["Type"], $animation["Frames"]);
 		}
 
+		$personaPieces = [];
+		foreach($packet->clientData["PersonaPieces"] as $piece){
+			$personaPiece[] = new PersonaSkinPiece($piece["PieceId"], $piece["PieceType"], $piece["PackId"], $piece["IsDefault"], $piece["ProductId"]);
+		}
+
+		$pieceTintColors = [];
+		foreach($packet->clientData["PieceTintColors"] as $tintColor){
+			$pieceTintColors[] = new PersonaPieceTintColor($tintColor["PieceType"], $tintColor["Colors"]);
+		}
+
 		$skinData = new SkinData(
 			$packet->clientData["SkinId"],
 			base64_decode($packet->clientData["SkinResourcePatch"] ?? "", true),
@@ -1870,7 +1882,13 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 			$packet->clientData["PremiumSkin"] ?? false,
 			$packet->clientData["PersonaSkin"] ?? false,
 			$packet->clientData["CapeOnClassicSkin"] ?? false,
-			$packet->clientData["CapeId"] ?? ""
+			$packet->clientData["CapeId"] ?? "",
+			null,
+			$packet->clientData["ArmSize"] ?? "",
+			$packet->clientData["SkinColor"] ?? "",
+			$personaPieces,
+			$pieceTintColors,
+			true
 		);
 
 		$skin = SkinAdapterSingleton::get()->fromSkinData($skinData);

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1884,7 +1884,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 			$packet->clientData["CapeOnClassicSkin"] ?? false,
 			$packet->clientData["CapeId"] ?? "",
 			null,
-			$packet->clientData["ArmSize"] ?? "",
+			$packet->clientData["ArmSize"] ?? SkinData::ARM_SIZE_WIDE,
 			$packet->clientData["SkinColor"] ?? "",
 			$personaPieces,
 			$pieceTintColors,

--- a/src/pocketmine/network/mcpe/NetworkBinaryStream.php
+++ b/src/pocketmine/network/mcpe/NetworkBinaryStream.php
@@ -98,8 +98,12 @@ class NetworkBinaryStream extends BinaryStream{
 		$capeOnClassic = $this->getBool();
 		$capeId = $this->getString();
 		$fullSkinId = $this->getString();
+		$armSize = $this->getString();
+		$skinColor = $this->getString();
+		$personaPieces = $this->getLInt();
+		$pieceTintColor = $this->getLInt();
 
-		return new SkinData($skinId, $skinResourcePatch, $skinData, $animations, $capeData, $geometryData, $animationData, $premium, $persona, $capeOnClassic, $capeId, $fullSkinId);
+		return new SkinData($skinId, $skinResourcePatch, $skinData, $animations, $capeData, $geometryData, $animationData, $premium, $persona, $capeOnClassic, $capeId, $fullSkinId, $armSize, $skinColor, $personaPieces, $pieceTintColor);
 	}
 
 	/**
@@ -123,6 +127,10 @@ class NetworkBinaryStream extends BinaryStream{
 		$this->putBool($skin->isPersonaCapeOnClassic());
 		$this->putString($skin->getCapeId());
 		$this->putString($skin->getFullSkinId());
+		$this->putString($skin->getArmSize());
+		$this->putString($skin->getSkinColor());
+		$this->putLInt($skin->getPersonaPieces());
+		$this->putLInt($skin->getPieceTintColor());
 	}
 
 	private function getSkinImage() : SkinImage{

--- a/src/pocketmine/network/mcpe/NetworkBinaryStream.php
+++ b/src/pocketmine/network/mcpe/NetworkBinaryStream.php
@@ -37,6 +37,8 @@ use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\IntTag;
 use pocketmine\network\mcpe\protocol\types\CommandOriginData;
 use pocketmine\network\mcpe\protocol\types\EntityLink;
+use pocketmine\network\mcpe\protocol\types\PersonaPieceTintColor;
+use pocketmine\network\mcpe\protocol\types\PersonaSkinPiece;
 use pocketmine\network\mcpe\protocol\types\SkinAnimation;
 use pocketmine\network\mcpe\protocol\types\SkinData;
 use pocketmine\network\mcpe\protocol\types\SkinImage;
@@ -100,10 +102,33 @@ class NetworkBinaryStream extends BinaryStream{
 		$fullSkinId = $this->getString();
 		$armSize = $this->getString();
 		$skinColor = $this->getString();
-		$personaPieces = $this->getLInt();
-		$pieceTintColor = $this->getLInt();
+		$personaPieceCount = $this->getLInt();
+		$personaPieces = [];
+		for($i = 0; $i < $personaPieceCount; ++$i){
+			$personaPieces[] = new PersonaSkinPiece(
+				$pieceId = $this->getString(),
+				$pieceType = $this->getString(),
+				$packId = $this->getString(),
+				$isDefaultPiece = $this->getBool(),
+				$productId = $this->getString()
+			);
+		}
+		$pieceTintColorCount = $this->getLInt();
+		$pieceTintColors = [];
+		for($i = 0; $i < $pieceTintColorCount; ++$i){
+			$pieceType = $this->getString();
+			$colorCount = $this->getLInt();
+			$colors = [];
+			for($j = 0; $j < $colorCount; ++$j){
+				$colors[] = $this->getString();
+			}
+			$pieceTintColors[] = new PersonaPieceTintColor(
+				$pieceType,
+				$colors
+			);
+		}
 
-		return new SkinData($skinId, $skinResourcePatch, $skinData, $animations, $capeData, $geometryData, $animationData, $premium, $persona, $capeOnClassic, $capeId, $fullSkinId, $armSize, $skinColor, $personaPieces, $pieceTintColor);
+		return new SkinData($skinId, $skinResourcePatch, $skinData, $animations, $capeData, $geometryData, $animationData, $premium, $persona, $capeOnClassic, $capeId, $fullSkinId, $armSize, $skinColor, $personaPieces, $pieceTintColors);
 	}
 
 	/**
@@ -129,8 +154,22 @@ class NetworkBinaryStream extends BinaryStream{
 		$this->putString($skin->getFullSkinId());
 		$this->putString($skin->getArmSize());
 		$this->putString($skin->getSkinColor());
-		$this->putLInt($skin->getPersonaPieces());
-		$this->putLInt($skin->getPieceTintColor());
+		$this->putLInt(count($skin->getPersonaPieces()));
+		foreach($skin->getPersonaPieces() as $piece){
+			$this->putString($piece->getPieceId());
+			$this->putString($piece->getPieceType());
+			$this->putString($piece->getPackId());
+			$this->putBool($piece->isDefaultPiece());
+			$this->putString($piece->getProductId());
+		}
+		$this->putLInt(count($skin->getPieceTintColors()));
+		foreach($skin->getPieceTintColors() as $tint){
+			$this->putString($tint->getPieceType());
+			$this->putLInt(count($tint->getColors()));
+			foreach($tint->getColors() as $color){
+				$this->putString($color);
+			}
+		}
 	}
 
 	private function getSkinImage() : SkinImage{

--- a/src/pocketmine/network/mcpe/protocol/PlayerListPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/PlayerListPacket.php
@@ -67,6 +67,11 @@ class PlayerListPacket extends DataPacket{
 
 			$this->entries[$i] = $entry;
 		}
+		if($this->type === self::TYPE_ADD){
+			for($i = 0; $i < $count; ++$i){
+				$this->entries[$i]->skinData->setVerified($this->getBool());
+			}
+		}
 	}
 
 	protected function encodePayload(){
@@ -85,6 +90,11 @@ class PlayerListPacket extends DataPacket{
 				$this->putBool($entry->isHost);
 			}else{
 				$this->putUUID($entry->uuid);
+			}
+		}
+		if($this->type === self::TYPE_ADD){
+			foreach($this->entries as $entry){
+				$this->putBool($entry->skinData->isVerified());
 			}
 		}
 	}

--- a/src/pocketmine/network/mcpe/protocol/PlayerSkinPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/PlayerSkinPacket.php
@@ -46,6 +46,7 @@ class PlayerSkinPacket extends DataPacket{
 		$this->skin = $this->getSkin();
 		$this->newSkinName = $this->getString();
 		$this->oldSkinName = $this->getString();
+		$this->skin->setVerified($this->getBool());
 	}
 
 	protected function encodePayload(){
@@ -53,6 +54,7 @@ class PlayerSkinPacket extends DataPacket{
 		$this->putSkin($this->skin);
 		$this->putString($this->newSkinName);
 		$this->putString($this->oldSkinName);
+		$this->putBool($this->skin->isVerified());
 	}
 
 	public function handle(NetworkSession $session) : bool{

--- a/src/pocketmine/network/mcpe/protocol/ProtocolInfo.php
+++ b/src/pocketmine/network/mcpe/protocol/ProtocolInfo.php
@@ -41,7 +41,7 @@ interface ProtocolInfo{
 	/** Current Minecraft PE version reported by the server. This is usually the earliest currently supported version. */
 	public const MINECRAFT_VERSION = 'v1.14.0';
 	/** Version number sent to clients in ping responses. */
-	public const MINECRAFT_VERSION_NETWORK = '1.14.0';
+	public const MINECRAFT_VERSION_NETWORK = '1.14.60';
 
 	public const LOGIN_PACKET = 0x01;
 	public const PLAY_STATUS_PACKET = 0x02;

--- a/src/pocketmine/network/mcpe/protocol/ProtocolInfo.php
+++ b/src/pocketmine/network/mcpe/protocol/ProtocolInfo.php
@@ -37,7 +37,7 @@ interface ProtocolInfo{
 	 */
 
 	/** Actual Minecraft: PE protocol version */
-	public const CURRENT_PROTOCOL = 389;
+	public const CURRENT_PROTOCOL = 390;
 	/** Current Minecraft PE version reported by the server. This is usually the earliest currently supported version. */
 	public const MINECRAFT_VERSION = 'v1.14.0';
 	/** Version number sent to clients in ping responses. */

--- a/src/pocketmine/network/mcpe/protocol/ProtocolInfo.php
+++ b/src/pocketmine/network/mcpe/protocol/ProtocolInfo.php
@@ -39,7 +39,7 @@ interface ProtocolInfo{
 	/** Actual Minecraft: PE protocol version */
 	public const CURRENT_PROTOCOL = 390;
 	/** Current Minecraft PE version reported by the server. This is usually the earliest currently supported version. */
-	public const MINECRAFT_VERSION = 'v1.14.0';
+	public const MINECRAFT_VERSION = 'v1.14.60';
 	/** Version number sent to clients in ping responses. */
 	public const MINECRAFT_VERSION_NETWORK = '1.14.60';
 

--- a/src/pocketmine/network/mcpe/protocol/types/PersonaPieceTintColor.php
+++ b/src/pocketmine/network/mcpe/protocol/types/PersonaPieceTintColor.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace pocketmine\network\mcpe\protocol\types;
+
+class PersonaPieceTintColor{
+
+	/** @var string */
+	private $pieceType;
+	/** @var string[] */
+	private $colors;
+
+	/**
+	 * @param string[] $colors
+	 */
+	public function __construct(string $pieceType, array $colors){
+		$this->pieceType = $pieceType;
+		$this->colors = $colors;
+	}
+
+	public function getPieceType() : string{
+		return $this->pieceType;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function getColors(): array{
+		return $this->colors;
+	}
+}

--- a/src/pocketmine/network/mcpe/protocol/types/PersonaPieceTintColor.php
+++ b/src/pocketmine/network/mcpe/protocol/types/PersonaPieceTintColor.php
@@ -49,7 +49,7 @@ final class PersonaPieceTintColor{
 	/**
 	 * @return string[]
 	 */
-	public function getColors(): array{
+	public function getColors() : array{
 		return $this->colors;
 	}
 }

--- a/src/pocketmine/network/mcpe/protocol/types/PersonaPieceTintColor.php
+++ b/src/pocketmine/network/mcpe/protocol/types/PersonaPieceTintColor.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace pocketmine\network\mcpe\protocol\types;
 
-class PersonaPieceTintColor{
+final class PersonaPieceTintColor{
 
 	public const PIECE_TYPE_PERSONA_EYES = "persona_eyes";
 	public const PIECE_TYPE_PERSONA_HAIR = "persona_hair";

--- a/src/pocketmine/network/mcpe/protocol/types/PersonaPieceTintColor.php
+++ b/src/pocketmine/network/mcpe/protocol/types/PersonaPieceTintColor.php
@@ -5,6 +5,10 @@ namespace pocketmine\network\mcpe\protocol\types;
 
 class PersonaPieceTintColor{
 
+	public const PIECE_TYPE_PERSONA_EYES = "persona_eyes";
+	public const PIECE_TYPE_PERSONA_HAIR = "persona_hair";
+	public const PIECE_TYPE_PERSONA_MOUTH = "persona_mouth";
+
 	/** @var string */
 	private $pieceType;
 	/** @var string[] */

--- a/src/pocketmine/network/mcpe/protocol/types/PersonaPieceTintColor.php
+++ b/src/pocketmine/network/mcpe/protocol/types/PersonaPieceTintColor.php
@@ -1,4 +1,24 @@
 <?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
 declare(strict_types=1);
 
 namespace pocketmine\network\mcpe\protocol\types;

--- a/src/pocketmine/network/mcpe/protocol/types/PersonaSkinPiece.php
+++ b/src/pocketmine/network/mcpe/protocol/types/PersonaSkinPiece.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace pocketmine\network\mcpe\protocol\types;
+
+class PersonaSkinPiece{
+
+	/** @var string */
+	private $pieceId;
+	/** @var string */
+	private $pieceType;
+	/** @var string */
+	private $packId;
+	/** @var bool */
+	private $isDefaultPiece;
+	/** @var string */
+	private $productId;
+
+	public function __construct(string $pieceId, string $pieceType, string $packId, bool $isDefaultPiece, string $productId){
+		$this->pieceId = $pieceId;
+		$this->pieceType = $pieceType;
+		$this->packId = $packId;
+		$this->isDefaultPiece = $isDefaultPiece;
+		$this->productId = $productId;
+	}
+
+	public function getPieceId() : string{
+		return $this->pieceId;
+	}
+
+	public function getPieceType() : string{
+		return $this->pieceType;
+	}
+
+	public function getPackId() : string{
+		return $this->packId;
+	}
+
+	public function isDefaultPiece() : bool{
+		return $this->isDefaultPiece;
+	}
+
+	public function getProductId() : string{
+		return $this->productId;
+	}
+}

--- a/src/pocketmine/network/mcpe/protocol/types/PersonaSkinPiece.php
+++ b/src/pocketmine/network/mcpe/protocol/types/PersonaSkinPiece.php
@@ -5,6 +5,17 @@ namespace pocketmine\network\mcpe\protocol\types;
 
 class PersonaSkinPiece{
 
+	public const PIECE_TYPE_PERSONA_BODY = "persona_body";
+	public const PIECE_TYPE_PERSONA_BOTTOM = "persona_bottom";
+	public const PIECE_TYPE_PERSONA_EYES = "persona_eyes";
+	public const PIECE_TYPE_PERSONA_FACIAL_HAIR = "persona_facial_hair";
+	public const PIECE_TYPE_PERSONA_FEET = "persona_feet";
+	public const PIECE_TYPE_PERSONA_HAIR = "persona_hair";
+	public const PIECE_TYPE_PERSONA_MOUTH = "persona_mouth";
+	public const PIECE_TYPE_PERSONA_SKELETON = "persona_skeleton";
+	public const PIECE_TYPE_PERSONA_SKIN = "persona_skin";
+	public const PIECE_TYPE_PERSONA_TOP = "persona_top";
+
 	/** @var string */
 	private $pieceId;
 	/** @var string */

--- a/src/pocketmine/network/mcpe/protocol/types/PersonaSkinPiece.php
+++ b/src/pocketmine/network/mcpe/protocol/types/PersonaSkinPiece.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace pocketmine\network\mcpe\protocol\types;
 
-class PersonaSkinPiece{
+final class PersonaSkinPiece{
 
 	public const PIECE_TYPE_PERSONA_BODY = "persona_body";
 	public const PIECE_TYPE_PERSONA_BOTTOM = "persona_bottom";

--- a/src/pocketmine/network/mcpe/protocol/types/PersonaSkinPiece.php
+++ b/src/pocketmine/network/mcpe/protocol/types/PersonaSkinPiece.php
@@ -1,4 +1,24 @@
 <?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
 declare(strict_types=1);
 
 namespace pocketmine\network\mcpe\protocol\types;

--- a/src/pocketmine/network/mcpe/protocol/types/SkinData.php
+++ b/src/pocketmine/network/mcpe/protocol/types/SkinData.php
@@ -27,6 +27,9 @@ use pocketmine\utils\UUID;
 
 class SkinData{
 
+	public const ARM_SIZE_SLIM = "slim";
+	public const ARM_SIZE_WIDE = "wide";
+
 	/** @var string */
 	private $skinId;
 	/** @var string */

--- a/src/pocketmine/network/mcpe/protocol/types/SkinData.php
+++ b/src/pocketmine/network/mcpe/protocol/types/SkinData.php
@@ -67,7 +67,7 @@ class SkinData{
 	 * @param PersonaSkinPiece[]      $personaPieces
 	 * @param PersonaPieceTintColor[] $pieceTintColors
 	 */
-	public function __construct(string $skinId, string $resourcePatch, SkinImage $skinImage, array $animations = [], SkinImage $capeImage = null, string $geometryData = "", string $animationData = "", bool $premium = false, bool $persona = false, bool $personaCapeOnClassic = false, string $capeId = "", ?string $fullSkinId = null, string $armSize = "", string $skinColor = "", array $personaPieces = [], array $pieceTintColors = []){
+	public function __construct(string $skinId, string $resourcePatch, SkinImage $skinImage, array $animations = [], SkinImage $capeImage = null, string $geometryData = "", string $animationData = "", bool $premium = false, bool $persona = false, bool $personaCapeOnClassic = false, string $capeId = "", ?string $fullSkinId = null, string $armSize = "", string $skinColor = "", array $personaPieces = [], array $pieceTintColors = [], bool $isVerified = false){
 		$this->skinId = $skinId;
 		$this->resourcePatch = $resourcePatch;
 		$this->skinImage = $skinImage;
@@ -85,7 +85,7 @@ class SkinData{
 		$this->skinColor = $skinColor;
 		$this->personaPieces = $personaPieces;
 		$this->pieceTintColors = $pieceTintColors;
-		$this->isVerified = false; // Placeholder value until setVerified() is called
+		$this->isVerified = $isVerified;
 	}
 
 	public function getSkinId() : string{

--- a/src/pocketmine/network/mcpe/protocol/types/SkinData.php
+++ b/src/pocketmine/network/mcpe/protocol/types/SkinData.php
@@ -70,7 +70,7 @@ class SkinData{
 	 * @param PersonaSkinPiece[]      $personaPieces
 	 * @param PersonaPieceTintColor[] $pieceTintColors
 	 */
-	public function __construct(string $skinId, string $resourcePatch, SkinImage $skinImage, array $animations = [], SkinImage $capeImage = null, string $geometryData = "", string $animationData = "", bool $premium = false, bool $persona = false, bool $personaCapeOnClassic = false, string $capeId = "", ?string $fullSkinId = null, string $armSize = "", string $skinColor = "", array $personaPieces = [], array $pieceTintColors = [], bool $isVerified = false){
+	public function __construct(string $skinId, string $resourcePatch, SkinImage $skinImage, array $animations = [], SkinImage $capeImage = null, string $geometryData = "", string $animationData = "", bool $premium = false, bool $persona = false, bool $personaCapeOnClassic = false, string $capeId = "", ?string $fullSkinId = null, string $armSize = self::ARM_SIZE_WIDE, string $skinColor = "", array $personaPieces = [], array $pieceTintColors = [], bool $isVerified = false){
 		$this->skinId = $skinId;
 		$this->resourcePatch = $resourcePatch;
 		$this->skinImage = $skinImage;

--- a/src/pocketmine/network/mcpe/protocol/types/SkinData.php
+++ b/src/pocketmine/network/mcpe/protocol/types/SkinData.php
@@ -59,6 +59,8 @@ class SkinData{
 	private $personaPieces;
 	/** @var PersonaPieceTintColor[] */
 	private $pieceTintColors;
+	/** @var bool */
+	private $isVerified;
 
 	/**
 	 * @param SkinAnimation[]         $animations
@@ -83,6 +85,7 @@ class SkinData{
 		$this->skinColor = $skinColor;
 		$this->personaPieces = $personaPieces;
 		$this->pieceTintColors = $pieceTintColors;
+		$this->isVerified = false; // Placeholder value until setVerified() is called
 	}
 
 	public function getSkinId() : string{
@@ -156,5 +159,16 @@ class SkinData{
 	 */
 	public function getPieceTintColors() : array{
 		return $this->pieceTintColors;
+	}
+
+	public function isVerified() : bool{
+		return $this->isVerified;
+	}
+
+	/**
+	 * @internal
+	 */
+	public function setVerified(bool $verified) : void{
+		$this->isVerified = $verified;
 	}
 }

--- a/src/pocketmine/network/mcpe/protocol/types/SkinData.php
+++ b/src/pocketmine/network/mcpe/protocol/types/SkinData.php
@@ -51,11 +51,19 @@ class SkinData{
 	private $capeId;
 	/** @var string */
 	private $fullSkinId;
+	/** @var string */
+	private $armSize;
+	/** @var string */
+	private $skinColor;
+	/** @var int */
+	private $personaPieces;
+	/** @var int */
+	private $pieceTintColor;
 
 	/**
 	 * @param SkinAnimation[] $animations
 	 */
-	public function __construct(string $skinId, string $resourcePatch, SkinImage $skinImage, array $animations = [], SkinImage $capeImage = null, string $geometryData = "", string $animationData = "", bool $premium = false, bool $persona = false, bool $personaCapeOnClassic = false, string $capeId = "", ?string $fullSkinId = null){
+	public function __construct(string $skinId, string $resourcePatch, SkinImage $skinImage, array $animations = [], SkinImage $capeImage = null, string $geometryData = "", string $animationData = "", bool $premium = false, bool $persona = false, bool $personaCapeOnClassic = false, string $capeId = "", ?string $fullSkinId = null, string $armSize = "", string $skinColor = "", int $personaPieces = 0, int $pieceTintColor = 0){
 		$this->skinId = $skinId;
 		$this->resourcePatch = $resourcePatch;
 		$this->skinImage = $skinImage;
@@ -69,6 +77,10 @@ class SkinData{
 		$this->capeId = $capeId;
 		//this has to be unique or the client will do stupid things
 		$this->fullSkinId = $fullSkinId ?? UUID::fromRandom()->toString();
+		$this->armSize = $armSize;
+		$this->skinColor = $skinColor;
+		$this->personaPieces = $personaPieces;
+		$this->pieceTintColor = $pieceTintColor;
 	}
 
 	public function getSkinId() : string{
@@ -120,5 +132,21 @@ class SkinData{
 
 	public function getFullSkinId() : string{
 		return $this->fullSkinId;
+	}
+
+	public function getArmSize() : string{
+		return $this->armSize;
+	}
+
+	public function getSkinColor() : string{
+		return $this->skinColor;
+	}
+
+	public function getPersonaPieces() : int{
+		return $this->personaPieces;
+	}
+
+	public function getPieceTintColor() : int{
+		return $this->pieceTintColor;
 	}
 }

--- a/src/pocketmine/network/mcpe/protocol/types/SkinData.php
+++ b/src/pocketmine/network/mcpe/protocol/types/SkinData.php
@@ -55,15 +55,17 @@ class SkinData{
 	private $armSize;
 	/** @var string */
 	private $skinColor;
-	/** @var int */
+	/** @var PersonaSkinPiece[] */
 	private $personaPieces;
-	/** @var int */
-	private $pieceTintColor;
+	/** @var PersonaPieceTintColor[] */
+	private $pieceTintColors;
 
 	/**
-	 * @param SkinAnimation[] $animations
+	 * @param SkinAnimation[]         $animations
+	 * @param PersonaSkinPiece[]      $personaPieces
+	 * @param PersonaPieceTintColor[] $pieceTintColors
 	 */
-	public function __construct(string $skinId, string $resourcePatch, SkinImage $skinImage, array $animations = [], SkinImage $capeImage = null, string $geometryData = "", string $animationData = "", bool $premium = false, bool $persona = false, bool $personaCapeOnClassic = false, string $capeId = "", ?string $fullSkinId = null, string $armSize = "", string $skinColor = "", int $personaPieces = 0, int $pieceTintColor = 0){
+	public function __construct(string $skinId, string $resourcePatch, SkinImage $skinImage, array $animations = [], SkinImage $capeImage = null, string $geometryData = "", string $animationData = "", bool $premium = false, bool $persona = false, bool $personaCapeOnClassic = false, string $capeId = "", ?string $fullSkinId = null, string $armSize = "", string $skinColor = "", array $personaPieces = [], array $pieceTintColors = []){
 		$this->skinId = $skinId;
 		$this->resourcePatch = $resourcePatch;
 		$this->skinImage = $skinImage;
@@ -80,7 +82,7 @@ class SkinData{
 		$this->armSize = $armSize;
 		$this->skinColor = $skinColor;
 		$this->personaPieces = $personaPieces;
-		$this->pieceTintColor = $pieceTintColor;
+		$this->pieceTintColors = $pieceTintColors;
 	}
 
 	public function getSkinId() : string{
@@ -142,11 +144,17 @@ class SkinData{
 		return $this->skinColor;
 	}
 
-	public function getPersonaPieces() : int{
+	/**
+	 * @return PersonaSkinPiece[]
+	 */
+	public function getPersonaPieces() : array{
 		return $this->personaPieces;
 	}
 
-	public function getPieceTintColor() : int{
-		return $this->pieceTintColor;
+	/**
+	 * @return PersonaPieceTintColor[]
+	 */
+	public function getPieceTintColors() : array{
+		return $this->pieceTintColors;
 	}
 }


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This pull request adds support for the new 1.14.60 update

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
SkinData now has 4 extra properties, armSize, skinColor, personaPieces, pieceTintColor with a getter for each.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
1.14.60 clients can now join

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
There is no BC breaks

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
A 1.14.60 client can join the server fine on a clean installation using these changes
![image](https://user-images.githubusercontent.com/30378179/79372114-68761580-7f4d-11ea-9801-04e33fc85206.png)
