### PR TITLE
Fixed SingletonTrait not being recognized after PhpStorm 2.3 version

### DIFF
--- a/src/utils/SingletonTrait.php
+++ b/src/utils/SingletonTrait.php
@@ -27,10 +27,12 @@ trait SingletonTrait{
 	/** @var self|null */
 	private static $instance = null;
 
+	/** @return static */
 	private static function make() : self{
 		return new self;
 	}
 
+	/** @return static */
 	public static function getInstance() : self{
 		if(self::$instance === null){
 			self::$instance = self::make();


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Since `PhpStorm 2.3` and later, there is a bug where functions or variables in a class are marked as undefined when using the `getInstance()` method of `SingletonTrait`.

![image](https://user-images.githubusercontent.com/32565818/111566640-e20f2700-87e0-11eb-8309-04b19d39087b.png)

After this commit, `SingletonTrait` works fine even with `PhpStorm 2.3` and above.

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
![image](https://user-images.githubusercontent.com/32565818/111567256-fc95d000-87e1-11eb-96f5-80c275d7b764.png)