### PR TITLE
Implemented Swimming

### DIFF
--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -25,6 +25,7 @@ namespace pocketmine\entity;
 
 use pocketmine\block\Block;
 use pocketmine\block\BlockLegacyIds;
+use pocketmine\block\Water;
 use pocketmine\data\bedrock\EffectIdMap;
 use pocketmine\entity\animation\DeathAnimation;
 use pocketmine\entity\animation\HurtAnimation;
@@ -607,6 +608,14 @@ abstract class Living extends Entity{
 
 			if($this->doAirSupplyTick($tickDiff)){
 				$hasUpdate = true;
+			}
+
+			if(
+				$this->isSwimming() && !$this->isUnderwater() &&
+				$this->getWorld()->getBlock($this->getPosition()->add(0, 1, 0))->getId() === BlockLegacyIds::AIR &&
+				!$this->getWorld()->getBlock($this->getPosition()->subtract(0, 1, 0)) instanceof Water
+			){
+				$this->setSwimming(false);
 			}
 		}
 

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -119,6 +119,13 @@ abstract class Living extends Entity{
 	/** @var bool */
 	protected $swimming = false;
 
+	/** @var float */
+	protected $originalWidth;
+	/** @var float */
+	protected $originalHeight;
+	/** @var float */
+	protected $originalEyeHeight;
+
 	abstract public function getName() : string;
 
 	protected function initEntity(CompoundTag $nbt) : void{
@@ -229,10 +236,16 @@ abstract class Living extends Entity{
 		if($value !== $this->isSwimming()) {
 			$this->swimming = $value;
 			if($this->swimming){
+				$this->originalWidth = $this->width;
+				$this->originalHeight = $this->height;
+				$this->originalEyeHeight = $this->eyeHeight;
 				$this->height = $this->eyeHeight = $this->width;
 				$this->recalculateBoundingBox();
 			}else{
-				$this->setScale($this->getScale());
+				$this->width = $this->originalWidth;
+				$this->height = $this->originalHeight;
+				$this->eyeHeight = $this->originalEyeHeight;
+				$this->recalculateBoundingBox();
 			}
 		}
 	}

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -237,15 +237,14 @@ abstract class Living extends Entity{
 		if($value !== $this->isSwimming()) {
 			$this->swimming = $value;
 			if($this->swimming){
-				$this->originalWidth = $this->width;
-				$this->originalHeight = $this->height;
-				$this->originalEyeHeight = $this->eyeHeight;
-				$this->height = $this->eyeHeight = $this->width;
+				$width = $this->size->getWidth();
+				$this->originalWidth = $width;
+				$this->originalHeight = $this->size->getHeight();
+				$this->originalEyeHeight = $this->size->getEyeHeight();
+				$this->size = new EntitySizeInfo($width, $width, $width);
 				$this->recalculateBoundingBox();
 			}else{
-				$this->width = $this->originalWidth;
-				$this->height = $this->originalHeight;
-				$this->eyeHeight = $this->originalEyeHeight;
+				$this->size = new EntitySizeInfo($this->originalHeight, $this->originalWidth, $this->originalEyeHeight);
 				$this->recalculateBoundingBox();
 			}
 		}

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -120,12 +120,8 @@ abstract class Living extends Entity{
 	/** @var bool */
 	protected $swimming = false;
 
-	/** @var float */
-	protected $originalWidth;
-	/** @var float */
-	protected $originalHeight;
-	/** @var float */
-	protected $originalEyeHeight;
+	/** @var EntitySizeInfo */
+	protected $originalSize;
 
 	abstract public function getName() : string;
 
@@ -238,15 +234,13 @@ abstract class Living extends Entity{
 			$this->swimming = $value;
 			if($this->swimming){
 				$width = $this->size->getWidth();
-				$this->originalWidth = $width;
-				$this->originalHeight = $this->size->getHeight();
-				$this->originalEyeHeight = $this->size->getEyeHeight();
+				$this->originalSize = $this->size;
 				$this->size = new EntitySizeInfo($width, $width, $width);
-				$this->recalculateBoundingBox();
 			}else{
-				$this->size = new EntitySizeInfo($this->originalHeight, $this->originalWidth, $this->originalEyeHeight);
-				$this->recalculateBoundingBox();
+				$this->size = $this->originalSize;
 			}
+
+			$this->recalculateBoundingBox();
 		}
 	}
 

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -120,9 +120,6 @@ abstract class Living extends Entity{
 	/** @var bool */
 	protected $swimming = false;
 
-	/** @var EntitySizeInfo */
-	protected $originalSize;
-
 	abstract public function getName() : string;
 
 	protected function initEntity(CompoundTag $nbt) : void{
@@ -234,10 +231,9 @@ abstract class Living extends Entity{
 			$this->swimming = $value;
 			if($this->swimming){
 				$width = $this->size->getWidth();
-				$this->originalSize = $this->size;
 				$this->size = new EntitySizeInfo($width, $width, $width);
 			}else{
-				$this->size = $this->originalSize;
+				$this->size = $this->getInitialSizeInfo();
 			}
 
 			$this->recalculateBoundingBox();

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -116,6 +116,8 @@ abstract class Living extends Entity{
 	protected $sprinting = false;
 	/** @var bool */
 	protected $sneaking = false;
+	/** @var bool */
+	protected $swimming = false;
 
 	abstract public function getName() : string;
 
@@ -221,6 +223,22 @@ abstract class Living extends Entity{
 			$this->setMovementSpeed($value ? ($moveSpeed * 1.3) : ($moveSpeed / 1.3));
 			$this->moveSpeedAttr->markSynchronized(false); //TODO: reevaluate this hack
 		}
+	}
+
+	public function setSwimming(bool $value = true) : void{
+		if($value !== $this->isSwimming()) {
+			$this->swimming = $value;
+			if($this->swimming){
+				$this->height = $this->eyeHeight = $this->width;
+				$this->recalculateBoundingBox();
+			}else{
+				$this->setScale($this->getScale());
+			}
+		}
+	}
+
+	public function isSwimming() : bool{
+		return $this->swimming;
 	}
 
 	public function getMovementSpeed() : float{
@@ -787,6 +805,7 @@ abstract class Living extends Entity{
 		$properties->setGenericFlag(EntityMetadataFlags::BREATHING, $this->breathing);
 		$properties->setGenericFlag(EntityMetadataFlags::SNEAKING, $this->sneaking);
 		$properties->setGenericFlag(EntityMetadataFlags::SPRINTING, $this->sprinting);
+		$properties->setGenericFlag(EntityMetadataFlags::SWIMMING, $this->swimming);
 	}
 
 	protected function onDispose() : void{

--- a/src/event/player/PlayerToggleSwimEvent.php
+++ b/src/event/player/PlayerToggleSwimEvent.php
@@ -38,7 +38,7 @@ class PlayerToggleSwimEvent extends PlayerEvent implements Cancellable{
 		$this->isSwimming = $isSwimming;
 	}
 
-	public function isFlying() : bool{
+	public function isSwimming() : bool{
 		return $this->isSwimming;
 	}
 }

--- a/src/event/player/PlayerToggleSwimEvent.php
+++ b/src/event/player/PlayerToggleSwimEvent.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\event\player;
+
+use pocketmine\event\Cancellable;
+use pocketmine\event\CancellableTrait;
+use pocketmine\player\Player;
+
+class PlayerToggleSwimEvent extends PlayerEvent implements Cancellable{
+	use CancellableTrait;
+
+	/** @var bool */
+	protected $isSwimming;
+
+	public function __construct(Player $player, bool $isSwimming){
+		$this->player = $player;
+		$this->isSwimming = $isSwimming;
+	}
+
+	public function isFlying() : bool{
+		return $this->isSwimming;
+	}
+}

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -571,12 +571,12 @@ class InGamePacketHandler extends PacketHandler{
 				break;
 			case PlayerActionPacket::ACTION_START_SWIMMING:
 				if(!$this->player->toggleSwim(true)){
-					$this->player->sendData($this->player);
+					$this->player->sendData([$this->player]);
 				}
 				break;
 			case PlayerActionPacket::ACTION_STOP_SWIMMING:
 				if(!$this->player->toggleSwim(false)){
-					$this->player->sendData($this->player);
+					$this->player->sendData([$this->player]);
 				}
 				break;
 			case PlayerActionPacket::ACTION_INTERACT_BLOCK: //TODO: ignored (for now)

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -570,9 +570,14 @@ class InGamePacketHandler extends PacketHandler{
 				$this->player->continueBreakBlock($pos, $packet->face);
 				break;
 			case PlayerActionPacket::ACTION_START_SWIMMING:
-				break; //TODO
+				if(!$this->player->toggleSwim(true)){
+					$this->player->sendData($this->player);
+				}
+				break;
 			case PlayerActionPacket::ACTION_STOP_SWIMMING:
-				//TODO: handle this when it doesn't spam every damn tick (yet another spam bug!!)
+				if(!$this->player->toggleSwim(false)){
+					$this->player->sendData($this->player);
+				}
 				break;
 			case PlayerActionPacket::ACTION_INTERACT_BLOCK: //TODO: ignored (for now)
 				break;

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1749,7 +1749,9 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 
 	public function toggleSwim(bool $swim) : bool{
 		$ev = new PlayerToggleSwimEvent($this, $swim);;
-		$ev->setCancelled(!$this->isUnderwater());
+		if(!$this->isUnderwater()){
+			$ev->cancel();
+		}
 		$ev->call();
 		if($ev->isCancelled()){
 			return false;

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1727,7 +1727,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		$ev->call();
 		if($ev->isCancelled()){
 			return false;
-		};
+		}
 		$this->setSneaking($sneak);
 		return true;
 	}


### PR DESCRIPTION
## Introduction
This pull request aims to add the missing swimming functionality that was added back in 1.4.

## Changes
### API changes
Added
Living->swimming (protected)
Living->setSwimming(bool $value) : void;
PlayerToggleSwimEvent
Player->toggleSwim(bool $swim) : bool
### Behavioural changes
Hunger now takes account for swimming, 0.015, as stated in the comment.

## Backwards compatibility
This is backwards compatible with current API.

## Follow-up
I'm not too certain how well I like the setSwimming() function.

## Tests
I tested by going underwater and sprinting and going to the surface for air. I've also included a video to show it in action.
[Streamable Video](https://streamable.com/a97q6n)
