### PR TITLE
Make use of Generator->getSpawn() instead of using hardcoded values

### DIFF
--- a/src/pocketmine/level/format/io/leveldb/LevelDB.php
+++ b/src/pocketmine/level/format/io/leveldb/LevelDB.php
@@ -30,6 +30,7 @@ use pocketmine\level\format\io\exception\CorruptedChunkException;
 use pocketmine\level\format\io\exception\UnsupportedChunkFormatException;
 use pocketmine\level\format\SubChunk;
 use pocketmine\level\generator\Flat;
+use pocketmine\level\generator\Generator;
 use pocketmine\level\generator\GeneratorManager;
 use pocketmine\level\Level;
 use pocketmine\level\LevelException;
@@ -211,6 +212,9 @@ class LevelDB extends BaseLevelProvider{
 			//TODO: add support for limited worlds
 		}
 
+		/** @var Generator $gen */
+		$gen = new $generator($options);
+		$spawn = $gen->getSpawn();
 		$levelData = new CompoundTag("", [
 			//Vanilla fields
 			new IntTag("DayCycleStopTime", -1),
@@ -223,9 +227,9 @@ class LevelDB extends BaseLevelProvider{
 			new IntTag("NetworkVersion", ProtocolInfo::CURRENT_PROTOCOL),
 			//new IntTag("Platform", 2), //TODO: find out what the possible values are for
 			new LongTag("RandomSeed", $seed),
-			new IntTag("SpawnX", 0),
-			new IntTag("SpawnY", 32767),
-			new IntTag("SpawnZ", 0),
+			new IntTag("SpawnX", $spawn->getFloorX()),
+			new IntTag("SpawnY", $spawn->getFloorY()),
+			new IntTag("SpawnZ", $spawn->getFloorZ()),
 			new IntTag("StorageVersion", self::CURRENT_STORAGE_VERSION),
 			new LongTag("Time", 0),
 			new ByteTag("eduLevel", 0),

--- a/src/pocketmine/level/format/io/region/McRegion.php
+++ b/src/pocketmine/level/format/io/region/McRegion.php
@@ -28,6 +28,7 @@ use pocketmine\level\format\io\BaseLevelProvider;
 use pocketmine\level\format\io\ChunkUtils;
 use pocketmine\level\format\io\exception\CorruptedChunkException;
 use pocketmine\level\format\SubChunk;
+use pocketmine\level\generator\Generator;
 use pocketmine\level\generator\GeneratorManager;
 use pocketmine\level\Level;
 use pocketmine\nbt\BigEndianNBTStream;
@@ -268,15 +269,18 @@ class McRegion extends BaseLevelProvider{
 			mkdir($path . "/region", 0777);
 		}
 		//TODO, add extra details
+		/** @var Generator $gen */
+		$gen = new $generator($options);
+		$spawn = $gen->getSpawn();
 		$levelData = new CompoundTag("Data", [
 			new ByteTag("hardcore", ($options["hardcore"] ?? false) === true ? 1 : 0),
 			new ByteTag("Difficulty", Level::getDifficultyFromString((string) ($options["difficulty"] ?? "normal"))),
 			new ByteTag("initialized", 1),
 			new IntTag("GameType", 0),
 			new IntTag("generatorVersion", 1), //2 in MCPE
-			new IntTag("SpawnX", 256),
-			new IntTag("SpawnY", 70),
-			new IntTag("SpawnZ", 256),
+			new IntTag("SpawnX", $spawn->getFloorX()),
+			new IntTag("SpawnY", $spawn->getFloorY()),
+			new IntTag("SpawnZ", $spawn->getFloorZ()),
 			new IntTag("version", static::getPcWorldFormatVersion()),
 			new IntTag("DayTime", 0),
 			new LongTag("LastPlayed", (int) (microtime(true) * 1000)),


### PR DESCRIPTION
## Introduction
It is currently impossible to set the spawn point of a level as it generates as Generator->getSpawn()'s value is never used.

### Relevant issues
* Fixes #1258

## Changes
### API changes
None

### Behavioural changes
Returning a Vector3 value for Generator->getSpawn() now affects the newly generated world instead of being always at approximately XZ: 256, 256 (on the default PMAnvil world format)

## Backwards compatibility
None

## Follow-up
None

## Tests
Start a new world with the default `Normal` world generator, it should initially set your spawnpoint to (127, 127) as declared at:

https://github.com/pmmp/PocketMine-MP/blob/c3a795e876071601ee31ecfddc6218d8c58b79fa/src/pocketmine/level/generator/normal/Normal.php#L258-L260