### PR TITLE
Copy Pasta: Stop player sprint when they attack entities

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2672,7 +2672,8 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 							if(!$this->server->getConfigBool("pvp")){
 								$cancelled = true;
 							}
-						}	
+						}
+
 						$ev = new EntityDamageByEntityEvent($this, $target, EntityDamageEvent::CAUSE_ENTITY_ATTACK, $heldItem->getAttackPoints());
 
 						$meleeEnchantmentDamage = 0;
@@ -2698,7 +2699,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 						$target->attack($ev);
 
 						$this->setSprinting(false);
-						
+
 						if($ev->isCancelled()){
 							if($heldItem instanceof Durable and $this->isSurvival()){
 								$this->inventory->sendContents($this);

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2674,6 +2674,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 							}
 						}
 
+						$this->setSprinting(false);
 						$ev = new EntityDamageByEntityEvent($this, $target, EntityDamageEvent::CAUSE_ENTITY_ATTACK, $heldItem->getAttackPoints());
 
 						$meleeEnchantmentDamage = 0;

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2672,8 +2672,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 							if(!$this->server->getConfigBool("pvp")){
 								$cancelled = true;
 							}
-						}
-						
+						}	
 						$ev = new EntityDamageByEntityEvent($this, $target, EntityDamageEvent::CAUSE_ENTITY_ATTACK, $heldItem->getAttackPoints());
 
 						$meleeEnchantmentDamage = 0;

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2673,8 +2673,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 								$cancelled = true;
 							}
 						}
-
-						$this->setSprinting(false);
+						
 						$ev = new EntityDamageByEntityEvent($this, $target, EntityDamageEvent::CAUSE_ENTITY_ATTACK, $heldItem->getAttackPoints());
 
 						$meleeEnchantmentDamage = 0;
@@ -2699,6 +2698,8 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 						$target->attack($ev);
 
+						$this->setSprinting(false);
+						
 						if($ev->isCancelled()){
 							if($heldItem instanceof Durable and $this->isSurvival()){
 								$this->inventory->sendContents($this);


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This makes attaching more similar to vanilla in that players are forced to stop sprinting when they attack.
Original PR: #3581 

## Changes
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
Players are now forced to stop sprinting when they attack other entities

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
In-game testing shows players now stop sprinting when they attack others.