### PR TITLE
Fix "Ender pearl still teleporting to Vector after level change"

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -386,6 +386,9 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	/** @var Vector3|null */
 	protected $lastRightClickPos = null;
 
+	/** @var int */
+	protected $activePearlsCounter = 0;
+
 	/**
 	 * @return TranslationContainer|string
 	 */
@@ -950,6 +953,8 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 			$this->loadQueue = [];
 			$this->level->sendTime($this);
 			$this->level->sendDifficulty($this);
+
+			$this->resetActivePearls();
 
 			return true;
 		}
@@ -3739,6 +3744,8 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		$this->level->dropExperience($this, $ev->getXpDropAmount());
 		$this->setXpAndProgress(0, 0);
 
+		$this->resetActivePearls();
+
 		if($ev->getDeathMessage() != ""){
 			$this->server->broadcastMessage($ev->getDeathMessage());
 		}
@@ -3877,6 +3884,24 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		}
 
 		return false;
+	}
+
+	public function hasActivePearls() : bool{
+		return $this->activePearlsCounter > 0;
+	}
+
+	public function increaseActivePearls() : void{
+		$this->activePearlsCounter++;
+	}
+
+	public function decreaseActivePearls() : void{
+		if($this->hasActivePearls()){
+			$this->activePearlsCounter--;
+		}
+	}
+
+	public function resetActivePearls() : void{
+		$this->activePearlsCounter = 0;
 	}
 
 	/**

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -954,8 +954,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 			$this->level->sendTime($this);
 			$this->level->sendDifficulty($this);
 
-			$this->resetActivePearls();
-
 			return true;
 		}
 
@@ -3879,6 +3877,8 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 			//TODO: workaround for player last pos not getting updated
 			//Entity::updateMovement() normally handles this, but it's overridden with an empty function in Player
 			$this->resetLastMovements();
+
+			$this->resetActivePearls();
 
 			return true;
 		}

--- a/src/pocketmine/entity/projectile/EnderPearl.php
+++ b/src/pocketmine/entity/projectile/EnderPearl.php
@@ -34,6 +34,10 @@ class EnderPearl extends Throwable{
 	protected function onHit(ProjectileHitEvent $event) : void{
 		$owner = $this->getOwningEntity();
 		if($owner !== null){
+			if($owner->getLevel() !== $this->level){
+				return;
+			}
+			
 			//TODO: check end gateways (when they are added)
 			//TODO: spawn endermites at origin
 

--- a/src/pocketmine/entity/projectile/EnderPearl.php
+++ b/src/pocketmine/entity/projectile/EnderPearl.php
@@ -27,19 +27,33 @@ use pocketmine\event\entity\EntityDamageEvent;
 use pocketmine\event\entity\ProjectileHitEvent;
 use pocketmine\level\sound\EndermanTeleportSound;
 use pocketmine\network\mcpe\protocol\LevelEventPacket;
+use pocketmine\Player;
 
 class EnderPearl extends Throwable{
 	public const NETWORK_ID = self::ENDER_PEARL;
 
+	public function spawnToAll() : void{
+		parent::spawnToAll();
+
+		$owner = $this->getOwningEntity();
+		if($owner instanceof Player){
+			$owner->increaseActivePearls();
+		}
+	}
+
 	protected function onHit(ProjectileHitEvent $event) : void{
 		$owner = $this->getOwningEntity();
 		if($owner !== null){
-			if($owner->getLevel() !== $this->level){
+			if($owner instanceof Player && !$owner->hasActivePearls()){
 				return;
 			}
 			
 			//TODO: check end gateways (when they are added)
 			//TODO: spawn endermites at origin
+
+			if($owner instanceof Player){
+				$owner->decreaseActivePearls();
+			}
 
 			$this->level->broadcastLevelEvent($owner, LevelEventPacket::EVENT_PARTICLE_ENDERMAN_TELEPORT);
 			$this->level->addSound(new EndermanTeleportSound($owner));


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Fix #3397 

### Relevant issues
<!-- List relevant issues here -->
- Ender pearl still teleports to Vector if player was teleported to another world or died

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
- Added:
`Player::hasActivePearls()` to check if player has an active pearls
`Player::increaseActivePearls()` to increase the count of items
`Player::decreaseActivePearls()` to decrease the count of items
`Player::resetActivePearls()` to reset existing pearls

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
- Ender pearl now doesn't teleport if player has been teleported or died

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Compatible

## Tests
Without fix: https://youtu.be/Ueijz2fbt1E
With fix: https://youtu.be/7b6uRJbpSsg
