### PR TITLE
Fix wrong item use logic

### DIFF
--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -333,8 +333,8 @@ class InGamePacketHandler extends PacketHandler{
 				if($this->player->isUsingItem()){
 					if(!$this->player->consumeHeldItem()){
 						$this->session->getInvManager()->syncSlot($this->player->getInventory(), $this->player->getInventory()->getHeldItemIndex());
+						return true;
 					}
-					return true;
 				}
 				if(!$this->player->useHeldItem()){
 					$this->session->getInvManager()->syncSlot($this->player->getInventory(), $this->player->getInventory()->getHeldItemIndex());

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1472,7 +1472,7 @@ class Player extends Human implements CommandSender, ChunkLoader, ChunkListener,
 		}
 
 		//TODO: check if item has a release action - if it doesn't, this shouldn't be set
-		$this->setUsingItem(false);
+		$this->setUsingItem(true);
 
 		return true;
 	}
@@ -1507,7 +1507,7 @@ class Player extends Human implements CommandSender, ChunkLoader, ChunkListener,
 			return true;
 		}
 
-		return false;
+		return true;
 	}
 
 	/**

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1472,7 +1472,7 @@ class Player extends Human implements CommandSender, ChunkLoader, ChunkListener,
 		}
 
 		//TODO: check if item has a release action - if it doesn't, this shouldn't be set
-		$this->setUsingItem(true);
+		$this->setUsingItem(false);
 
 		return true;
 	}


### PR DESCRIPTION
It was possible to use an item only once. It was necessary to switch slots in the hotbar in order to reuse the item. This change fixes this.

UPD: Changed the previous fix, now the tools do not break