### PR TITLE
Use objects for internal structures created in TextFormat::toJSON()

### DIFF
--- a/src/pocketmine/timings/Timings.php
+++ b/src/pocketmine/timings/Timings.php
@@ -149,7 +149,7 @@ abstract class Timings{
 	}
 
 	public static function getScheduledTaskTimings(TaskHandler $task, int $period) : TimingsHandler{
-		$name = "Task: " . ($task->getOwnerName() ?? "Unknown") . " Runnable: " . $task->getTaskName();
+		$name = "Task: " . $task->getOwnerName() . " Runnable: " . $task->getTaskName();
 
 		if($period > 0){
 			$name .= "(interval:" . $period . ")";

--- a/src/pocketmine/utils/TextFormat.php
+++ b/src/pocketmine/utils/TextFormat.php
@@ -141,8 +141,8 @@ abstract class TextFormat{
 		if(!is_array($string)){
 			$string = self::tokenize($string);
 		}
-		$newString = [];
-		$pointer =& $newString;
+		$newString = new TextFormatJsonObject();
+		$pointer = $newString;
 		$color = "white";
 		$bold = false;
 		$italic = false;
@@ -152,165 +152,164 @@ abstract class TextFormat{
 		$index = 0;
 
 		foreach($string as $token){
-			if(isset($pointer["text"])){
-				if(!isset($newString["extra"])){
-					$newString["extra"] = [];
+			if($pointer->text !== null){
+				if($newString->extra === null){
+					$newString->extra = [];
 				}
-				$newString["extra"][$index] = [];
-				$pointer =& $newString["extra"][$index];
+				$newString->extra[$index] = $pointer = new TextFormatJsonObject();
 				if($color !== "white"){
-					$pointer["color"] = $color;
+					$pointer->color = $color;
 				}
 				if($bold){
-					$pointer["bold"] = true;
+					$pointer->bold = true;
 				}
 				if($italic){
-					$pointer["italic"] = true;
+					$pointer->italic = true;
 				}
 				if($underlined){
-					$pointer["underlined"] = true;
+					$pointer->underlined = true;
 				}
 				if($strikethrough){
-					$pointer["strikethrough"] = true;
+					$pointer->strikethrough = true;
 				}
 				if($obfuscated){
-					$pointer["obfuscated"] = true;
+					$pointer->obfuscated = true;
 				}
 				++$index;
 			}
 			switch($token){
 				case TextFormat::BOLD:
 					if(!$bold){
-						$pointer["bold"] = true;
+						$pointer->bold = true;
 						$bold = true;
 					}
 					break;
 				case TextFormat::OBFUSCATED:
 					if(!$obfuscated){
-						$pointer["obfuscated"] = true;
+						$pointer->obfuscated = true;
 						$obfuscated = true;
 					}
 					break;
 				case TextFormat::ITALIC:
 					if(!$italic){
-						$pointer["italic"] = true;
+						$pointer->italic = true;
 						$italic = true;
 					}
 					break;
 				case TextFormat::UNDERLINE:
 					if(!$underlined){
-						$pointer["underlined"] = true;
+						$pointer->underlined = true;
 						$underlined = true;
 					}
 					break;
 				case TextFormat::STRIKETHROUGH:
 					if(!$strikethrough){
-						$pointer["strikethrough"] = true;
+						$pointer->strikethrough = true;
 						$strikethrough = true;
 					}
 					break;
 				case TextFormat::RESET:
 					if($color !== "white"){
-						$pointer["color"] = "white";
+						$pointer->color = "white";
 						$color = "white";
 					}
 					if($bold){
-						$pointer["bold"] = false;
+						$pointer->bold = false;
 						$bold = false;
 					}
 					if($italic){
-						$pointer["italic"] = false;
+						$pointer->italic = false;
 						$italic = false;
 					}
 					if($underlined){
-						$pointer["underlined"] = false;
+						$pointer->underlined = false;
 						$underlined = false;
 					}
 					if($strikethrough){
-						$pointer["strikethrough"] = false;
+						$pointer->strikethrough = false;
 						$strikethrough = false;
 					}
 					if($obfuscated){
-						$pointer["obfuscated"] = false;
+						$pointer->obfuscated = false;
 						$obfuscated = false;
 					}
 					break;
 
 				//Colors
 				case TextFormat::BLACK:
-					$pointer["color"] = "black";
+					$pointer->color = "black";
 					$color = "black";
 					break;
 				case TextFormat::DARK_BLUE:
-					$pointer["color"] = "dark_blue";
+					$pointer->color = "dark_blue";
 					$color = "dark_blue";
 					break;
 				case TextFormat::DARK_GREEN:
-					$pointer["color"] = "dark_green";
+					$pointer->color = "dark_green";
 					$color = "dark_green";
 					break;
 				case TextFormat::DARK_AQUA:
-					$pointer["color"] = "dark_aqua";
+					$pointer->color = "dark_aqua";
 					$color = "dark_aqua";
 					break;
 				case TextFormat::DARK_RED:
-					$pointer["color"] = "dark_red";
+					$pointer->color = "dark_red";
 					$color = "dark_red";
 					break;
 				case TextFormat::DARK_PURPLE:
-					$pointer["color"] = "dark_purple";
+					$pointer->color = "dark_purple";
 					$color = "dark_purple";
 					break;
 				case TextFormat::GOLD:
-					$pointer["color"] = "gold";
+					$pointer->color = "gold";
 					$color = "gold";
 					break;
 				case TextFormat::GRAY:
-					$pointer["color"] = "gray";
+					$pointer->color = "gray";
 					$color = "gray";
 					break;
 				case TextFormat::DARK_GRAY:
-					$pointer["color"] = "dark_gray";
+					$pointer->color = "dark_gray";
 					$color = "dark_gray";
 					break;
 				case TextFormat::BLUE:
-					$pointer["color"] = "blue";
+					$pointer->color = "blue";
 					$color = "blue";
 					break;
 				case TextFormat::GREEN:
-					$pointer["color"] = "green";
+					$pointer->color = "green";
 					$color = "green";
 					break;
 				case TextFormat::AQUA:
-					$pointer["color"] = "aqua";
+					$pointer->color = "aqua";
 					$color = "aqua";
 					break;
 				case TextFormat::RED:
-					$pointer["color"] = "red";
+					$pointer->color = "red";
 					$color = "red";
 					break;
 				case TextFormat::LIGHT_PURPLE:
-					$pointer["color"] = "light_purple";
+					$pointer->color = "light_purple";
 					$color = "light_purple";
 					break;
 				case TextFormat::YELLOW:
-					$pointer["color"] = "yellow";
+					$pointer->color = "yellow";
 					$color = "yellow";
 					break;
 				case TextFormat::WHITE:
-					$pointer["color"] = "white";
+					$pointer->color = "white";
 					$color = "white";
 					break;
 				default:
-					$pointer["text"] = $token;
+					$pointer->text = $token;
 					break;
 			}
 		}
 
-		if(isset($newString["extra"])){
-			foreach($newString["extra"] as $k => $d){
-				if(!isset($d["text"])){
-					unset($newString["extra"][$k]);
+		if($newString->extra !== null){
+			foreach($newString->extra as $k => $d){
+				if($d->text === null){
+					unset($newString->extra[$k]);
 				}
 			}
 		}

--- a/src/pocketmine/utils/TextFormatJsonObject.php
+++ b/src/pocketmine/utils/TextFormatJsonObject.php
@@ -23,6 +23,10 @@ declare(strict_types=1);
 
 namespace pocketmine\utils;
 
+/**
+ * @internal
+ * @see TextFormat::toJSON()
+ */
 final class TextFormatJsonObject implements \JsonSerializable{
 	/** @var string|null */
 	public $text = null;

--- a/src/pocketmine/utils/TextFormatJsonObject.php
+++ b/src/pocketmine/utils/TextFormatJsonObject.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\utils;
+
+final class TextFormatJsonObject implements \JsonSerializable{
+	/** @var string|null */
+	public $text = null;
+	/** @var string|null */
+	public $color = null;
+	/** @var bool|null */
+	public $bold = null;
+	/** @var bool|null */
+	public $italic = null;
+	/** @var bool|null */
+	public $underlined = null;
+	/** @var bool|null */
+	public $strikethrough = null;
+	/** @var bool|null */
+	public $obfuscated = null;
+	/**
+	 * @var TextFormatJsonObject[]|null
+	 * @phpstan-var array<int, TextFormatJsonObject>|null
+	 */
+	public $extra = null;
+
+	public function jsonSerialize(){
+		$result = (array) $this;
+		foreach($result as $k => $v){
+			if($v === null){
+				unset($result[$k]);
+			}
+		}
+		return $result;
+	}
+}


### PR DESCRIPTION
## Introduction
I stumbled across some difficult-to-navigate code today as I was playing with some new PHPStan features and decided it would be a good idea to replace some assoc arrays with objects. Since it's impractical to define recursive assoc array structures with PHPStan, objects were the only option.
## Changes
### API changes
No API changes.

### Behavioural changes
Behaviour should be the same as before, barring any bugs which I haven't yet tested for.

## Backwards compatibility
Fully backwards compatible.

## Tests
Not yet tested, but it passes a PHPStan run.