### PR TITLE
Support the ServerSettings.

### DIFF
--- a/src/pocketmine/network/mcpe/PlayerNetworkSessionAdapter.php
+++ b/src/pocketmine/network/mcpe/PlayerNetworkSessionAdapter.php
@@ -308,7 +308,7 @@ class PlayerNetworkSessionAdapter extends NetworkSession{
 	}
 
 	public function handleServerSettingsRequest(ServerSettingsRequestPacket $packet) : bool{
-		return false; //TODO: GUI stuff
+		return $this->player->handleServerSettingsRequest();
 	}
 
 	public function handleSetLocalPlayerAsInitialized(SetLocalPlayerAsInitializedPacket $packet) : bool{


### PR DESCRIPTION
## Introduction
ServerSettings are not currently supported by PMMP.

### Relevant issues
none

## Changes
### API changes
Yes. API is changing. Information about this is included in the commit.

### Behavioural changes
There is essentially no performance impact.

## Backwards compatibility
There are no changes that are not backward compatible.

## Follow-up
none

## Tests
[Test with script plugin (serversettings-test.php)](https://gist.github.com/PJZ9n/a35ab569d0aeb757c0bc0e84ca2614b5/revisions#diff-cb688af410f1f190b85bf8e94c326b19)
This succeeded successfully. Confirm that the Server Settings are displayed like this.
![screenshot_20200613_152935](https://user-images.githubusercontent.com/38120936/84561848-bdd27580-ad8a-11ea-9880-23c8d4b9d044.png)
And of course you can get the response.
![screenshot_20200613_153100](https://user-images.githubusercontent.com/38120936/84561874-eeb2aa80-ad8a-11ea-967d-23034548e50b.png)
*I am sorry that the language setting of the client and PMMP is not English. However, this does not affect the test.
