### PR TITLE
Fix DiskResourceProvider::getResource() returning null

### DIFF
--- a/src/plugin/DiskResourceProvider.php
+++ b/src/plugin/DiskResourceProvider.php
@@ -54,8 +54,8 @@ class DiskResourceProvider implements ResourceProvider{
 	 */
 	public function getResource(string $filename){
 		$filename = rtrim(str_replace("\\", "/", $filename), "/");
-		if(file_exists($this->file . "resources/" . $filename)){
-			$resource = fopen($this->file . "resources/" . $filename, "rb");
+		if(file_exists($this->file . $filename)){
+			$resource = fopen($this->file . $filename, "rb");
 			if($resource === false) throw new AssumptionFailedError("fopen() should not fail on a file which exists");
 			return $resource;
 		}


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
`DiskProviderResource::getResource()` suffixes `resources/` to file causing `DiskResourceProvider::getResource("file.txt")` to check for
`plugins/TestPlugin/resources/resources/file.txt`

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Crashdump: https://pastebin.com/raw/YYVGJ1QX<br>
Test plugin:
- phar: https://transfer.sh/p4PcJ/ResourceTestPlugin_v0.0.1.phar
- zipped: https://transfer.sh/8E8ze/ResourceTestPlugin.zip
```
ResourceTestPlugin-master/plugin.yml
ResourceTestPlugin-master/resources/test.yml
ResourceTestPlugin-master/src/muqsit/resourcetestplugin/Main.php
```