### PR TITLE
Fix timings calculation bug in PermissionManager

### DIFF
--- a/src/permission/PermissionManager.php
+++ b/src/permission/PermissionManager.php
@@ -108,7 +108,7 @@ class PermissionManager{
 			$this->defaultPerms[$permission->getName()] = $permission;
 			$this->dirtyPermissibles(false);
 		}
-		Timings::$permissionDefaultTimer->startTiming();
+		Timings::$permissionDefaultTimer->stopTiming();
 	}
 
 	private function dirtyPermissibles(bool $op) : void{


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
`Timings::$permissionDefaultTimer->stopTiming()` didn't get called, leading to inaccurate timings report. 