### PR TITLE
Introduce new command overload system

### DIFF
--- a/src/command/Command.php
+++ b/src/command/Command.php
@@ -119,7 +119,7 @@ abstract class Command{
 		$offset = 0;
 		$parameters = $overload->getParameters();
 		$argCount = count($parameters);
-		usort($parameters, function (Parameter $a, Parameter $b): int {
+		usort($parameters, function(Parameter $a, Parameter $b) : int{
 			if($a->getLength() === PHP_INT_MAX){
 				return 1;
 			}

--- a/src/command/Command.php
+++ b/src/command/Command.php
@@ -101,7 +101,6 @@ abstract class Command{
 			return false;
 		}
 		foreach($this->overloads as $overload){
-			var_dump($overload->canParse($sender, $args));
 			if($overload->canParse($sender, $args)){
 				$handler = $overload->getCommandHandler();
 				if($handler !== null){

--- a/src/command/Command.php
+++ b/src/command/Command.php
@@ -101,6 +101,7 @@ abstract class Command{
 			return false;
 		}
 		foreach($this->overloads as $overload){
+			var_dump($overload->canParse($sender, $args));
 			if($overload->canParse($sender, $args)){
 				$handler = $overload->getCommandHandler();
 				if($handler !== null){
@@ -139,9 +140,7 @@ abstract class Command{
 			$argument = implode(" ", array_slice($args, $offset, $parameter->getLength()));
 			if($parameter->canParse($sender, $argument)){
 				$result[$parameter->getName()] = $parameter->parse($sender, $argument);
-				if(!$parameter->isOptional){
-					$offset += $parameter->getLength();
-				}
+				$offset += $parameter->getLength();
 			}
 		}
 		return $result;

--- a/src/command/Command.php
+++ b/src/command/Command.php
@@ -175,7 +175,7 @@ abstract class Command{
 	 */
 	public function getOverloads() : array{
 		if(count($this->overloads) === 0){
-			$this->overloads[] = new Overload($this);
+			$this->overloads[] = new Overload();
 		}
 		return $this->overloads;
 	}

--- a/src/command/Command.php
+++ b/src/command/Command.php
@@ -102,7 +102,10 @@ abstract class Command{
 		}
 		foreach($this->overloads as $overload){
 			if($overload->canParse($sender, $args)){
-				$this->onRun($sender, $this->parseArguments($sender, $overload, $args));
+				$handler = $overload->getCommandHandler();
+				if($handler !== null){
+					($handler)($sender, $this->parseArguments($sender, $overload, $args));
+				}
 				return true;
 			}
 		}
@@ -142,13 +145,6 @@ abstract class Command{
 			}
 		}
 		return $result;
-	}
-
-	/**
-	 * @param mixed[] $args An array containing objects or values
-	 */
-	public function onRun(CommandSender $sender, array $args){
-
 	}
 
 	public function getName() : string{

--- a/src/command/Command.php
+++ b/src/command/Command.php
@@ -108,6 +108,11 @@ abstract class Command{
 		return true;
 	}
 
+	/**
+	 * @param string[] $args
+	 *
+	 * @return array<string, mixed>
+	 */
 	public function parseArguments(CommandSender $sender, Overload $overload, array $args) : array{
 		$result = [];
 		$offset = 0;
@@ -128,7 +133,7 @@ abstract class Command{
 	}
 
 	/**
-	 * @param mixed[]       $args An array containing objects or values
+	 * @param mixed[] $args An array containing objects or values
 	 */
 	public function onRun(CommandSender $sender, array $args){
 
@@ -153,7 +158,7 @@ abstract class Command{
 		$this->permission = $permission;
 	}
 
-	public function addOverload(Overload $overload){
+	public function addOverload(Overload $overload) : void{
 		$this->overloads[] = $overload;
 	}
 

--- a/src/command/Command.php
+++ b/src/command/Command.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
  */
 namespace pocketmine\command;
 
+use pocketmine\command\parameter\Parameter;
 use pocketmine\command\utils\CommandException;
 use pocketmine\lang\TranslationContainer;
 use pocketmine\permission\PermissionManager;
@@ -116,7 +117,18 @@ abstract class Command{
 	public function parseArguments(CommandSender $sender, Overload $overload, array $args) : array{
 		$result = [];
 		$offset = 0;
-		foreach($overload->getParameters() as $parameter){
+		$parameters = $overload->getParameters();
+		$argCount = count($parameters);
+		usort($parameters, function (Parameter $a, Parameter $b): int {
+			if($a->getLength() === PHP_INT_MAX){
+				return 1;
+			}
+			return -1;
+		});
+		foreach($parameters as $parameter){
+			if($offset > $argCount){
+				break;
+			}
 			if($parameter->getLength() === PHP_INT_MAX){
 				$result[$parameter->getName()] = implode(" ", array_slice($args, $offset));
 				break;

--- a/src/command/Command.php
+++ b/src/command/Command.php
@@ -138,12 +138,7 @@ abstract class Command{
 			}
 			$argument = implode(" ", array_slice($args, $offset, $parameter->getLength()));
 			if($parameter->canParse($sender, $argument)){
-				try{
-					$parsed = $parameter->parse($sender, $argument);
-				}catch(\Throwable $e){
-					$parsed = $parameter->getDefault();
-				}
-				$result[$parameter->getName()] = $parsed;
+				$result[$parameter->getName()] = $parameter->parse($sender, $argument);
 				if(!$parameter->isOptional){
 					$offset += $parameter->getLength();
 				}

--- a/src/command/Command.php
+++ b/src/command/Command.php
@@ -114,7 +114,7 @@ abstract class Command{
 	 *
 	 * @return array<string, mixed>
 	 */
-	public function parseArguments(CommandSender $sender, Overload $overload, array $args) : array{
+	private function parseArguments(CommandSender $sender, Overload $overload, array $args) : array{
 		$result = [];
 		$offset = 0;
 		$parameters = $overload->getParameters();

--- a/src/command/Command.php
+++ b/src/command/Command.php
@@ -138,7 +138,12 @@ abstract class Command{
 			}
 			$argument = implode(" ", array_slice($args, $offset, $parameter->getLength()));
 			if($parameter->canParse($sender, $argument)){
-				$result[$parameter->getName()] = $parameter->parse($sender, $argument);
+				try{
+					$parsed = $parameter->parse($sender, $argument);
+				}catch(\Throwable $e){
+					$parsed = $parameter->getDefault();
+				}
+				$result[$parameter->getName()] = $parsed;
 				if(!$parameter->isOptional){
 					$offset += $parameter->getLength();
 				}

--- a/src/command/Overload.php
+++ b/src/command/Overload.php
@@ -27,18 +27,22 @@ use pocketmine\command\parameter\defaults\TextParameter;
 use pocketmine\command\parameter\Parameter;
 use pocketmine\command\utils\CommandException;
 use pocketmine\command\utils\InvalidCommandSyntaxException;
+use pocketmine\utils\Utils;
+
 use function count;
 use function implode;
 
 class Overload{
-	/** @var Command */
-	protected $command;
-
+	/** @var \Closure|null */
+	protected $commandHandler = null;
 	/** @var Parameter[] */
 	protected $parameters = [];
 
-	public function __construct(Command $command){
-		$this->command = $command;
+	public function __construct(?\Closure $commandHandler = null){
+		if($commandHandler !== null){
+			Utils::validateCallableSignature(function(CommandSender $sender, array $args){}, $commandHandler);
+		}
+		$this->commandHandler = $commandHandler;
 	}
 
 	public function addParameter(Parameter $parameter) : self{
@@ -52,10 +56,6 @@ class Overload{
 		$parameter->setOverload($this);
 		$this->parameters[] = $parameter;
 		return $this;
-	}
-
-	public function getCommand() : Command{
-		return $this->command;
 	}
 
 	/**
@@ -103,5 +103,17 @@ class Overload{
 			$parsed = true;
 		}
 		return $parsed;
+	}
+
+	public function getCommandHandler() : ?\Closure{
+		return $this->commandHandler;
+	}
+
+	public function setCommandHandler(?\Closure $handler) : self{
+		if($handler !== null){
+			Utils::validateCallableSignature(function(CommandSender $sender, array $args){}, $handler);
+		}
+		$this->commandHandler = $handler;
+		return $this;
 	}
 }

--- a/src/command/Overload.php
+++ b/src/command/Overload.php
@@ -28,7 +28,6 @@ use pocketmine\command\parameter\Parameter;
 use pocketmine\command\utils\CommandException;
 use pocketmine\command\utils\InvalidCommandSyntaxException;
 use pocketmine\utils\Utils;
-
 use function count;
 use function implode;
 

--- a/src/command/Overload.php
+++ b/src/command/Overload.php
@@ -57,6 +57,9 @@ class Overload{
 		return $this->command;
 	}
 
+	/**
+	 * @return Parameter[]
+	 */
 	public function getParameters() : array{
 		if(count($this->parameters) === 0){
 			return [new TextParameter("args", true)]; //Prevents parameters from being sent with empty values

--- a/src/command/Overload.php
+++ b/src/command/Overload.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace pocketmine\command;
 
-use pocketmine\command\parameter\defaults\TextParameter;
 use pocketmine\command\parameter\Parameter;
 use pocketmine\command\utils\CommandException;
 use pocketmine\command\utils\InvalidCommandSyntaxException;
@@ -61,9 +60,6 @@ class Overload{
 	 * @return Parameter[]
 	 */
 	public function getParameters() : array{
-		if(count($this->parameters) === 0){
-			return [new TextParameter("args", true)]; //Prevents parameters from being sent with empty values
-		}
 		$parameters = [];
 		foreach($this->parameters as $position => $parameter){
 			$parameter->prepare();

--- a/src/command/Overload.php
+++ b/src/command/Overload.php
@@ -26,6 +26,8 @@ namespace pocketmine\command;
 use pocketmine\command\parameter\defaults\TextParameter;
 use pocketmine\command\parameter\Parameter;
 use pocketmine\command\utils\CommandException;
+use pocketmine\command\utils\InvalidCommandSyntaxException;
+
 use function array_shift;
 use function count;
 use function implode;
@@ -49,6 +51,7 @@ class Overload{
 				}
 			}
 		}
+		$parameter->setOverload($this);
 		$this->parameters[] = $parameter;
 		return $this;
 	}
@@ -76,7 +79,7 @@ class Overload{
 		$argsCount = count($args);
 
 		if($argsCount < count($this->parameters)){
-			return false;
+			throw new InvalidCommandSyntaxException();
 		}
 		$offset = 0;
 		foreach($this->getParameters() as $parameter){
@@ -85,6 +88,7 @@ class Overload{
 			}
 			$argument = implode(" ", array_slice($args, $offset, $parameter->getLength()));
 			if(!$parameter->canParse($sender, $argument)){
+				$sender->sendMessage($sender->getServer()->getLanguage()->translateString($parameter->getFailMessage()));
 				return false;
 			}
 			if(!$parameter->isOptional){

--- a/src/command/Overload.php
+++ b/src/command/Overload.php
@@ -27,8 +27,6 @@ use pocketmine\command\parameter\defaults\TextParameter;
 use pocketmine\command\parameter\Parameter;
 use pocketmine\command\utils\CommandException;
 use pocketmine\command\utils\InvalidCommandSyntaxException;
-
-use function array_shift;
 use function count;
 use function implode;
 

--- a/src/command/Overload.php
+++ b/src/command/Overload.php
@@ -78,24 +78,30 @@ class Overload{
 	 */
 	public function canParse(CommandSender $sender, array $args) : bool{
 		$argsCount = count($args);
+		$parameterCount = count($this->parameters);
 
-		if($argsCount < count($this->parameters)){
+		if($argsCount < $parameterCount){
 			throw new InvalidCommandSyntaxException();
 		}
 		$offset = 0;
+		$parsed = false;
 		foreach($this->getParameters() as $parameter){
+			if($offset > $parameterCount){
+				break;
+			}
 			if($parameter->getLength() === PHP_INT_MAX){
-				return true;
+				$parsed = true;
+				break;
 			}
 			$argument = implode(" ", array_slice($args, $offset, $parameter->getLength()));
 			if(!$parameter->canParse($sender, $argument)){
-				$sender->sendMessage($sender->getServer()->getLanguage()->translateString($parameter->getFailMessage($sender)));
-				return false;
+				break;
 			}
 			if(!$parameter->isOptional){
 				$offset += $parameter->getLength();
 			}
+			$parsed = true;
 		}
-		return true;
+		return $parsed;
 	}
 }

--- a/src/command/Overload.php
+++ b/src/command/Overload.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\command;
+
+use pocketmine\command\parameter\defaults\TextParameter;
+use pocketmine\command\parameter\Parameter;
+use pocketmine\command\utils\CommandException;
+use function array_shift;
+use function count;
+use function implode;
+
+class Overload{
+	/** @var Command */
+	protected $command;
+
+	/** @var Parameter[] */
+	protected $parameters = [];
+
+	public function __construct(Command $command){
+		$this->command = $command;
+	}
+
+	public function addParameter(Parameter $parameter) : self{
+		if(count($this->parameters) !== 0){
+			foreach($this->parameters as $oldParameter){
+				if($parameter->getName() === $oldParameter->getName()){
+					throw new CommandException("Cannot register multiple parameters with the same name");
+				}
+			}
+		}
+		$this->parameters[] = $parameter;
+		return $this;
+	}
+
+	public function getCommand() : Command{
+		return $this->command;
+	}
+
+	public function getParameters() : array{
+		if(count($this->parameters) === 0){
+			return [new TextParameter("args", true)]; //Prevents parameters from being sent with empty values
+		}
+		$parameters = [];
+		foreach($this->parameters as $position => $parameter){
+			$parameter->prepare();
+			$parameters[] = $parameter;
+		}
+		return $parameters;
+	}
+
+	public function canParse(CommandSender $sender, array $args) : bool{
+		$argsCount = count($args);
+
+		if($argsCount < count($this->parameters)){
+			return false;
+		}
+		$offset = 0;
+		foreach($this->getParameters() as $parameter){
+			if($parameter->getLength() === PHP_INT_MAX){
+				return true;
+			}
+			$argument = implode(" ", array_slice($args, $offset, $parameter->getLength()));
+			if(!$parameter->canParse($sender, $argument)){
+				return false;
+			}
+			if(!$parameter->isOptional){
+				$offset += $parameter->getLength();
+			}
+		}
+		return true;
+	}
+
+	public function parse(CommandSender $sender, array $args) : array{
+		$results = [];
+		foreach($this->parameters as $parameter){
+			$results[$parameter->getName()] = $parameter->parse($sender, ($parameter instanceof TextParameter ? implode(" ", $args) : array_shift($args)));
+		}
+		return $results;
+	}
+}

--- a/src/command/Overload.php
+++ b/src/command/Overload.php
@@ -38,7 +38,7 @@ class Overload{
 
 	public function __construct(?\Closure $commandHandler = null){
 		if($commandHandler !== null){
-			Utils::validateCallableSignature(function(CommandSender $sender, array $args){}, $commandHandler);
+			Utils::validateCallableSignature(function(CommandSender $sender, array $args) : void{}, $commandHandler);
 		}
 		$this->commandHandler = $commandHandler;
 	}
@@ -106,7 +106,7 @@ class Overload{
 
 	public function setCommandHandler(?\Closure $handler) : self{
 		if($handler !== null){
-			Utils::validateCallableSignature(function(CommandSender $sender, array $args){}, $handler);
+			Utils::validateCallableSignature(function(CommandSender $sender, array $args) : void{}, $handler);
 		}
 		$this->commandHandler = $handler;
 		return $this;

--- a/src/command/Overload.php
+++ b/src/command/Overload.php
@@ -75,6 +75,9 @@ class Overload{
 		return $parameters;
 	}
 
+	/**
+	 * @param string[] $args
+	 */
 	public function canParse(CommandSender $sender, array $args) : bool{
 		$argsCount = count($args);
 
@@ -88,7 +91,7 @@ class Overload{
 			}
 			$argument = implode(" ", array_slice($args, $offset, $parameter->getLength()));
 			if(!$parameter->canParse($sender, $argument)){
-				$sender->sendMessage($sender->getServer()->getLanguage()->translateString($parameter->getFailMessage()));
+				$sender->sendMessage($sender->getServer()->getLanguage()->translateString($parameter->getFailMessage($sender)));
 				return false;
 			}
 			if(!$parameter->isOptional){
@@ -96,13 +99,5 @@ class Overload{
 			}
 		}
 		return true;
-	}
-
-	public function parse(CommandSender $sender, array $args) : array{
-		$results = [];
-		foreach($this->parameters as $parameter){
-			$results[$parameter->getName()] = $parameter->parse($sender, ($parameter instanceof TextParameter ? implode(" ", $args) : array_shift($args)));
-		}
-		return $results;
 	}
 }

--- a/src/command/parameter/Parameter.php
+++ b/src/command/parameter/Parameter.php
@@ -51,7 +51,7 @@ abstract class Parameter extends CommandParameter{
 	 * Returns whether parsing is possible
 	 */
 	public function canParse(CommandSender $sender, string $argument) : bool{
-		return $this->parse($sender, $argument) !== null || $this->isOptional;
+		return $this->parse($sender, $argument) !== null;
 	}
 
 	/**
@@ -109,7 +109,5 @@ abstract class Parameter extends CommandParameter{
 	/**
 	 * @return mixed
 	 */
-	public function getDefault(){
-		return null;
-	}
+	abstract public function getDefault();
 }

--- a/src/command/parameter/Parameter.php
+++ b/src/command/parameter/Parameter.php
@@ -105,9 +105,4 @@ abstract class Parameter extends CommandParameter{
 		$this->overload = $overload;
 		return $this;
 	}
-
-	/**
-	 * @return mixed
-	 */
-	abstract public function getDefault();
 }

--- a/src/command/parameter/Parameter.php
+++ b/src/command/parameter/Parameter.php
@@ -25,6 +25,7 @@ namespace pocketmine\command\parameter;
 
 use pocketmine\command\CommandSender;
 use pocketmine\command\Overload;
+use pocketmine\lang\Language;
 use pocketmine\network\mcpe\protocol\AvailableCommandsPacket;
 use pocketmine\network\mcpe\protocol\types\command\CommandEnum;
 use pocketmine\network\mcpe\protocol\types\command\CommandParameter;
@@ -76,8 +77,8 @@ abstract class Parameter extends CommandParameter{
 	/**
 	 * Returns the translation of fail message
 	 */
-	public function getFailMessage() : string{
-		return "%commands.generic.usage";
+	public function getFailMessage(Language $language) : string{
+		return $language->translateString("%commands.generic.usage");
 	}
 
 	public function getEnum() : ?CommandEnum{

--- a/src/command/parameter/Parameter.php
+++ b/src/command/parameter/Parameter.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace pocketmine\command\parameter;
 
 use pocketmine\command\CommandSender;
+use pocketmine\command\Overload;
 use pocketmine\network\mcpe\protocol\AvailableCommandsPacket;
 use pocketmine\network\mcpe\protocol\types\command\CommandEnum;
 use pocketmine\network\mcpe\protocol\types\command\CommandParameter;
@@ -31,6 +32,9 @@ use pocketmine\network\mcpe\protocol\types\command\CommandParameter;
 abstract class Parameter extends CommandParameter{
 	/** @var int the length of parameter */
 	protected $length = 1;
+
+	/** @var Overload */
+	protected $overload;
 
 	public function __construct(string $name, bool $optional = false){
 		$this->paramName = $name;
@@ -69,6 +73,13 @@ abstract class Parameter extends CommandParameter{
 	 */
 	abstract public function getTargetName() : string;
 
+	/**
+	 * Returns the translation of fail message
+	 */
+	public function getFailMessage(CommandSender $sender) : string{
+		return $sender->getServer()->getLanguage()->translateString("%commands.generic.usage", [$this->getOverload()->getCommand()->getUsage()]);
+	}
+
 	public function setEnum(?CommandEnum $enum) : self{
 		$this->enum = $enum;
 		return $this;
@@ -97,5 +108,14 @@ abstract class Parameter extends CommandParameter{
 
 	public function getLength() : int{
 		return $this->length;
+	}
+
+	public function getOverload() : Overload{
+		return $this->overload;
+	}
+
+	public function setOverload(Overload $overload) : self{
+		$this->overload = $overload;
+		return $this;
 	}
 }

--- a/src/command/parameter/Parameter.php
+++ b/src/command/parameter/Parameter.php
@@ -84,15 +84,6 @@ abstract class Parameter extends CommandParameter{
 		return $this->enum;
 	}
 
-	public function setPostfix(?string $postfix) : Parameter{
-		$this->postfix = $postfix;
-		return $this;
-	}
-
-	public function getPostfix() : ?string{
-		return $this->postfix;
-	}
-
 	public function prepare() : void{
 	}
 

--- a/src/command/parameter/Parameter.php
+++ b/src/command/parameter/Parameter.php
@@ -88,11 +88,6 @@ abstract class Parameter extends CommandParameter{
 	public function prepare() : void{
 	}
 
-	public function setLength(int $length) : self{
-		$this->length = $length;
-		return $this;
-	}
-
 	public function getLength() : int{
 		return $this->length;
 	}

--- a/src/command/parameter/Parameter.php
+++ b/src/command/parameter/Parameter.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\command\parameter;
+
+use pocketmine\command\CommandSender;
+use pocketmine\network\mcpe\protocol\AvailableCommandsPacket;
+use pocketmine\network\mcpe\protocol\types\command\CommandEnum;
+use pocketmine\network\mcpe\protocol\types\command\CommandParameter;
+
+abstract class Parameter extends CommandParameter{
+	/** @var int the length of parameter */
+	protected $length = 1;
+
+	public function __construct(string $name, bool $optional = false){
+		$this->paramName = $name;
+		$this->isOptional = $optional;
+		$this->paramType = AvailableCommandsPacket::ARG_FLAG_VALID | $this->getNetworkType();
+	}
+
+	public function getName() : string{
+		return $this->paramName;
+	}
+
+	/**
+	 * Returns whether parsing is possible
+	 */
+	public function canParse(CommandSender $sender, string $argument) : bool{
+		return $this->parse($sender, $argument) !== null;
+	}
+
+	/**
+	 * Returns the parsed value.
+	 *
+	 * @param CommandSender $sender
+	 * @param string        $argument
+	 *
+	 * @return mixed
+	 */
+	abstract public function parse(CommandSender $sender, string $argument);
+
+	/**
+	 * Returns the network type of parameters
+	 */
+	abstract public function getNetworkType() : int;
+
+	/**
+	 * Returns the name of parameter
+	 */
+	abstract public function getTargetName() : string;
+
+	public function setEnum(?CommandEnum $enum) : self{
+		$this->enum = $enum;
+		return $this;
+	}
+
+	public function getEnum() : ?CommandEnum{
+		return $this->enum;
+	}
+
+	public function setPostfix(?string $postfix) : Parameter{
+		$this->postfix = $postfix;
+		return $this;
+	}
+
+	public function getPostfix() : ?string{
+		return $this->postfix;
+	}
+
+	public function prepare() : void{
+	}
+
+	public function setLength(int $length) : self{
+		$this->length = $length;
+		return $this;
+	}
+
+	public function getLength() : int{
+		return $this->length;
+	}
+}

--- a/src/command/parameter/Parameter.php
+++ b/src/command/parameter/Parameter.php
@@ -80,11 +80,6 @@ abstract class Parameter extends CommandParameter{
 		return "%commands.generic.usage";
 	}
 
-	public function setEnum(?CommandEnum $enum) : self{
-		$this->enum = $enum;
-		return $this;
-	}
-
 	public function getEnum() : ?CommandEnum{
 		return $this->enum;
 	}

--- a/src/command/parameter/Parameter.php
+++ b/src/command/parameter/Parameter.php
@@ -51,7 +51,7 @@ abstract class Parameter extends CommandParameter{
 	 * Returns whether parsing is possible
 	 */
 	public function canParse(CommandSender $sender, string $argument) : bool{
-		return $this->parse($sender, $argument) !== null;
+		return $this->parse($sender, $argument) !== null || $this->isOptional;
 	}
 
 	/**
@@ -109,5 +109,7 @@ abstract class Parameter extends CommandParameter{
 	/**
 	 * @return mixed
 	 */
-	abstract public function getDefault();
+	public function getDefault(){
+		return null;
+	}
 }

--- a/src/command/parameter/Parameter.php
+++ b/src/command/parameter/Parameter.php
@@ -76,8 +76,8 @@ abstract class Parameter extends CommandParameter{
 	/**
 	 * Returns the translation of fail message
 	 */
-	public function getFailMessage(CommandSender $sender) : string{
-		return $sender->getServer()->getLanguage()->translateString("%commands.generic.usage", [$this->getOverload()->getCommand()->getUsage()]);
+	public function getFailMessage() : string{
+		return "%commands.generic.usage";
 	}
 
 	public function setEnum(?CommandEnum $enum) : self{

--- a/src/command/parameter/Parameter.php
+++ b/src/command/parameter/Parameter.php
@@ -105,4 +105,9 @@ abstract class Parameter extends CommandParameter{
 		$this->overload = $overload;
 		return $this;
 	}
+
+	/**
+	 * @return mixed
+	 */
+	abstract public function getDefault();
 }

--- a/src/command/parameter/defaults/EnumParameter.php
+++ b/src/command/parameter/defaults/EnumParameter.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\command\parameter\defaults;
+
+use pocketmine\command\CommandSender;
+use pocketmine\command\parameter\Parameter;
+use function mb_strpos;
+use function mb_strtolower;
+
+abstract class EnumParameter extends Parameter{
+	/** @var bool */
+	protected $exact = false;
+
+	/** @var bool */
+	protected $caseSensitive = false;
+
+	public function __construct(string $name, bool $optional = false, bool $exact = false, bool $caseSensitive = false){
+		parent::__construct($name, $optional);
+		$this->exact = $exact;
+		$this->caseSensitive = $caseSensitive;
+	}
+
+	public function setExact(bool $exact) : self{
+		$this->exact = $exact;
+		return $this;
+	}
+
+	public function isExact() : bool{
+		return $this->exact;
+	}
+
+	public function setCaseSensitive(bool $caseSensitive) : self{
+		$this->caseSensitive = $caseSensitive;
+		return $this;
+	}
+
+	public function isCaseSensitive() : bool{
+		return $this->caseSensitive;
+	}
+
+	public function parseSilent(CommandSender $sender, string $argument){
+		if($this->isExact()){
+			foreach($this->enum->getValues() as $name => $value){
+				if(($this->isCaseSensitive() ? $argument : mb_strtolower($argument)) === $value){
+					return $value;
+				}
+			}
+			return null;
+		}
+		foreach($this->enum->getValues() as $name => $value){
+			if(mb_strpos($value, $this->isCaseSensitive() ? $argument : mb_strtolower($argument)) !== false){
+				return $value;
+			}
+		}
+		return null;
+	}
+}

--- a/src/command/parameter/defaults/EnumParameter.php
+++ b/src/command/parameter/defaults/EnumParameter.php
@@ -59,18 +59,23 @@ abstract class EnumParameter extends Parameter{
 		return $this->caseSensitive;
 	}
 
+	/**
+	 * @return mixed
+	 */
 	public function parseSilent(CommandSender $sender, string $argument){
-		if($this->isExact()){
+		if($this->enum !== null){
+			if($this->isExact()){
+				foreach($this->enum->getValues() as $name => $value){
+					if(($this->isCaseSensitive() ? $argument : mb_strtolower($argument)) === $value){
+						return $value;
+					}
+				}
+				return null;
+			}
 			foreach($this->enum->getValues() as $name => $value){
-				if(($this->isCaseSensitive() ? $argument : mb_strtolower($argument)) === $value){
+				if(mb_strpos($value, $this->isCaseSensitive() ? $argument : mb_strtolower($argument)) !== false){
 					return $value;
 				}
-			}
-			return null;
-		}
-		foreach($this->enum->getValues() as $name => $value){
-			if(mb_strpos($value, $this->isCaseSensitive() ? $argument : mb_strtolower($argument)) !== false){
-				return $value;
 			}
 		}
 		return null;

--- a/src/command/parameter/defaults/FloatParameter.php
+++ b/src/command/parameter/defaults/FloatParameter.php
@@ -39,8 +39,4 @@ class FloatParameter extends NumericParameter{
 	public function getTargetName() : string{
 		return "float";
 	}
-
-	public function getDefault(){
-		return -1;
-	}
 }

--- a/src/command/parameter/defaults/FloatParameter.php
+++ b/src/command/parameter/defaults/FloatParameter.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace pocketmine\command\parameter\defaults;
+
+use pocketmine\command\CommandSender;
+use pocketmine\command\parameter\Parameter;
+use pocketmine\network\mcpe\protocol\AvailableCommandsPacket;
+use function is_numeric;
+
+class FloatParameter extends Parameter{
+
+	public function canParse(CommandSender $sender, string $argument) : bool{
+		return is_numeric($argument);
+	}
+
+	public function parse(CommandSender $sender, string $argument){
+		return (float) $argument;
+	}
+
+	public function getNetworkType() : int{
+		return AvailableCommandsPacket::ARG_TYPE_FLOAT;
+	}
+
+	public function getTargetName() : string{
+		return "float";
+	}
+}

--- a/src/command/parameter/defaults/FloatParameter.php
+++ b/src/command/parameter/defaults/FloatParameter.php
@@ -1,5 +1,24 @@
 <?php
 
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
 declare(strict_types=1);
 
 namespace pocketmine\command\parameter\defaults;

--- a/src/command/parameter/defaults/FloatParameter.php
+++ b/src/command/parameter/defaults/FloatParameter.php
@@ -24,15 +24,9 @@ declare(strict_types=1);
 namespace pocketmine\command\parameter\defaults;
 
 use pocketmine\command\CommandSender;
-use pocketmine\command\parameter\Parameter;
 use pocketmine\network\mcpe\protocol\AvailableCommandsPacket;
-use function is_numeric;
 
-class FloatParameter extends Parameter{
-
-	public function canParse(CommandSender $sender, string $argument) : bool{
-		return is_numeric($argument);
-	}
+class FloatParameter extends NumericParameter{
 
 	public function parse(CommandSender $sender, string $argument){
 		return (float) $argument;

--- a/src/command/parameter/defaults/FloatParameter.php
+++ b/src/command/parameter/defaults/FloatParameter.php
@@ -39,4 +39,8 @@ class FloatParameter extends NumericParameter{
 	public function getTargetName() : string{
 		return "float";
 	}
+
+	public function getDefault(){
+		return -1;
+	}
 }

--- a/src/command/parameter/defaults/IntegerParameter.php
+++ b/src/command/parameter/defaults/IntegerParameter.php
@@ -39,4 +39,13 @@ class IntegerParameter extends FloatParameter{
 	public function getTargetName() : string{
 		return "int";
 	}
+
+	public function setPostfix(?string $postfix) : self{
+		$this->postfix = $postfix;
+		return $this;
+	}
+
+	public function getPostfix() : ?string{
+		return $this->postfix;
+	}
 }

--- a/src/command/parameter/defaults/IntegerParameter.php
+++ b/src/command/parameter/defaults/IntegerParameter.php
@@ -48,4 +48,8 @@ class IntegerParameter extends NumericParameter{
 	public function getPostfix() : ?string{
 		return $this->postfix;
 	}
+
+	public function getDefault(){
+		return -1;
+	}
 }

--- a/src/command/parameter/defaults/IntegerParameter.php
+++ b/src/command/parameter/defaults/IntegerParameter.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\command\parameter\defaults;
+
+use pocketmine\command\CommandSender;
+use pocketmine\network\mcpe\protocol\AvailableCommandsPacket;
+
+class IntegerParameter extends FloatParameter{
+
+	public function parse(CommandSender $sender, string $argument){
+		return (int) $argument;
+	}
+
+	public function getNetworkType() : int{
+		return AvailableCommandsPacket::ARG_TYPE_INT;
+	}
+
+	public function getTargetName() : string{
+		return "int";
+	}
+}

--- a/src/command/parameter/defaults/IntegerParameter.php
+++ b/src/command/parameter/defaults/IntegerParameter.php
@@ -48,8 +48,4 @@ class IntegerParameter extends NumericParameter{
 	public function getPostfix() : ?string{
 		return $this->postfix;
 	}
-
-	public function getDefault(){
-		return -1;
-	}
 }

--- a/src/command/parameter/defaults/NumericParameter.php
+++ b/src/command/parameter/defaults/NumericParameter.php
@@ -24,28 +24,12 @@ declare(strict_types=1);
 namespace pocketmine\command\parameter\defaults;
 
 use pocketmine\command\CommandSender;
-use pocketmine\network\mcpe\protocol\AvailableCommandsPacket;
+use pocketmine\command\parameter\Parameter;
+use function is_numeric;
 
-class IntegerParameter extends NumericParameter{
+abstract class NumericParameter extends Parameter{
 
-	public function parse(CommandSender $sender, string $argument){
-		return (int) $argument;
-	}
-
-	public function getNetworkType() : int{
-		return AvailableCommandsPacket::ARG_TYPE_INT;
-	}
-
-	public function getTargetName() : string{
-		return "int";
-	}
-
-	public function setPostfix(?string $postfix) : self{
-		$this->postfix = $postfix;
-		return $this;
-	}
-
-	public function getPostfix() : ?string{
-		return $this->postfix;
+	public function canParse(CommandSender $sender, string $argument) : bool{
+		return is_numeric($argument);
 	}
 }

--- a/src/command/parameter/defaults/NumericParameter.php
+++ b/src/command/parameter/defaults/NumericParameter.php
@@ -30,10 +30,6 @@ use function is_numeric;
 abstract class NumericParameter extends Parameter{
 
 	public function canParse(CommandSender $sender, string $argument) : bool{
-		return is_numeric($argument) || $this->isOptional;
-	}
-
-	public function getDefault(){
-		return -1;
+		return is_numeric($argument);
 	}
 }

--- a/src/command/parameter/defaults/NumericParameter.php
+++ b/src/command/parameter/defaults/NumericParameter.php
@@ -30,6 +30,10 @@ use function is_numeric;
 abstract class NumericParameter extends Parameter{
 
 	public function canParse(CommandSender $sender, string $argument) : bool{
-		return is_numeric($argument);
+		return is_numeric($argument) || $this->isOptional;
+	}
+
+	public function getDefault(){
+		return -1;
 	}
 }

--- a/src/command/parameter/defaults/PlayerParameter.php
+++ b/src/command/parameter/defaults/PlayerParameter.php
@@ -56,7 +56,7 @@ class PlayerParameter extends EnumParameter{
 		if(!parent::canParse($sender, $argument)){
 			return false;
 		}
-		return preg_match("/^([a-zA-Z_] [a-zA-Z_ 0-9]*)$/", $argument) !== false;
+		return preg_match("/^([a-zA-Z_] [a-zA-Z_ 0-9]*)$/", $argument) !== false || $this->isOptional;
 	}
 
 	public function parse(CommandSender $sender, string $argument){

--- a/src/command/parameter/defaults/PlayerParameter.php
+++ b/src/command/parameter/defaults/PlayerParameter.php
@@ -56,7 +56,7 @@ class PlayerParameter extends EnumParameter{
 		if(!parent::canParse($sender, $argument)){
 			return false;
 		}
-		return preg_match("/^([a-zA-Z_] [a-zA-Z_ 0-9]*)$/", $argument) !== false || $this->isOptional;
+		return preg_match("/^([a-zA-Z_] [a-zA-Z_ 0-9]*)$/", $argument) !== false;
 	}
 
 	public function parse(CommandSender $sender, string $argument){

--- a/src/command/parameter/defaults/PlayerParameter.php
+++ b/src/command/parameter/defaults/PlayerParameter.php
@@ -56,7 +56,7 @@ class PlayerParameter extends EnumParameter{
 		if(!parent::canParse($sender, $argument)){
 			return false;
 		}
-		return preg_match("/^([a-zA-Z_] [a-zA-Z_ 0-9]*)$/", $argument) !== false;
+		return Player::isValidUserName($argument);
 	}
 
 	public function parse(CommandSender $sender, string $argument){

--- a/src/command/parameter/defaults/PlayerParameter.php
+++ b/src/command/parameter/defaults/PlayerParameter.php
@@ -78,6 +78,7 @@ class PlayerParameter extends EnumParameter{
 	 * @return IPlayer|null
 	 */
 	public function parseSilent(CommandSender $sender, string $argument){
+		/** @var string|null $value */
 		$value = parent::parseSilent($sender, $argument);
 		if($value !== null){
 			if(!$this->isIncludeOffline()){

--- a/src/command/parameter/defaults/PlayerParameter.php
+++ b/src/command/parameter/defaults/PlayerParameter.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\command\parameter\defaults;
+
+use pocketmine\command\CommandSender;
+use pocketmine\network\mcpe\protocol\AvailableCommandsPacket;
+use pocketmine\network\mcpe\protocol\types\command\CommandEnum;
+use pocketmine\player\IPlayer;
+use pocketmine\player\Player;
+use pocketmine\Server;
+use function array_map;
+use function mb_strpos;
+use function preg_match;
+
+class PlayerParameter extends EnumParameter{
+	/** @var bool */
+	protected $includeOffline = false;
+
+	public function __construct(string $name, bool $optional = false, bool $exact = false, bool $caseSensitive = false, bool $includeOffline = false){
+		parent::__construct($name, $optional, $exact, $caseSensitive);
+		$this->includeOffline = $includeOffline;
+	}
+
+	public function setIncludeOffline(bool $includeOffline) : self{
+		$this->includeOffline = $includeOffline;
+		return $this;
+	}
+
+	public function isIncludeOffline() : bool{
+		return $this->includeOffline;
+	}
+
+	public function canParse(CommandSender $sender, string $argument) : bool{
+		if(!parent::canParse($sender, $argument)){
+			return false;
+		}
+		return preg_match("/^([a-zA-Z_] [a-zA-Z_ 0-9]*)$/", $argument) !== false;
+	}
+
+	public function parse(CommandSender $sender, string $argument){
+		return $this->parseSilent($sender, $argument);
+	}
+
+	public function getNetworkType() : int{
+		return AvailableCommandsPacket::ARG_TYPE_TARGET;
+	}
+
+	public function getTargetName() : string{
+		return "target";
+	}
+
+	/**
+	 * @return IPlayer|null
+	 */
+	public function parseSilent(CommandSender $sender, string $argument){
+		$value = parent::parseSilent($sender, $argument);
+		if($value !== null){
+			if(!$this->isIncludeOffline()){
+				return $sender->getServer()->getPlayer($value);
+			}
+			if($sender->getServer()->hasOfflinePlayerData($value)){
+				return $sender->getServer()->getOfflinePlayer($value);
+			}
+		}
+		return null;
+	}
+
+	public function prepare() : void{
+		$this->setEnum(new CommandEnum("player", array_map(function(Player $player) : string{
+			if(mb_strpos($player->getName(), " ") !== false){
+				return "\"{$player->getName()}\"";
+			}
+			return $player->getName();
+		}, Server::getInstance()->getOnlinePlayers())));
+	}
+}

--- a/src/command/parameter/defaults/PlayerParameter.php
+++ b/src/command/parameter/defaults/PlayerParameter.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace pocketmine\command\parameter\defaults;
 
 use pocketmine\command\CommandSender;
+use pocketmine\lang\Language;
 use pocketmine\network\mcpe\protocol\AvailableCommandsPacket;
 use pocketmine\network\mcpe\protocol\types\command\CommandEnum;
 use pocketmine\player\IPlayer;
@@ -70,8 +71,8 @@ class PlayerParameter extends EnumParameter{
 		return "target";
 	}
 
-	public function getFailMessage(CommandSender $sender) : string{
-		return $sender->getServer()->getLanguage()->translateString("%commands.generic.player.notFound");
+	public function getFailMessage(Language $language) : string{
+		return $language->translateString("%commands.generic.player.notFound");
 	}
 
 	/**
@@ -92,11 +93,11 @@ class PlayerParameter extends EnumParameter{
 	}
 
 	public function prepare() : void{
-		$this->setEnum(new CommandEnum("player", array_map(function(Player $player) : string{
+		$this->enum = new CommandEnum("player", array_map(function(Player $player) : string{
 			if(mb_strpos($player->getName(), " ") !== false){
 				return "\"{$player->getName()}\"";
 			}
 			return $player->getName();
-		}, Server::getInstance()->getOnlinePlayers())));
+		}, Server::getInstance()->getOnlinePlayers()));
 	}
 }

--- a/src/command/parameter/defaults/PlayerParameter.php
+++ b/src/command/parameter/defaults/PlayerParameter.php
@@ -70,6 +70,10 @@ class PlayerParameter extends EnumParameter{
 		return "target";
 	}
 
+	public function getFailMessage(CommandSender $sender) : string{
+		return $sender->getServer()->getLanguage()->translateString("%commands.generic.player.notFound");
+	}
+
 	/**
 	 * @return IPlayer|null
 	 */

--- a/src/command/parameter/defaults/StringParameter.php
+++ b/src/command/parameter/defaults/StringParameter.php
@@ -34,7 +34,7 @@ class StringParameter extends Parameter{
 	}
 
 	public function parse(CommandSender $sender, string $argument){
-		return (string) $argument;
+		return $argument;
 	}
 
 	public function getNetworkType() : int{

--- a/src/command/parameter/defaults/StringParameter.php
+++ b/src/command/parameter/defaults/StringParameter.php
@@ -44,4 +44,8 @@ class StringParameter extends Parameter{
 	public function getTargetName() : string{
 		return "string";
 	}
+
+	public function getDefault(){
+		return "";
+	}
 }

--- a/src/command/parameter/defaults/StringParameter.php
+++ b/src/command/parameter/defaults/StringParameter.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\command\parameter\defaults;
+
+use pocketmine\command\CommandSender;
+use pocketmine\command\parameter\Parameter;
+use pocketmine\network\mcpe\protocol\AvailableCommandsPacket;
+
+class StringParameter extends Parameter{
+
+	public function canParse(CommandSender $sender, string $argument) : bool{
+		return true;
+	}
+
+	public function parse(CommandSender $sender, string $argument){
+		return (string) $argument;
+	}
+
+	public function getNetworkType() : int{
+		return AvailableCommandsPacket::ARG_TYPE_STRING;
+	}
+
+	public function getTargetName() : string{
+		return "string";
+	}
+}

--- a/src/command/parameter/defaults/StringParameter.php
+++ b/src/command/parameter/defaults/StringParameter.php
@@ -44,8 +44,4 @@ class StringParameter extends Parameter{
 	public function getTargetName() : string{
 		return "string";
 	}
-
-	public function getDefault(){
-		return "";
-	}
 }

--- a/src/command/parameter/defaults/TextParameter.php
+++ b/src/command/parameter/defaults/TextParameter.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace pocketmine\command\parameter\defaults;
 
 use pocketmine\network\mcpe\protocol\AvailableCommandsPacket;
-
 use const PHP_INT_MAX;
 
 class TextParameter extends StringParameter{

--- a/src/command/parameter/defaults/TextParameter.php
+++ b/src/command/parameter/defaults/TextParameter.php
@@ -24,13 +24,12 @@ declare(strict_types=1);
 namespace pocketmine\command\parameter\defaults;
 
 use pocketmine\network\mcpe\protocol\AvailableCommandsPacket;
-use const PHP_INT_MAX;
 
 class TextParameter extends StringParameter{
 
 	public function __construct(string $name, bool $optional = false){
 		parent::__construct($name, $optional);
-		$this->setLength(PHP_INT_MAX);
+		$this->length = PHP_INT_MAX;
 	}
 
 	public function getNetworkType() : int{

--- a/src/command/parameter/defaults/TextParameter.php
+++ b/src/command/parameter/defaults/TextParameter.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\command\parameter\defaults;
+
+use pocketmine\network\mcpe\protocol\AvailableCommandsPacket;
+
+use const PHP_INT_MAX;
+
+class TextParameter extends StringParameter{
+
+	public function __construct(string $name, bool $optional = false){
+		parent::__construct($name, $optional);
+		$this->setLength(PHP_INT_MAX);
+	}
+
+	public function getNetworkType() : int{
+		return AvailableCommandsPacket::ARG_TYPE_RAWTEXT;
+	}
+
+	public function getTargetName() : string{
+		return "text";
+	}
+}

--- a/src/command/parameter/defaults/Vector3Parameter.php
+++ b/src/command/parameter/defaults/Vector3Parameter.php
@@ -43,6 +43,9 @@ class Vector3Parameter extends Parameter{
 	}
 
 	public function canParse(CommandSender $sender, string $argument) : bool{
+		if($this->isOptional){
+			return true;
+		}
 		$coordinateArgs = explode(" ", $argument);
 		if(count($coordinateArgs) !== 3){
 			return false;

--- a/src/command/parameter/defaults/Vector3Parameter.php
+++ b/src/command/parameter/defaults/Vector3Parameter.php
@@ -43,9 +43,6 @@ class Vector3Parameter extends Parameter{
 	}
 
 	public function canParse(CommandSender $sender, string $argument) : bool{
-		if($sender->getServer()->getPlayer($argument) !== null){
-			return true;
-		}
 		$coordinateArgs = explode(" ", $argument);
 		if(count($coordinateArgs) !== 3){
 			return false;
@@ -54,10 +51,6 @@ class Vector3Parameter extends Parameter{
 	}
 
 	public function parse(CommandSender $sender, string $argument){
-		$target = $sender->getServer()->getPlayer($argument);
-		if($target !== null){
-			return $target->getPosition()->asVector3();
-		}
 		[$x, $y, $z] = explode(" ", $argument);
 		if($sender instanceof Player){
 			$x = $this->getCoordinates($x);

--- a/src/command/parameter/defaults/Vector3Parameter.php
+++ b/src/command/parameter/defaults/Vector3Parameter.php
@@ -32,14 +32,12 @@ use function count;
 use function explode;
 use function is_numeric;
 use function substr;
-use const PHP_INT_MAX;
-use const PHP_INT_MIN;
 
 class Vector3Parameter extends Parameter{
 
 	public function __construct(string $name, bool $optional = false){
 		parent::__construct($name, $optional);
-		$this->setLength(3);
+		$this->length = 3;
 	}
 
 	public function canParse(CommandSender $sender, string $argument) : bool{

--- a/src/command/parameter/defaults/Vector3Parameter.php
+++ b/src/command/parameter/defaults/Vector3Parameter.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\command\parameter\defaults;
+
+use pocketmine\command\CommandSender;
+use pocketmine\command\parameter\Parameter;
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\AvailableCommandsPacket;
+use pocketmine\player\Player;
+use function count;
+use function explode;
+use function is_numeric;
+use function substr;
+use const PHP_INT_MAX;
+use const PHP_INT_MIN;
+
+class Vector3Parameter extends Parameter{
+
+	public function __construct(string $name, bool $optional = false){
+		parent::__construct($name, $optional);
+		$this->setLength(3);
+	}
+
+	public function canParse(CommandSender $sender, string $argument) : bool{
+		if($sender->getServer()->getPlayer($argument) !== null){
+			return true;
+		}
+		$coordinateArgs = explode(" ", $argument);
+		if(count($coordinateArgs) !== 3){
+			return false;
+		}
+		return true;
+	}
+
+	public function parse(CommandSender $sender, string $argument){
+		$target = $sender->getServer()->getPlayer($argument);
+		if($target !== null){
+			return $target->getPosition()->asVector3();
+		}
+		[$x, $y, $z] = explode(" ", $argument);
+		if($sender instanceof Player){
+			$x = $this->getCoordinates($x);
+			$y = $this->getCoordinates($y);
+			$z = $this->getCoordinates($z);
+			if(is_numeric($x) && is_numeric($y) && is_numeric($z)){
+				return new Vector3((float) $sender->getPosition()->getX() + $x, (float) $sender->getPosition()->getY() + $y, (float) $sender->getPosition()->getZ() + $z);
+			}
+		}
+		if(is_numeric($x) && is_numeric($y) && is_numeric($z)){
+			return new Vector3((float) $x, (float) $y, (float) $z);
+		}
+		return null;
+	}
+
+	private function getCoordinates(string $input) : float{
+		if($input[0] === "~"){
+			$input = substr($input, 1);
+		}
+		$i = (double) $input;
+
+		if($i < PHP_INT_MIN){
+			$i = PHP_INT_MIN;
+		}elseif($i > PHP_INT_MAX){
+			$i = PHP_INT_MAX;
+		}
+
+		return $i;
+	}
+
+	public function getNetworkType() : int{
+		return AvailableCommandsPacket::ARG_TYPE_POSITION;
+	}
+
+	public function getTargetName() : string{
+		return "x y z";
+	}
+}

--- a/src/command/parameter/defaults/Vector3Parameter.php
+++ b/src/command/parameter/defaults/Vector3Parameter.php
@@ -63,9 +63,7 @@ class Vector3Parameter extends Parameter{
 			$x = $this->getCoordinates($x);
 			$y = $this->getCoordinates($y);
 			$z = $this->getCoordinates($z);
-			if(is_numeric($x) && is_numeric($y) && is_numeric($z)){
-				return new Vector3((float) $sender->getPosition()->getX() + $x, (float) $sender->getPosition()->getY() + $y, (float) $sender->getPosition()->getZ() + $z);
-			}
+			return new Vector3((float) $sender->getPosition()->getX() + $x, (float) $sender->getPosition()->getY() + $y, (float) $sender->getPosition()->getZ() + $z);
 		}
 		if(is_numeric($x) && is_numeric($y) && is_numeric($z)){
 			return new Vector3((float) $x, (float) $y, (float) $z);

--- a/src/command/parameter/defaults/Vector3Parameter.php
+++ b/src/command/parameter/defaults/Vector3Parameter.php
@@ -43,9 +43,6 @@ class Vector3Parameter extends Parameter{
 	}
 
 	public function canParse(CommandSender $sender, string $argument) : bool{
-		if($this->isOptional){
-			return true;
-		}
 		$coordinateArgs = explode(" ", $argument);
 		if(count($coordinateArgs) !== 3){
 			return false;

--- a/src/network/mcpe/NetworkSession.php
+++ b/src/network/mcpe/NetworkSession.php
@@ -25,6 +25,7 @@ namespace pocketmine\network\mcpe;
 
 use Ds\Set;
 use Mdanter\Ecc\Crypto\Key\PublicKeyInterface;
+use pocketmine\command\Overload;
 use pocketmine\entity\Attribute;
 use pocketmine\entity\effect\EffectInstance;
 use pocketmine\entity\Entity;
@@ -777,9 +778,9 @@ class NetworkSession{
 				0,
 				0,
 				$aliasObj,
-				[
-					[CommandParameter::standard("args", AvailableCommandsPacket::ARG_TYPE_RAWTEXT, 0, true)]
-				]
+				array_map(function(Overload $overload) : array{
+					return $overload->getParameters();
+				}, $command->getOverloads())
 			);
 
 			$pk->commandData[$command->getName()] = $data;

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -832,6 +832,10 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		if($this->getHealth() <= 0){
 			$this->respawn();
 		}
+
+		foreach($this->server->getOnlinePlayers() as $player){
+			$player->getNetworkSession()->syncAvailableCommands();
+		}
 	}
 
 	protected function orderChunks() : void{
@@ -1972,6 +1976,10 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 			$this->server->broadcastMessage($quitMessage);
 		}
 		$this->save();
+
+		foreach($this->server->getOnlinePlayers() as $player){
+			$player->getNetworkSession()->syncAvailableCommands();
+		}
 
 		$this->spawned = false;
 

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -832,10 +832,6 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		if($this->getHealth() <= 0){
 			$this->respawn();
 		}
-
-		foreach($this->server->getOnlinePlayers() as $player){
-			$player->getNetworkSession()->syncAvailableCommands();
-		}
 	}
 
 	protected function orderChunks() : void{
@@ -1976,10 +1972,6 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 			$this->server->broadcastMessage($quitMessage);
 		}
 		$this->save();
-
-		foreach($this->server->getOnlinePlayers() as $player){
-			$player->getNetworkSession()->syncAvailableCommands();
-		}
 
 		$this->spawned = false;
 


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

This pull request will rewrite some command execution processes and will provide developers with a more accurate and diverse way to execute the commands.

### Relevant issues
<!-- List relevant issues here -->
<!-- -->
There are no relevant issues.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
- The following classes have been added:
  - `Overload`
  - `Parameter`
  - `EnumParameter`
  - `PlayerParameter`
  - `StringParameter`
  - `TextParameter`
  - `Vector3Parameter`
  - `NumericParameter`
  - `FloatParameter`
  - `IntegerParameter`
- The following methods have been added:
  - `Command->addOverload()`
  - `Command->getOverloads()`
  - `Command->parseArguments()`
- The following methods have been changed:
  - `Command->execute()` is no longer abstract

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

There are no behavior changes.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

There are no backwards compatibility issues.

Developers can still override `Command->execute()` and there is no problem with using it.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->

- PHPStan analyze test

```
Note: Using configuration file C:\Users\user\Desktop\MCBE\PocketMine-MP-command-overload\phpstan.neon.dist.
 1282/1282 [============================] 100%

 ------ ---------------------------------------------------------------
  Line   src\command\Overload.php                                      
 ------ ---------------------------------------------------------------
  41     Anonymous function should have native return typehint "void".
  109    Anonymous function should have native return typehint "void".
 ------ ---------------------------------------------------------------

                                                                                                                        
 [ERROR] Found 2 errors
```

- Example plugin

```php
<?php

/**
 * @name TestCommandPlugin
 * @author alvin0319
 * @main alvin0319\TestCommandPlugin\TestCommandPlugin
 * @version 1.0.0
 * @api 4.0.0
 */

declare(strict_types=1);

namespace alvin0319\TestCommandPlugin;

use pocketmine\command\Command;
use pocketmine\command\CommandSender;
use pocketmine\command\Overload;
use pocketmine\command\parameter\defaults\PlayerParameter;
use pocketmine\command\parameter\defaults\Vector3Parameter;
use pocketmine\plugin\PluginBase;

class TestCommandPlugin extends PluginBase{

	protected function onEnable() : void{
		$this->getServer()->getCommandMap()->register("test", new class extends Command{

			public function __construct(){
				parent::__construct("test", "Test command");
				$this->addOverload((new Overload())
					->addParameter((new Vector3Parameter("vector")))
					->setCommandHandler(function(CommandSender $sender, array $args){
						$vector = $args["vector"];

						$sender->sendMessage("Vector: $vector");
					})
				);
				$this->addOverload((new Overload(function(CommandSender $sender, array $args){
					$target = $args["target"]->getName();
					$sender->sendMessage("Target: {$target}");
				}))
					->addParameter(new PlayerParameter("target"))
				);
			}
		});
	}
}
```