### PR TITLE
rename server.phar to server-phar.php

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -30,7 +30,7 @@ If you use a custom binary, you'll need to replace `composer` usages in this gui
 Preprocessor requires that the `cpp` (c preprocessor) is available in your PATH.
 
 ## Building `PocketMine-MP.phar`
-Run `build/server.phar` using your preferred PHP binary. It'll drop a `PocketMine-MP.phar` into the current working directory.
+Run `build/server-phar.php` using your preferred PHP binary. It'll drop a `PocketMine-MP.phar` into the current working directory.
 
 You can also use the `--out` option to change the output filename.
 


### PR DESCRIPTION
## Introduction
server.phar not found on folder build
https://github.com/pmmp/PocketMine-MP/blob/master/build/server-phar.php

## Tests
create PocketMine-MP.phar api 4.0 on my pc with server-phar.php and works

