### PR TITLE
Introduce a ChunkPos type

### DIFF
--- a/src/block/Block.php
+++ b/src/block/Block.php
@@ -40,6 +40,7 @@ use pocketmine\math\Vector3;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\player\Player;
 use pocketmine\world\BlockTransaction;
+use pocketmine\world\ChunkPos;
 use pocketmine\world\Position;
 use pocketmine\world\World;
 use function assert;
@@ -140,7 +141,7 @@ class Block{
 	}
 
 	public function writeStateToWorld() : void{
-		$this->pos->getWorld()->getChunkAtPosition($this->pos)->setFullBlock($this->pos->x & 0xf, $this->pos->y, $this->pos->z & 0xf, $this->getFullId());
+		$this->pos->getWorld()->getChunk(ChunkPos::fromVec3($this->pos))->setFullBlock($this->pos->x & 0xf, $this->pos->y, $this->pos->z & 0xf, $this->getFullId());
 
 		$tileType = $this->idInfo->getTileClass();
 		$oldTile = $this->pos->getWorld()->getTile($this->pos);

--- a/src/block/tile/Chest.php
+++ b/src/block/tile/Chest.php
@@ -28,6 +28,7 @@ use pocketmine\block\inventory\DoubleChestInventory;
 use pocketmine\math\Vector3;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\IntTag;
+use pocketmine\world\ChunkPos;
 use pocketmine\world\World;
 use function abs;
 
@@ -99,7 +100,7 @@ class Chest extends Spawnable implements Container, Nameable{
 			$this->inventory->removeAllViewers();
 
 			if($this->doubleInventory !== null){
-				if($this->isPaired() and $this->pos->getWorld()->isChunkLoaded($this->pairX >> 4, $this->pairZ >> 4)){
+				if($this->isPaired() and $this->pos->getWorld()->isChunkLoaded(ChunkPos::fromBlockCoords($this->pairX, $this->pairZ))){
 					$this->doubleInventory->removeAllViewers();
 					if(($pair = $this->getPair()) !== null){
 						$pair->doubleInventory = null;

--- a/src/network/mcpe/ChunkCache.php
+++ b/src/network/mcpe/ChunkCache.php
@@ -180,7 +180,8 @@ class ChunkCache implements ChunkListener{
 	 */
 	public function onChunkChanged(Chunk $chunk) : void{
 		//FIXME: this gets fired for stuff that doesn't change terrain related things (like lighting updates)
-		$this->destroyOrRestart($chunk->getX(), $chunk->getZ());
+		$pos = $chunk->getPos();
+		$this->destroyOrRestart($pos->getX(), $pos->getZ());
 	}
 
 	/**
@@ -196,8 +197,9 @@ class ChunkCache implements ChunkListener{
 	 * @see ChunkListener::onChunkUnloaded()
 	 */
 	public function onChunkUnloaded(Chunk $chunk) : void{
-		$this->destroy($chunk->getX(), $chunk->getZ());
-		$this->world->unregisterChunkListener($this, $chunk->getX(), $chunk->getZ());
+		$pos = $chunk->getPos();
+		$this->destroy($pos->getX(), $pos->getZ());
+		$this->world->unregisterChunkListener($this, $pos->getX(), $pos->getZ());
 	}
 
 	/**

--- a/src/network/mcpe/ChunkCache.php
+++ b/src/network/mcpe/ChunkCache.php
@@ -108,8 +108,7 @@ class ChunkCache implements ChunkListener{
 
 			$this->world->getServer()->getAsyncPool()->submitTask(
 				new ChunkRequestTask(
-					$chunkPos->getX(),
-					$chunkPos->getZ(),
+					$chunkPos,
 					$this->world->getChunk($chunkPos->getX(), $chunkPos->getZ()),
 					$this->caches[$chunkPos->hash],
 					$this->compressor,

--- a/src/network/mcpe/ChunkCache.php
+++ b/src/network/mcpe/ChunkCache.php
@@ -93,7 +93,7 @@ class ChunkCache implements ChunkListener{
 	 * @return CompressBatchPromise a promise of resolution which will contain a compressed chunk packet.
 	 */
 	public function request(ChunkPos $chunkPos) : CompressBatchPromise{
-		$this->world->registerChunkListener($this, $chunkPos->getX(), $chunkPos->getZ());
+		$this->world->registerChunkListener($this, $chunkPos);
 
 		if(isset($this->caches[$chunkPos->hash])){
 			++$this->hits;
@@ -109,7 +109,7 @@ class ChunkCache implements ChunkListener{
 			$this->world->getServer()->getAsyncPool()->submitTask(
 				new ChunkRequestTask(
 					$chunkPos,
-					$this->world->getChunk($chunkPos->getX(), $chunkPos->getZ()),
+					$this->world->getChunk($chunkPos),
 					$this->caches[$chunkPos->hash],
 					$this->compressor,
 					function() use ($chunkPos) : void{
@@ -195,7 +195,7 @@ class ChunkCache implements ChunkListener{
 	public function onChunkUnloaded(Chunk $chunk) : void{
 		$pos = $chunk->getPos();
 		$this->destroy($pos);
-		$this->world->unregisterChunkListener($this, $pos->getX(), $pos->getZ());
+		$this->world->unregisterChunkListener($this, $pos);
 	}
 
 	/**

--- a/src/network/mcpe/ChunkRequestTask.php
+++ b/src/network/mcpe/ChunkRequestTask.php
@@ -30,6 +30,7 @@ use pocketmine\network\mcpe\protocol\LevelChunkPacket;
 use pocketmine\network\mcpe\protocol\serializer\PacketBatch;
 use pocketmine\network\mcpe\serializer\ChunkSerializer;
 use pocketmine\scheduler\AsyncTask;
+use pocketmine\world\ChunkPos;
 use pocketmine\world\format\Chunk;
 use pocketmine\world\format\io\FastChunkSerializer;
 
@@ -53,12 +54,12 @@ class ChunkRequestTask extends AsyncTask{
 	/**
 	 * @phpstan-param (\Closure() : void)|null $onError
 	 */
-	public function __construct(int $chunkX, int $chunkZ, Chunk $chunk, CompressBatchPromise $promise, Compressor $compressor, ?\Closure $onError = null){
+	public function __construct(ChunkPos $chunkPos, Chunk $chunk, CompressBatchPromise $promise, Compressor $compressor, ?\Closure $onError = null){
 		$this->compressor = $compressor;
 
 		$this->chunk = FastChunkSerializer::serializeWithoutLight($chunk);
-		$this->chunkX = $chunkX;
-		$this->chunkZ = $chunkZ;
+		$this->chunkX = $chunkPos->getX();
+		$this->chunkZ = $chunkPos->getZ();
 		$this->tiles = ChunkSerializer::serializeTiles($chunk);
 
 		$this->storeLocal(self::TLS_KEY_PROMISE, $promise);

--- a/src/network/mcpe/NetworkSession.php
+++ b/src/network/mcpe/NetworkSession.php
@@ -826,7 +826,7 @@ class NetworkSession{
 					return;
 				}
 				$currentWorld = $this->player->getLocation()->getWorld();
-				if($world !== $currentWorld or !$this->player->isUsingChunk($chunkPos->getX(), $chunkPos->getZ())){
+				if($world !== $currentWorld or !$this->player->isUsingChunk($chunkPos)){
 					$this->logger->debug("Tried to send no-longer-active chunk $chunkPos in world " . $world->getFolderName());
 					return;
 				}
@@ -841,7 +841,7 @@ class NetworkSession{
 		);
 	}
 
-	public function stopUsingChunk(int $chunkX, int $chunkZ) : void{
+	public function stopUsingChunk(ChunkPos $pos) : void{
 
 	}
 

--- a/src/network/mcpe/NetworkSession.php
+++ b/src/network/mcpe/NetworkSession.php
@@ -100,6 +100,7 @@ use pocketmine\Server;
 use pocketmine\timings\Timings;
 use pocketmine\utils\TextFormat;
 use pocketmine\utils\Utils;
+use pocketmine\world\ChunkPos;
 use pocketmine\world\Position;
 use function array_map;
 use function array_values;
@@ -817,7 +818,7 @@ class NetworkSession{
 		Utils::validateCallableSignature(function(int $chunkX, int $chunkZ) : void{}, $onCompletion);
 
 		$world = $this->player->getLocation()->getWorld();
-		ChunkCache::getInstance($world, $this->compressor)->request($chunkX, $chunkZ)->onResolve(
+		ChunkCache::getInstance($world, $this->compressor)->request(new ChunkPos($chunkX, $chunkZ))->onResolve(
 
 			//this callback may be called synchronously or asynchronously, depending on whether the promise is resolved yet
 			function(CompressBatchPromise $promise) use ($world, $chunkX, $chunkZ, $onCompletion) : void{

--- a/src/player/ChunkSelector.php
+++ b/src/player/ChunkSelector.php
@@ -23,16 +23,16 @@ declare(strict_types=1);
 
 namespace pocketmine\player;
 
-use pocketmine\world\World;
+use pocketmine\world\ChunkPos;
 
 //TODO: turn this into an interface?
 final class ChunkSelector{
 
 	/**
-	 * @preturn \Generator|int[]
-	 * @phpstan-return \Generator<int, int, void, void>
+	 * @preturn \Generator|ChunkPos[]
+	 * @phpstan-return \Generator<int, ChunkPos, void, void>
 	 */
-	public function selectChunks(int $radius, int $centerX, int $centerZ) : \Generator{
+	public function selectChunks(int $radius, ChunkPos $chunkPos) : \Generator{
 		$radiusSquared = $radius ** 2;
 
 		for($x = 0; $x < $radius; ++$x){
@@ -44,23 +44,23 @@ final class ChunkSelector{
 				//If the chunk is in the radius, others at the same offsets in different quadrants are also guaranteed to be.
 
 				/* Top right quadrant */
-				yield World::chunkHash($centerX + $x, $centerZ + $z);
+				yield $chunkPos->add($x, $z);
 				/* Top left quadrant */
-				yield World::chunkHash($centerX - $x - 1, $centerZ + $z);
+				yield $chunkPos->add(-$x - 1, $z);
 				/* Bottom right quadrant */
-				yield World::chunkHash($centerX + $x, $centerZ - $z - 1);
+				yield $chunkPos->add($x, -$z - 1);
 				/* Bottom left quadrant */
-				yield World::chunkHash($centerX - $x - 1, $centerZ - $z - 1);
+				yield $chunkPos->add(-$x - 1, -$z - 1);
 
 				if($x !== $z){
 					/* Top right quadrant mirror */
-					yield World::chunkHash($centerX + $z, $centerZ + $x);
+					yield $chunkPos->add($z, $x);
 					/* Top left quadrant mirror */
-					yield World::chunkHash($centerX - $z - 1, $centerZ + $x);
+					yield $chunkPos->add(-$z - 1, $x);
 					/* Bottom right quadrant mirror */
-					yield World::chunkHash($centerX + $z, $centerZ - $x - 1);
+					yield $chunkPos->add($z, -$x - 1);
 					/* Bottom left quadrant mirror */
-					yield World::chunkHash($centerX - $z - 1, $centerZ - $x - 1);
+					yield $chunkPos->add(-$z - 1, -$x - 1);
 				}
 			}
 		}

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -2337,7 +2337,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 	}
 
 	public function onChunkChanged(Chunk $chunk) : void{
-		if(isset($this->usedChunks[$hash = World::chunkHash($chunk->getX(), $chunk->getZ())])){
+		if(isset($this->usedChunks[$hash = $chunk->getPos()->hash])){
 			$this->usedChunks[$hash] = UsedChunkStatus::NEEDED();
 			$this->nextChunkOrderRun = 0;
 		}

--- a/src/world/ChunkManager.php
+++ b/src/world/ChunkManager.php
@@ -40,9 +40,9 @@ interface ChunkManager{
 	 */
 	public function setBlockAt(int $x, int $y, int $z, Block $block) : void;
 
-	public function getChunk(int $chunkX, int $chunkZ, bool $create = false) : ?Chunk;
+	public function getChunk(ChunkPos $chunkPos, bool $create = false) : ?Chunk;
 
-	public function setChunk(int $chunkX, int $chunkZ, ?Chunk $chunk) : void;
+	public function setChunk(ChunkPos $chunkPos, ?Chunk $chunk) : void;
 
 	/**
 	 * Returns the height of the world

--- a/src/world/ChunkPos.php
+++ b/src/world/ChunkPos.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\world;
+
+use pocketmine\math\Vector3;
+
+final class ChunkPos{
+	/** @var int */
+	private $x;
+	/** @var int */
+	private $z;
+
+	/** @var int */
+	public $hash;
+
+	public function __construct(int $chunkX, int $chunkZ){
+		$this->x = $chunkX;
+		$this->z = $chunkZ;
+		$this->hash = World::chunkHash($chunkX, $chunkZ);
+	}
+
+	public function getX() : int{
+		return $this->x;
+	}
+
+	public function getZ() : int{
+		return $this->z;
+	}
+
+	public function equals(ChunkPos $other) : bool{
+		return $this->x === $other->x and $this->z === $other->z;
+	}
+
+	public function hash() : int{
+		return $this->hash;
+	}
+
+	public function add(int $chunkX, int $chunkZ) : self{
+		return new self($this->x + $chunkX, $this->z + $chunkZ);
+	}
+
+	public function __toString(){
+		return "ChunkPos(x=$this->x, z=$this->z)";
+	}
+
+	public static function fromHash(int $hash) : self{
+		World::getXZ($hash, $chunkX, $chunkZ);
+		return new self($chunkX, $chunkZ);
+	}
+
+	public static function fromVec3(Vector3 $vector3) : self{
+		return new self($vector3->getFloorX() >> 4, $vector3->getFloorZ() >> 4);
+	}
+}

--- a/src/world/ChunkPos.php
+++ b/src/world/ChunkPos.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace pocketmine\world;
 
 use pocketmine\math\Vector3;
+use function sqrt;
 
 final class ChunkPos{
 	/** @var int */
@@ -52,6 +53,14 @@ final class ChunkPos{
 		return $this->x === $other->x and $this->z === $other->z;
 	}
 
+	public function distanceSquared(ChunkPos $other) : int{
+		return ($this->x - $other->x) ** 2 + ($this->z - $other->z) ** 2;
+	}
+
+	public function distance(ChunkPos $other) : float{
+		return sqrt($this->distanceSquared($other));
+	}
+
 	public function hash() : int{
 		return $this->hash;
 	}
@@ -71,5 +80,9 @@ final class ChunkPos{
 
 	public static function fromVec3(Vector3 $vector3) : self{
 		return new self($vector3->getFloorX() >> 4, $vector3->getFloorZ() >> 4);
+	}
+
+	public static function fromBlockCoords(int $x, int $z) : self{
+		return new self($x >> 4, $z >> 4);
 	}
 }

--- a/src/world/SimpleChunkManager.php
+++ b/src/world/SimpleChunkManager.php
@@ -67,7 +67,7 @@ class SimpleChunkManager implements ChunkManager{
 
 	public function getChunk(int $chunkX, int $chunkZ, bool $create = false) : ?Chunk{
 		$hash = World::chunkHash($chunkX, $chunkZ);
-		return $this->chunks[$hash] ?? ($create ? $this->chunks[$hash] = new Chunk($chunkX, $chunkZ) : null);
+		return $this->chunks[$hash] ?? ($create ? $this->chunks[$hash] = new Chunk(new ChunkPos($chunkX, $chunkZ)) : null);
 	}
 
 	public function setChunk(int $chunkX, int $chunkZ, ?Chunk $chunk) : void{

--- a/src/world/SimpleChunkManager.php
+++ b/src/world/SimpleChunkManager.php
@@ -65,17 +65,16 @@ class SimpleChunkManager implements ChunkManager{
 		}
 	}
 
-	public function getChunk(int $chunkX, int $chunkZ, bool $create = false) : ?Chunk{
-		$hash = World::chunkHash($chunkX, $chunkZ);
-		return $this->chunks[$hash] ?? ($create ? $this->chunks[$hash] = new Chunk(new ChunkPos($chunkX, $chunkZ)) : null);
+	public function getChunk(ChunkPos $chunkPos, bool $create = false) : ?Chunk{
+		return $this->chunks[$chunkPos->hash] ?? ($create ? $this->chunks[$chunkPos->hash] = new Chunk($chunkPos) : null);
 	}
 
-	public function setChunk(int $chunkX, int $chunkZ, ?Chunk $chunk) : void{
+	public function setChunk(ChunkPos $chunkPos, ?Chunk $chunk) : void{
 		if($chunk === null){
-			unset($this->chunks[World::chunkHash($chunkX, $chunkZ)]);
+			unset($this->chunks[$chunkPos->hash]);
 			return;
 		}
-		$this->chunks[World::chunkHash($chunkX, $chunkZ)] = $chunk;
+		$this->chunks[$chunkPos->hash] = $chunk;
 	}
 
 	public function cleanChunks() : void{

--- a/src/world/World.php
+++ b/src/world/World.php
@@ -422,7 +422,8 @@ class World implements ChunkManager{
 		$this->unloadCallbacks = [];
 
 		foreach($this->chunks as $chunk){
-			$this->unloadChunk($chunk->getX(), $chunk->getZ(), false);
+			$pos = $chunk->getPos();
+			$this->unloadChunk($pos->getX(), $pos->getZ(), false);
 		}
 
 		$this->save();

--- a/src/world/World.php
+++ b/src/world/World.php
@@ -1907,8 +1907,7 @@ class World implements ChunkManager{
 			return;
 		}
 
-		$chunk->setX($chunkX);
-		$chunk->setZ($chunkZ);
+		$chunk->setPos(new ChunkPos($chunkX, $chunkZ));
 
 		$chunkHash = World::chunkHash($chunkX, $chunkZ);
 		$oldChunk = $this->getChunk($chunkX, $chunkZ, false);
@@ -2113,7 +2112,7 @@ class World implements ChunkManager{
 		}
 
 		if($chunk === null and $create){
-			$chunk = new Chunk($x, $z);
+			$chunk = new Chunk(new ChunkPos($x, $z));
 		}
 
 		$this->timings->syncChunkLoadDataTimer->stopTiming();

--- a/src/world/WorldManager.php
+++ b/src/world/WorldManager.php
@@ -278,13 +278,8 @@ class WorldManager{
 		if($backgroundGeneration){
 			$this->server->getLogger()->notice($this->server->getLanguage()->translateString("pocketmine.level.backgroundGeneration", [$name]));
 
-			$spawnLocation = $world->getSpawnLocation();
-			$centerX = $spawnLocation->getFloorX() >> 4;
-			$centerZ = $spawnLocation->getFloorZ() >> 4;
-
-			foreach((new ChunkSelector())->selectChunks(3, $centerX, $centerZ) as $index){
-				World::getXZ($index, $chunkX, $chunkZ);
-				$world->populateChunk($chunkX, $chunkZ, true);
+			foreach((new ChunkSelector())->selectChunks(3, ChunkPos::fromVec3($world->getSpawnLocation())) as $chunkPos){
+				$world->populateChunk($chunkPos, true);
 			}
 		}
 

--- a/src/world/biome/Biome.php
+++ b/src/world/biome/Biome.php
@@ -27,6 +27,7 @@ use pocketmine\block\Block;
 use pocketmine\block\utils\TreeType;
 use pocketmine\utils\Random;
 use pocketmine\world\ChunkManager;
+use pocketmine\world\ChunkPos;
 use pocketmine\world\generator\populator\Populator;
 
 abstract class Biome{
@@ -116,9 +117,9 @@ abstract class Biome{
 		$this->populators[] = $populator;
 	}
 
-	public function populateChunk(ChunkManager $world, int $chunkX, int $chunkZ, Random $random) : void{
+	public function populateChunk(ChunkManager $world, ChunkPos $chunkPos, Random $random) : void{
 		foreach($this->populators as $populator){
-			$populator->populate($world, $chunkX, $chunkZ, $random);
+			$populator->populate($world, $chunkPos, $random);
 		}
 	}
 

--- a/src/world/format/Chunk.php
+++ b/src/world/format/Chunk.php
@@ -35,6 +35,7 @@ use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\IntTag;
 use pocketmine\nbt\tag\StringTag;
 use pocketmine\player\Player;
+use pocketmine\world\ChunkPos;
 use pocketmine\world\World;
 use function array_fill;
 use function array_filter;
@@ -50,10 +51,8 @@ class Chunk{
 
 	public const MAX_SUBCHUNKS = 16;
 
-	/** @var int */
-	protected $x;
-	/** @var int */
-	protected $z;
+	/** @var ChunkPos */
+	private $pos;
 
 	/** @var int */
 	private $dirtyFlags = 0;
@@ -94,9 +93,8 @@ class Chunk{
 	 * @param CompoundTag[] $entities
 	 * @param CompoundTag[] $tiles
 	 */
-	public function __construct(int $chunkX, int $chunkZ, array $subChunks = [], ?array $entities = null, ?array $tiles = null, ?BiomeArray $biomeIds = null, ?HeightArray $heightMap = null){
-		$this->x = $chunkX;
-		$this->z = $chunkZ;
+	public function __construct(ChunkPos $pos, array $subChunks = [], ?array $entities = null, ?array $tiles = null, ?BiomeArray $biomeIds = null, ?HeightArray $heightMap = null){
+		$this->pos = $pos;
 
 		$this->subChunks = new \SplFixedArray(Chunk::MAX_SUBCHUNKS);
 
@@ -113,19 +111,19 @@ class Chunk{
 	}
 
 	public function getX() : int{
-		return $this->x;
+		return $this->pos->getX();
 	}
 
 	public function getZ() : int{
-		return $this->z;
+		return $this->pos->getZ();
 	}
 
-	public function setX(int $x) : void{
-		$this->x = $x;
+	public function getPos() : ChunkPos{
+		return $this->pos;
 	}
 
-	public function setZ(int $z) : void{
-		$this->z = $z;
+	public function setPos(ChunkPos $pos) : void{
+		$this->pos = $pos;
 	}
 
 	/**
@@ -500,7 +498,7 @@ class Chunk{
 						}elseif($saveIdTag instanceof IntTag){ //legacy MCPE format
 							$saveId = "legacy(" . $saveIdTag->getValue() . ")";
 						}
-						$world->getLogger()->warning("Chunk $this->x $this->z: Deleted unknown entity type $saveId");
+						$world->getLogger()->warning("Chunk $this->pos: Deleted unknown entity type $saveId");
 						continue;
 					}
 				}catch(\Exception $t){ //TODO: this shouldn't be here
@@ -520,7 +518,7 @@ class Chunk{
 				if(($tile = $tileFactory->createFromData($world, $nbt)) !== null){
 					$world->addTile($tile);
 				}else{
-					$world->getLogger()->warning("Chunk $this->x $this->z: Deleted unknown tile entity type " . $nbt->getString("id", "<unknown>"));
+					$world->getLogger()->warning("Chunk $this->pos: Deleted unknown tile entity type " . $nbt->getString("id", "<unknown>"));
 					continue;
 				}
 			}

--- a/src/world/format/Chunk.php
+++ b/src/world/format/Chunk.php
@@ -110,14 +110,6 @@ class Chunk{
 		$this->NBTentities = $entities;
 	}
 
-	public function getX() : int{
-		return $this->pos->getX();
-	}
-
-	public function getZ() : int{
-		return $this->pos->getZ();
-	}
-
 	public function getPos() : ChunkPos{
 		return $this->pos;
 	}

--- a/src/world/format/io/BaseWorldProvider.php
+++ b/src/world/format/io/BaseWorldProvider.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\world\format\io;
 
+use pocketmine\world\ChunkPos;
 use pocketmine\world\format\Chunk;
 use pocketmine\world\format\io\exception\CorruptedChunkException;
 use pocketmine\world\format\io\exception\CorruptedWorldException;
@@ -62,8 +63,8 @@ abstract class BaseWorldProvider implements WorldProvider{
 	/**
 	 * @throws CorruptedChunkException
 	 */
-	public function loadChunk(int $chunkX, int $chunkZ) : ?Chunk{
-		return $this->readChunk($chunkX, $chunkZ);
+	public function loadChunk(ChunkPos $chunkPos) : ?Chunk{
+		return $this->readChunk($chunkPos);
 	}
 
 	public function saveChunk(Chunk $chunk) : void{
@@ -76,7 +77,7 @@ abstract class BaseWorldProvider implements WorldProvider{
 	/**
 	 * @throws CorruptedChunkException
 	 */
-	abstract protected function readChunk(int $chunkX, int $chunkZ) : ?Chunk;
+	abstract protected function readChunk(ChunkPos $chunkPos) : ?Chunk;
 
 	abstract protected function writeChunk(Chunk $chunk) : void;
 }

--- a/src/world/format/io/FastChunkSerializer.php
+++ b/src/world/format/io/FastChunkSerializer.php
@@ -25,6 +25,7 @@ namespace pocketmine\world\format\io;
 
 use pocketmine\block\BlockLegacyIds;
 use pocketmine\utils\BinaryStream;
+use pocketmine\world\ChunkPos;
 use pocketmine\world\format\BiomeArray;
 use pocketmine\world\format\Chunk;
 use pocketmine\world\format\HeightArray;
@@ -147,7 +148,7 @@ final class FastChunkSerializer{
 			}
 		}
 
-		$chunk = new Chunk($x, $z, $subChunks, null, null, $biomeIds, $heightMap);
+		$chunk = new Chunk(new ChunkPos($x, $z), $subChunks, null, null, $biomeIds, $heightMap);
 		$chunk->setGenerated($terrainGenerated);
 		$chunk->setPopulated($terrainPopulated);
 		$chunk->setLightPopulated($lightPopulated);

--- a/src/world/format/io/FastChunkSerializer.php
+++ b/src/world/format/io/FastChunkSerializer.php
@@ -63,8 +63,9 @@ final class FastChunkSerializer{
 		$includeLight = $includeLight && $chunk->isLightPopulated();
 
 		$stream = new BinaryStream();
-		$stream->putInt($chunk->getX());
-		$stream->putInt($chunk->getZ());
+		$pos = $chunk->getPos();
+		$stream->putInt($pos->getX());
+		$stream->putInt($pos->getZ());
 		$stream->putByte(
 			($includeLight ? self::FLAG_HAS_LIGHT : 0) |
 			($chunk->isPopulated() ? self::FLAG_POPULATED : 0) |

--- a/src/world/format/io/WorldProvider.php
+++ b/src/world/format/io/WorldProvider.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\world\format\io;
 
+use pocketmine\world\ChunkPos;
 use pocketmine\world\format\Chunk;
 use pocketmine\world\format\io\exception\CorruptedChunkException;
 use pocketmine\world\format\io\exception\CorruptedWorldException;
@@ -54,7 +55,7 @@ interface WorldProvider{
 	 *
 	 * @throws CorruptedChunkException
 	 */
-	public function loadChunk(int $chunkX, int $chunkZ) : ?Chunk;
+	public function loadChunk(ChunkPos $chunkPos) : ?Chunk;
 
 	/**
 	 * Performs garbage collection in the world provider, such as cleaning up regions in Region-based worlds.

--- a/src/world/format/io/leveldb/LevelDB.php
+++ b/src/world/format/io/leveldb/LevelDB.php
@@ -414,7 +414,8 @@ class LevelDB extends BaseWorldProvider implements WritableWorldProvider{
 
 	protected function writeChunk(Chunk $chunk) : void{
 		$idMap = LegacyBlockIdToStringIdMap::getInstance();
-		$index = LevelDB::chunkIndex($chunk->getX(), $chunk->getZ());
+		$pos = $chunk->getPos();
+		$index = LevelDB::chunkIndex($pos->getX(), $pos->getZ());
 
 		$write = new \LevelDBWriteBatch();
 		$write->put($index . self::TAG_VERSION, chr(self::CURRENT_LEVEL_CHUNK_VERSION));

--- a/src/world/format/io/leveldb/LevelDB.php
+++ b/src/world/format/io/leveldb/LevelDB.php
@@ -33,6 +33,7 @@ use pocketmine\utils\Binary;
 use pocketmine\utils\BinaryDataException;
 use pocketmine\utils\BinaryStream;
 use pocketmine\utils\Utils;
+use pocketmine\world\ChunkPos;
 use pocketmine\world\format\BiomeArray;
 use pocketmine\world\format\Chunk;
 use pocketmine\world\format\io\BaseWorldProvider;
@@ -393,8 +394,7 @@ class LevelDB extends BaseWorldProvider implements WritableWorldProvider{
 		}
 
 		$chunk = new Chunk(
-			$chunkX,
-			$chunkZ,
+			new ChunkPos($chunkX, $chunkZ),
 			$subChunks,
 			$entities,
 			$tiles,

--- a/src/world/format/io/region/LegacyAnvilChunkTrait.php
+++ b/src/world/format/io/region/LegacyAnvilChunkTrait.php
@@ -29,6 +29,7 @@ use pocketmine\nbt\tag\ByteArrayTag;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\IntArrayTag;
 use pocketmine\nbt\tag\ListTag;
+use pocketmine\world\ChunkPos;
 use pocketmine\world\format\BiomeArray;
 use pocketmine\world\format\Chunk;
 use pocketmine\world\format\io\ChunkUtils;
@@ -93,8 +94,7 @@ trait LegacyAnvilChunkTrait{
 		}
 
 		$result = new Chunk(
-			$chunk->getInt("xPos"),
-			$chunk->getInt("zPos"),
+			new ChunkPos($chunk->getInt("xPos"), $chunk->getInt("zPos")),
 			$subChunks,
 			($entitiesTag = $chunk->getTag("Entities")) instanceof ListTag ? self::getCompoundList("Entities", $entitiesTag) : [],
 			($tilesTag = $chunk->getTag("TileEntities")) instanceof ListTag ? self::getCompoundList("TileEntities", $tilesTag) : [],

--- a/src/world/format/io/region/McRegion.php
+++ b/src/world/format/io/region/McRegion.php
@@ -30,6 +30,7 @@ use pocketmine\nbt\tag\ByteArrayTag;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\IntArrayTag;
 use pocketmine\nbt\tag\ListTag;
+use pocketmine\world\ChunkPos;
 use pocketmine\world\format\BiomeArray;
 use pocketmine\world\format\Chunk;
 use pocketmine\world\format\io\ChunkUtils;
@@ -90,8 +91,7 @@ class McRegion extends RegionWorldProvider{
 		}
 
 		$result = new Chunk(
-			$chunk->getInt("xPos"),
-			$chunk->getInt("zPos"),
+			new ChunkPos($chunk->getInt("xPos"), $chunk->getInt("zPos")),
 			$subChunks,
 			($entitiesTag = $chunk->getTag("Entities")) instanceof ListTag ? self::getCompoundList("Entities", $entitiesTag) : [],
 			($tilesTag = $chunk->getTag("TileEntities")) instanceof ListTag ? self::getCompoundList("TileEntities", $tilesTag) : [],

--- a/src/world/format/io/region/RegionWorldProvider.php
+++ b/src/world/format/io/region/RegionWorldProvider.php
@@ -214,8 +214,9 @@ abstract class RegionWorldProvider extends BaseWorldProvider{
 	}
 
 	protected function writeChunk(Chunk $chunk) : void{
-		$chunkX = $chunk->getX();
-		$chunkZ = $chunk->getZ();
+		$pos = $chunk->getPos();
+		$chunkX = $pos->getX();
+		$chunkZ = $pos->getZ();
 
 		self::getRegionIndex($chunkX, $chunkZ, $regionX, $regionZ);
 		$this->loadRegion($regionX, $regionZ);

--- a/src/world/format/io/region/RegionWorldProvider.php
+++ b/src/world/format/io/region/RegionWorldProvider.php
@@ -27,6 +27,7 @@ use pocketmine\nbt\NBT;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\ListTag;
 use pocketmine\utils\Utils;
+use pocketmine\world\ChunkPos;
 use pocketmine\world\format\Chunk;
 use pocketmine\world\format\io\BaseWorldProvider;
 use pocketmine\world\format\io\data\JavaWorldData;
@@ -198,7 +199,9 @@ abstract class RegionWorldProvider extends BaseWorldProvider{
 	/**
 	 * @throws CorruptedChunkException
 	 */
-	protected function readChunk(int $chunkX, int $chunkZ) : ?Chunk{
+	protected function readChunk(ChunkPos $chunkPos) : ?Chunk{
+		$chunkX = $chunkPos->getX();
+		$chunkZ = $chunkPos->getZ();
 		$regionX = $regionZ = null;
 		self::getRegionIndex($chunkX, $chunkZ, $regionX, $regionZ);
 		assert(is_int($regionX) and is_int($regionZ));
@@ -247,7 +250,7 @@ abstract class RegionWorldProvider extends BaseWorldProvider{
 			for($chunkX = $rX; $chunkX < $rX + 32; ++$chunkX){
 				for($chunkZ = $rZ; $chunkZ < $rZ + 32; ++$chunkZ){
 					try{
-						$chunk = $this->loadChunk($chunkX, $chunkZ);
+						$chunk = $this->loadChunk(new ChunkPos($chunkX, $chunkZ));
 						if($chunk !== null){
 							yield $chunk;
 						}

--- a/src/world/generator/Flat.php
+++ b/src/world/generator/Flat.php
@@ -26,6 +26,7 @@ namespace pocketmine\world\generator;
 use pocketmine\block\VanillaBlocks;
 use pocketmine\item\LegacyStringToItemParser;
 use pocketmine\world\ChunkManager;
+use pocketmine\world\ChunkPos;
 use pocketmine\world\format\Chunk;
 use pocketmine\world\generator\object\OreType;
 use pocketmine\world\generator\populator\Ore;
@@ -148,7 +149,7 @@ class Flat extends Generator{
 	}
 
 	protected function generateBaseChunk() : void{
-		$this->chunk = new Chunk(0, 0);
+		$this->chunk = new Chunk(new ChunkPos(0, 0));
 		$this->chunk->setGenerated();
 
 		for($Z = 0; $Z < 16; ++$Z){
@@ -174,8 +175,7 @@ class Flat extends Generator{
 
 	public function generateChunk(int $chunkX, int $chunkZ) : void{
 		$chunk = clone $this->chunk;
-		$chunk->setX($chunkX);
-		$chunk->setZ($chunkZ);
+		$chunk->setPos(new ChunkPos($chunkX, $chunkZ));
 		$this->world->setChunk($chunkX, $chunkZ, $chunk);
 	}
 

--- a/src/world/generator/Flat.php
+++ b/src/world/generator/Flat.php
@@ -173,16 +173,16 @@ class Flat extends Generator{
 		}
 	}
 
-	public function generateChunk(int $chunkX, int $chunkZ) : void{
+	public function generateChunk(ChunkPos $chunkPos) : void{
 		$chunk = clone $this->chunk;
-		$chunk->setPos(new ChunkPos($chunkX, $chunkZ));
-		$this->world->setChunk($chunkX, $chunkZ, $chunk);
+		$chunk->setPos($chunkPos);
+		$this->world->setChunk($chunkPos, $chunk);
 	}
 
-	public function populateChunk(int $chunkX, int $chunkZ) : void{
-		$this->random->setSeed(0xdeadbeef ^ ($chunkX << 8) ^ $chunkZ ^ $this->seed);
+	public function populateChunk(ChunkPos $chunkPos) : void{
+		$this->random->setSeed(0xdeadbeef ^ ($chunkPos->getX() << 8) ^ $chunkPos->getZ() ^ $this->seed);
 		foreach($this->populators as $populator){
-			$populator->populate($this->world, $chunkX, $chunkZ, $this->random);
+			$populator->populate($this->world, $chunkPos, $this->random);
 		}
 
 	}

--- a/src/world/generator/Generator.php
+++ b/src/world/generator/Generator.php
@@ -29,6 +29,7 @@ namespace pocketmine\world\generator;
 use pocketmine\utils\Random;
 use pocketmine\utils\Utils;
 use pocketmine\world\ChunkManager;
+use pocketmine\world\ChunkPos;
 use function preg_match;
 
 abstract class Generator{
@@ -74,7 +75,7 @@ abstract class Generator{
 		$this->random = new Random($seed);
 	}
 
-	abstract public function generateChunk(int $chunkX, int $chunkZ) : void;
+	abstract public function generateChunk(ChunkPos $chunkPos) : void;
 
-	abstract public function populateChunk(int $chunkX, int $chunkZ) : void;
+	abstract public function populateChunk(ChunkPos $chunkPos) : void;
 }

--- a/src/world/generator/GeneratorChunkManager.php
+++ b/src/world/generator/GeneratorChunkManager.php
@@ -23,16 +23,16 @@ declare(strict_types=1);
 
 namespace pocketmine\world\generator;
 
+use pocketmine\world\ChunkPos;
 use pocketmine\world\format\Chunk;
 use pocketmine\world\SimpleChunkManager;
-use pocketmine\world\World;
 
 class GeneratorChunkManager extends SimpleChunkManager{
 
-	public function getChunk(int $chunkX, int $chunkZ, bool $create = false) : ?Chunk{
-		if(!isset($this->chunks[World::chunkHash($chunkX, $chunkZ)])){
+	public function getChunk(ChunkPos $chunkPos, bool $create = false) : ?Chunk{
+		if(!isset($this->chunks[$chunkPos->hash])){
 			throw new \InvalidArgumentException("Chunk does not exist");
 		}
-		return parent::getChunk($chunkX, $chunkZ, $create);
+		return parent::getChunk($chunkPos, $create);
 	}
 }

--- a/src/world/generator/PopulationTask.php
+++ b/src/world/generator/PopulationTask.php
@@ -25,6 +25,7 @@ namespace pocketmine\world\generator;
 
 use pocketmine\block\BlockFactory;
 use pocketmine\scheduler\AsyncTask;
+use pocketmine\world\ChunkPos;
 use pocketmine\world\format\Chunk;
 use pocketmine\world\format\io\FastChunkSerializer;
 use pocketmine\world\World;
@@ -92,7 +93,7 @@ class PopulationTask extends AsyncTask{
 			$zz = -1 + (int) ($i / 3);
 			$ck = $this->{"chunk$i"};
 			if($ck === null){
-				$chunks[$i] = new Chunk($chunk->getX() + $xx, $chunk->getZ() + $zz);
+				$chunks[$i] = new Chunk(new ChunkPos($chunk->getX() + $xx, $chunk->getZ() + $zz));
 			}else{
 				$chunks[$i] = FastChunkSerializer::deserialize($ck);
 			}

--- a/src/world/generator/PopulationTask.php
+++ b/src/world/generator/PopulationTask.php
@@ -25,7 +25,6 @@ namespace pocketmine\world\generator;
 
 use pocketmine\block\BlockFactory;
 use pocketmine\scheduler\AsyncTask;
-use pocketmine\world\ChunkPos;
 use pocketmine\world\format\Chunk;
 use pocketmine\world\format\io\FastChunkSerializer;
 use pocketmine\world\World;
@@ -66,7 +65,7 @@ class PopulationTask extends AsyncTask{
 		$this->chunk = FastChunkSerializer::serialize($chunk);
 
 		$pos = $chunk->getPos();
-		foreach($world->getAdjacentChunks($pos->getX(), $pos->getZ()) as $i => $c){
+		foreach($world->getAdjacentChunks($pos) as $i => $c){
 			$this->{"chunk$i"} = $c !== null ? FastChunkSerializer::serialize($c) : null;
 		}
 
@@ -101,25 +100,25 @@ class PopulationTask extends AsyncTask{
 			}
 		}
 
-		$manager->setChunk($centerCPos->getX(), $centerCPos->getZ(), $chunk);
+		$manager->setChunk($centerCPos, $chunk);
 		if(!$chunk->isGenerated()){
-			$generator->generateChunk($centerCPos->getX(), $centerCPos->getZ());
-			$chunk = $manager->getChunk($centerCPos->getX(), $centerCPos->getZ());
+			$generator->generateChunk($centerCPos);
+			$chunk = $manager->getChunk($centerCPos);
 			$chunk->setGenerated();
 		}
 
 		foreach($chunks as $i => $c){
 			$cPos = $c->getPos();
-			$manager->setChunk($cPos->getX(), $cPos->getZ(), $c);
+			$manager->setChunk($cPos, $c);
 			if(!$c->isGenerated()){
-				$generator->generateChunk($cPos->getX(), $cPos->getZ());
-				$chunks[$i] = $manager->getChunk($cPos->getX(), $cPos->getZ());
+				$generator->generateChunk($centerCPos);
+				$chunks[$i] = $manager->getChunk($cPos);
 				$chunks[$i]->setGenerated();
 			}
 		}
 
-		$generator->populateChunk($centerCPos->getX(), $centerCPos->getZ());
-		$chunk = $manager->getChunk($centerCPos->getX(), $centerCPos->getZ());
+		$generator->populateChunk($centerCPos);
+		$chunk = $manager->getChunk($centerCPos);
 		$chunk->setPopulated();
 
 		$blockFactory = BlockFactory::getInstance();
@@ -154,12 +153,12 @@ class PopulationTask extends AsyncTask{
 				if($c !== null){
 					$c = FastChunkSerializer::deserialize($c);
 					$cpos = $c->getPos();
-					$world->generateChunkCallback($cpos->getX(), $cpos->getZ(), $this->state ? $c : null);
+					$world->generateChunkCallback($cpos, $this->state ? $c : null);
 				}
 			}
 
 			$pos = $chunk->getPos();
-			$world->generateChunkCallback($pos->getX(), $pos->getZ(), $this->state ? $chunk : null);
+			$world->generateChunkCallback($pos, $this->state ? $chunk : null);
 		}
 	}
 }

--- a/src/world/generator/hell/Nether.php
+++ b/src/world/generator/hell/Nether.php
@@ -26,6 +26,7 @@ namespace pocketmine\world\generator\hell;
 use pocketmine\block\VanillaBlocks;
 use pocketmine\world\biome\Biome;
 use pocketmine\world\ChunkManager;
+use pocketmine\world\ChunkPos;
 use pocketmine\world\generator\Generator;
 use pocketmine\world\generator\InvalidGeneratorOptionsException;
 use pocketmine\world\generator\noise\Simplex;
@@ -76,12 +77,14 @@ class Nether extends Generator{
 		$this->populators[] = $ores;*/
 	}
 
-	public function generateChunk(int $chunkX, int $chunkZ) : void{
+	public function generateChunk(ChunkPos $chunkPos) : void{
+		$chunkX = $chunkPos->getX();
+		$chunkZ = $chunkPos->getZ();
 		$this->random->setSeed(0xdeadbeef ^ ($chunkX << 8) ^ $chunkZ ^ $this->seed);
 
 		$noise = $this->noiseBase->getFastNoise3D(16, 128, 16, 4, 8, 4, $chunkX * 16, 0, $chunkZ * 16);
 
-		$chunk = $this->world->getChunk($chunkX, $chunkZ);
+		$chunk = $this->world->getChunk($chunkPos);
 
 		$bedrock = VanillaBlocks::BEDROCK()->getFullId();
 		$netherrack = VanillaBlocks::NETHERRACK()->getFullId();
@@ -111,18 +114,18 @@ class Nether extends Generator{
 		}
 
 		foreach($this->generationPopulators as $populator){
-			$populator->populate($this->world, $chunkX, $chunkZ, $this->random);
+			$populator->populate($this->world, $chunkPos, $this->random);
 		}
 	}
 
-	public function populateChunk(int $chunkX, int $chunkZ) : void{
-		$this->random->setSeed(0xdeadbeef ^ ($chunkX << 8) ^ $chunkZ ^ $this->seed);
+	public function populateChunk(ChunkPos $chunkPos) : void{
+		$this->random->setSeed(0xdeadbeef ^ ($chunkPos->getX() << 8) ^ $chunkPos->getZ() ^ $this->seed);
 		foreach($this->populators as $populator){
-			$populator->populate($this->world, $chunkX, $chunkZ, $this->random);
+			$populator->populate($this->world, $chunkPos, $this->random);
 		}
 
-		$chunk = $this->world->getChunk($chunkX, $chunkZ);
+		$chunk = $this->world->getChunk($chunkPos);
 		$biome = Biome::getBiome($chunk->getBiomeId(7, 7));
-		$biome->populateChunk($this->world, $chunkX, $chunkZ, $this->random);
+		$biome->populateChunk($this->world, $chunkPos, $this->random);
 	}
 }

--- a/src/world/generator/normal/Normal.php
+++ b/src/world/generator/normal/Normal.php
@@ -26,6 +26,7 @@ namespace pocketmine\world\generator\normal;
 use pocketmine\block\VanillaBlocks;
 use pocketmine\world\biome\Biome;
 use pocketmine\world\ChunkManager;
+use pocketmine\world\ChunkPos;
 use pocketmine\world\generator\biome\BiomeSelector;
 use pocketmine\world\generator\Gaussian;
 use pocketmine\world\generator\Generator;
@@ -144,12 +145,14 @@ class Normal extends Generator{
 		return $this->selector->pickBiome($x + $xNoise - 1, $z + $zNoise - 1);
 	}
 
-	public function generateChunk(int $chunkX, int $chunkZ) : void{
+	public function generateChunk(ChunkPos $chunkPos) : void{
+		$chunkX = $chunkPos->getX();
+		$chunkZ = $chunkPos->getZ();
 		$this->random->setSeed(0xdeadbeef ^ ($chunkX << 8) ^ $chunkZ ^ $this->seed);
 
 		$noise = $this->noiseBase->getFastNoise3D(16, 128, 16, 4, 8, 4, $chunkX * 16, 0, $chunkZ * 16);
 
-		$chunk = $this->world->getChunk($chunkX, $chunkZ);
+		$chunk = $this->world->getChunk($chunkPos);
 
 		$biomeCache = [];
 
@@ -211,18 +214,18 @@ class Normal extends Generator{
 		}
 
 		foreach($this->generationPopulators as $populator){
-			$populator->populate($this->world, $chunkX, $chunkZ, $this->random);
+			$populator->populate($this->world, $chunkPos, $this->random);
 		}
 	}
 
-	public function populateChunk(int $chunkX, int $chunkZ) : void{
-		$this->random->setSeed(0xdeadbeef ^ ($chunkX << 8) ^ $chunkZ ^ $this->seed);
+	public function populateChunk(ChunkPos $chunkPos) : void{
+		$this->random->setSeed(0xdeadbeef ^ ($chunkPos->getX() << 8) ^ $chunkPos->getZ() ^ $this->seed);
 		foreach($this->populators as $populator){
-			$populator->populate($this->world, $chunkX, $chunkZ, $this->random);
+			$populator->populate($this->world, $chunkPos, $this->random);
 		}
 
-		$chunk = $this->world->getChunk($chunkX, $chunkZ);
+		$chunk = $this->world->getChunk($chunkPos);
 		$biome = Biome::getBiome($chunk->getBiomeId(7, 7));
-		$biome->populateChunk($this->world, $chunkX, $chunkZ, $this->random);
+		$biome->populateChunk($this->world, $chunkPos, $this->random);
 	}
 }

--- a/src/world/generator/populator/GroundCover.php
+++ b/src/world/generator/populator/GroundCover.php
@@ -29,13 +29,14 @@ use pocketmine\block\Liquid;
 use pocketmine\utils\Random;
 use pocketmine\world\biome\Biome;
 use pocketmine\world\ChunkManager;
+use pocketmine\world\ChunkPos;
 use function count;
 use function min;
 
 class GroundCover extends Populator{
 
-	public function populate(ChunkManager $world, int $chunkX, int $chunkZ, Random $random) : void{
-		$chunk = $world->getChunk($chunkX, $chunkZ);
+	public function populate(ChunkManager $world, ChunkPos $chunkPos, Random $random) : void{
+		$chunk = $world->getChunk($chunkPos);
 		$factory = BlockFactory::getInstance();
 		for($x = 0; $x < 16; ++$x){
 			for($z = 0; $z < 16; ++$z){

--- a/src/world/generator/populator/Ore.php
+++ b/src/world/generator/populator/Ore.php
@@ -25,6 +25,7 @@ namespace pocketmine\world\generator\populator;
 
 use pocketmine\utils\Random;
 use pocketmine\world\ChunkManager;
+use pocketmine\world\ChunkPos;
 use pocketmine\world\generator\object\Ore as ObjectOre;
 use pocketmine\world\generator\object\OreType;
 
@@ -32,7 +33,9 @@ class Ore extends Populator{
 	/** @var OreType[] */
 	private $oreTypes = [];
 
-	public function populate(ChunkManager $world, int $chunkX, int $chunkZ, Random $random) : void{
+	public function populate(ChunkManager $world, ChunkPos $chunkPos, Random $random) : void{
+		$chunkX = $chunkPos->getX();
+		$chunkZ = $chunkPos->getZ();
 		foreach($this->oreTypes as $type){
 			$ore = new ObjectOre($random, $type);
 			for($i = 0; $i < $ore->type->clusterCount; ++$i){

--- a/src/world/generator/populator/Populator.php
+++ b/src/world/generator/populator/Populator.php
@@ -28,8 +28,9 @@ namespace pocketmine\world\generator\populator;
 
 use pocketmine\utils\Random;
 use pocketmine\world\ChunkManager;
+use pocketmine\world\ChunkPos;
 
 abstract class Populator{
 
-	abstract public function populate(ChunkManager $world, int $chunkX, int $chunkZ, Random $random) : void;
+	abstract public function populate(ChunkManager $world, ChunkPos $chunkPos, Random $random) : void;
 }

--- a/src/world/generator/populator/TallGrass.php
+++ b/src/world/generator/populator/TallGrass.php
@@ -27,6 +27,7 @@ use pocketmine\block\BlockLegacyIds;
 use pocketmine\block\VanillaBlocks;
 use pocketmine\utils\Random;
 use pocketmine\world\ChunkManager;
+use pocketmine\world\ChunkPos;
 
 class TallGrass extends Populator{
 	/** @var ChunkManager */
@@ -44,8 +45,10 @@ class TallGrass extends Populator{
 		$this->baseAmount = $amount;
 	}
 
-	public function populate(ChunkManager $world, int $chunkX, int $chunkZ, Random $random) : void{
+	public function populate(ChunkManager $world, ChunkPos $chunkPos, Random $random) : void{
 		$this->world = $world;
+		$chunkX = $chunkPos->getX();
+		$chunkZ = $chunkPos->getZ();
 		$amount = $random->nextRange(0, $this->randomAmount) + $this->baseAmount;
 
 		$block = VanillaBlocks::TALL_GRASS();

--- a/src/world/generator/populator/Tree.php
+++ b/src/world/generator/populator/Tree.php
@@ -27,6 +27,7 @@ use pocketmine\block\BlockLegacyIds;
 use pocketmine\block\utils\TreeType;
 use pocketmine\utils\Random;
 use pocketmine\world\ChunkManager;
+use pocketmine\world\ChunkPos;
 use pocketmine\world\generator\object\Tree as ObjectTree;
 
 class Tree extends Populator{
@@ -55,8 +56,10 @@ class Tree extends Populator{
 		$this->baseAmount = $amount;
 	}
 
-	public function populate(ChunkManager $world, int $chunkX, int $chunkZ, Random $random) : void{
+	public function populate(ChunkManager $world, ChunkPos $chunkPos, Random $random) : void{
 		$this->world = $world;
+		$chunkX = $chunkPos->getX();
+		$chunkZ = $chunkPos->getZ();
 		$amount = $random->nextRange(0, $this->randomAmount) + $this->baseAmount;
 		for($i = 0; $i < $amount; ++$i){
 			$x = $random->nextRange($chunkX << 4, ($chunkX << 4) + 15);

--- a/src/world/light/LightPopulationTask.php
+++ b/src/world/light/LightPopulationTask.php
@@ -35,11 +35,10 @@ use function igbinary_unserialize;
 
 class LightPopulationTask extends AsyncTask{
 	private const TLS_KEY_WORLD = "world";
+	private const TLS_KEY_CHUNK_POS = "chunkPos";
 
 	/** @var string */
 	public $chunk;
-	/** @var ChunkPos */
-	private $chunkPos;
 
 	/** @var string */
 	private $resultHeightMap;
@@ -50,7 +49,7 @@ class LightPopulationTask extends AsyncTask{
 
 	public function __construct(World $world, Chunk $chunk){
 		$this->storeLocal(self::TLS_KEY_WORLD, $world);
-		$this->chunkPos = $chunk->getPos();
+		$this->storeLocal(self::TLS_KEY_CHUNK_POS, $chunk->getPos());
 		$this->chunk = FastChunkSerializer::serialize($chunk);
 	}
 
@@ -77,7 +76,8 @@ class LightPopulationTask extends AsyncTask{
 	public function onCompletion() : void{
 		/** @var World $world */
 		$world = $this->fetchLocal(self::TLS_KEY_WORLD);
-		$pos = $this->chunkPos;
+		/** @var ChunkPos $pos */
+		$pos = $this->fetchLocal(self::TLS_KEY_CHUNK_POS);
 		if(!$world->isClosed() and $world->isChunkLoaded($pos->getX(), $pos->getZ())){
 			/** @var Chunk $chunk */
 			$chunk = $world->getChunk($pos->getX(), $pos->getZ());

--- a/src/world/light/LightPopulationTask.php
+++ b/src/world/light/LightPopulationTask.php
@@ -25,6 +25,7 @@ namespace pocketmine\world\light;
 
 use pocketmine\block\BlockFactory;
 use pocketmine\scheduler\AsyncTask;
+use pocketmine\world\ChunkPos;
 use pocketmine\world\format\Chunk;
 use pocketmine\world\format\io\FastChunkSerializer;
 use pocketmine\world\format\LightArray;
@@ -37,11 +38,8 @@ class LightPopulationTask extends AsyncTask{
 
 	/** @var string */
 	public $chunk;
-
-	/** @var int */
-	private $chunkX;
-	/** @var int */
-	private $chunkZ;
+	/** @var ChunkPos */
+	private $chunkPos;
 
 	/** @var string */
 	private $resultHeightMap;
@@ -52,7 +50,7 @@ class LightPopulationTask extends AsyncTask{
 
 	public function __construct(World $world, Chunk $chunk){
 		$this->storeLocal(self::TLS_KEY_WORLD, $world);
-		[$this->chunkX, $this->chunkZ] = [$chunk->getX(), $chunk->getZ()];
+		$this->chunkPos = $chunk->getPos();
 		$this->chunk = FastChunkSerializer::serialize($chunk);
 	}
 
@@ -79,9 +77,10 @@ class LightPopulationTask extends AsyncTask{
 	public function onCompletion() : void{
 		/** @var World $world */
 		$world = $this->fetchLocal(self::TLS_KEY_WORLD);
-		if(!$world->isClosed() and $world->isChunkLoaded($this->chunkX, $this->chunkZ)){
+		$pos = $this->chunkPos;
+		if(!$world->isClosed() and $world->isChunkLoaded($pos->getX(), $pos->getZ())){
 			/** @var Chunk $chunk */
-			$chunk = $world->getChunk($this->chunkX, $this->chunkZ);
+			$chunk = $world->getChunk($pos->getX(), $pos->getZ());
 			//TODO: calculated light information might not be valid if the terrain changed during light calculation
 
 			/** @var int[] $heightMapArray */

--- a/src/world/light/LightPopulationTask.php
+++ b/src/world/light/LightPopulationTask.php
@@ -78,9 +78,9 @@ class LightPopulationTask extends AsyncTask{
 		$world = $this->fetchLocal(self::TLS_KEY_WORLD);
 		/** @var ChunkPos $pos */
 		$pos = $this->fetchLocal(self::TLS_KEY_CHUNK_POS);
-		if(!$world->isClosed() and $world->isChunkLoaded($pos->getX(), $pos->getZ())){
+		if(!$world->isClosed() and $world->isChunkLoaded($pos)){
 			/** @var Chunk $chunk */
-			$chunk = $world->getChunk($pos->getX(), $pos->getZ());
+			$chunk = $world->getChunk($pos);
 			//TODO: calculated light information might not be valid if the terrain changed during light calculation
 
 			/** @var int[] $heightMapArray */

--- a/src/world/light/SkyLightUpdate.php
+++ b/src/world/light/SkyLightUpdate.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace pocketmine\world\light;
 
 use pocketmine\block\BlockFactory;
+use pocketmine\world\ChunkPos;
 use pocketmine\world\World;
 use function max;
 
@@ -41,7 +42,7 @@ class SkyLightUpdate extends LightUpdate{
 	}
 
 	public function recalculateNode(int $x, int $y, int $z) : void{
-		$chunk = $this->world->getChunk($x >> 4, $z >> 4);
+		$chunk = $this->world->getChunk(ChunkPos::fromBlockCoords($x, $z));
 		if($chunk === null){
 			return;
 		}

--- a/src/world/utils/SubChunkIteratorManager.php
+++ b/src/world/utils/SubChunkIteratorManager.php
@@ -25,6 +25,7 @@ namespace pocketmine\world\utils;
 
 use pocketmine\utils\Utils;
 use pocketmine\world\ChunkManager;
+use pocketmine\world\ChunkPos;
 use pocketmine\world\format\Chunk;
 use pocketmine\world\format\SubChunk;
 use function assert;
@@ -61,7 +62,7 @@ class SubChunkIteratorManager{
 			$this->currentZ = $z >> 4;
 			$this->currentSubChunk = null;
 
-			$this->currentChunk = $this->world->getChunk($this->currentX, $this->currentZ, $create);
+			$this->currentChunk = $this->world->getChunk(new ChunkPos($this->currentX, $this->currentZ), $create);
 			if($this->currentChunk === null){
 				return false;
 			}

--- a/tests/phpstan/configs/l8-baseline.neon
+++ b/tests/phpstan/configs/l8-baseline.neon
@@ -261,7 +261,7 @@ parameters:
 			path: ../../../src/network/NetworkSessionManager.php
 
 		-
-			message: "#^Parameter \\#3 \\$chunk of class pocketmine\\\\network\\\\mcpe\\\\ChunkRequestTask constructor expects pocketmine\\\\world\\\\format\\\\Chunk, pocketmine\\\\world\\\\format\\\\Chunk\\|null given\\.$#"
+			message: "#^Parameter \\#2 \\$chunk of class pocketmine\\\\network\\\\mcpe\\\\ChunkRequestTask constructor expects pocketmine\\\\world\\\\format\\\\Chunk, pocketmine\\\\world\\\\format\\\\Chunk\\|null given\\.$#"
 			count: 1
 			path: ../../../src/network/mcpe/ChunkCache.php
 

--- a/tests/phpstan/configs/l8-baseline.neon
+++ b/tests/phpstan/configs/l8-baseline.neon
@@ -821,13 +821,8 @@ parameters:
 			path: ../../../src/world/generator/PopulationTask.php
 
 		-
-			message: "#^Cannot call method getX\\(\\) on pocketmine\\\\world\\\\format\\\\Chunk\\|null\\.$#"
-			count: 5
-			path: ../../../src/world/generator/PopulationTask.php
-
-		-
-			message: "#^Cannot call method getZ\\(\\) on pocketmine\\\\world\\\\format\\\\Chunk\\|null\\.$#"
-			count: 5
+			message: "#^Cannot call method getPos\\(\\) on pocketmine\\\\world\\\\format\\\\Chunk\\|null\\.$#"
+			count: 1
 			path: ../../../src/world/generator/PopulationTask.php
 
 		-


### PR DESCRIPTION
## Introduction
Chunk positions are used in many places, and pretty much always as an X/Z pair.
This PR unifies these X/Z coordinate pairs behind a `ChunkPos` type.

This has the following advantages:
- `chunkHash` doesn't need to be recomputed all the time (it's calculated in the constructor and stored on `ChunkPos->hash`.
- No more getting X and Z mixed up, since they are now unified into one type.
- More self-descriptive function signatures.
- Enables getting rid of specializations like `getViewersForPosition()`, since now a `ChunkPos` can be constructed using a `Vector3`.

## Changes
### API changes
- Almost all cases where a chunk X/Z pair would be accepted as integers, now accept a `ChunkPos` argument instead.

### Behavioural changes
It's possible this might have negative performance impacts - this has not yet been assessed. However, considering that chunk coordinates are not heavily used in the core code, I doubt that the overhead of instantiating the occasional `ChunkPos` object will be a problem.

Reducing the number of calls to `World::blockHash()` should have a marginally positive performance impact, but again I don't believe the difference is significant anyway.

## Backwards compatibility
This is BC-breaking.