### PR TITLE
Players no longer burn when hit by other players

### DIFF
--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -559,7 +559,10 @@ abstract class Living extends Entity implements Damageable{
 			if($e !== null){
 				if((
 					$source->getCause() === EntityDamageEvent::CAUSE_PROJECTILE or
-					$source->getCause() === EntityDamageEvent::CAUSE_ENTITY_ATTACK
+					(
+						$source->getCause() === EntityDamageEvent::CAUSE_ENTITY_ATTACK &&
+						!$e instanceof Player
+					)
 				) and $e->isOnFire()){
 					$this->setOnFire(2 * $this->level->getDifficulty());
 				}

--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -556,7 +556,7 @@ abstract class Living extends Entity implements Damageable{
 			if($e !== null){
 				if((
 					$source->getCause() === EntityDamageEvent::CAUSE_ENTITY_ATTACK and
-					!$e instanceof Player
+					$e instanceof Zombie
 				) and $e->isOnFire()){
 					$this->setOnFire(2 * $this->level->getDifficulty());
 				}

--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -552,17 +552,11 @@ abstract class Living extends Entity implements Damageable{
 
 		if($source instanceof EntityDamageByEntityEvent){
 			$e = $source->getDamager();
-			if($source instanceof EntityDamageByChildEntityEvent){
-				$e = $source->getChild();
-			}
 
 			if($e !== null){
 				if((
-					$source->getCause() === EntityDamageEvent::CAUSE_PROJECTILE or
-					(
-						$source->getCause() === EntityDamageEvent::CAUSE_ENTITY_ATTACK &&
-						!$e instanceof Player
-					)
+					$source->getCause() === EntityDamageEvent::CAUSE_ENTITY_ATTACK and
+					!$e instanceof Player
 				) and $e->isOnFire()){
 					$this->setOnFire(2 * $this->level->getDifficulty());
 				}

--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -554,13 +554,6 @@ abstract class Living extends Entity implements Damageable{
 			$e = $source->getDamager();
 
 			if($e !== null){
-				if((
-					$source->getCause() === EntityDamageEvent::CAUSE_ENTITY_ATTACK and
-					$e instanceof Zombie
-				) and $e->isOnFire()){
-					$this->setOnFire(2 * $this->level->getDifficulty());
-				}
-
 				$deltaX = $this->x - $e->x;
 				$deltaZ = $this->z - $e->z;
 				$this->knockBack($e, $source->getBaseDamage(), $deltaX, $deltaZ, $source->getKnockBack());

--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -552,6 +552,9 @@ abstract class Living extends Entity implements Damageable{
 
 		if($source instanceof EntityDamageByEntityEvent){
 			$e = $source->getDamager();
+			if($source instanceof EntityDamageByChildEntityEvent){
+				$e = $source->getChild();
+			}
 
 			if($e !== null){
 				$deltaX = $this->x - $e->x;


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
As explained in issue #3170, in neither Minecraft Bedrock nor Java, does the action exist anymore that players can set each other on fire by hitting each other, this PR allows mobs that are on fire to still set players on fire with damage (as that still exists).
### Relevant issues
Fixes #3170 

## Follow-up
Looking at this, the fix could be better, I originally wanted to check if it were an instanceof Monster, however looking at 4.0, that class no longer exists, so I don't want to add the extra burden of dealing with this in 4.0 changes. Ideally, you could actually just remove this if statement in general if you didn't care about mobs, because projectiles are already handled within the [projectile](https://github.com/pmmp/PocketMine-MP/blob/master/src/entity/projectile/Projectile.php#L301-L308) class.

EDIT: 
It seems much more logical to have the setting on fire be handled within Human (or Player), but not targeting a branch that can take this, limits that. The only entities capable of being set on fire through contact are players, ex: a zombie hitting a player whilst on fire will set the player on fire, but a player hitting a zombie on fire whilst on fire does nothing.

