### PR TITLE
Force xuid to be empty if `xbox-auth = off` in server.properties

### DIFF
--- a/src/network/mcpe/handler/LoginPacketHandler.php
+++ b/src/network/mcpe/handler/LoginPacketHandler.php
@@ -121,7 +121,7 @@ class LoginPacketHandler extends PacketHandler{
 			$uuid,
 			$skin,
 			$clientData->LanguageCode,
-			$extraData->XUID,
+			$this->server->requiresAuthentication() ? $extraData->XUID : "",
 			(array) $clientData
 		);
 		($this->playerInfoConsumer)($playerInfo);


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Some proxy software leaves the XUID in the login packet for reference but PM4 will reject the login because the keychain is not signed by Mojang.  Additionally, there may be some use cases where an invalid xuid is presented by the client when the client isn't authenticated.

This update causes the server to ignore existing xuid information in the login packet, if `xbox-auth` is set to off in server.properties.

### Relevant issues
<!-- List relevant issues here -->

* Fixes #3089 


## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
None

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
PocketMine-MP will now ignore any existing xuid in the login packet if authentication is not required.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
None
## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
None

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
