### PR TITLE
Match vanilla armor equiping

### DIFF
--- a/src/item/Armor.php
+++ b/src/item/Armor.php
@@ -122,13 +122,25 @@ class Armor extends Durable{
 		return 0;
 	}
 
-	public function onActivate(Player $player, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector) : ItemUseResult{
-		$existing = $player->getArmorInventory()->getItem($this->getArmorSlot());
+	public function fastEquip(Player $player) : ItemUseResult{
+		$armorInventory = $player->getArmorInventory();
+
+		$existing = $armorInventory->getItem($this->getArmorSlot());
+		$armorInventory->setItem($this->getArmorSlot(), $this->pop());
+
 		if(!$existing->isNull()){
-			return ItemUseResult::FAIL();
+			$player->getInventory()->addItem($existing);
 		}
-		$player->getArmorInventory()->setItem($this->getArmorSlot(), $this->pop());
+
 		return ItemUseResult::SUCCESS();
+	}
+
+	public function onClickAir(Player $player, Vector3 $directionVector) : ItemUseResult{
+		return $this->fastEquip($player);
+	}
+
+	public function onActivate(Player $player, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector) : ItemUseResult{
+		return $this->fastEquip($player);
 	}
 
 	protected function deserializeCompoundTag(CompoundTag $tag) : void{


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Since a few MCPE versions ago, fast armor equipping has changed:

- Both clicking air & blocks trigger this behavior. 
- You can replace armor that's already in your armor inventory

### Relevant issues
<!-- List relevant issues here -->
* None

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
None

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
Matches vanilla again

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Nothing has to be changed

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->

Join the server and fast equip an item from your hotbar.
