### PR TITLE
EmotePacket: make emotes visible to other players

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3254,12 +3254,11 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		$emoteId = UUID::fromString($rawEmoteId);
 		$event = new PlayerEmoteEvent($this, $emoteId);
 		$event->call();
-		if ($event->isCancelled()) {
+		if($event->isCancelled()){
 			return true;
 		}
 
-		$newPacket = EmotePacket::create($this->getId(), $rawEmoteId, EmotePacket::FLAG_S2C);
-		$this->getLevelNonNull()->broadcastPacketToViewers($this, $newPacket);
+		$this->getLevelNonNull()->broadcastPacketToViewers($this, EmotePacket::create($this->getId(), $rawEmoteId, EmotePacket::FLAG_SERVER));
 
 		return true;
 	}

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -395,7 +395,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	protected $lineHeight = null;
 	/** @var string */
 	protected $locale = "en_US";
-	/** @var string[] */
+	/** @var UUID[] */
 	protected $emoteIds = [];
 
 	/** @var int */
@@ -841,6 +841,9 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		return $this->locale;
 	}
 
+	/**
+	 * @return UUID[]
+	 */
 	public function getEmoteIds() : array{
 		return $this->emoteIds;
 	}

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -839,13 +839,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	}
 
 	/**
-	 * @return UUID[]
-	 */
-	public function getEmoteIds() : array{
-		return $this->emoteIds;
-	}
-
-	/**
 	 * Called when a player changes their skin.
 	 * Plugin developers should not use this, use setSkin() and sendSkin() instead.
 	 */

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -117,7 +117,6 @@ use pocketmine\network\mcpe\protocol\ContainerClosePacket;
 use pocketmine\network\mcpe\protocol\ContainerOpenPacket;
 use pocketmine\network\mcpe\protocol\DataPacket;
 use pocketmine\network\mcpe\protocol\DisconnectPacket;
-use pocketmine\network\mcpe\protocol\EmoteListPacket;
 use pocketmine\network\mcpe\protocol\EmotePacket;
 use pocketmine\network\mcpe\protocol\InteractPacket;
 use pocketmine\network\mcpe\protocol\InventoryTransactionPacket;
@@ -395,8 +394,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	protected $lineHeight = null;
 	/** @var string */
 	protected $locale = "en_US";
-	/** @var UUID[] */
-	protected $emoteIds = [];
 
 	/** @var int */
 	protected $startAction = -1;
@@ -3260,11 +3257,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 		$this->getLevelNonNull()->broadcastPacketToViewers($this, EmotePacket::create($this->getId(), $rawEmoteId, EmotePacket::FLAG_SERVER));
 
-		return true;
-	}
-
-	public function handleEmoteList(EmoteListPacket $packet) : bool{
-		$this->emoteIds = $packet->getEmoteIds();
 		return true;
 	}
 

--- a/src/pocketmine/event/player/PlayerEmoteEvent.php
+++ b/src/pocketmine/event/player/PlayerEmoteEvent.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\event\player;
+
+use pocketmine\event\Cancellable;
+use pocketmine\Player;
+use pocketmine\utils\UUID;
+
+/**
+ * Class PlayerEmoteEvent
+ * @package pocketmine\event\player
+ */
+class PlayerEmoteEvent extends PlayerEvent implements Cancellable {
+
+	/** @var UUID */
+	protected $emoteId;
+
+	public function __construct(Player $player, UUID $emoteId) {
+		$this->player = $player;
+		$this->emoteId = $emoteId;
+	}
+
+	public function getEmoteId() : UUID{
+		return $this->emoteId;
+	}
+
+	public function setEmoteId(UUID $emoteId) : void{
+		$this->emoteId = $emoteId;
+	}
+
+}

--- a/src/pocketmine/event/player/PlayerEmoteEvent.php
+++ b/src/pocketmine/event/player/PlayerEmoteEvent.php
@@ -27,26 +27,18 @@ use pocketmine\event\Cancellable;
 use pocketmine\Player;
 use pocketmine\utils\UUID;
 
