### PR TITLE
let arrow and attack like vanilla and add Player::getDeviceID,Player::getDeviceOS

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -383,7 +383,15 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	protected $lastRightClickTime = 0.0;
 	/** @var Vector3|null */
 	protected $lastRightClickPos = null;
-
+	
+	
+	/** @var string */
+	protected $deviceId;
+	/** @var string */
+	protected $deviceModel;
+	/** @var int */
+	protected $deviceOS;
+	
 	/**
 	 * @return TranslationContainer|string
 	 */
@@ -1886,7 +1894,11 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		$this->username = TextFormat::clean($packet->username);
 		$this->displayName = $this->username;
 		$this->iusername = strtolower($this->username);
-
+		
+		$this->deviceId = $packet->clientData["DeviceId"];
+		$this->deviceModel = $packet->clientData["DeviceModel"];
+		$this->deviceOS = $packet->clientData["DeviceOS"];
+		
 		if($packet->locale !== null){
 			$this->locale = $packet->locale;
 		}
@@ -4076,5 +4088,17 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 	public function isLoaderActive() : bool{
 		return $this->isConnected();
+	}
+	
+	public function getDeviceId() : string{
+		return $this->deviceId;
+	}
+	
+	public function getDeviceModel() : string{
+		return $this->deviceModel;
+	}
+	
+	public function getDeviceOS() : int{
+		return $this->deviceOS;
 	}
 }

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2619,7 +2619,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 								$cancelled = true;
 							}
 						}
-
+						$this->setSprinting(false);
 						$ev = new EntityDamageByEntityEvent($this, $target, EntityDamageEvent::CAUSE_ENTITY_ATTACK, $heldItem->getAttackPoints());
 
 						$meleeEnchantmentDamage = 0;

--- a/src/pocketmine/entity/projectile/Arrow.php
+++ b/src/pocketmine/entity/projectile/Arrow.php
@@ -51,8 +51,8 @@ class Arrow extends Projectile{
 	public $width = 0.25;
 	public $height = 0.25;
 
-	protected $gravity = 0.05;
-	protected $drag = 0.01;
+	protected $gravity = 0.03;
+	protected $drag = 0.05;
 
 	/** @var float */
 	protected $damage = 2.0;


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
let arrow and attack like vanilla and add Player::getDeviceID,Player::getDeviceOS
### Relevant issues
* Fixes #1
attack to break sprinting
* Fixes #2
fixed arrow drag and gravity to let it fly like vanilla
-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Player::getDeviceID
Player::getDeviceOS
### Behavioural changes
none

## Backwards compatibility
none

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
