### PR TITLE
Fix deprecated required variable $drops to optional

### DIFF
--- a/src/pocketmine/event/block/BlockBreakEvent.php
+++ b/src/pocketmine/event/block/BlockBreakEvent.php
@@ -48,7 +48,7 @@ class BlockBreakEvent extends BlockEvent implements Cancellable{
 	/**
 	 * @param Item[] $drops
 	 */
-	public function __construct(Player $player, Block $block, Item $item, bool $instaBreak = false, array $drops, int $xpDrops = 0){
+	public function __construct(Player $player, Block $block, Item $item, bool $instaBreak = false, array $drops = [], int $xpDrops = 0){
 		parent::__construct($block);
 		$this->item = $item;
 		$this->player = $player;

--- a/src/pocketmine/network/rcon/RCONInstance.php
+++ b/src/pocketmine/network/rcon/RCONInstance.php
@@ -77,13 +77,13 @@ class RCONInstance extends Thread{
 	 * @param resource             $socket
 	 * @param resource             $ipcSocket
 	 */
-	public function __construct($socket, string $password, ?int $maxClients, \ThreadedLogger $logger, $ipcSocket, ?SleeperNotifier $notifier){
+	public function __construct($socket, string $password, int $maxClients, \ThreadedLogger $logger, $ipcSocket, ?SleeperNotifier $notifier){
 		$this->stop = false;
 		$this->cmd = "";
 		$this->response = "";
 		$this->socket = $socket;
 		$this->password = $password;
-		$this->maxClients = $maxClients ?? 50;
+		$this->maxClients = $maxClients;
 		$this->logger = $logger;
 		$this->ipcSocket = $ipcSocket;
 		$this->notifier = $notifier;

--- a/src/pocketmine/network/rcon/RCONInstance.php
+++ b/src/pocketmine/network/rcon/RCONInstance.php
@@ -77,13 +77,13 @@ class RCONInstance extends Thread{
 	 * @param resource             $socket
 	 * @param resource             $ipcSocket
 	 */
-	public function __construct($socket, string $password, int $maxClients = 50, \ThreadedLogger $logger, $ipcSocket, ?SleeperNotifier $notifier){
+	public function __construct($socket, string $password, ?int $maxClients, \ThreadedLogger $logger, $ipcSocket, ?SleeperNotifier $notifier){
 		$this->stop = false;
 		$this->cmd = "";
 		$this->response = "";
 		$this->socket = $socket;
 		$this->password = $password;
-		$this->maxClients = $maxClients;
+		$this->maxClients = $maxClients ?? 50;
 		$this->logger = $logger;
 		$this->ipcSocket = $ipcSocket;
 		$this->notifier = $notifier;


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Since php 8, the following error occurs on `stable` and `master` branches
```bash
[04:50:30] [Server thread/CRITICAL]: ErrorException: "Required parameter $drops follows optional parameter $instaBreak" (EXCEPTION) in "pmsrc/src/pocketmine/event/block/BlockBreakEvent" at line 51
[04:50:30] [Server thread/CRITICAL]: #0 pmsrc/vendor/composer/ClassLoader(444): pocketmine\utils\Utils::errorExceptionHandler(integer 8192, string[64] Required parameter $drops follows optional parameter $instaBreak, string[105] phar:///home/pmmp/PocketMine-MP.phar/src/pocketmine/event/, integer 51)
[04:50:30] [Server thread/CRITICAL]: #1 pmsrc/vendor/composer/ClassLoader(444): include()
[04:50:30] [Server thread/CRITICAL]: #2 pmsrc/vendor/composer/ClassLoader(322): Composer\Autoload\includeFile(string[127] phar:///home/pmmp/PocketMine-MP.phar/vendor/composer/../..)
[04:50:30] [Server thread/CRITICAL]: #3 (): Composer\Autoload\ClassLoader->loadClass(string[38] pocketmine\event\block\BlockBreakEvent)
[04:50:30] [Server thread/CRITICAL]: #4 pmsrc/src/pocketmine/plugin/PluginManager(712): ReflectionClass->__construct(string[38] pocketmine\event\block\BlockBreakEvent)
[04:50:30] [Server thread/CRITICAL]: #5 plugins/WEdit.phar/src/WEdit/Main(97): pocketmine\plugin\PluginManager->registerEvents(object WEdit\Event, object WEdit\Main)
[04:50:30] [Server thread/CRITICAL]: #6 pmsrc/src/pocketmine/plugin/PluginBase(116): WEdit\Main->onEnable()
[04:50:30] [Server thread/CRITICAL]: #7 pmsrc/src/pocketmine/plugin/PluginManager(552): pocketmine\plugin\PluginBase->setEnabled(boolean 1)
[04:50:30] [Server thread/CRITICAL]: #8 pmsrc/src/pocketmine/Server(1786): pocketmine\plugin\PluginManager->enablePlugin(object WEdit\Main)
[04:50:30] [Server thread/CRITICAL]: #9 pmsrc/src/pocketmine/Server(1772): pocketmine\Server->enablePlugin(object WEdit\Main)
[04:50:30] [Server thread/CRITICAL]: #10 pmsrc/src/pocketmine/Server(1585): pocketmine\Server->enablePlugins(integer 1)
[04:50:30] [Server thread/CRITICAL]: #11 pmsrc/src/pocketmine/PocketMine(286): pocketmine\Server->__construct(object BaseClassLoader, object pocketmine\utils\MainLogger, string[33] /home/pmmp/, string[41] /home/pmmp/plugins/)
[04:50:30] [Server thread/CRITICAL]: #12 pmsrc/src/pocketmine/PocketMine(316): pocketmine\server()
[04:50:30] [Server thread/CRITICAL]: #13 pmsrc(11): require(string[88] phar:///home/pmmp/PocketMine-MP.phar/src/pocketmine/Pocket)
```

https://github.com/pmmp/PocketMine-MP/blob/02ee0f23c040780a4449ea8a75d56fc0a6a66ac2/src/pocketmine/event/block/BlockBreakEvent.php#L51

https://github.com/pmmp/PocketMine-MP/blob/02ee0f23c040780a4449ea8a75d56fc0a6a66ac2/src/pocketmine/network/rcon/RCONInstance.php#L80

See also [php8 migration](https://www.php.net/manual/en/migration80.deprecated.php#migration80.deprecated.core)

### Relevant issues
<!-- List relevant issues here -->
<!--

* 

-->
none

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

* `BlockBreakEvent::__construct()` argument `$drops` is now optional
* `RCONInstance::__construct()` argument `$maxClients` is now required

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
none

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

* BCBreak will not occur because only changing a value that was originally required to optional

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
none

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
The error will no longer be displayed.