### PR TITLE
Fix for PlayerItemConsumeEvent

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2577,6 +2577,10 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 								}
 								$ev->call();
 								if($ev->isCancelled() or !$this->consumeObject($slot)){
+									foreach($slot->getAdditionalEffects() as $effect) {
+										$this->removeEffect($effect->getId());
+									}
+									
 									$this->inventory->sendContents($this);
 									return true;
 								}


### PR DESCRIPTION
Remove effects which may get applied when consuming something (e.g. golden apple), when event has been cancelled.

## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Cause it is a expected behaviour, when cancelling an event that it should fall back to it's origin state.

### Relevant issues
* Fixes #3707 
