### PR TITLE
Added missing Enchantment IDs

### DIFF
--- a/src/pocketmine/item/enchantment/Enchantment.php
+++ b/src/pocketmine/item/enchantment/Enchantment.php
@@ -66,6 +66,9 @@ class Enchantment{
 	public const RIPTIDE = 30;
 	public const LOYALTY = 31;
 	public const CHANNELING = 32;
+	public const MULTISHOT = 33;
+	public const PIERCING = 34;
+	public const QUICK_CHARGE = 35;
 
 	public const RARITY_COMMON = 10;
 	public const RARITY_UNCOMMON = 5;


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
PocketMine has been missing the crossbow enchantments, but this pull request adds their IDs to the Enchantment class.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
- The constant ``Enchantment::MULTISHOT`` has been added with the value 33
- The constant ``Enchantment::PIERCING`` has been added with the value 34
- The constant ``Enchantment::QUICK_CHARGE`` has been added with the value 35
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
There is no behavioural changes
## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
There are no backwards compatibility breaks