### PR TITLE
canAddItem(): consider item max stack size

### DIFF
--- a/src/pocketmine/inventory/BaseInventory.php
+++ b/src/pocketmine/inventory/BaseInventory.php
@@ -252,7 +252,7 @@ abstract class BaseInventory implements Inventory{
 		for($i = 0, $size = $this->getSize(); $i < $size; ++$i){
 			$slot = $this->getItem($i);
 			if($item->equals($slot)){
-				if(($diff = $slot->getMaxStackSize() - $slot->getCount()) > 0){
+				if(($diff = min($slot->getMaxStackSize(), $item->getMaxStackSize()) - $slot->getCount()) > 0){
 					$count -= $diff;
 				}
 			}elseif($slot->isNull()){

--- a/src/pocketmine/inventory/BaseInventory.php
+++ b/src/pocketmine/inventory/BaseInventory.php
@@ -256,7 +256,7 @@ abstract class BaseInventory implements Inventory{
 					$count -= $diff;
 				}
 			}elseif($slot->isNull()){
-				$count -= $this->getMaxStackSize();
+				$count -= min($this->getMaxStackSize(), $item->getMaxStackSize());
 			}
 
 			if($count <= 0){


### PR DESCRIPTION
## Introduction
`Inventory->canAddItem()` returns true regardless of the item's max stack size. This causes unexpected behavior when, for example, 4 swords are being checked if they can be added to an inventory that has less than 4 slots.

### Relevant issues
`N/A`

## Changes
`Inventory->canAddItem() now checks the item's max stack size too`

## Backwards compatibility
`Yes`

## Follow-up
`N/A`

## Tests
I'm not quite sure how I would provide tests for this.