### PR TITLE
Isolate and always show IP details on install

### DIFF
--- a/src/pocketmine/wizard/SetupWizard.php
+++ b/src/pocketmine/wizard/SetupWizard.php
@@ -92,6 +92,7 @@ class SetupWizard{
 		$config->save();
 
 		if(strtolower($this->getInput($this->lang->get("skip_installer"), "n", "y/N")) === "y"){
+			$this->IPDetails();
 			return true;
 		}
 
@@ -101,6 +102,7 @@ class SetupWizard{
 		$this->generateUserFiles();
 
 		$this->networkFunctions();
+		$this->IPDetails();
 
 		$this->endWizard();
 
@@ -218,7 +220,9 @@ LICENSE;
 		}
 
 		$config->save();
-
+	}
+	
+	private function IPDetails() : void{
 		$this->message($this->lang->get("ip_get"));
 
 		$externalIP = Internet::getIP();

--- a/src/pocketmine/wizard/SetupWizard.php
+++ b/src/pocketmine/wizard/SetupWizard.php
@@ -92,7 +92,7 @@ class SetupWizard{
 		$config->save();
 
 		if(strtolower($this->getInput($this->lang->get("skip_installer"), "n", "y/N")) === "y"){
-			$this->IPDetails();
+			$this->printIpDetails();
 			return true;
 		}
 
@@ -102,7 +102,7 @@ class SetupWizard{
 		$this->generateUserFiles();
 
 		$this->networkFunctions();
-		$this->IPDetails();
+		$this->printIpDetails();
 
 		$this->endWizard();
 
@@ -222,7 +222,7 @@ LICENSE;
 		$config->save();
 	}
 	
-	private function IPDetails() : void{
+	private function printIpDetails() : void{
 		$this->message($this->lang->get("ip_get"));
 
 		$externalIP = Internet::getIP();


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Skipping the installation wizard does not display any IP information in the console. I think it would be more usable if it does.

### Relevant issues
<!-- List relevant issues here -->
N/A

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
1 private function created within the Wizard class.

### Behavioral changes
<!-- Any change in how the server behaves, or its performance? -->
On first startup, the IP information for the server will be displayed in the console.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
N/A

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
Could possibly be replicated on API 4.

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
![image](https://user-images.githubusercontent.com/16521025/95692713-c2eae880-0bf5-11eb-8b81-b6a1356050e1.png)