-/**
- * Class PlayerEmoteEvent
- * @package pocketmine\event\player
- */
-class PlayerEmoteEvent extends PlayerEvent implements Cancellable {
+class PlayerEmoteEvent extends PlayerEvent implements Cancellable{
 
 	/** @var UUID */
 	protected $emoteId;
 
-	public function __construct(Player $player, UUID $emoteId) {
+	public function __construct(Player $player, UUID $emoteId){
 		$this->player = $player;
 		$this->emoteId = $emoteId;
 	}
 
 	public function getEmoteId() : UUID{
 		return $this->emoteId;
-	}
-
-	public function setEmoteId(UUID $emoteId) : void{
-		$this->emoteId = $emoteId;
 	}
 
 }

--- a/src/pocketmine/network/mcpe/PlayerNetworkSessionAdapter.php
+++ b/src/pocketmine/network/mcpe/PlayerNetworkSessionAdapter.php
@@ -326,11 +326,11 @@ class PlayerNetworkSessionAdapter extends NetworkSession{
 		return true; //TODO: implement this properly - this is here to silence debug spam from MCPE dev builds
 	}
 
-	public function handleEmote(EmotePacket $packet): bool {
+	public function handleEmote(EmotePacket $packet) : bool{
 		return $this->player->handleEmote($packet);
 	}
 
-	public function handleEmoteList(EmoteListPacket $packet): bool {
+	public function handleEmoteList(EmoteListPacket $packet) : bool{
 		return $this->player->handleEmoteList($packet);
 	}
 }

--- a/src/pocketmine/network/mcpe/PlayerNetworkSessionAdapter.php
+++ b/src/pocketmine/network/mcpe/PlayerNetworkSessionAdapter.php
@@ -39,6 +39,8 @@ use pocketmine\network\mcpe\protocol\CommandRequestPacket;
 use pocketmine\network\mcpe\protocol\ContainerClosePacket;
 use pocketmine\network\mcpe\protocol\CraftingEventPacket;
 use pocketmine\network\mcpe\protocol\DataPacket;
+use pocketmine\network\mcpe\protocol\EmoteListPacket;
+use pocketmine\network\mcpe\protocol\EmotePacket;
 use pocketmine\network\mcpe\protocol\InteractPacket;
 use pocketmine\network\mcpe\protocol\InventoryTransactionPacket;
 use pocketmine\network\mcpe\protocol\ItemFrameDropItemPacket;
@@ -322,5 +324,13 @@ class PlayerNetworkSessionAdapter extends NetworkSession{
 
 	public function handleNetworkStackLatency(NetworkStackLatencyPacket $packet) : bool{
 		return true; //TODO: implement this properly - this is here to silence debug spam from MCPE dev builds
+	}
+
+	public function handleEmote(EmotePacket $packet): bool {
+		return $this->player->handleEmote($packet);
+	}
+
+	public function handleEmoteList(EmoteListPacket $packet): bool {
+		return $this->player->handleEmoteList($packet);
 	}
 }

--- a/src/pocketmine/network/mcpe/PlayerNetworkSessionAdapter.php
+++ b/src/pocketmine/network/mcpe/PlayerNetworkSessionAdapter.php
@@ -39,7 +39,6 @@ use pocketmine\network\mcpe\protocol\CommandRequestPacket;
 use pocketmine\network\mcpe\protocol\ContainerClosePacket;
 use pocketmine\network\mcpe\protocol\CraftingEventPacket;
 use pocketmine\network\mcpe\protocol\DataPacket;
-use pocketmine\network\mcpe\protocol\EmoteListPacket;
 use pocketmine\network\mcpe\protocol\EmotePacket;
 use pocketmine\network\mcpe\protocol\InteractPacket;
 use pocketmine\network\mcpe\protocol\InventoryTransactionPacket;

--- a/src/pocketmine/network/mcpe/PlayerNetworkSessionAdapter.php
+++ b/src/pocketmine/network/mcpe/PlayerNetworkSessionAdapter.php
@@ -329,8 +329,4 @@ class PlayerNetworkSessionAdapter extends NetworkSession{
 	public function handleEmote(EmotePacket $packet) : bool{
 		return $this->player->handleEmote($packet);
 	}
-
-	public function handleEmoteList(EmoteListPacket $packet) : bool{
-		return $this->player->handleEmoteList($packet);
-	}
 }

--- a/src/pocketmine/network/mcpe/protocol/EmoteListPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/EmoteListPacket.php
@@ -47,10 +47,14 @@ class EmoteListPacket extends DataPacket/* implements ClientboundPacket*/{
 		return $result;
 	}
 
-	public function getPlayerEntityRuntimeId() : int{ return $this->playerEntityRuntimeId; }
+	public function getPlayerEntityRuntimeId() : int{
+		return $this->playerEntityRuntimeId;
+	}
 
 	/** @return UUID[] */
-	public function getEmoteIds() : array{ return $this->emoteIds; }
+	public function getEmoteIds() : array{
+		return $this->emoteIds;
+	}
 
 	protected function decodePayload() : void{
 		$this->playerEntityRuntimeId = $this->getEntityRuntimeId();

--- a/src/pocketmine/network/mcpe/protocol/EmoteListPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/EmoteListPacket.php
@@ -47,14 +47,10 @@ class EmoteListPacket extends DataPacket/* implements ClientboundPacket*/{
 		return $result;
 	}
 
-	public function getPlayerEntityRuntimeId() : int{
-		return $this->playerEntityRuntimeId;
-	}
+	public function getPlayerEntityRuntimeId() : int{ return $this->playerEntityRuntimeId; }
 
 	/** @return UUID[] */
-	public function getEmoteIds() : array{
-		return $this->emoteIds;
-	}
+	public function getEmoteIds() : array{ return $this->emoteIds; }
 
 	protected function decodePayload() : void{
 		$this->playerEntityRuntimeId = $this->getEntityRuntimeId();

--- a/src/pocketmine/network/mcpe/protocol/EmotePacket.php
+++ b/src/pocketmine/network/mcpe/protocol/EmotePacket.php
@@ -30,7 +30,8 @@ use pocketmine\network\mcpe\NetworkSession;
 class EmotePacket extends DataPacket/* implements ClientboundPacket, ServerboundPacket*/{
 	public const NETWORK_ID = ProtocolInfo::EMOTE_PACKET;
 
-	private const FLAG_SERVER = 1 << 0;
+	public const FLAG_C2S = 0;// TODO: find the proper value
+	public const FLAG_S2C = 1;
 
 	/** @var int */
 	private $entityRuntimeId;

--- a/src/pocketmine/network/mcpe/protocol/EmotePacket.php
+++ b/src/pocketmine/network/mcpe/protocol/EmotePacket.php
@@ -30,8 +30,7 @@ use pocketmine\network\mcpe\NetworkSession;
 class EmotePacket extends DataPacket/* implements ClientboundPacket, ServerboundPacket*/{
 	public const NETWORK_ID = ProtocolInfo::EMOTE_PACKET;
 
-	public const FLAG_C2S = 0;// TODO: find the proper value
-	public const FLAG_S2C = 1;
+	public const FLAG_SERVER = 1 << 0;
 
 	/** @var int */
 	private $entityRuntimeId;


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Currently, other players can't see the emotes.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

none.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

* Added event `PlayerEmoteEvent`
* Added `Player::getEmoteIds()`

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

players can see the emotes.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

this is only added new features.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

none.

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
https://youtu.be/e3gtmlLw7vE