### PR TITLE
Fixes #3495

### DIFF
--- a/src/pocketmine/item/Bow.php
+++ b/src/pocketmine/item/Bow.php
@@ -93,7 +93,7 @@ class Bow extends Tool{
 			$entity = $ev->getProjectile(); //This might have been changed by plugins
 
 			if($ev->isCancelled()){
-				$entity->flagForDespawn();
+				$entity->close();
 				$player->getInventory()->sendContents($player);
 			}else{
 				$entity->setMotion($entity->getMotion()->multiply($ev->getForce()));


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Fixes #3495
### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
This fixes the  issue mentioned. When `Entity::flagForDespawn` is used it will tick the arrow one time before despawning. With this fix Punch and Infinity enchantments will stop processing that tick if the EntityShootBowEvent event is cancelled
## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Tested in my Ubuntu 16.04.3 LTS server.