### PR TITLE
Added missing Window Types

### DIFF
--- a/src/pocketmine/network/mcpe/protocol/types/WindowTypes.php
+++ b/src/pocketmine/network/mcpe/protocol/types/WindowTypes.php
@@ -51,9 +51,12 @@ interface WindowTypes{
 	public const ELEMENT_CONSTRUCTOR = 21;
 	public const MATERIAL_REDUCER = 22;
 	public const LAB_TABLE = 23;
-
+	public const LOOM = 24;
+	public const LECTERN = 25;
+	public const GRINDSTONE = 26;
 	public const BLAST_FURNACE = 27;
 	public const SMOKER = 28;
 	public const STONECUTTER = 29;
+	public const CARTOGRAPHY = 30;
 
 }


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
PocketMine has been missing a few window types, but this pull request adds their IDs to the WindowTypes class.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
- The constant ``WindowTypes::LOOM`` has been added with the value 24
- The constant ``WindowTypes::LECTERN`` has been added with the value 25
- The constant ``WindowTypes::GRINDSTONE`` has been added with the value 26
- The constant ``WindowTypes::CARTOGRAPHY`` has been added with the value 30

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
There is no behavioural changes
## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
There are no backwards compatibility breaks