### PR TITLE
Default SkinData::$isVerified to true

### DIFF
--- a/src/pocketmine/network/mcpe/protocol/types/SkinData.php
+++ b/src/pocketmine/network/mcpe/protocol/types/SkinData.php
@@ -70,7 +70,7 @@ class SkinData{
 	 * @param PersonaSkinPiece[]      $personaPieces
 	 * @param PersonaPieceTintColor[] $pieceTintColors
 	 */
-	public function __construct(string $skinId, string $resourcePatch, SkinImage $skinImage, array $animations = [], SkinImage $capeImage = null, string $geometryData = "", string $animationData = "", bool $premium = false, bool $persona = false, bool $personaCapeOnClassic = false, string $capeId = "", ?string $fullSkinId = null, string $armSize = self::ARM_SIZE_WIDE, string $skinColor = "", array $personaPieces = [], array $pieceTintColors = [], bool $isVerified = false){
+	public function __construct(string $skinId, string $resourcePatch, SkinImage $skinImage, array $animations = [], SkinImage $capeImage = null, string $geometryData = "", string $animationData = "", bool $premium = false, bool $persona = false, bool $personaCapeOnClassic = false, string $capeId = "", ?string $fullSkinId = null, string $armSize = self::ARM_SIZE_WIDE, string $skinColor = "", array $personaPieces = [], array $pieceTintColors = [], bool $isVerified = true){
 		$this->skinId = $skinId;
 		$this->resourcePatch = $resourcePatch;
 		$this->skinImage = $skinImage;


### PR DESCRIPTION
## Introduction
1.16 introduced a new setting, Only Allow Trusted Skins, which replaced all non-trusted skins with a Steve skin. Defaulting this to true will prevent all legacy skins etc. from becoming Steve.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #3627 
* Fixes #3632 
* Fixes #3633 

-->

## Changes
### API changes
There have been no API changes made

### Behavioural changes
There will be no performance changes, but all skins will now be shown by the client without them having to disable the new setting.

## Backwards compatibility
There is no backwards compatibility issues

## Tests
Joining a clean PMMP server with another player will allow you to see their skin successfully.
