### PR TITLE
Add limit for WriteableBook

### DIFF
--- a/src/pocketmine/event/player/PlayerEditBookEvent.php
+++ b/src/pocketmine/event/player/PlayerEditBookEvent.php
@@ -52,6 +52,9 @@ class PlayerEditBookEvent extends PlayerEvent implements Cancellable{
 		$this->newBook = $newBook;
 		$this->action = $action;
 		$this->modifiedPages = $modifiedPages;
+		if($newBook.getBookSize()>64){
+			this.setCancelled(true);
+		}
 	}
 
 	/**

--- a/src/pocketmine/item/WritableBook.php
+++ b/src/pocketmine/item/WritableBook.php
@@ -170,6 +170,13 @@ class WritableBook extends Item{
 
 		return $pages;
 	}
+	
+	/**
+	 * Returns the amount of pages in this book
+	 */
+	public function getBookSize(): int{
+		return sizeof($this->getPagesTag()->getValue());	
+	}
 
 	protected function getPagesTag() : ListTag{
 		$pagesTag = $this->getNamedTag()->getListTag(self::TAG_PAGES);


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
limit the number of pages in a writeable book to 64

### Relevant issues
Fixes #3459
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
getBookSize():int in item/WriteableBook
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
The book cannot exceed the 64 page limit.
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
yes
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.
too lazy to test but should be fine.
Attach scripts or actions to test this pull request, as well as the result
-->
