### PR TITLE
Burning players no longer set arrows on fire

### DIFF
--- a/src/pocketmine/item/Bow.php
+++ b/src/pocketmine/item/Bow.php
@@ -59,7 +59,6 @@ class Bow extends Tool{
 			($player->yaw > 180 ? 360 : 0) - $player->yaw,
 			-$player->pitch
 		);
-		$nbt->setShort("Fire", $player->isOnFire() ? 45 * 60 : 0);
 
 		$diff = $player->getItemUseDuration();
 		$p = $diff / 20;


### PR DESCRIPTION
## Introduction
In vanilla Minecraft, arrows do not catch fire whilst a player is on fire. This PR removes that intentional behavior, as it does not exist in Java 1.8 or Bedrock.

### Relevant issues
Fixes #3504

## Tests
Testing consisted of setting a player on fire, the player does not set the arrow on fire.
