### PR TITLE
EmoteListPacket can be ServerboundPacket

### DIFF
--- a/src/network/mcpe/protocol/EmoteListPacket.php
+++ b/src/network/mcpe/protocol/EmoteListPacket.php
@@ -29,7 +29,7 @@ use pocketmine\network\mcpe\protocol\serializer\PacketSerializer;
 use pocketmine\uuid\UUID;
 use function count;
 
-class EmoteListPacket extends DataPacket implements ClientboundPacket, ServerBoundPacket{
+class EmoteListPacket extends DataPacket implements ClientboundPacket, ServerboundPacket{
 	public const NETWORK_ID = ProtocolInfo::EMOTE_LIST_PACKET;
 
 	/** @var int */

--- a/src/network/mcpe/protocol/EmoteListPacket.php
+++ b/src/network/mcpe/protocol/EmoteListPacket.php
@@ -29,7 +29,7 @@ use pocketmine\network\mcpe\protocol\serializer\PacketSerializer;
 use pocketmine\uuid\UUID;
 use function count;
 
-class EmoteListPacket extends DataPacket implements ClientboundPacket{
+class EmoteListPacket extends DataPacket implements ClientboundPacket, ServerBoundPacket{
 	public const NETWORK_ID = ProtocolInfo::EMOTE_LIST_PACKET;
 
 	/** @var int */


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

In 4.0, a packet processing error occurs when the player applies an emote to a custom skin and tries to connect.

Like this, 
![image](https://user-images.githubusercontent.com/32565818/85913437-d608c100-b86f-11ea-9cad-1f09af78e21f.png)



### Relevant issues
<!-- List relevant issues here -->
<!--
-->

## Changes
*  EmoteListPacket is now implemented as ServerboundPacket.
### API changes
<!-- Any additions to the API that should be documented in release notes? -->


### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
