### PR TITLE
Provide a default for health

### DIFF
--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -106,7 +106,7 @@ abstract class Living extends Entity implements Damageable{
 			$health = $this->namedtag->getShort("Health");
 			$this->namedtag->removeTag("Health");
 		}else{
-			$health = $this->namedtag->getFloat("Health");
+			$health = $this->namedtag->getFloat("Health", $this->getMaxHealth());
 		}
 
 		$this->setHealth($health);


### PR DESCRIPTION
## Introduction
When a new player would join without this, after commit https://github.com/pmmp/PocketMine-MP/commit/09eb904f6b818756e59325bf71ea72e2e3a12a2b, they would be kicked because there was no default provided for Health.

## Tests
There isn't much to say about this other than I tried to join after resetting my player data, and it worked fine.