### PR TITLE
Fix entity still being lit on fire on cancelled projectile damage event

### DIFF
--- a/src/pocketmine/entity/projectile/Projectile.php
+++ b/src/pocketmine/entity/projectile/Projectile.php
@@ -302,11 +302,16 @@ abstract class Projectile extends Entity{
 
 			$entityHit->attack($ev);
 
-			if(!$ev->isCancelled() and $this->isOnFire()){
-				$ev = new EntityCombustByEntityEvent($this, $entityHit, 5);
-				$ev->call();
-				if(!$ev->isCancelled()){
-					$entityHit->setOnFire($ev->getDuration());
+			if($this->isOnFire()){
+				$ev2 = new EntityCombustByEntityEvent($this, $entityHit, 5);
+				
+				if($ev->isCancelled()) {
+					$ev2->setCancelled();
+				}
+				
+				$ev2->call();
+				if(!$ev2->isCancelled()){
+					$entityHit->setOnFire($ev2->getDuration());
 				}
 			}
 		}

--- a/src/pocketmine/entity/projectile/Projectile.php
+++ b/src/pocketmine/entity/projectile/Projectile.php
@@ -302,7 +302,7 @@ abstract class Projectile extends Entity{
 
 			$entityHit->attack($ev);
 
-			if($this->isOnFire()){
+			if(!$ev->isCancelled() and $this->isOnFire()){
 				$ev = new EntityCombustByEntityEvent($this, $entityHit, 5);
 				$ev->call();
 				if(!$ev->isCancelled()){


### PR DESCRIPTION
## Introduction
This change simply makes it so that if a projectile induced entity damage event was cancelled, its victim would not be set on fire if the projectile was burning, which is the most logical and expected outcome.

The pull request also considers a situation where a plugin developer may want to allow setting the damaged entity on fire, without inducing projectile damage and knockback directly.

This is necessary if one were to implement Endermen entities to prevent setting them on fire once the event is cancelled as Endermen teleport away once hit by an arrow, and do not take any arrow damage while still being able to be set on fire by other means without using a separate external event listener for `EntityCombustByEntityEvent`.

The issue is also noticeable on most PocketMine-MP third party servers that uses spawn protection plugins. Shooting a flaming arrow to a spawn protected player will still set them on fire prior to this change unless the next `EntityCombustByEntityEvent` is cancelled.

### Relevant issues
None

## Changes
### API changes
None

### Behavioural changes
`EntityCombustByEntityEvent` will be cancelled prior the call if the `EntityDamageEvent` preceding it was cancelled.

Therefore, the damaged entity is no longer set on fire from a burning projectile if the entity damage event was cancelled.

## Backwards compatibility
No BC-breaking changes

## Follow-up
None

## Tests
Shooting an entity with a flaming arrow, then cancelling the damage event via external plugins:
```php
public function onProjectileDamage(EntityDamageByChildEntityEvent $ev) : void {
	$ev->setCancelled();
}
```

Expected result: The entity should not be lit on fire, as the damage event was cancelled.

Current result (without this change): The entity will still be set on fire regardless if the event was cancelled.
