### PR TITLE
the plugin config folder is no longer created

### DIFF
--- a/src/plugin/PluginManager.php
+++ b/src/plugin/PluginManager.php
@@ -148,9 +148,6 @@ class PluginManager{
 						$this->server->getLogger()->error("Projected dataFolder '" . $dataFolder . "' for " . $description->getName() . " exists and is not a directory");
 						return null;
 					}
-					if(!file_exists($dataFolder)){
-						mkdir($dataFolder, 0777, true);
-					}
 
 					$prefixed = $loader->getAccessProtocol() . $path;
 					$loader->loadPlugin($prefixed);


### PR DESCRIPTION
Removed annoying empty folders that are created when the plugin is launched, but the plugin does not use this folder
