### PR TITLE
A hook function for plugins to use newly loaded soft dependencies

### DIFF
--- a/src/plugin/Plugin.php
+++ b/src/plugin/Plugin.php
@@ -39,6 +39,13 @@ interface Plugin{
 	public function isEnabled() : bool;
 
 	/**
+	 * Called when a plugin soft dependency is resolved
+	 *
+	 * @return void
+	 */
+	public function onDependencyResolution() : void;
+
+	/**
 	 * Called by the plugin manager when the plugin is enabled or disabled to inform the plugin of its enabled state.
 	 *
 	 * @internal This is intended for core use only and should not be used by plugins

--- a/src/plugin/PluginBase.php
+++ b/src/plugin/PluginBase.php
@@ -117,6 +117,15 @@ abstract class PluginBase implements Plugin, CommandExecutor{
 	}
 
 	/**
+	 * Called when a plugin soft dependency is resolved
+	 *
+	 * @return void
+	 */
+	public function onDependencyResolution() : void {
+
+	}
+
+	/**
 	 * Called when the plugin is disabled
 	 * Use this to free open things and finish actions
 	 *

--- a/src/plugin/PluginManager.php
+++ b/src/plugin/PluginManager.php
@@ -198,6 +198,7 @@ class PluginManager{
 					 */
 					$plugin = new $mainClass($loader, $this->server, $description, $dataFolder, $prefixed, new DiskResourceProvider($prefixed . "/resources/"));
 					$this->plugins[$plugin->getDescription()->getName()] = $plugin;
+					$this->resolveLoadedDependency($plugin);
 
 					return $plugin;
 				}
@@ -385,6 +386,19 @@ class PluginManager{
 		}
 
 		return $loadedPlugins;
+	}
+
+	public function resolveLoadedDependency(Plugin $plugin) : int {
+		$resolved = 0;
+		foreach($this->plugins as $loadedPlugin) {
+			foreach($loadedPlugin->getDescription()->getSoftDepend() as $pluginName) {
+				if($plugin->getName() === $pluginName) {
+					$loadedPlugin->onDependencyResolution();
+					$resolved += 1;
+				}
+			}
+		}
+		return $resolved;
 	}
 
 	public function isPluginEnabled(Plugin $plugin) : bool{


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
PocketMine's existing plugin loading system doesn't inform already loaded plugins if a soft dependency is loaded.
This PR intends to resolve that issue by providing plugin developers with an API method which is called whenever a soft dependency is loaded.
### Relevant issues
<!-- List relevant issues here -->
Issue #2825 can be considered a counterpoint which resolves the issue by removing the root cause entirely

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
A new hook function `onDependencyResolution()` is added to the `Plugin` class for developers to hook into for dependency tracking.
<!--### Behavioral changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
No backwards compatibility changes are made. The new hook function is optional to use.
## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
N/A
## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
```php
<?php
declare(strict_types=1);
/**
 * @name DependHookTest
 * @main jasonwynn10\DependHookTest\Main
 * @version 0.1.0
 * @api 4.0.0
 * @description A test script
 * @author jasonwynn10
 * @load STARTUP
 * @softdepend unloadedPlugin
 */
namespace jasonwynn10\DependHookTest {

	use pocketmine\plugin\PluginBase;

	class Main extends PluginBase {
		public $softDepend = null;
		public function onLoad() : void {
			// will return null because plugin is unloaded
			$this->softDepend = $this->getServer()->getPluginManager()->getPlugin("unloadedPlugin");
			if($this->softDepend !== null) {
				// enable economy features idk
			}
		}
		public function onDependencyResolution() : void {
			// will return plugin instance because plugin is now loaded
			$this->softDepend = $this->getServer()->getPluginManager()->getPlugin("unloadedPlugin");
			if($this->softDepend !== null) {
				// enable economy features
			}
		}
	}
}
```