### PR TITLE
Improved food consumption

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1790,7 +1790,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	public function isHungry() : bool{
-		return $this->isCreative() or parent::isHungry();
+		return $this->isSurvival() and parent::isHungry();
 	}
 
 	public function canBreathe() : bool{

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1782,7 +1782,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	public function isHungry() : bool{
-		return $this->isSurvival() and parent::isHungry();
+		return $this->isCreative(true) or ($this->isSurvival() and parent::isHungry());
 	}
 
 	public function canBreathe() : bool{

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1781,6 +1781,14 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		return 0.0;
 	}
 
+	public function canConsumeObject(Consumable $consumable) : bool{
+		if($this->isCreative()){
+			return true;
+		}
+
+		return parent::canConsumeObject($consumable);
+	}
+
 	public function isHungry() : bool{
 		return $this->isCreative() or parent::isHungry();
 	}

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -1782,7 +1782,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	public function isHungry() : bool{
-		return $this->isCreative(true) or ($this->isSurvival() and parent::isHungry());
+		return $this->isCreative() or parent::isHungry();
 	}
 
 	public function canBreathe() : bool{

--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -296,21 +296,25 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 		return $ev->getAmount();
 	}
 
-	public function consumeObject(Consumable $consumable) : bool{
-		if($consumable instanceof MaybeConsumable and !$consumable->canBeConsumed()){
-			return false;
-		}
-
+	public function canConsumeObject(Consumable $consumable) : bool{
 		if($consumable instanceof FoodSource){
 			if($consumable->requiresHunger() and !$this->isHungry()){
 				return false;
 			}
 
+			return true;
+		}
+
+		return parent::canConsumeObject($consumable);
+	}
+
+	protected function onConsumeObject(Consumable $consumable) : void{
+		parent::onConsumeObject($consumable);
+
+		if($consumable instanceof FoodSource){
 			$this->addFood($consumable->getFoodRestore());
 			$this->addSaturation($consumable->getSaturationRestore());
 		}
-
-		return parent::consumeObject($consumable);
 	}
 
 	/**

--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -356,17 +356,31 @@ abstract class Living extends Entity implements Damageable{
 	}
 
 	/**
+	 * Returns the possibility to consume or not the given Consumable object.
+	 */
+	public function canConsumeObject(Consumable $consumable) : bool{
+		return $consumable instanceof MaybeConsumable and $consumable->canBeConsumed();
+	}
+
+	/**
+	 * Called when an Consumable object is going to be consumed.
+	 */
+	protected function onConsumeObject(Consumable $consumable) : void{
+		foreach($consumable->getAdditionalEffects() as $effect){
+			$this->addEffect($effect);
+		}
+	}
+
+	/**
 	 * Causes the mob to consume the given Consumable object, applying applicable effects, health bonuses, food bonuses,
 	 * etc.
 	 */
 	public function consumeObject(Consumable $consumable) : bool{
-		if($consumable instanceof MaybeConsumable and !$consumable->canBeConsumed()){
+		if(!$this->canConsumeObject($consumable)){
 			return false;
 		}
 
-		foreach($consumable->getAdditionalEffects() as $effect){
-			$this->addEffect($effect);
-		}
+		$this->onConsumeObject($consumable);
 
 		$consumable->onConsume($this);
 


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This PR aims to improve the already implemented food consumption by allowing the possibility to easily customize the food effects and allows the creative players to eat.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #3591
-->
* Fixes #3591

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
- Added public function `Living::canConsumeObject(Consumable)` to check if the given Consumable can be effectively consumed.
- Added protected function `Living::onConsumeObject(Consumable)` to allow the customization of bonuses given when consume objects.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
Players in creative gamemode can now eat foods.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Yes.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
https://streamable.com/ntglcq