### PR TITLE
Used wrong variable to store persona pieces on login

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1863,7 +1863,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 		$personaPieces = [];
 		foreach($packet->clientData["PersonaPieces"] as $piece){
-			$personaPiece[] = new PersonaSkinPiece($piece["PieceId"], $piece["PieceType"], $piece["PackId"], $piece["IsDefault"], $piece["ProductId"]);
+			$personaPieces[] = new PersonaSkinPiece($piece["PieceId"], $piece["PieceType"], $piece["PackId"], $piece["IsDefault"], $piece["ProductId"]);
 		}
 
 		$pieceTintColors = [];


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
When developing the 1.14.60 update, I miss typed a variable which can have serious side effects. This pull request fixes the typo.
### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
https://github.com/pmmp/PocketMine-MP/commit/a107ad74048145c1969b2541eb8f053d70337b09#commitcomment-38561123
