### PR TITLE
Call InventoryCloseEvent when Player->removeWindow() is called. (#4130)

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -4140,6 +4140,10 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 		if($id !== null){
 			$inventory->close($this);
+			
+			$ev = new InventoryCloseEvent($inventory, $this);
+			$ev->call();
+			
 			unset($this->windows[$hash], $this->windowIndex[$id], $this->permanentWindows[$id]);
 		}
 	}


### PR DESCRIPTION
## Introduction
When the method Player->removeWindow() is called, InventoryCloseEvent is not called as explained in issue #4130. Technically, it should be because the player is still closing the inventory even thought its being closed by the server/plugin.

### Relevant issues
There is no way to track if an inventory is closed with Player->removeWindow(), so plugins like ``InvMenu`` break. InvMenu depends on InventoryCloseEvent to remove players from a window session. Without this event being called, players become stuck in this session and cannot view any other windows.
[Example](https://user-images.githubusercontent.com/60823817/111855257-33f7a000-88fa-11eb-8dc8-99aad349d61c.mp4) (short video)

## Changes
### API changes
Yes, there are additional changes when method Player->removeWindow() is called: InventoryCloseEvent gets called.

### Behavioural changes
none

## Backwards compatibility
Some developers have caught onto this, and have been calling the event themselves. They will need to remove this call to prevent the event from triggering twice.

## Follow-up
n/a

## Tests
Installed Inventory Menu and ran the same script used in the video above. After being send the first window and having it removed, the player could receive more windows.