### PR TITLE
Added ApiMap (basic dependency injection container)

### DIFF
--- a/src/plugin/ApiMap.php
+++ b/src/plugin/ApiMap.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\plugin;
+
+use function get_class;
+use function is_string;
+use InvalidArgumentException;
+use ReflectionClass;
+use RuntimeException;
+use pocketmine\utils\Utils;
+
+/**
+ * Alows different modules to expose APIs using types.
+ */
+final class ApiMap{
+	/**
+	 * @var ApiMapEntry[]
+	 * @phpstan-var array<class-string, ApiMapEntry>
+	 */
+	private $apiMap = [];
+
+	/**
+	 * @see Server::provideApi()
+	 *
+	 * @phpstan-template T of object
+	 * @phpstan-param class-string<T> $interface
+	 * @phpstan-param T $impl
+	 *
+	 * @throws InvalidArgumentException if $impl is not an instance of $interface
+	 * @throws RuntimeException if two non-default APIs are provided for the same interface
+	 */
+	public function provideApi(string $interface, ?Plugin $plugin, object $impl, bool $default = false) : void{
+		if(!($impl instanceof $interface)){
+			$class = get_class($impl);
+			throw new InvalidArgumentException("\$impl is an instance of $class, which does not extend/implement $interface");
+		}
+
+		if(isset($this->apiMap[$interface])){
+			if(!$this->apiMap[$interface]->default && !$default) {
+				// two non-default implementations
+				$otherPlugin = $this->apiMap[$interface]->plugin;
+				$otherPluginName = $otherPlugin !== null ? $otherPlugin->getName() : "PocketMine";
+				$pluginName = $plugin !== null ? $plugin->getName() : "PocketMine";
+
+				$class = new ReflectionClass($interface);
+				$doc = $class->getDocComment();
+				$tags = is_string($doc) ? Utils::parseDocComment($doc) : [];
+				$purpose = $tags["purpose"] ?? "an implementation of $interface";
+
+				// TODO switch to user-friendly exceptions
+				throw new RuntimeException("Multiple plugins ($otherPluginName, $pluginName) are providing $purpose. Please disable one of them or check configuration.");
+			}
+
+			if($default) {
+				return;
+			}
+		}
+
+		$entry = new ApiMapEntry;
+		$entry->plugin = $plugin;
+		$entry->impl = $impl;
+		$entry->default = $default;
+		$this->apiMap[$interface] = $entry;
+	}
+
+	/**
+	 * @see Server::getApi()
+	 *
+	 * @phpstan-template T of object
+	 * @phpstan-param class-string<T> $interface
+	 *
+	 * @phpstan-return T|null
+	 */
+	public function getApi(string $interface, bool &$default = false) : ?object {
+		if(!isset($this->apiMap[$interface])) {
+			return null;
+		}
+		$default = $this->apiMap[$interface]->default;
+		/** @phpstan-var T $impl */
+		$impl = $this->apiMap[$interface]->impl;
+		return $impl;
+	}
+}

--- a/src/plugin/ApiMapEntry.php
+++ b/src/plugin/ApiMapEntry.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\plugin;
+
+/**
+ * @internal
+ */
+final class ApiMapEntry{
+	/** @var Plugin|null */
+	public $plugin;
+	/** @var object */
+	public $impl;
+	/** @var bool */
+	public $default;
+}

--- a/tests/phpunit/plugin/ApiMapTest.php
+++ b/tests/phpunit/plugin/ApiMapTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\plugin;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use stdClass;
+
+/**
+ * @purpose (api map test purpose)
+ */
+class ApiMapTest extends TestCase{
+	public function testGetSet() : void{
+		$apiMap = new ApiMap;
+		$apiMap->provideApi(TestCase::class, null, $this);
+		self::assertSame($this, $apiMap->getApi(TestCase::class));
+		self::assertNull($apiMap->getApi(self::class));
+	}
+
+	public function testWrongInheritance() : void{
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('$impl is an instance of pocketmine\plugin\ApiMap, which does not extend/implement pocketmine\plugin\ApiMapTest');
+		$apiMap = new ApiMap;
+		$apiMap->provideApi(self::class, null, new ApiMap);
+	}
+
+	public function testConflict() : void{
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage("Multiple plugins (PocketMine, PocketMine) are providing (api map test purpose). Please disable one of them or check configuration.");
+
+		$apiMap = new ApiMap;
+		$apiMap->provideApi(self::class, null, $this);
+		$apiMap->provideApi(self::class, null, $this);
+	}
+
+	public function testDefault() : void{
+		$apiMap = new ApiMap;
+
+		$foo = new stdClass;
+		$bar = new stdClass;
+
+		$apiMap->provideApi(stdClass::class, null, $foo, true);
+		$apiMap->provideApi(stdClass::class, null, $bar, false);
+		self::assertSame($bar, $apiMap->getApi(stdClass::class));
+
+
+		$apiMap = new ApiMap;
+
+		$foo = new stdClass;
+		$bar = new stdClass;
+
+		$apiMap->provideApi(stdClass::class, null, $foo, false);
+		$apiMap->provideApi(stdClass::class, null, $bar, true);
+		self::assertSame($foo, $apiMap->getApi(stdClass::class));
+	}
+}
+


### PR DESCRIPTION
## Introduction
This provides a type-based approach for plugins to expose APIs to each other.

For example, PocketMine can provide a `BanList` interface with a default implementation (using the current banned-players.txt etc), then plugins can set it to their own implementation.

This class also handles conflict conditions.

For details, please check the documentation in the code.

### Relevant issues
Resolves #3087

## Changes
### API changes
Added the `ApiMap` class.

Its methods are directly re-exported in `Server`.

### Behavioural changes
None yet.

## Backwards compatibility
This is a pure API addition with no BC issues.

## Follow-up
Improve error messages.

## Tests
See `ApiMapTest`.