### PR TITLE
Change "logged in from another location" to localized strings

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1981,8 +1981,8 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	protected function processLogin(){
 		foreach($this->server->getLoggedInPlayers() as $p){
 			if($p !== $this and ($p->iusername === $this->iusername or $this->getUniqueId()->equals($p->getUniqueId()))){
-				if(!$p->kick("logged in from another location")){
-					$this->close($this->getLeaveMessage(), "Logged in from another location");
+				if(!$p->kick("disconnectionScreen.loggedinOtherLocation")){ // "Logged in from other location"
+					$this->close($this->getLeaveMessage(), "disconnectionScreen.serverIdConflict"); // "Cannot join world. The account you are signed in to is currently playing in this world on a different device."
 
 					return;
 				}


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
These reasons are present in the game localization, so it's better to use localized strings.

Reference (1.14.60.5 en_US.lang disconnectionScreen section): https://hastebin.com/exugozoyez.sql

### Relevant issues


## Changes
### API changes

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
Maybe some plugins check for the exact ``"logged in from another location"`` string in ``PlayerKickEvent``.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->

Requires translations:

| Name | Value in eng.ini |
| :----: | :-----: |
| `disconnectionScreen.loggedinOtherLocation` | `Logged in from other location` |
| `disconnectionScreen.serverIdConflict` | `Cannot join world. The account you are signed in to is currently playing in this world on a different device.` |

## Tests
Try to join from different devices. Also, do the same thing with ``PlayerKickEvent->setCancelled()``.