### PR TITLE
Sugarcanes can be placed on podzol

### DIFF
--- a/src/pocketmine/block/Sugarcane.php
+++ b/src/pocketmine/block/Sugarcane.php
@@ -111,7 +111,7 @@ class Sugarcane extends Flowable{
 			$this->getLevelNonNull()->setBlock($blockReplace, BlockFactory::get(Block::SUGARCANE_BLOCK), true);
 
 			return true;
-		}elseif($down->getId() === self::GRASS or $down->getId() === self::DIRT or $down->getId() === self::SAND){
+		}elseif($down->getId() === self::GRASS or $down->getId() === self::DIRT or $down->getId() === self::SAND or $down->getId() === self::PODZOL){
 			$block0 = $down->getSide(Vector3::SIDE_NORTH);
 			$block1 = $down->getSide(Vector3::SIDE_SOUTH);
 			$block2 = $down->getSide(Vector3::SIDE_WEST);


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Sugarcanes can be placed on podzol.
https://minecraft.gamepedia.com/Sugar_Cane#Farming
### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
This PR makes it so sugar canes can be placed on podzol.

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Go in-game and try to place sugarcanes on podzol