### PR TITLE
Sugarcanes can be placed on podzol

### DIFF
--- a/src/block/Sugarcane.php
+++ b/src/block/Sugarcane.php
@@ -125,7 +125,7 @@ class Sugarcane extends Flowable{
 		$down = $this->getSide(Facing::DOWN);
 		if($down->isSameType($this)){
 			return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
-		}elseif($down->getId() === BlockLegacyIds::GRASS or $down->getId() === BlockLegacyIds::DIRT or $down->getId() === BlockLegacyIds::SAND){
+		}elseif($down->getId() === BlockLegacyIds::GRASS or $down->getId() === BlockLegacyIds::DIRT or $down->getId() === BlockLegacyIds::SAND or $down->getId() === BlockLegacyIds::PODZOL){
 			foreach(Facing::HORIZONTAL as $side){
 				if($down->getSide($side) instanceof Water){
 					return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Sugarcanes can be placed on podzol.
https://minecraft.gamepedia.com/Sugar_Cane#Farming
### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
This PR makes it so sugar canes can be placed on podzol.

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Go in-game and try to place sugarcanes on podzol