### PR TITLE
Utils: fix parsing of single-line doc comments, closes #3388

### DIFF
--- a/src/pocketmine/utils/Utils.php
+++ b/src/pocketmine/utils/Utils.php
@@ -663,6 +663,9 @@ class Utils{
 	 */
 	public static function parseDocComment(string $docComment) : array{
 		$rawDocComment = substr($docComment, 3, -2); //remove the opening and closing markers
+		if($rawDocComment === false){ //usually empty doc comment, but this is safer and statically analysable
+			return [];
+		}
 		preg_match_all('/(*ANYCRLF)^[\t ]*(?:\* )?@([a-zA-Z]+)(?:[\t ]+(.+?))?[\t ]*$/m', $rawDocComment, $matches);
 
 		return array_combine($matches[1], $matches[2]);

--- a/src/pocketmine/utils/Utils.php
+++ b/src/pocketmine/utils/Utils.php
@@ -662,7 +662,8 @@ class Utils{
 	 * @return string[] an array of tagName => tag value. If the tag has no value, an empty string is used as the value.
 	 */
 	public static function parseDocComment(string $docComment) : array{
-		preg_match_all('/(*ANYCRLF)^[\t ]*\* @([a-zA-Z]+)(?:[\t ]+(.+))?[\t ]*$/m', $docComment, $matches);
+		$rawDocComment = substr($docComment, 3, -2); //remove the opening and closing markers
+		preg_match_all('/(*ANYCRLF)^[\t ]*(?:\* )?@([a-zA-Z]+)(?:[\t ]+(.+?))?[\t ]*$/m', $rawDocComment, $matches);
 
 		return array_combine($matches[1], $matches[2]);
 	}

--- a/tests/phpstan/configs/phpstan-bugs.neon
+++ b/tests/phpstan/configs/phpstan-bugs.neon
@@ -131,6 +131,11 @@ parameters:
 			path: ../../../src/pocketmine/network/mcpe/protocol/DataPacket.php
 
 		-
+			message: "#^Strict comparison using \\=\\=\\= between string and false will always evaluate to false\\.$#"
+			count: 1
+			path: ../../../src/pocketmine/utils/Utils.php
+
+		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNotNull\\(\\) with int and string will always evaluate to true\\.$#"
 			count: 1
 			path: ../../phpunit/block/BlockTest.php

--- a/tests/phpunit/utils/UtilsTest.php
+++ b/tests/phpunit/utils/UtilsTest.php
@@ -63,6 +63,27 @@ class UtilsTest extends TestCase{
 		self::assertEquals("HIGHEST", $tags["priority"]);
 	}
 
+	/**
+	 * @return string[][]
+	 * @phpstan-return list<array{string}>
+	 */
+	public function parseDocCommentOneLineProvider() : array{
+		return [
+			["/** @ignoreCancelled true dummy */"],
+			["/**@ignoreCancelled true dummy*/"],
+			["/** @ignoreCancelled    true dummy */"]
+		];
+	}
+
+	/**
+	 * @dataProvider parseDocCommentOneLineProvider
+	 */
+	public function testParseOneLineDocComment(string $comment) : void{
+		$tags = Utils::parseDocComment($comment);
+		self::assertArrayHasKey("ignoreCancelled", $tags);
+		self::assertEquals("true dummy", $tags["ignoreCancelled"]);
+	}
+
 	public function testNamespacedNiceClosureName() : void{
 		//be careful with this test. The closure has to be declared on the same line as the assertion.
 		self::assertSame('closure@' . Utils::cleanPath(__FILE__) . '#L' . __LINE__, Utils::getNiceClosureName(function() : void{}));

--- a/tests/phpunit/utils/UtilsTest.php
+++ b/tests/phpunit/utils/UtilsTest.php
@@ -84,6 +84,11 @@ class UtilsTest extends TestCase{
 		self::assertEquals("true dummy", $tags["ignoreCancelled"]);
 	}
 
+	public function testParseEmptyDocComment() : void{
+		$tags = Utils::parseDocComment("");
+		self::assertCount(0, $tags);
+	}
+
 	public function testNamespacedNiceClosureName() : void{
 		//be careful with this test. The closure has to be declared on the same line as the assertion.
 		self::assertSame('closure@' . Utils::cleanPath(__FILE__) . '#L' . __LINE__, Utils::getNiceClosureName(function() : void{}));


### PR DESCRIPTION
## Introduction
Doc comments like the following parsed correctly:
```
/**
 * @ignoreCancelled
 */
```
but not like this:
```
/** @ignoreCancelled */
```
This pull request fixes this problem.

### Relevant issues
#3388

## Changes
### Behavioural changes
`Utils::parseDocComment()` now returns results in more cases.

## Backwards compatibility
No BC breaks are expected.

## Follow-up
Support `-` and other symbols in tag names (I noticed these wouldn't parse during my work to fix this bug).

## Tests
New PHPUnit test cases have been added.