### PR TITLE
Changed Config into a pure static function class.

### DIFF
--- a/src/utils/Config.php
+++ b/src/utils/Config.php
@@ -55,354 +55,83 @@ use const JSON_BIGINT_AS_STRING;
 use const JSON_PRETTY_PRINT;
 
 /**
- * Config Class for simple config manipulation of multiple formats.
+ * Legacy utility class for configuration parsing.
  */
-class Config{
-	public const DETECT = -1; //Detect by file extension
-	public const PROPERTIES = 0; // .properties
-	public const CNF = Config::PROPERTIES; // .cnf
-	public const JSON = 1; // .js, .json
-	public const YAML = 2; // .yml, .yaml
-	//const EXPORT = 3; // .export, .xport
-	public const SERIALIZED = 4; // .sl
-	public const ENUM = 5; // .txt, .list, .enum
-	public const ENUMERATION = Config::ENUM;
-
+final class Config{
 	/**
-	 * @var mixed[]
-	 * @phpstan-var array<string, mixed>
+	 * The legacy `Config::fixYAMLIndexes` function,
+	 * used for escaping boolean key types in a YAML file.
+	 *
+	 * @deprecated The exact behaviour of this function is undocumented and unreliable.
+	 * This function may be removed in the future.
+	 * Only use this function for YAML config syntax backward compatibility.
 	 */
-	private $config = [];
-
-	/**
-	 * @var mixed[]
-	 * @phpstan-var array<string, mixed>
-	 */
-	private $nestedCache = [];
-
-	/** @var string */
-	private $file;
-	/** @var int */
-	private $type = Config::DETECT;
-	/** @var int */
-	private $jsonOptions = JSON_PRETTY_PRINT | JSON_BIGINT_AS_STRING;
-
-	/** @var bool */
-	private $changed = false;
-
-	/** @var int[] */
-	public static $formats = [
-		"properties" => Config::PROPERTIES,
-		"cnf" => Config::CNF,
-		"conf" => Config::CNF,
-		"config" => Config::CNF,
-		"json" => Config::JSON,
-		"js" => Config::JSON,
-		"yml" => Config::YAML,
-		"yaml" => Config::YAML,
-		//"export" => Config::EXPORT,
-		//"xport" => Config::EXPORT,
-		"sl" => Config::SERIALIZED,
-		"serialize" => Config::SERIALIZED,
-		"txt" => Config::ENUM,
-		"list" => Config::ENUM,
-		"enum" => Config::ENUM
-	];
-
-	/**
-	 * @param string  $file Path of the file to be loaded
-	 * @param int     $type Config type to load, -1 by default (detect)
-	 * @param mixed[] $default Array with the default values that will be written to the file if it did not exist
-	 * @phpstan-param array<string, mixed> $default
-	 */
-	public function __construct(string $file, int $type = Config::DETECT, array $default = []){
-		$this->load($file, $type, $default);
-	}
-
-	/**
-	 * Removes all the changes in memory and loads the file again
-	 */
-	public function reload() : void{
-		$this->config = [];
-		$this->nestedCache = [];
-		$this->load($this->file, $this->type);
-	}
-
-	public function hasChanged() : bool{
-		return $this->changed;
-	}
-
-	public function setChanged(bool $changed = true) : void{
-		$this->changed = $changed;
-	}
-
 	public static function fixYAMLIndexes(string $str) : string{
 		return preg_replace("#^( *)(y|Y|yes|Yes|YES|n|N|no|No|NO|true|True|TRUE|false|False|FALSE|on|On|ON|off|Off|OFF)( *)\:#m", "$1\"$2\"$3:", $str);
 	}
 
 	/**
-	 * @param mixed[] $default
-	 * @phpstan-param array<string, mixed> $default
+	 * Sets the element in $array as specified by the dot-delimited $path.
 	 *
-	 * @throws \InvalidArgumentException if config type could not be auto-detected
-	 * @throws \InvalidStateException if config type is invalid
-	 */
-	private function load(string $file, int $type = Config::DETECT, array $default = []) : void{
-		$this->file = $file;
-
-		$this->type = $type;
-		if($this->type === Config::DETECT){
-			$extension = explode(".", basename($this->file));
-			$extension = strtolower(trim(array_pop($extension)));
-			if(isset(Config::$formats[$extension])){
-				$this->type = Config::$formats[$extension];
-			}else{
-				throw new \InvalidArgumentException("Cannot detect config type of " . $this->file);
-			}
-		}
-
-		if(!file_exists($file)){
-			$this->config = $default;
-			$this->save();
-		}else{
-			$content = file_get_contents($this->file);
-			if($content === false){
-				throw new \RuntimeException("Unable to load config file");
-			}
-			$config = null;
-			switch($this->type){
-				case Config::PROPERTIES:
-					$config = $this->parseProperties($content);
-					break;
-				case Config::JSON:
-					$config = json_decode($content, true);
-					break;
-				case Config::YAML:
-					$content = self::fixYAMLIndexes($content);
-					$config = yaml_parse($content);
-					break;
-				case Config::SERIALIZED:
-					$config = unserialize($content);
-					break;
-				case Config::ENUM:
-					$config = self::parseList($content);
-					break;
-				default:
-					throw new \InvalidStateException("Config type is unknown");
-			}
-			$this->config = is_array($config) ? $config : $default;
-			if($this->fillDefaults($default, $this->config) > 0){
-				$this->save();
-			}
-		}
-	}
-
-	/**
-	 * Returns the path of the config.
-	 */
-	public function getPath() : string{
-		return $this->file;
-	}
-
-	/**
-	 * Flushes the config to disk in the appropriate format.
-	 *
-	 * @throws \InvalidStateException if config type is not valid
-	 */
-	public function save() : void{
-		$content = null;
-		switch($this->type){
-			case Config::PROPERTIES:
-				$content = $this->writeProperties();
-				break;
-			case Config::JSON:
-				$content = json_encode($this->config, $this->jsonOptions);
-				break;
-			case Config::YAML:
-				$content = yaml_emit($this->config, YAML_UTF8_ENCODING);
-				break;
-			case Config::SERIALIZED:
-				$content = serialize($this->config);
-				break;
-			case Config::ENUM:
-				$content = implode("\r\n", array_keys($this->config));
-				break;
-			default:
-				throw new \InvalidStateException("Config type is unknown, has not been set or not detected");
-		}
-
-		file_put_contents($this->file, $content);
-
-		$this->changed = false;
-	}
-
-	/**
-	 * Sets the options for the JSON encoding when saving
-	 *
-	 * @return Config $this
-	 * @throws \RuntimeException if the Config is not in JSON
-	 * @see json_encode
-	 */
-	public function setJsonOptions(int $options) : Config{
-		if($this->type !== Config::JSON){
-			throw new \RuntimeException("Attempt to set JSON options for non-JSON config");
-		}
-		$this->jsonOptions = $options;
-		$this->changed = true;
-
-		return $this;
-	}
-
-	/**
-	 * Enables the given option in addition to the currently set JSON options
-	 *
-	 * @return Config $this
-	 * @throws \RuntimeException if the Config is not in JSON
-	 * @see json_encode
-	 */
-	public function enableJsonOption(int $option) : Config{
-		if($this->type !== Config::JSON){
-			throw new \RuntimeException("Attempt to enable JSON option for non-JSON config");
-		}
-		$this->jsonOptions |= $option;
-		$this->changed = true;
-
-		return $this;
-	}
-
-	/**
-	 * Disables the given option for the JSON encoding when saving
-	 *
-	 * @return Config $this
-	 * @throws \RuntimeException if the Config is not in JSON
-	 * @see json_encode
-	 */
-	public function disableJsonOption(int $option) : Config{
-		if($this->type !== Config::JSON){
-			throw new \RuntimeException("Attempt to disable JSON option for non-JSON config");
-		}
-		$this->jsonOptions &= ~$option;
-		$this->changed = true;
-
-		return $this;
-	}
-
-	/**
-	 * Returns the options for the JSON encoding when saving
-	 *
-	 * @throws \RuntimeException if the Config is not in JSON
-	 * @see json_encode
-	 */
-	public function getJsonOptions() : int{
-		if($this->type !== Config::JSON){
-			throw new \RuntimeException("Attempt to get JSON options for non-JSON config");
-		}
-		return $this->jsonOptions;
-	}
-
-	/**
-	 * @param string $k
-	 *
-	 * @return bool|mixed
-	 */
-	public function __get($k){
-		return $this->get($k);
-	}
-
-	/**
-	 * @param string $k
-	 * @param mixed  $v
-	 */
-	public function __set($k, $v) : void{
-		$this->set($k, $v);
-	}
-
-	/**
-	 * @param string $k
-	 *
-	 * @return bool
-	 */
-	public function __isset($k){
-		return $this->exists($k);
-	}
-
-	/**
-	 * @param string $k
-	 */
-	public function __unset($k){
-		$this->remove($k);
-	}
-
-	/**
+	 * @param array<string, mixed> &$array
 	 * @param string $key
 	 * @param mixed  $value
 	 */
-	public function setNested($key, $value) : void{
+	public static function setNested(array &$array, string $key, $value) : void{
 		$vars = explode(".", $key);
-		$base = array_shift($vars);
-
-		if(!isset($this->config[$base])){
-			$this->config[$base] = [];
-		}
-
-		$base =& $this->config[$base];
 
 		while(count($vars) > 0){
 			$baseKey = array_shift($vars);
-			if(!isset($base[$baseKey])){
-				$base[$baseKey] = [];
+			if(!isset($array[$baseKey])){
+				$array[$baseKey] = [];
 			}
-			$base =& $base[$baseKey];
+			$array =& $array[$baseKey];
 		}
 
-		$base = $value;
-		$this->nestedCache = [];
-		$this->changed = true;
+		$array = $value;
 	}
 
 	/**
-	 * @param string $key
-	 * @param mixed  $default
+	 * Gets the element in $array as specified by the dot-delimited $path.
 	 *
+	 * @param array<string, mixed> $array
+	 * @param string $key
+	 * @param mixed $default
 	 * @return mixed
 	 */
-	public function getNested($key, $default = null){
-		if(isset($this->nestedCache[$key])){
-			return $this->nestedCache[$key];
-		}
-
+	public static function getNested(array $array, string $key, $default = null){
 		$vars = explode(".", $key);
-		$base = array_shift($vars);
-		if(isset($this->config[$base])){
-			$base = $this->config[$base];
-		}else{
-			return $default;
-		}
+		$baseKey = array_shift($vars);
 
 		while(count($vars) > 0){
 			$baseKey = array_shift($vars);
-			if(is_array($base) and isset($base[$baseKey])){
-				$base = $base[$baseKey];
+			if(isset($array[$baseKey])){
+				$array = $array[$baseKey];
 			}else{
 				return $default;
 			}
 		}
 
-		return $this->nestedCache[$key] = $base;
+		return $array;
 	}
 
-	public function removeNested(string $key) : void{
-		$this->nestedCache = [];
-		$this->changed = true;
-
+	/**
+	 * Removes the element in $array as specified by the dot-delimited $path.
+	 *
+	 * This method only removes the item at $path,
+	 * but not the parent of $path even if it is an empty array.
+	 *
+	 * @param array<string, mixed> &$array
+	 * @param string $key
+	 */
+	public static function removeNested(array &$array, string $key) : void{
 		$vars = explode(".", $key);
 
-		$currentNode =& $this->config;
 		while(count($vars) > 0){
 			$nodeName = array_shift($vars);
-			if(isset($currentNode[$nodeName])){
+			if(isset($array[$nodeName])){
 				if(count($vars) === 0){ //final node
-					unset($currentNode[$nodeName]);
+					unset($array[$nodeName]);
 				}elseif(is_array($currentNode[$nodeName])){
 					$currentNode =& $currentNode[$nodeName];
 				}
@@ -413,122 +142,17 @@ class Config{
 	}
 
 	/**
-	 * @param string $k
-	 * @param mixed  $default
+	 * Serializes an array with the server.properties format.
 	 *
-	 * @return bool|mixed
+	 * @param (string|bool|string[])[] $map
+	 * @param bool $withHeader whether to emit the header lines containing the current timestamp.
 	 */
-	public function get($k, $default = false){
-		return $this->config[$k] ?? $default;
-	}
-
-	/**
-	 * @param string $k key to be set
-	 * @param mixed  $v value to set key
-	 */
-	public function set($k, $v = true) : void{
-		$this->config[$k] = $v;
-		$this->changed = true;
-		foreach($this->nestedCache as $nestedKey => $nvalue){
-			if(substr($nestedKey, 0, strlen($k) + 1) === ($k . ".")){
-				unset($this->nestedCache[$nestedKey]);
-			}
+	public static function writeProperties(array $map, bool $withHeader = false) : string{
+		$content = "";
+		if($withheader){
+			$content .= "#Properties Config file\r\n#" . date("D M j H:i:s T Y") . "\r\n";
 		}
-	}
-
-	/**
-	 * @param mixed[] $v
-	 * @phpstan-param array<string, mixed> $v
-	 */
-	public function setAll(array $v) : void{
-		$this->config = $v;
-		$this->changed = true;
-	}
-
-	/**
-	 * @param string $k
-	 * @param bool   $lowercase If set, searches Config in single-case / lowercase.
-	 */
-	public function exists($k, bool $lowercase = false) : bool{
-		if($lowercase){
-			$k = strtolower($k); //Convert requested  key to lower
-			$array = array_change_key_case($this->config, CASE_LOWER); //Change all keys in array to lower
-			return isset($array[$k]); //Find $k in modified array
-		}else{
-			return isset($this->config[$k]);
-		}
-	}
-
-	/**
-	 * @param string $k
-	 */
-	public function remove($k) : void{
-		unset($this->config[$k]);
-		$this->changed = true;
-	}
-
-	/**
-	 * @return mixed[]
-	 * @phpstan-return list<string>|array<string, mixed>
-	 */
-	public function getAll(bool $keys = false) : array{
-		return ($keys ? array_keys($this->config) : $this->config);
-	}
-
-	/**
-	 * @param mixed[] $defaults
-	 * @phpstan-param array<string, mixed> $defaults
-	 */
-	public function setDefaults(array $defaults) : void{
-		$this->fillDefaults($defaults, $this->config);
-	}
-
-	/**
-	 * @param mixed[] $default
-	 * @param mixed[] $data reference parameter
-	 * @phpstan-param array<string, mixed> $default
-	 * @phpstan-param array<string, mixed> $data
-	 */
-	private function fillDefaults(array $default, &$data) : int{
-		$changed = 0;
-		foreach($default as $k => $v){
-			if(is_array($v)){
-				if(!isset($data[$k]) or !is_array($data[$k])){
-					$data[$k] = [];
-				}
-				$changed += $this->fillDefaults($v, $data[$k]);
-			}elseif(!isset($data[$k])){
-				$data[$k] = $v;
-				++$changed;
-			}
-		}
-
-		if($changed > 0){
-			$this->changed = true;
-		}
-
-		return $changed;
-	}
-
-	/**
-	 * @return true[]
-	 * @phpstan-return array<string, true>
-	 */
-	private static function parseList(string $content) : array{
-		$result = [];
-		foreach(explode("\n", trim(str_replace("\r\n", "\n", $content))) as $v){
-			$v = trim($v);
-			if($v == ""){
-				continue;
-			}
-			$result[$v] = true;
-		}
-		return $result;
-	}
-
-	private function writeProperties() : string{
-		$content = "#Properties Config file\r\n#" . date("D M j H:i:s T Y") . "\r\n";
-		foreach($this->config as $k => $v){
+		foreach($map as $k => $v){
 			if(is_bool($v)){
 				$v = $v ? "on" : "off";
 			}elseif(is_array($v)){
@@ -541,9 +165,13 @@ class Config{
 	}
 
 	/**
-	 * @return mixed[]
+	 * @param string $content
+	 * @param string[] &$repetitions
+	 *
+	 * @return string[]
+	 * @phpstan-return array<string, string>
 	 */
-	private function parseProperties(string $content) : array{
+	public static function parseProperties(string $content, &$repetitions = []) : array{
 		$result = [];
 		if(preg_match_all('/^\s*([a-zA-Z0-9\-_\.]+)[ \t]*=([^\r\n]*)/um', $content, $matches) > 0){ //false or 0 matches
 			foreach($matches[1] as $i => $k){
@@ -561,7 +189,7 @@ class Config{
 						break;
 				}
 				if(isset($result[$k])){
-					\GlobalLogger::get()->debug("[Config] Repeated property " . $k . " on file " . $this->file);
+					$repetitions[] = $k;
 				}
 				$result[$k] = $v;
 			}


### PR DESCRIPTION
## Introduction
Implements #3766. Please refer to the discussion in that issue.

## Changes
### API changes
Removed most methods in Config class.

Only `fixYAMLIndexes`, `setNested`, `getNested`, `removeNested`, `writeProperties` and `parseProperties` remain.
All of them have been changed to static functions.

## Backwards compatibility
See discussion in #3766.

## Tests
N/A