### PR TITLE
Add all entity ids

### DIFF
--- a/src/pocketmine/entity/EntityIds.php
+++ b/src/pocketmine/entity/EntityIds.php
@@ -74,6 +74,7 @@ interface EntityIds{
 	public const AGENT = 56, LEARN_TO_CODE_MASCOT = 56;
 	public const VINDICATOR = 57;
 	public const PHANTOM = 58;
+	public const RAVAGER = 59;
 
 	public const ARMOR_STAND = 61;
 	public const TRIPOD_CAMERA = 62;
@@ -127,4 +128,15 @@ interface EntityIds{
 	public const TROPICALFISH = 111, TROPICAL_FISH = 111;
 	public const COD = 112, FISH = 112;
 	public const PANDA = 113;
+
+	public const VILLAGER_V2 = 115;
+
+	public const WANDERING_TRADER = 118;
+
+	public const FOX = 121;
+	public const BEE = 122;
+	public const PIGLIN = 123;
+	public const HOGLIN = 124;
+	public const STRIDER = 125;
+	public const ZOGLIN = 126;
 }

--- a/src/pocketmine/network/mcpe/protocol/AddActorPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/AddActorPacket.php
@@ -140,7 +140,16 @@ class AddActorPacket extends DataPacket{
 		EntityIds::AGENT => "minecraft:agent",
 		EntityIds::ICE_BOMB => "minecraft:ice_bomb",
 		EntityIds::PHANTOM => "minecraft:phantom",
-		EntityIds::TRIPOD_CAMERA => "minecraft:tripod_camera"
+		EntityIds::TRIPOD_CAMERA => "minecraft:tripod_camera",
+		EntityIds::RAVAGER => "minecraft:ravager",
+		EntityIds::VILLAGER_V2 => "minecraft:villager_v2",
+		EntityIds::FOX => "minecraft:fox",
+		EntityIds::BEE => "minecraft:bee",
+		EntityIds::PIGLIN => "minecraft:piglin",
+		EntityIds::HOGLIN => "minecraft:hoglin",
+		EntityIds::STRIDER => "minecraft:strider",
+		EntityIds::ZOGLIN => "minecraft:zoglin",
+		EntityIds::WANDERING_TRADER => "minecraft:wandering_trader"
 	];
 
 	/** @var int|null */


### PR DESCRIPTION
## Introduction
This pull request aims to add all minecraft entity ids

### Relevant issues
N/A

## Changes
- Added all entity ids to AddActorPacket.php and EntityIds.php

### API changes
N/A

### Behavioural changes
N/A

## Backwards compatibility
Yes

## Follow-up
N/A

Requires translations:
N/A

## Tests

![grafik](https://user-images.githubusercontent.com/47496465/95012464-0d3df980-0639-11eb-8173-aa72f93a8a52.png)
![grafik](https://user-images.githubusercontent.com/47496465/95012496-542bef00-0639-11eb-86b6-367e9adf772f.png)
![grafik](https://user-images.githubusercontent.com/47496465/95012499-5f7f1a80-0639-11eb-8b70-35310736f075.png)



