### PR TITLE
Fix that a hoe gets damage applied to it, when it's used to break a block

### DIFF
--- a/src/pocketmine/block/BlockToolType.php
+++ b/src/pocketmine/block/BlockToolType.php
@@ -35,5 +35,6 @@ interface BlockToolType{
 	public const TYPE_PICKAXE = 1 << 2;
 	public const TYPE_AXE = 1 << 3;
 	public const TYPE_SHEARS = 1 << 4;
+	public const TYPE_HOE = 1 << 5;
 
 }

--- a/src/pocketmine/block/Sponge.php
+++ b/src/pocketmine/block/Sponge.php
@@ -31,6 +31,10 @@ class Sponge extends Solid{
 		$this->meta = $meta;
 	}
 
+	public function getToolType() : int{
+		return BlockToolType::TYPE_HOE;
+	}
+
 	public function getHardness() : float{
 		return 0.6;
 	}

--- a/src/pocketmine/item/Hoe.php
+++ b/src/pocketmine/item/Hoe.php
@@ -23,11 +23,19 @@ declare(strict_types=1);
 
 namespace pocketmine\item;
 
+use pocketmine\block\Block;
 use pocketmine\entity\Entity;
 
 class Hoe extends TieredTool{
 
 	public function onAttackEntity(Entity $victim) : bool{
 		return $this->applyDamage(1);
+	}
+
+	public function onDestroyBlock(Block $block) : bool{
+		if($block->getHardness() > 0){
+			return $this->applyDamage(1);
+		}
+		return false;
 	}
 }

--- a/src/pocketmine/item/Hoe.php
+++ b/src/pocketmine/item/Hoe.php
@@ -24,9 +24,14 @@ declare(strict_types=1);
 namespace pocketmine\item;
 
 use pocketmine\block\Block;
+use pocketmine\block\BlockToolType;
 use pocketmine\entity\Entity;
 
 class Hoe extends TieredTool{
+
+	public function getBlockToolType() : int{
+		return BlockToolType::TYPE_HOE;
+	}
 
 	public function onAttackEntity(Entity $victim) : bool{
 		return $this->applyDamage(1);


### PR DESCRIPTION
## Introduction
Right now when a hoe is used to break a block, no damage is applied to the hoe. This PR aims to fix that.

### Relevant issues
#3965 

* Damage is added when the hoe is used


## Changes
### API changes
Nope no API changes

### Behavioural changes
Damage is added to a hoe when it is used to break a block. 

## Backwards compatibility
No BC break

## Follow-up
~~* We probably still need to add the hoe tool to the BlockToolType interface. However, I do not know its value. I assume the values are just random bit values. But I am not sure~~ I added the hoe to the BlockToolType interface
* I don't know the correct damage value for the hoe

## Tests
Before the changes:
https://file.mohamedelyousfi.be/taRO5/seMADENI98.mp4
After the changes:
https://file.mohamedelyousfi.be/taRO5/SIYOCUzu30.mp4

The "dura" in chat indicates the damage on the item and not the durability.

This is one of my first PR's, so feedback is appreciated :)
