### PR TITLE
Fixed crash when executing command /version with multiple authors declared in 'author'

### DIFF
--- a/src/pocketmine/plugin/PluginDescription.php
+++ b/src/pocketmine/plugin/PluginDescription.php
@@ -157,9 +157,7 @@ class PluginDescription{
 		$this->authors = [];
 		if(isset($plugin["author"])){
 			if(is_array($authors = $plugin["author"])){
-				foreach($authors as $author){
-					$this->authors[] = $author;
-				}
+				$this->authors = $authors;
 			}else{
 				$this->authors[] = $plugin["author"];
 			}

--- a/src/pocketmine/plugin/PluginDescription.php
+++ b/src/pocketmine/plugin/PluginDescription.php
@@ -157,7 +157,7 @@ class PluginDescription{
 		$this->authors = [];
 		if(isset($plugin["author"])){
 			if(is_array($plugin["author"])){
-				$this->authors = $authors["author"];
+				$this->authors = $plugin["author"];
 			}else{
 				$this->authors[] = $plugin["author"];
 			}

--- a/src/pocketmine/plugin/PluginDescription.php
+++ b/src/pocketmine/plugin/PluginDescription.php
@@ -156,7 +156,13 @@ class PluginDescription{
 		}
 		$this->authors = [];
 		if(isset($plugin["author"])){
-			$this->authors[] = $plugin["author"];
+			if(is_array($authors = $plugin["author"])){
+				foreach($authors as $author){
+					$this->authors[] = $author;
+				}
+			}else{
+				$this->authors[] = $plugin["author"];
+			}
 		}
 		if(isset($plugin["authors"])){
 			foreach($plugin["authors"] as $author){

--- a/src/pocketmine/plugin/PluginDescription.php
+++ b/src/pocketmine/plugin/PluginDescription.php
@@ -156,8 +156,8 @@ class PluginDescription{
 		}
 		$this->authors = [];
 		if(isset($plugin["author"])){
-			if(is_array($authors = $plugin["author"])){
-				$this->authors = $authors;
+			if(is_array($plugin["author"])){
+				$this->authors = $authors["author"];
 			}else{
 				$this->authors[] = $plugin["author"];
 			}


### PR DESCRIPTION
## Introduction
I made this pull request to fix an issue with the /version command.
When providing a plugin with an array value in 'author', it would crash, because the array won't be parsed into `authors` property.

To fix this, I've made a check if its an array, if so, the array gets "parsed" into `authors` property, like said above.

### Relevant issues
- Fixes #3902 

## Changes
### API changes
/

### Behavioural changes
/

## Backwards compatibility
Everything fine with it.

## Follow-up
/

## Tests
The tests with some plugin which have an array-value in author section went successful.
The `plugin.yml` can look like this:
```yaml
name: "TestPlugin"
version: 1.0.0
description: "Just for testing the API..."
author: ["FirstDev", "SecondDev"]
authors: ["Another", "AndAnother"]
api:
  - 3.0.0
main: TestPlugin\TestPlugin
```
Before my fix, the server would crash, now, everything goes well.
The if-case for the grammar with "Author" and "Authors" is still working like before.

You can perform the test also, just run `/version TestPlugin` in the console/ingame.
## Some last words
I hope you are fine with my pull request... please don't worry too much about it, its my first PR for PocketMine itself.

Best Regards.