### PR TITLE
Force kill server if main thread freeze within a certain time

### DIFF
--- a/src/pocketmine/Server.php
+++ b/src/pocketmine/Server.php
@@ -107,6 +107,7 @@ use pocketmine\utils\Terminal;
 use pocketmine\utils\TextFormat;
 use pocketmine\utils\Utils;
 use pocketmine\utils\UUID;
+use pocketmine\utils\Watchdog;
 use function array_filter;
 use function array_key_exists;
 use function array_shift;
@@ -250,6 +251,9 @@ class Server{
 
 	/** @var \AttachableThreadedLogger */
 	private $logger;
+
+	/** @var Watchdog */
+	private $watchdog;
 
 	/** @var MemoryManager */
 	private $memoryManager;
@@ -1303,6 +1307,7 @@ class Server{
 		$this->tickSleeper = new SleeperHandler();
 		$this->autoloader = $autoloader;
 		$this->logger = $logger;
+		$this->watchdog = new Watchdog($logger);
 
 		try{
 			if(!file_exists($dataPath . "worlds/")){
@@ -1579,6 +1584,10 @@ class Server{
 
 			if($this->getProperty("ticks-per.autosave", 6000) > 0){
 				$this->autoSaveTicks = (int) $this->getProperty("ticks-per.autosave", 6000);
+			}
+
+			if($this->getProperty("watchdog.timeout", 180) > 0){
+				$this->watchdog->timeout = (int) $this->getProperty("watchdog.timeout", 180);
 			}
 
 			$this->enablePlugins(PluginLoadOrder::POSTWORLD);
@@ -2410,6 +2419,8 @@ class Server{
 
 			$this->network->updateName();
 			$this->network->resetStatistics();
+
+			$this->watchdog->lastRespond = time();
 		}
 
 		if($this->autoSave and ++$this->autoSaveTicker >= $this->autoSaveTicks){

--- a/src/pocketmine/resources/pocketmine.yml
+++ b/src/pocketmine/resources/pocketmine.yml
@@ -187,3 +187,6 @@ plugins:
   #False will place plugin data under plugin_data under --data.
   #This option exists for backwards compatibility with existing installations.
   legacy-data-dir: false
+
+watchdog:
+  timeout: 180

--- a/src/pocketmine/utils/Watchdog.php
+++ b/src/pocketmine/utils/Watchdog.php
@@ -44,14 +44,14 @@ class Watchdog extends Thread{
 
 	public function run(){
 		$this->lastRespond = time();
-		
+
 		while(!$this->isKilled){
 			if($this->lastRespond + $this->timeout <= time()){
 				$this->logger->info("Server killed due to freeze for " . $this->timeout . " seconds.");
 				Process::kill(Process::pid());
 				return;
 			}
-			
+
 			sleep(1);
 		}
 	}

--- a/src/pocketmine/utils/Watchdog.php
+++ b/src/pocketmine/utils/Watchdog.php
@@ -37,21 +37,21 @@ class Watchdog extends Thread{
 	/** @var int */
 	public $timeout = 180;
 
-	public function __construct(\AttachableThreadedLogger $logger)
-	{
+	public function __construct(\AttachableThreadedLogger $logger){
 		$this->logger = $logger;
 		$this->start();
 	}
 
-	public function run()
-	{
+	public function run(){
 		$this->lastRespond = time();
+		
 		while(!$this->isKilled){
-			if($this->lastRespond + $this->timeout <= time()) {
+			if($this->lastRespond + $this->timeout <= time()){
 				$this->logger->info("Server killed due to freeze for " . $this->timeout . " seconds.");
 				Process::kill(Process::pid());
 				return;
 			}
+			
 			sleep(1);
 		}
 	}

--- a/src/pocketmine/utils/Watchdog.php
+++ b/src/pocketmine/utils/Watchdog.php
@@ -48,7 +48,7 @@ class Watchdog extends Thread{
 		$this->lastRespond = time();
 		while(!$this->isKilled){
 			if($this->lastRespond + $this->timeout <= time()) {
-				$this->logger->info("Server killed due to freeze for ".$this->timeout." seconds.");
+				$this->logger->info("Server killed due to freeze for " . $this->timeout . " seconds.");
 				Process::kill(Process::pid());
 				return;
 			}

--- a/src/pocketmine/utils/Watchdog.php
+++ b/src/pocketmine/utils/Watchdog.php
@@ -27,8 +27,7 @@ use pocketmine\Thread;
 use function sleep;
 use function time;
 
-class Watchdog extends Thread
-{
+class Watchdog extends Thread{
 	/** @var int */
 	public $lastRespond;
 

--- a/src/pocketmine/utils/Watchdog.php
+++ b/src/pocketmine/utils/Watchdog.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\utils;
+
+use pocketmine\Thread;
+
+class Watchdog extends Thread
+{
+	/** @var int */
+	public $lastRespond;
+
+	/** @var \AttachableThreadedLogger */
+	private $logger;
+
+	/** @var int */
+	public $timeout = 180;
+
+	public function __construct(\AttachableThreadedLogger $logger)
+	{
+		$this->logger = $logger;
+		$this->start();
+	}
+
+	public function run()
+	{
+		$this->lastRespond = time();
+		while(!$this->isKilled){
+			if($this->lastRespond + $this->timeout <= time()) {
+				$this->logger->info("Server killed due to freeze for ".$this->timeout." seconds.");
+				Process::kill(Process::pid());
+				return;
+			}
+			sleep(1);
+		}
+	}
+}

--- a/src/pocketmine/utils/Watchdog.php
+++ b/src/pocketmine/utils/Watchdog.php
@@ -24,6 +24,8 @@ declare(strict_types=1);
 namespace pocketmine\utils;
 
 use pocketmine\Thread;
+use function sleep;
+use function time;
 
 class Watchdog extends Thread
 {


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Force kill server if main thread freeze within a certain time.
You can choose `watchdog.timeout` at `pocketmine.yml` your timeout main thread.
```yaml
watchdog:
  timeout: 180 # in seconds
```
This will make your server keep online, when process killed your server should automatically restart (if you use `start.sh`).

https://en.wikipedia.org/wiki/Watchdog_timer

### Relevant issues
* Fixes https://github.com/pmmp/PocketMine-MP/issues/4134

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Sleep the main thread then wait server killed.
![Screenshot (504)](https://user-images.githubusercontent.com/35138228/113143290-2c1ef080-9256-11eb-8821-e50b53b54102.png)

```php
public function onEnable() {
    sleep(999);
}
```
