### PR TITLE
Glass: Block type changed to solid

### DIFF
--- a/src/pocketmine/block/Glass.php
+++ b/src/pocketmine/block/Glass.php
@@ -25,7 +25,7 @@ namespace pocketmine\block;
 
 use pocketmine\item\Item;
 
-class Glass extends Transparent{
+class Glass extends Solid{
 
 	protected $id = self::GLASS;
 
@@ -39,6 +39,10 @@ class Glass extends Transparent{
 
 	public function getHardness() : float{
 		return 0.3;
+	}
+
+	public function getLightFilter() : int{
+		return 0;
 	}
 
 	public function getDropsForCompatibleTool(Item $item) : array{


### PR DESCRIPTION
On the glass it was impossible to put blocks requiring a solid block underneath