### PR TITLE
Added constants for devices

### DIFF
--- a/src/pocketmine/network/mcpe/protocol/AddPlayerPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/AddPlayerPacket.php
@@ -28,6 +28,7 @@ namespace pocketmine\network\mcpe\protocol;
 use pocketmine\item\Item;
 use pocketmine\math\Vector3;
 use pocketmine\network\mcpe\NetworkSession;
+use pocketmine\network\mcpe\protocol\types\DeviceIds;
 use pocketmine\network\mcpe\protocol\types\EntityLink;
 use pocketmine\utils\UUID;
 use function count;
@@ -84,7 +85,7 @@ class AddPlayerPacket extends DataPacket{
 	/** @var string */
 	public $deviceId = ""; //TODO: fill player's device ID (???)
 	/** @var int */
-	public $buildPlatform = -1;
+	public $buildPlatform = DeviceIds::UNKNOWN;
 
 	protected function decodePayload(){
 		$this->uuid = $this->getUUID();

--- a/src/pocketmine/network/mcpe/protocol/AddPlayerPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/AddPlayerPacket.php
@@ -28,7 +28,7 @@ namespace pocketmine\network\mcpe\protocol;
 use pocketmine\item\Item;
 use pocketmine\math\Vector3;
 use pocketmine\network\mcpe\NetworkSession;
-use pocketmine\network\mcpe\protocol\types\DeviceIds;
+use pocketmine\network\mcpe\protocol\types\DeviceOS;
 use pocketmine\network\mcpe\protocol\types\EntityLink;
 use pocketmine\utils\UUID;
 use function count;
@@ -85,7 +85,7 @@ class AddPlayerPacket extends DataPacket{
 	/** @var string */
 	public $deviceId = ""; //TODO: fill player's device ID (???)
 	/** @var int */
-	public $buildPlatform = DeviceIds::UNKNOWN;
+	public $buildPlatform = DeviceOS::UNKNOWN;
 
 	protected function decodePayload(){
 		$this->uuid = $this->getUUID();

--- a/src/pocketmine/network/mcpe/protocol/types/DeviceIds.php
+++ b/src/pocketmine/network/mcpe/protocol/types/DeviceIds.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\network\mcpe\protocol\types;
+
+interface DeviceIds{
+
+  public const UNKNOWN = -1;
+  public const ANDROID = 1;
+  public const IOS = 2;
+  public const OSX = 3;
+  public const AMAZON = 4;
+  public const GEAR_VR = 5;
+  public const WINDOWS_10 = 7;
+  public const WIN32 = 8;
+  public const DEDICATED = 9;
+  public const PLAYSTATION = 11;
+  public const NINTENDO = 12;
+  public const XBOX = 13;
+  public const WINDOWS_PHONE = 14;
+
+}

--- a/src/pocketmine/network/mcpe/protocol/types/DeviceIds.php
+++ b/src/pocketmine/network/mcpe/protocol/types/DeviceIds.php
@@ -31,9 +31,11 @@ interface DeviceIds{
 	public const OSX = 3;
 	public const AMAZON = 4;
 	public const GEAR_VR = 5;
+	public const HOLOLENS = 6;
 	public const WINDOWS_10 = 7;
 	public const WIN32 = 8;
 	public const DEDICATED = 9;
+	public const TVOS = 10;
 	public const PLAYSTATION = 11;
 	public const NINTENDO = 12;
 	public const XBOX = 13;

--- a/src/pocketmine/network/mcpe/protocol/types/DeviceIds.php
+++ b/src/pocketmine/network/mcpe/protocol/types/DeviceIds.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\network\mcpe\protocol\types;
 
-interface DeviceIds{
+final class DeviceIds{
 
 	public const UNKNOWN = -1;
 	public const ANDROID = 1;

--- a/src/pocketmine/network/mcpe/protocol/types/DeviceIds.php
+++ b/src/pocketmine/network/mcpe/protocol/types/DeviceIds.php
@@ -25,18 +25,18 @@ namespace pocketmine\network\mcpe\protocol\types;
 
 interface DeviceIds{
 
-  public const UNKNOWN = -1;
-  public const ANDROID = 1;
-  public const IOS = 2;
-  public const OSX = 3;
-  public const AMAZON = 4;
-  public const GEAR_VR = 5;
-  public const WINDOWS_10 = 7;
-  public const WIN32 = 8;
-  public const DEDICATED = 9;
-  public const PLAYSTATION = 11;
-  public const NINTENDO = 12;
-  public const XBOX = 13;
-  public const WINDOWS_PHONE = 14;
+	public const UNKNOWN = -1;
+	public const ANDROID = 1;
+	public const IOS = 2;
+	public const OSX = 3;
+	public const AMAZON = 4;
+	public const GEAR_VR = 5;
+	public const WINDOWS_10 = 7;
+	public const WIN32 = 8;
+	public const DEDICATED = 9;
+	public const PLAYSTATION = 11;
+	public const NINTENDO = 12;
+	public const XBOX = 13;
+	public const WINDOWS_PHONE = 14;
 
 }

--- a/src/pocketmine/network/mcpe/protocol/types/DeviceOS.php
+++ b/src/pocketmine/network/mcpe/protocol/types/DeviceOS.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\network\mcpe\protocol\types;
 
-final class DeviceIds{
+final class DeviceOS{
 
 	public const UNKNOWN = -1;
 	public const ANDROID = 1;

--- a/src/pocketmine/network/mcpe/protocol/types/PlayerListEntry.php
+++ b/src/pocketmine/network/mcpe/protocol/types/PlayerListEntry.php
@@ -40,7 +40,7 @@ class PlayerListEntry{
 	/** @var string */
 	public $platformChatId = "";
 	/** @var int */
-	public $buildPlatform = -1;
+	public $buildPlatform = DeviceIds::UNKNOWN;
 	/** @var bool */
 	public $isTeacher = false;
 	/** @var bool */

--- a/src/pocketmine/network/mcpe/protocol/types/PlayerListEntry.php
+++ b/src/pocketmine/network/mcpe/protocol/types/PlayerListEntry.php
@@ -40,7 +40,7 @@ class PlayerListEntry{
 	/** @var string */
 	public $platformChatId = "";
 	/** @var int */
-	public $buildPlatform = DeviceIds::UNKNOWN;
+	public $buildPlatform = DeviceOS::UNKNOWN;
 	/** @var bool */
 	public $isTeacher = false;
 	/** @var bool */


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
As of right now, there are classes for input mode, dimensions, containers, but the device os constants from LoginPacket (and PlayerAuthInputPacket) have been left out. This PR adds all known constants of devices.

## Changes
### API changes
Nope
### Behavioural changes
None
## Backwards compatibility
Still backwards compatible.