### PR TITLE
Fix taking items from creative inventory causing mismatch

### DIFF
--- a/src/network/mcpe/convert/TypeConverter.php
+++ b/src/network/mcpe/convert/TypeConverter.php
@@ -183,7 +183,7 @@ class TypeConverter{
 					case NetworkInventoryAction::ACTION_MAGIC_SLOT_CREATIVE_DELETE_ITEM:
 						return new DestroyItemAction($new);
 					case NetworkInventoryAction::ACTION_MAGIC_SLOT_CREATIVE_CREATE_ITEM:
-						return new CreateItemAction($new);
+						return new CreateItemAction($old);
 					default:
 						throw new \UnexpectedValueException("Unexpected creative action type $action->inventorySlot");
 


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Dragging items from creative inventory into hotbar causes transaction mismatch due to `NetworkInventoryAction::$newItem` being supplied as the `sourceItem` to `CreateItemAction`

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
* Fixes #3436 

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Prior to this, the transaction would be cancelled due to mismatch:
```
[04:18:37.069] [Server thread/DEBUG]: [NetworkSession: MuqsitRayyanXO] Failed to execute inventory transaction: Action pocketmine\inventory\transaction\action\CreateItemAction is not valid in the current transaction
[04:18:37.069] [Server thread/DEBUG]: [NetworkSession: MuqsitRayyanXO] Actions: [{"sourceType":0,"windowId":0,"sourceFlags":0,"inventorySlot":5,"oldItem":{},"newItem":{}},{"sourceType":3,"windowId":null,"sourceFlags":0,"inventorySlot":1,"oldItem":{},"newItem":{}}]
[04:18:37.070] [Server thread/DEBUG]: [NetworkSession: MuqsitRayyanXO] Unhandled InventoryTransactionPacket: HgACAAAFANYBgAEAAAAAAwHWAYABAAAAAAA=
```