### PR TITLE
Handle InvalidArgumentException thrown by VanillaEnchantments::fromString

### DIFF
--- a/src/command/defaults/EnchantCommand.php
+++ b/src/command/defaults/EnchantCommand.php
@@ -69,13 +69,17 @@ class EnchantCommand extends VanillaCommand{
 
 		if(is_numeric($args[1])){
 			$enchantment = VanillaEnchantments::byMcpeId((int) $args[1]);
+			if(!($enchantment instanceof Enchantment)){
+				$sender->sendMessage(new TranslationContainer("commands.enchant.notFound", [$args[1]]));
+				return true;
+			}
 		}else{
-			$enchantment = VanillaEnchantments::fromString($args[1]);
-		}
-
-		if(!($enchantment instanceof Enchantment)){
-			$sender->sendMessage(new TranslationContainer("commands.enchant.notFound", [$args[1]]));
-			return true;
+			try{
+				$enchantment = VanillaEnchantments::fromString($args[1]);
+			}catch(\InvalidArgumentException $e){
+				$sender->sendMessage(new TranslationContainer("commands.enchant.notFound", [$args[1]]));
+				return true;
+			}
 		}
 
 		$level = 1;


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Commit https://github.com/pmmp/PocketMine-MP/commit/a01c086481da988ab3409bc399d82f72ed9134ce causes `/enchant` to throw unhandled `\InvalidArgumentException` when supplied an unregistered string enchantment ID.

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Prior to this patch:
* Run `/enchant steve aqua_affinity 1` (`aqua_affinity` is not a registered enchantment)
* Server throws `Error: No such registry member: pocketmine\item\enchantment\VanillaEnchantments::AQUA_AFFINITY` (https://pastebin.com/raw/UDqLFC2i)

With this patch:
* Run `/enchant steve aqua_affinity 1`
* An error message is displayed in chat
![image](https://user-images.githubusercontent.com/15074389/97060650-72886900-15ad-11eb-9aaa-02ccabc938e2.png)
