### PR TITLE
Removed `setCancelled` from `Cancellable`

### DIFF
--- a/src/event/Cancellable.php
+++ b/src/event/Cancellable.php
@@ -37,7 +37,7 @@ interface Cancellable{
 	/**
 	 * Returns whether this instance of the event is currently cancelled.
 	 *
-	 * If it is cancelled, downstream handlers that do not declare `@handleCancelled` will be called with this event.
+	 * If it is cancelled, only downstream handlers that declare `@handleCancelled` will be called with this event.
 	 */
 	public function isCancelled() : bool;
 }

--- a/src/event/Cancellable.php
+++ b/src/event/Cancellable.php
@@ -24,10 +24,20 @@ declare(strict_types=1);
 namespace pocketmine\event;
 
 /**
- * Events that can be cancelled must use the interface Cancellable
+ * This interface is implemented by an Event subclass if and only if it can be cancelled.
+ *
+ * The cancellation of an event directly affects whether downstream event handlers
+ * without `@handleCancelled` will be called with this event.
+ * Implementations may provide a direct setter for cancellation (typically by using `CancellableTrait`)
+ * or implement an alternative logic (such as a function on another data field) for `isCancelled()`.
+ * Furthermore, callers may interpret the cancellation for an addition meaning,
+ * but such additional meaning is not to be implied by the `Cancellable` interface.
  */
 interface Cancellable{
+	/**
+	 * Returns whether this instance of the event is currently cancelled.
+	 *
+	 * If it is cancelled, downstream handlers that do not declare `@handleCancelled` will be called with this event.
+	 */
 	public function isCancelled() : bool;
-
-	public function setCancelled(bool $value = true) : void;
 }

--- a/src/event/Cancellable.php
+++ b/src/event/Cancellable.php
@@ -30,8 +30,6 @@ namespace pocketmine\event;
  * without `@handleCancelled` will be called with this event.
  * Implementations may provide a direct setter for cancellation (typically by using `CancellableTrait`)
  * or implement an alternative logic (such as a function on another data field) for `isCancelled()`.
- * Furthermore, callers may interpret the cancellation for an addition meaning,
- * but such additional meaning is not to be implied by the `Cancellable` interface.
  */
 interface Cancellable{
 	/**


### PR DESCRIPTION
## Introduction
Before anyone screams, THIS CHANGE WILL NOT AFFECT MOST PLUGINS
(although it allows future changes to break some).

Currently `PlayerPreLoginEvent` has an inconsistent API, using kick reason to determine whether a player has to be kicked, but without using the normally-expected `Cancellable` API, due to interface restrictions that disallow the `setCancelled` method from requiring additional parameters. This change is 

## Changes
This commit rewrites the documentation of `Cancellable`,
clarifying the concept of "cancelled" from the perspective of the event
framework.

This commit also removes the `setCancelled` method from `Cancellable`.
This does not affect plugins using the (originally standard)
`setCancelled` method on events directly, since the implementation on
classes was not removed. On the other hand, it no longer requires
`Cancellable` events to implement this method, allowing flexibility on
cancelation conditions, e.g. subclasses may require additional
parameters for cancellation without needing to use hacks to check that
the user cancelled the event in the correct way.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
This PR removes a method from an interface, resulting in the following consequences:
- This does not break any usage that previously implements `Cancellable`.
- If a plugin provides an API that provides a `Cancellable` (synchronously or asynchronously), this plugin may break users of their API without violating normal compatibility requirements.

This PR reinterprets the meaning of cancellation, but generally speaking would not cause semantic changes.
