### PR TITLE
Arrow punch knockback not applies when damage cancelled

### DIFF
--- a/src/pocketmine/entity/projectile/Arrow.php
+++ b/src/pocketmine/entity/projectile/Arrow.php
@@ -142,7 +142,7 @@ class Arrow extends Projectile{
 
 	protected function onHitEntity(Entity $entityHit, RayTraceResult $hitResult) : void{
 		parent::onHitEntity($entityHit, $hitResult);
-		if($this->punchKnockback > 0){
+		if(!$this->damageCancelled && $this->punchKnockback > 0){
 			$horizontalSpeed = sqrt($this->motion->x ** 2 + $this->motion->z ** 2);
 			if($horizontalSpeed > 0){
 				$multiplier = $this->punchKnockback * 0.6 / $horizontalSpeed;

--- a/src/pocketmine/entity/projectile/Projectile.php
+++ b/src/pocketmine/entity/projectile/Projectile.php
@@ -59,6 +59,9 @@ abstract class Projectile extends Entity{
 	protected $blockHitId;
 	/** @var int|null */
 	protected $blockHitData;
+	
+	/** @var bool */
+	protected $damageCancelled = false;
 
 	public function __construct(Level $level, CompoundTag $nbt, ?Entity $shootingEntity = null){
 		parent::__construct($level, $nbt);
@@ -307,6 +310,8 @@ abstract class Projectile extends Entity{
 				$ev->call();
 				if(!$ev->isCancelled()){
 					$entityHit->setOnFire($ev->getDuration());
+				} else {
+					$this->damageCancelled = true;
 				}
 			}
 		}


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Fix https://github.com/pmmp/PocketMine-MP/issues/3495
### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Add field damageCancelled on Projectile.php

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
