### PR TITLE
Add get LoginPacket method on Player class

### DIFF
--- a/src/pocketmine/network/mcpe/protocol/SetScorePacket.php
+++ b/src/pocketmine/network/mcpe/protocol/SetScorePacket.php
@@ -61,6 +61,7 @@ class SetScorePacket extends DataPacket{
 						throw new \UnexpectedValueException("Unknown entry type $entry->type");
 				}
 			}
+			$this->entries[] = $entry;
 		}
 	}
 


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
As we know, we can handling this on DataPacketReceiveEvent. But we need alternative method to getting LoginPacket of player without creating Event.

## Changes
<!-- Any additions to the API that should be documented in release notes? -->
Add method getLoginPacket on Player class.
