### PR TITLE
Setup GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Compile PHP
         if: steps.php-build-cache.outputs.cache-hit != 'true'
         run: |
-          sudo apt update && sudo apt install -y re2c libtool
+          sudo apt update && sudo apt install -y re2c libtool libtool-bin
           ./build/php/compile.sh -j8 -f #we don't need additional extensions right now
           export PATH=$(pwd)/bin/php7/bin:$PATH
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,13 +24,13 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "./bin"
-          key: "php-build-${{ hashFiles('./build/php/compile.sh') }}"
+          key: "php-build-generic-${{ hashFiles('./build/php/compile.sh') }}"
 
       - name: Compile PHP
         if: steps.php-build-cache.outputs.cache-hit != 'true'
         run: |
           sudo apt update && sudo apt install -y re2c libtool libtool-bin
-          ./build/php/compile.sh -j8 -f #we don't need additional extensions right now
+          march=x86-64 ./build/php/compile.sh -j8
 
       - name: Prefix PHP to PATH
         run: echo "$(pwd)/bin/php7/bin" >> $GITHUB_PATH

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,43 +11,31 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php-version:
-          - "7.3"
-          - "7.4"
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - name: Setup PHP
-        # You may pin to the exact commit or the version.
-        # uses: shivammathur/setup-php@5efdcae81a18d7690bc4e26697a4a7d3d7c7f1a6
-        uses: shivammathur/setup-php@2.9.0
+      - name: Restore PHP build cache
+        id: php-build-cache
+        uses: actions/cach@v2
         with:
-          # Setup PHP version.
-          php-version: "${{ matrix.php-version }}"
-          # Setup PHP extensions.
-          extensions: mbstring, yaml, :xdebug
-          ini-values: extension=pthreads.so
-          # Setup popular tools globally.
-          tools: composer:v2
+          path: "./bin"
+          key: "php-build-${{ hashFiles('./build/php/compile.sh') }}"
+          restore-keys: "php-build-"
 
-      - name: Install pthreads
+      - name: Compile PHP
+        if: steps.php-build-cache.outputs.cache-hit != 'true'
         run: |
-          git clone https://github.com/pmmp/pthreads.git
-          cd pthreads
-          git checkout b81ab29df58fa0fb239a9d5ca1c2380a0d087feb
-          phpize
-          ./configure
-          make
-          make install
-          cd ..
+          ./build/php/compile.sh -j8 -f #we don't need additional extensions right now
+          export PATH=$(pwd)/bin/php7/bin:$PATH
+
+      - name: Install Composer
+        run: curl -sS https://getcomposer.org/installer | php
 
       - name: Install Composer dependencies
-        run: composer install --prefer-dist --no-interaction
+        run: php composer.phar install --prefer-dist --no-interaction
 
       - name: Run PHPStan
         run: ./vendor/bin/phpstan analyze --no-progress --memory-limit=2G

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,14 @@ jobs:
       - name: Install Composer
         run: curl -sS https://getcomposer.org/installer | php
 
+      - name: Restore Composer package cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.composer/cache/files
+            ~/.composer/cache/vcs
+          key: composer-cache
+
       - name: Install Composer dependencies
         run: php composer.phar install --prefer-dist --no-interaction
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
         uses: shivammathur/setup-php@2.9.0
         with:
           # Setup PHP version.
-          php-version: "${{ php-version }}"
+          php-version: "${{ matrix.php-version }}"
           # Setup PHP extensions.
           extensions: mbstring, yaml, :xdebug
           ini-values: extension=pthreads.so

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Compile PHP
         if: steps.php-build-cache.outputs.cache-hit != 'true'
         run: |
+          sudo apt update && sudo apt install -y re2c libtool
           ./build/php/compile.sh -j8 -f #we don't need additional extensions right now
           export PATH=$(pwd)/bin/php7/bin:$PATH
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
           tools: composer:v2
 
       - name: Install pthreads
-        run: -|
+        run: |
           git clone https://github.com/pmmp/pthreads.git
           cd pthreads
           git checkout b81ab29df58fa0fb239a9d5ca1c2380a0d087feb

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Restore PHP build cache
         id: php-build-cache
-        uses: actions/cach@v2
+        uses: actions/cache@v2
         with:
           path: "./bin"
           key: "php-build-${{ hashFiles('./build/php/compile.sh') }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,14 +25,15 @@ jobs:
         with:
           path: "./bin"
           key: "php-build-${{ hashFiles('./build/php/compile.sh') }}"
-          restore-keys: "php-build-"
 
       - name: Compile PHP
         if: steps.php-build-cache.outputs.cache-hit != 'true'
         run: |
           sudo apt update && sudo apt install -y re2c libtool libtool-bin
           ./build/php/compile.sh -j8 -f #we don't need additional extensions right now
-          export PATH=$(pwd)/bin/php7/bin:$PATH
+
+      - name: Prefix PHP to PATH
+        run: echo "$(pwd)/bin/php7/bin" >> $GITHUB_PATH
 
       - name: Install Composer
         run: curl -sS https://getcomposer.org/installer | php

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version:
+          - "7.3"
+          - "7.4"
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Setup PHP
+        # You may pin to the exact commit or the version.
+        # uses: shivammathur/setup-php@5efdcae81a18d7690bc4e26697a4a7d3d7c7f1a6
+        uses: shivammathur/setup-php@2.9.0
+        with:
+          # Setup PHP version.
+          php-version: "${{ php-version }}"
+          # Setup PHP extensions.
+          extensions: mbstring, yaml, :xdebug
+          ini-values: extension=pthreads.so
+          # Setup popular tools globally.
+          tools: composer:v2
+
+      - name: Install pthreads
+        run: -|
+          git clone https://github.com/pmmp/pthreads.git
+          cd pthreads
+          git checkout b81ab29df58fa0fb239a9d5ca1c2380a0d087feb
+          phpize
+          ./configure
+          make
+          make install
+          cd ..
+
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --no-interaction
+
+      - name: Run PHPStan
+        run: ./vendor/bin/phpstan analyze --no-progress --memory-limit=2G
+      
+      - name: Run PHPUnit tests
+        run: ./vendor/bin/phpunit --bootstrap vendor/autoload.php --fail-on-warning tests/phpunit
+        
+      - name: Run integration tests
+        run: ./tests/travis.sh -t4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+        with:
+          submodules: true
 
       - name: Restore PHP build cache
         id: php-build-cache


### PR DESCRIPTION
Travis CI has given OSS a big middle finger, suspending our builds without any notification at all.

I'd avoided migrating to GH Actions for a while because I knew it was going to be a colossal pain in the ass (like setting up a CI always is), but the time has come whether I like it or not.