### PR TITLE
Task: Remove currentTick parameter

### DIFF
--- a/src/scheduler/CancellableClosureTask.php
+++ b/src/scheduler/CancellableClosureTask.php
@@ -32,8 +32,8 @@ use pocketmine\utils\Utils;
  * Example usage:
  *
  * ```
- * TaskScheduler->scheduleTask(new CancellableClosureTask(function(int $currentTick) : bool{
- *     echo "HI on $currentTick\n";
+ * TaskScheduler->scheduleTask(new CancellableClosureTask(function() : bool{
+ *     echo "HI\n";
  *     $continue = false;
  *     return $continue; //stop repeating
  * });
@@ -47,20 +47,20 @@ class CancellableClosureTask extends Task{
 
 	/**
 	 * @var \Closure
-	 * @phpstan-var \Closure(int $currentTick) : bool
+	 * @phpstan-var \Closure() : bool
 	 */
 	private $closure;
 
 	/**
 	 * CancellableClosureTask constructor.
 	 *
-	 * The closure should follow the signature callback(int $currentTick) : bool. The return value will be used to
+	 * The closure should follow the signature callback() : bool. The return value will be used to
 	 * decide whether to continue repeating.
 	 *
-	 * @phpstan-param \Closure(int $currentTick) : bool $closure
+	 * @phpstan-param \Closure() : bool $closure
 	 */
 	public function __construct(\Closure $closure){
-		Utils::validateCallableSignature(function(int $currentTick) : bool{ return false; }, $closure);
+		Utils::validateCallableSignature(function() : bool{ return false; }, $closure);
 		$this->closure = $closure;
 	}
 
@@ -68,8 +68,8 @@ class CancellableClosureTask extends Task{
 		return Utils::getNiceClosureName($this->closure);
 	}
 
-	public function onRun(int $currentTick) : void{
-		if(!($this->closure)($currentTick)){
+	public function onRun() : void{
+		if(!($this->closure)()){
 			$this->getHandler()->cancel();
 		}
 	}

--- a/src/scheduler/ClosureTask.php
+++ b/src/scheduler/ClosureTask.php
@@ -31,8 +31,8 @@ use pocketmine\utils\Utils;
  * Example usage:
  *
  * ```
- * TaskScheduler->scheduleTask(new ClosureTask(function(int $currentTick) : void{
- *     echo "HI on $currentTick\n";
+ * TaskScheduler->scheduleTask(new ClosureTask(function() : void{
+ *     echo "HI\n";
  * });
  * ```
  */
@@ -40,16 +40,16 @@ class ClosureTask extends Task{
 
 	/**
 	 * @var \Closure
-	 * @phpstan-var \Closure(int) : void
+	 * @phpstan-var \Closure() : void
 	 */
 	private $closure;
 
 	/**
-	 * @param \Closure $closure Must accept only ONE parameter, $currentTick
-	 * @phpstan-param \Closure(int) : void $closure
+	 * @param \Closure $closure Must accept zero parameters
+	 * @phpstan-param \Closure() : void $closure
 	 */
 	public function __construct(\Closure $closure){
-		Utils::validateCallableSignature(function(int $currentTick) : void{}, $closure);
+		Utils::validateCallableSignature(function() : void{}, $closure);
 		$this->closure = $closure;
 	}
 
@@ -57,7 +57,7 @@ class ClosureTask extends Task{
 		return Utils::getNiceClosureName($this->closure);
 	}
 
-	public function onRun(int $currentTick) : void{
-		($this->closure)($currentTick);
+	public function onRun() : void{
+		($this->closure)();
 	}
 }

--- a/src/scheduler/Task.php
+++ b/src/scheduler/Task.php
@@ -60,7 +60,7 @@ abstract class Task{
 	 *
 	 * @return void
 	 */
-	abstract public function onRun(int $currentTick);
+	abstract public function onRun();
 
 	/**
 	 * Actions to execute if the Task is cancelled

--- a/src/scheduler/TaskHandler.php
+++ b/src/scheduler/TaskHandler.php
@@ -119,7 +119,7 @@ class TaskHandler{
 	public function run(int $currentTick) : void{
 		$this->timings->startTiming();
 		try{
-			$this->task->onRun($currentTick);
+			$this->task->onRun();
 		}finally{
 			$this->timings->stopTiming();
 		}

--- a/src/scheduler/TaskHandler.php
+++ b/src/scheduler/TaskHandler.php
@@ -116,7 +116,7 @@ class TaskHandler{
 		$this->task->setHandler(null);
 	}
 
-	public function run(int $currentTick) : void{
+	public function run() : void{
 		$this->timings->startTiming();
 		try{
 			$this->task->onRun();

--- a/src/scheduler/TaskScheduler.php
+++ b/src/scheduler/TaskScheduler.php
@@ -147,7 +147,7 @@ class TaskScheduler{
 				unset($this->tasks[$task->getTaskId()]);
 				continue;
 			}
-			$task->run($this->currentTick);
+			$task->run();
 			if($task->isRepeating()){
 				$task->setNextRun($this->currentTick + $task->getPeriod());
 				$this->queue->insert($task, $this->currentTick + $task->getPeriod());

--- a/tests/plugins/TesterPlugin/src/pmmp/TesterPlugin/CheckTestCompletionTask.php
+++ b/tests/plugins/TesterPlugin/src/pmmp/TesterPlugin/CheckTestCompletionTask.php
@@ -34,7 +34,7 @@ class CheckTestCompletionTask extends Task{
 		$this->plugin = $plugin;
 	}
 
-	public function onRun(int $currentTick){
+	public function onRun(){
 		$test = $this->plugin->getCurrentTest();
 		if($test === null){
 			if(!$this->plugin->startNextTest()){


### PR DESCRIPTION
## Introduction
This parameter is not used for the vast majority of task use cases and just serves as extra useless boilerplate code, especially for closure-based tasks.
This use case can be replaced using Server->getTick() in the cases where it matters.

## Changes
### API changes
- `Task->onRun()` now accepts zero parameters. Plugins that want to stay API-compatible with both old and new versions may provide a default for `currentTick` in their code instead of removing it.

## Backwards compatibility
This is a BC break.

## Tests
See CI.