### PR TITLE
Fix entities getting launch into the air

### DIFF
--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -518,8 +518,8 @@ abstract class Living extends Entity{
 			$motionY += $base;
 			$motionZ += $z * $f * $base;
 
-			if($motionY > $base){
-				$motionY = $base;
+			if($motionY > 0.4){
+				$motionY = 0.4;
 			}
 
 			$this->setMotion(new Vector3($motionX, $motionY, $motionZ));

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -467,7 +467,7 @@ abstract class Living extends Entity{
 			//TODO: knockback should not just apply for entity damage sources
 			//this doesn't matter for TNT right now because the PrimedTNT entity is considered the source, not the block.
 			$base = $source->getKnockBack();
-			$source->setKnockBack($base - min($base, $base * $this->getHighestArmorEnchantmentLevel(VanillaEnchantments::BLAST_PROTECTION()) * 0.15));
+			$source->setKnockBack($base - min($base, $base * $this->getHighestArmorEnchantmentLevel(VanillaEnchantments::BLAST_PROTECTION()) * 0.15), true);
 		}
 
 		parent::attack($source);
@@ -482,14 +482,14 @@ abstract class Living extends Entity{
 			$e = $source->getChild();
 			if($e !== null){
 				$motion = $e->getMotion();
-				$this->knockBack($motion->x, $motion->z, $source->getKnockBack());
+				$this->knockBack($motion->x, $motion->z, $source->getKnockBack(), true);
 			}
 		}elseif($source instanceof EntityDamageByEntityEvent){
 			$e = $source->getDamager();
 			if($e !== null){
 				$deltaX = $this->location->x - $e->location->x;
 				$deltaZ = $this->location->z - $e->location->z;
-				$this->knockBack($deltaX, $deltaZ, $source->getKnockBack());
+				$this->knockBack($deltaX, $deltaZ, $source->getKnockBack(), true);
 			}
 		}
 
@@ -503,7 +503,7 @@ abstract class Living extends Entity{
 		$this->broadcastAnimation(new HurtAnimation($this));
 	}
 
-	public function knockBack(float $x, float $z, float $base = 0.4) : void{
+	public function knockBack(float $x, float $z, float $base = 0.4, bool $vanilla = false) : void{
 		$f = sqrt($x * $x + $z * $z);
 		if($f <= 0){
 			return;
@@ -518,8 +518,14 @@ abstract class Living extends Entity{
 			$motionY += $base;
 			$motionZ += $z * $f * $base;
 
-			if($motionY > 0.4){
-				$motionY = 0.4;
+			if(!$vanilla){
+				if($motionY > $base){
+					$motionY = $base;
+				}
+			}else{
+				if($motionY > 0.4){
+					$motionY = 0.4;
+				}
 			}
 
 			$this->setMotion(new Vector3($motionX, $motionY, $motionZ));

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -482,14 +482,14 @@ abstract class Living extends Entity{
 			$e = $source->getChild();
 			if($e !== null){
 				$motion = $e->getMotion();
-				$this->knockBack($motion->x, $motion->z, $source->getKnockBack(), true);
+				$this->knockBack($motion->x, $motion->z, $source->getKnockBack(), 0.4);
 			}
 		}elseif($source instanceof EntityDamageByEntityEvent){
 			$e = $source->getDamager();
 			if($e !== null){
 				$deltaX = $this->location->x - $e->location->x;
 				$deltaZ = $this->location->z - $e->location->z;
-				$this->knockBack($deltaX, $deltaZ, $source->getKnockBack(), true);
+				$this->knockBack($deltaX, $deltaZ, $source->getKnockBack(), 0.4);
 			}
 		}
 
@@ -503,7 +503,7 @@ abstract class Living extends Entity{
 		$this->broadcastAnimation(new HurtAnimation($this));
 	}
 
-	public function knockBack(float $x, float $z, float $base = 0.4, bool $vanilla = false) : void{
+	public function knockBack(float $x, float $z, float $base = 0.4, float $verticalLimit = null) : void{
 		$f = sqrt($x * $x + $z * $z);
 		if($f <= 0){
 			return;
@@ -518,14 +518,9 @@ abstract class Living extends Entity{
 			$motionY += $base;
 			$motionZ += $z * $f * $base;
 
-			if(!$vanilla){
-				if($motionY > $base){
-					$motionY = $base;
-				}
-			}else{
-				if($motionY > 0.4){
-					$motionY = 0.4;
-				}
+			$verticalLimit = $verticalLimit ?? $base;
+			if($motionY > $verticalLimit){
+				$motionY = $verticalLimit;
 			}
 
 			$this->setMotion(new Vector3($motionX, $motionY, $motionZ));

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -503,7 +503,7 @@ abstract class Living extends Entity{
 		$this->broadcastAnimation(new HurtAnimation($this));
 	}
 
-	public function knockBack(float $x, float $z, float $base = 0.4, float $verticalLimit = null) : void{
+	public function knockBack(float $x, float $z, float $base = 0.4, ?float $verticalLimit = null) : void{
 		$f = sqrt($x * $x + $z * $z);
 		if($f <= 0){
 			return;

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -467,7 +467,7 @@ abstract class Living extends Entity{
 			//TODO: knockback should not just apply for entity damage sources
 			//this doesn't matter for TNT right now because the PrimedTNT entity is considered the source, not the block.
 			$base = $source->getKnockBack();
-			$source->setKnockBack($base - min($base, $base * $this->getHighestArmorEnchantmentLevel(VanillaEnchantments::BLAST_PROTECTION()) * 0.15), true);
+			$source->setKnockBack($base - min($base, $base * $this->getHighestArmorEnchantmentLevel(VanillaEnchantments::BLAST_PROTECTION()) * 0.15));
 		}
 
 		parent::attack($source);

--- a/src/item/enchantment/KnockbackEnchantment.php
+++ b/src/item/enchantment/KnockbackEnchantment.php
@@ -39,7 +39,7 @@ class KnockbackEnchantment extends MeleeWeaponEnchantment{
 	public function onPostAttack(Entity $attacker, Entity $victim, int $enchantmentLevel) : void{
 		if($victim instanceof Living){
 			$diff = $victim->getPosition()->subtractVector($attacker->getPosition());
-			$victim->knockBack($diff->x, $diff->z, $enchantmentLevel * 0.5);
+			$victim->knockBack($diff->x, $diff->z, $enchantmentLevel * 0.5, 0.4);
 		}
 	}
 }


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This PR fix entities getting launch into the air when getting knockback.
### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
Fixes #2707
## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
None
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
None
## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Added a verticalLimit only accepts float and default to null
## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
None
## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Script: https://wandbox.fetus.jp/permlink/X0bQydRSGzmmxorm