### PR TITLE
Update argument type constants

### DIFF
--- a/src/pocketmine/network/mcpe/protocol/AvailableCommandsPacket.php
+++ b/src/pocketmine/network/mcpe/protocol/AvailableCommandsPacket.php
@@ -49,25 +49,26 @@ class AvailableCommandsPacket extends DataPacket{
 	 * ARG_FLAG_VALID | (type const)
 	 */
 	public const ARG_TYPE_INT             = 0x01;
-	public const ARG_TYPE_FLOAT           = 0x02;
-	public const ARG_TYPE_VALUE           = 0x03;
-	public const ARG_TYPE_WILDCARD_INT    = 0x04;
-	public const ARG_TYPE_OPERATOR        = 0x05;
-	public const ARG_TYPE_TARGET          = 0x06;
+	public const ARG_TYPE_FLOAT           = 0x03;
+	public const ARG_TYPE_VALUE           = 0x04;
+	public const ARG_TYPE_WILDCARD_INT    = 0x05;
+	public const ARG_TYPE_OPERATOR        = 0x06;
+	public const ARG_TYPE_TARGET          = 0x07;
+	public const ARG_TYPE_WILDCARD_TARGET = 0x08;
 
-	public const ARG_TYPE_FILEPATH = 0x0e;
+	public const ARG_TYPE_FILEPATH = 0x10;
 
-	public const ARG_TYPE_STRING   = 0x1d;
+	public const ARG_TYPE_STRING   = 0x20;
 
-	public const ARG_TYPE_POSITION = 0x25;
+	public const ARG_TYPE_POSITION = 0x28;
 
-	public const ARG_TYPE_MESSAGE  = 0x29;
+	public const ARG_TYPE_MESSAGE  = 0x2c;
 
-	public const ARG_TYPE_RAWTEXT  = 0x2b;
+	public const ARG_TYPE_RAWTEXT  = 0x2e;
 
-	public const ARG_TYPE_JSON     = 0x2f;
+	public const ARG_TYPE_JSON     = 0x32;
 
-	public const ARG_TYPE_COMMAND  = 0x36;
+	public const ARG_TYPE_COMMAND  = 0x3f;
 
 	/**
 	 * Enums are a little different: they are composed as follows:


### PR DESCRIPTION
## Introduction
This PR updates the argument type constants in AvailableCommandsPacket and adds the new `WILDCARD_TARGET` argument type, as they were once again shifted by Mojang with their, and I quote, "some kind of dynamic ID bullshit".

## Changes
### API changes
N/A

### Behavioural changes
Command argument type constants now work fine.

## Backwards compatibility
No issues with backwards compatibility.