### PR TITLE
Introduce PlayerDisplayNameChangeEvent

### DIFF
--- a/src/event/player/PlayerDisplayNameChangeEvent.php
+++ b/src/event/player/PlayerDisplayNameChangeEvent.php
@@ -45,8 +45,4 @@ class PlayerDisplayNameChangeEvent extends PlayerEvent{
 	public function getNewName() : string{
 		return $this->newName;
 	}
-
-	public function setNewName(string $newName) : void{
-		$this->newName = $newName;
-	}
 }

--- a/src/event/player/PlayerDisplayNameChangeEvent.php
+++ b/src/event/player/PlayerDisplayNameChangeEvent.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\event\player;
+
+use pocketmine\player\Player;
+
+class PlayerDisplayNameChangeEvent extends PlayerEvent{
+
+	/** @var string */
+	private $oldName;
+	/** @var string */
+	private $newName;
+
+	public function __construct(Player $player, string $oldName, string $newName){
+		$this->player = $player;
+		$this->oldName = $oldName;
+		$this->newName = $newName;
+	}
+
+	public function getOldName() : string{
+		return $this->oldName;
+	}
+
+	public function getNewName() : string{
+		return $this->newName;
+	}
+
+	public function setNewName(string $newName) : void{
+		$this->newName = $newName;
+	}
+}

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -52,6 +52,7 @@ use pocketmine\event\player\PlayerChangeSkinEvent;
 use pocketmine\event\player\PlayerChatEvent;
 use pocketmine\event\player\PlayerCommandPreprocessEvent;
 use pocketmine\event\player\PlayerDeathEvent;
+use pocketmine\event\player\PlayerDisplayNameChangeEvent;
 use pocketmine\event\player\PlayerExhaustEvent;
 use pocketmine\event\player\PlayerGameModeChangeEvent;
 use pocketmine\event\player\PlayerInteractEvent;
@@ -622,7 +623,10 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 	}
 
 	public function setDisplayName(string $name) : void{
-		$this->displayName = $name;
+		$ev = new PlayerDisplayNameChangeEvent($this, $this->displayName, $name);
+		$ev->call();
+
+		$this->displayName = $ev->getNewName();
 	}
 
 	/**


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This PR aims at providing a way to detect when the display name of a player changes. The display name of the player might be used in variety of places like for setting nicks, in chat, for displaying on scoreboard and the likes. Currently you can't tell if the name was updated or not. 

PM provides the function to change display name so its only fitting for a way to detect name changes as well. Rather than using custom player class to detect name change.
### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
N/A
## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
- Introduced new `PlayerDisplayNameChangeEvent`
- `PlayerDisplayNameChangeEvent->getOldName()`
- `PlayerDisplayNameChangeEvent->getNewName()`
- `PlayerDisplayNameChangeEvent->setNewName()`
- Changes done to `Player::setDisplayName()` to call the event

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
N/A

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
N/A

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
N/A
## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
https://gist.github.com/Ifera/257e1a82f8dc2020e3fe970da92893fb
That gist also has the test result.
