### PR TITLE
Update TimeCommand.php to add new time constants

### DIFF
--- a/src/pocketmine/command/defaults/TimeCommand.php
+++ b/src/pocketmine/command/defaults/TimeCommand.php
@@ -97,33 +97,26 @@ class TimeCommand extends VanillaCommand{
 			}
 
 			switch ($args[1]){
-				case "day":{
+				case "day":
 					$value = Level::TIME_DAY;
 					break;
-				}
-				case "noon":{
+				case "noon":
 					$value = Level::TIME_NOON;
 					break;
-				}
-				case "sunset":{
+				case "sunset":
 					$value = Level::TIME_SUNSET;
 					break;
-				}
-				case "night":{
+				case "night":
 					$value = Level::TIME_NIGHT;
 					break;
-				}
-				case "midnight":{
+				case "midnight":
 					$value = Level::TIME_MIDNIGHT;
 					break;
-				}
-				case "sunrise":{
+				case "sunrise":
 					$value = Level::TIME_SUNRISE;
 					break;
-				}
-				default:{
+				default:
 					$value = $this->getInteger($sender, $args[1], 0);
-				}
 			}
 
 			foreach($sender->getServer()->getLevels() as $level){

--- a/src/pocketmine/command/defaults/TimeCommand.php
+++ b/src/pocketmine/command/defaults/TimeCommand.php
@@ -96,12 +96,34 @@ class TimeCommand extends VanillaCommand{
 				return true;
 			}
 
-			if($args[1] === "day"){
-				$value = Level::TIME_DAY;
-			}elseif($args[1] === "night"){
-				$value = Level::TIME_NIGHT;
-			}else{
-				$value = $this->getInteger($sender, $args[1], 0);
+			switch ($args[1]){
+				case "day":{
+					$value = Level::TIME_DAY;
+					break;
+				}
+				case "noon":{
+					$value = Level::TIME_NOON;
+					break;
+				}
+				case "sunset":{
+					$value = Level::TIME_SUNSET;
+					break;
+				}
+				case "night":{
+					$value = Level::TIME_NIGHT;
+					break;
+				}
+				case "midnight":{
+					$value = Level::TIME_MIDNIGHT;
+					break;
+				}
+				case "sunrise":{
+					$value = Level::TIME_SUNRISE;
+					break;
+				}
+				default:{
+					$value = $this->getInteger($sender, $args[1], 0);
+				}
 			}
 
 			foreach($sender->getServer()->getLevels() as $level){

--- a/src/pocketmine/command/defaults/TimeCommand.php
+++ b/src/pocketmine/command/defaults/TimeCommand.php
@@ -96,7 +96,7 @@ class TimeCommand extends VanillaCommand{
 				return true;
 			}
 
-			switch ($args[1]){
+			switch($args[1]){
 				case "day":
 					$value = Level::TIME_DAY;
 					break;
@@ -117,6 +117,7 @@ class TimeCommand extends VanillaCommand{
 					break;
 				default:
 					$value = $this->getInteger($sender, $args[1], 0);
+					break;
 			}
 
 			foreach($sender->getServer()->getLevels() as $level){

--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -557,13 +557,6 @@ abstract class Living extends Entity implements Damageable{
 			}
 
 			if($e !== null){
-				if((
-					$source->getCause() === EntityDamageEvent::CAUSE_PROJECTILE or
-					$source->getCause() === EntityDamageEvent::CAUSE_ENTITY_ATTACK
-				) and $e->isOnFire()){
-					$this->setOnFire(2 * $this->level->getDifficulty());
-				}
-
 				$deltaX = $this->x - $e->x;
 				$deltaZ = $this->z - $e->z;
 				$this->knockBack($e, $source->getBaseDamage(), $deltaX, $deltaZ, $source->getKnockBack());


### PR DESCRIPTION
@dktapps What happens if getInteger() is not an integer?

## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
As mentioned in #3385

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
No

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
Yesn't. Only additional command syntax.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Fully BC

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
Requires change in translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `%pocketmine.command.time.usage` | Should display additional parameters |


## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Its so simple (and i kind of don't want to bother to set up pmmp from source) that it should work right away