### PR TITLE
Fixed TNT broadcasting ignition sound

### DIFF
--- a/src/block/TNT.php
+++ b/src/block/TNT.php
@@ -100,6 +100,7 @@ class TNT extends Opaque{
 		$tnt = new PrimedTNT(Location::fromObject($this->pos->add(0.5, 0, 0.5), $this->pos->getWorld()));
 		$tnt->setFuse($fuse);
 		$tnt->setMotion(new Vector3(-sin($mot) * 0.02, 0.2, -cos($mot) * 0.02));
+
 		$tnt->spawnToAll();
 		$tnt->broadcastSound(new IgniteSound());
 	}

--- a/src/block/TNT.php
+++ b/src/block/TNT.php
@@ -34,6 +34,7 @@ use pocketmine\item\Item;
 use pocketmine\math\Vector3;
 use pocketmine\player\Player;
 use pocketmine\utils\Random;
+use pocketmine\world\sound\IgniteSound;
 use function cos;
 use function sin;
 use const M_PI;
@@ -99,8 +100,8 @@ class TNT extends Opaque{
 		$tnt = new PrimedTNT(Location::fromObject($this->pos->add(0.5, 0, 0.5), $this->pos->getWorld()));
 		$tnt->setFuse($fuse);
 		$tnt->setMotion(new Vector3(-sin($mot) * 0.02, 0.2, -cos($mot) * 0.02));
-
 		$tnt->spawnToAll();
+		$tnt->broadcastSound(new IgniteSound());
 	}
 
 	public function getFlameEncouragement() : int{

--- a/src/entity/object/PrimedTNT.php
+++ b/src/entity/object/PrimedTNT.php
@@ -35,7 +35,6 @@ use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataFlags;
 use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataProperties;
 use pocketmine\world\Explosion;
 use pocketmine\world\Position;
-use pocketmine\world\sound\IgniteSound;
 
 class PrimedTNT extends Entity implements Explosive{
 

--- a/src/entity/object/PrimedTNT.php
+++ b/src/entity/object/PrimedTNT.php
@@ -73,8 +73,6 @@ class PrimedTNT extends Entity implements Explosive{
 		parent::initEntity($nbt);
 
 		$this->fuse = $nbt->getShort("Fuse", 80);
-
-		$this->broadcastSound(new IgniteSound());
 	}
 
 	public function canCollideWith(Entity $entity) : bool{


### PR DESCRIPTION
## Introduction
This PR fixes the issue of the TNT ignite-sound not being broadcasted by the server correctly.

### Relevant issues
#3952 

## Changes
The broadcast sound method has been moved to the TNT class AFTER the spawnToAll() method has been called. This way the getViewer() method will be used correctly and the sound will be broadcasted to all the viewers, instead of no one.

### Behavioural changes
You can hear the TNT ignite

## Tests
See video
https://user-images.githubusercontent.com/40402787/103944544-1953be80-5134-11eb-88ce-aeb83a48c86a.mp4



