### PR TITLE
Fixed wrong meta value when pick cake block.

### DIFF
--- a/src/pocketmine/block/Cake.php
+++ b/src/pocketmine/block/Cake.php
@@ -109,7 +109,7 @@ class Cake extends Transparent implements FoodSource{
 		return true;
 	}
 
-	public function getVariant() : int{
+	public function getVariantBitmask() : int{
 		return 0;
 	}
 

--- a/src/pocketmine/block/Cake.php
+++ b/src/pocketmine/block/Cake.php
@@ -27,6 +27,8 @@ use pocketmine\entity\EffectInstance;
 use pocketmine\entity\Living;
 use pocketmine\item\FoodSource;
 use pocketmine\item\Item;
+use pocketmine\item\ItemFactory;
+use pocketmine\item\ItemIds;
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Vector3;
 use pocketmine\Player;
@@ -107,6 +109,10 @@ class Cake extends Transparent implements FoodSource{
 
 	public function requiresHunger() : bool{
 		return true;
+	}
+
+	public function getPickedItem() : Item{
+		return ItemFactory::get(ItemIds::CAKE);
 	}
 
 	/**

--- a/src/pocketmine/block/Cake.php
+++ b/src/pocketmine/block/Cake.php
@@ -27,8 +27,6 @@ use pocketmine\entity\EffectInstance;
 use pocketmine\entity\Living;
 use pocketmine\item\FoodSource;
 use pocketmine\item\Item;
-use pocketmine\item\ItemFactory;
-use pocketmine\item\ItemIds;
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Vector3;
 use pocketmine\Player;
@@ -111,8 +109,8 @@ class Cake extends Transparent implements FoodSource{
 		return true;
 	}
 
-	public function getPickedItem() : Item{
-		return ItemFactory::get(ItemIds::CAKE);
+	public function getVariant() : int{
+		return 0;
 	}
 
 	/**


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
The PR aims to fix an issue regarding the cake block picking that gives the item with the same block meta value instead of 0.

https://streamable.com/to40zq
 
### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
No.
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
No.
## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Yes.
## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Obviously it has been tested, I don't think it's necessary to give the demonstration given the simple solution of the problem.