### PR TITLE
InventoryPickupItemEvent: rename getItem() method to getItemEntity()

### DIFF
--- a/src/event/inventory/InventoryPickupItemEvent.php
+++ b/src/event/inventory/InventoryPickupItemEvent.php
@@ -32,14 +32,14 @@ class InventoryPickupItemEvent extends InventoryEvent implements Cancellable{
 	use CancellableTrait;
 
 	/** @var ItemEntity */
-	private $item;
+	private $itemEntity;
 
-	public function __construct(Inventory $inventory, ItemEntity $item){
-		$this->item = $item;
+	public function __construct(Inventory $inventory, ItemEntity $itemEntity){
+		$this->itemEntity = $itemEntity;
 		parent::__construct($inventory);
 	}
 
-	public function getItem() : ItemEntity{
-		return $this->item;
+	public function getItemEntity() : ItemEntity{
+		return $this->itemEntity;
 	}
 }


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

This is pretty much a continuation of b39bbffdc55f40898ec1d0b0cb31eec416b7aa02, where the former class of an item entity was renamed to ItemEntity, which distinguished it from the Item class, the representation of an item within an inventory.

The ambiguity from back then is still evident in the InventoryPickupItemEvent. This example line of code should illustrate why:

`$event->getItem()->getItem()->getName()` (whereas $event is an instance of InventoryPickupItemEvent)

As you can see, getting the name of an item involves the strange chain of two "->getItem()" calls. The first one returns an instance of ItemEntity, while the second call returns an instance of Item.


### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
`InventoryPickupItemEvent->getItem()` renamed to `InventoryPickupItemEvent->getItemEntity()`

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
none

## Backwards compatibility
<!-- Any possible backwards-incompatible changes? How are they solved, or how can they be solved? -->
This is clearly a backwards-incompatible change, hence the pr is targeted at the master branch in order to take effect in the 4.0 release.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
None that I can think of.

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
I am not aware of any relevant tests.