### PR TITLE
Player: Fixed wrong item use logic

### DIFF
--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1472,7 +1472,7 @@ class Player extends Human implements CommandSender, ChunkLoader, ChunkListener,
 		}
 
 		//TODO: check if item has a release action - if it doesn't, this shouldn't be set
-		$this->setUsingItem(true);
+		$this->setUsingItem(false);
 
 		return true;
 	}


### PR DESCRIPTION
It was possible to use an item only once. It was necessary to switch slots in the hotbar in order to reuse the item. This change fixes this.