### PR TITLE
Inventory variables may be null

### DIFF
--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -535,10 +535,7 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 		return min(100, 7 * $this->getXpLevel());
 	}
 
-	/**
-	 * @return PlayerInventory
-	 */
-	public function getInventory(){
+	public function getInventory() : ?PlayerInventory{
 		return $this->inventory;
 	}
 

--- a/src/pocketmine/entity/Living.php
+++ b/src/pocketmine/entity/Living.php
@@ -422,7 +422,7 @@ abstract class Living extends Entity implements Damageable{
 		return $result;
 	}
 
-	public function getArmorInventory() : ArmorInventory{
+	public function getArmorInventory() : ?ArmorInventory{
 		return $this->armorInventory;
 	}
 


### PR DESCRIPTION
## Introduction
I got a `TypeError` when I called `Living::getArmorInventory()` in `PlayerDeathEvent` and using `catch ($e)` is annoying

## Changes
 * `Living::getArmorInventory()`: Made the return type nullable
 * `Human::getInventory()`: Moved type hinting from the document to PHP for type checking, with nullable
 * No need to `try...catch`: With proper type hinting

## Backwards compatibility
Compatible