### PR TITLE
Remove duplicate call to Entity->resetFallDistance()

### DIFF
--- a/src/pocketmine/block/Water.php
+++ b/src/pocketmine/block/Water.php
@@ -70,8 +70,6 @@ class Water extends Liquid{
 		if($entity->isOnFire()){
 			$entity->extinguish();
 		}
-
-		$entity->resetFallDistance();
 	}
 
 	public function place(Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, Player $player = null) : bool{


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Removes duplicate call to `Entity::resetFallDistance()` introduced in this commit https://github.com/pmmp/PocketMine-MP/commit/8169803bb49a0b3315915188aeb8650a6c3bda64#diff-cf4efef19226a2cd7efd37f88350b474
(`Entity::resetFallDistance()` is called in Water#L69)

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
Unsure if the commit referenced above makes this redundant as well: https://github.com/pmmp/PocketMine-MP/blob/stable/src/pocketmine/block/Lava.php#L103
