### PR TITLE
Add closure task arguments.

### DIFF
--- a/src/pocketmine/scheduler/ClosureTask.php
+++ b/src/pocketmine/scheduler/ClosureTask.php
@@ -40,7 +40,7 @@ class ClosureTask extends Task{
 
 	/**
 	 * @var \Closure
-	 * @phpstan-var \Closure(int) : void|\Closure(int, TaskHandler) : void
+	 * @phpstan-var \Closure(int) : void|\Closure(int, TaskHandler|null) : void
 	 */
 	private $closure;
 
@@ -49,11 +49,11 @@ class ClosureTask extends Task{
 
 	/**
 	 * @param \Closure $closure Must accept only ONE parameter, $currentTick
-	 * @phpstan-param \Closure(int) : void|\Closure(int, TaskHandler) : void $closure
+	 * @phpstan-param \Closure(int) : void|\Closure(int, TaskHandler|null) : void $closure
 	 */
 	public function __construct(\Closure $closure){
 		try{
-			Utils::validateCallableSignature(function(int $currentTick, TaskHandler $handler): void{}, $closure);
+			Utils::validateCallableSignature(function(int $currentTick, ?TaskHandler $handler): void{}, $closure);
 			$this->useTaskHandler = true;
 		}catch(\TypeError $typeError){
 			//For backward compatibility

--- a/src/pocketmine/scheduler/ClosureTask.php
+++ b/src/pocketmine/scheduler/ClosureTask.php
@@ -55,7 +55,7 @@ class ClosureTask extends Task{
 		try{
 			Utils::validateCallableSignature(function(int $currentTick, TaskHandler $handler): void{}, $closure);
 			$this->useTaskHandler = true;
-		}catch (\TypeError $typeError){
+		}catch(\TypeError $typeError){
 			//For backward compatibility
 			Utils::validateCallableSignature(function(int $currentTick) : void{}, $closure);
 		}

--- a/src/pocketmine/scheduler/ClosureTask.php
+++ b/src/pocketmine/scheduler/ClosureTask.php
@@ -44,6 +44,7 @@ class ClosureTask extends Task{
 	 */
 	private $closure;
 
+	/** @var bool */
 	private $useTaskHandler = false;
 
 	/**


### PR DESCRIPTION
## Introduction
I can't find any way to use TaskHandler in ClosureTask.
ClosureTask is a Task, so you need to be able to access the TaskHandler.
The only way I know is to use pass by reference.
```php
$handler = $this->getScheduler()->scheduleRepeatingTask(new ClosureTask(function (int $currentTick) use (&$handler, $player): void {
```
However, this technique does not guarantee that $handler is a TaskHandler.
I think this is much more useful than having a currentTick argument :)

### Relevant issues
none

## Changes
### API changes
Yes, there are API changes. This is clear if you look at the commits.

### Behavioural changes
Does not affect performance.

## Backwards compatibility
It is fully backward compatible.

## Follow-up
none

Requires translations:
none

## Tests
[Test with Script plugin](https://gist.github.com/PJZ9n/9d12bd6a1cb86dac7a3ca58ea2c15cb2/revisions#diff-af582cb50ea11ee45a420a345cd31ae1)
![screenshot_20200615_203209](https://user-images.githubusercontent.com/38120936/84653333-36cafc00-af48-11ea-855b-ad8a0b4f9315.png)
![screenshot_20200615_203239](https://user-images.githubusercontent.com/38120936/84653338-37fc2900-af48-11ea-854a-2964355e18b3.png)
![screenshot_20200615_203303](https://user-images.githubusercontent.com/38120936/84653341-3894bf80-af48-11ea-87fa-301dc4ea446c.png)

