### PR TITLE
Use env to locate bash

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 DIR="$(cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 cd "$DIR"
 


### PR DESCRIPTION
This change uses env to locate bash, instead of hard-coding it. This is necessary on FreeBSD. Tested on Linux as well.

## Introduction
It's better to not hardcode the shell's path. Env is always in the same place, and can locate it.

### Relevant issues
N/A

## Changes
### API changes
N/A

### Behavioural changes
None

## Backwards compatibility
Completely

## Tests
Script still executes on Linux, but it also executes on FreeBSD as well now.