### PR TITLE
Fix sugarcane growing past the top of the world on random tick

### DIFF
--- a/src/block/Sugarcane.php
+++ b/src/block/Sugarcane.php
@@ -99,6 +99,9 @@ class Sugarcane extends Flowable{
 		if(!$this->getSide(Facing::DOWN)->isSameType($this)){
 			if($this->age === 15){
 				for($y = 1; $y < 3; ++$y){
+					if(!$this->pos->getWorld()->isInWorld($this->pos->x, $this->pos->y + $y, $this->pos->z)){
+						break;
+					}
 					$b = $this->pos->getWorld()->getBlockAt($this->pos->x, $this->pos->y + $y, $this->pos->z);
 					if($b->getId() === BlockLegacyIds::AIR){
 						$ev = new BlockGrowEvent($b, VanillaBlocks::SUGARCANE());


### PR DESCRIPTION
## Introduction
Sugarcane blocks were still growing past the top of the world, I think Dylan forgot to add this check to `onRandomTick`.

## Changes
Sugarcane no longer crashes the server, trying to grow past the top of the world.

## Backwards compatibility
`Yes`