### PR TITLE
3.12.2 changelog typo

### DIFF
--- a/changelogs/3.12.md
+++ b/changelogs/3.12.md
@@ -21,7 +21,7 @@ Plugin developers should **only** update their required API to this version if y
 - Fixed permission default timings not being reported in timings reports (they were never stopped, only started).
 - Resource packs with a directory tree like `pack.zip/MyPack/manifest.json` are now supported. Note that the manifest closest to the root will be used.
 - Fixed `SkinImage` height and width being inverted at the protocol layer.
-- Fixed blocks being able to be placed inside the spawn protectionb radius by clicking the side of a block outside the radius.
+- Fixed blocks being able to be placed inside the spawn protection radius by clicking the side of a block outside the radius.
 - Fixed server crash when `network.compression-level` is overridden by a CLI parameter.
 - Fixed moving entities spawning themselves to players registered on chunks when the players haven't received the chunk yet.
 - Cocoa pods now drop cocoa beans when broken instead of the block itself.


### PR DESCRIPTION
## Introduction
There was a typo in the new 3.12.2 changelogs