### PR TITLE
Fix wrong hardness value for Podzol

### DIFF
--- a/src/pocketmine/block/Podzol.php
+++ b/src/pocketmine/block/Podzol.php
@@ -40,6 +40,6 @@ class Podzol extends Solid{
 	}
 
 	public function getHardness() : float{
-		return 2.5;
+		return 0.5;
 	}
 }


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
The value of hardness was wrong for the Podzol block resulting in breaking particles not being shown correctly.
### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
No relevant issues.

## Changes
This PR changes the hardness value for the Podzol block from 2.5 to 0.5. Source: https://minecraft.gamepedia.com/Podzol

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
I tried breaking blocks of podzol with bare hands both before and after this change. Before the change, the blocks would have been broken before the breaking particles had reached its edges, while after the change they perfectly match client breaking time.
