### PR TITLE
Move the call of RespawnEvent 

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3811,9 +3811,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 			return;
 		}
 
-		$ev = new PlayerRespawnEvent($this, $this->getSpawn());
-		$ev->call();
-
 		$realSpawn = Position::fromObject($ev->getRespawnPosition()->add(0.5, 0, 0.5), $ev->getRespawnPosition()->getLevelNonNull());
 		$this->teleport($realSpawn);
 
@@ -3837,6 +3834,9 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 		$this->sendSettings();
 		$this->sendAllInventories();
+		
+		$ev = new PlayerRespawnEvent($this, $this->getSpawn());
+		$ev->call();
 
 		$this->spawnToAll();
 		$this->scheduleUpdate();

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3811,9 +3811,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 			return;
 		}
 
-		$realSpawn = Position::fromObject($ev->getRespawnPosition()->add(0.5, 0, 0.5), $ev->getRespawnPosition()->getLevelNonNull());
-		$this->teleport($realSpawn);
-
 		$this->setSprinting(false);
 		$this->setSneaking(false);
 
@@ -3837,6 +3834,9 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		
 		$ev = new PlayerRespawnEvent($this, $this->getSpawn());
 		$ev->call();
+		
+		$realSpawn = Position::fromObject($ev->getRespawnPosition()->add(0.5, 0, 0.5), $ev->getRespawnPosition()->getLevelNonNull());
+		$this->teleport($realSpawn);
 
 		$this->spawnToAll();
 		$this->scheduleUpdate();


### PR DESCRIPTION
This fix will for example let people to set player's xp on respawn, because before it was resetted to 0 by the attribute map (called after the event).

## Introduction
People can't modify player xp on respawn
