### PR TITLE
instead of kicking player for toggling flight cancel the event

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3134,12 +3134,12 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		$handled = false;
 
 		$isFlying = $packet->getFlag(AdventureSettingsPacket::FLYING);
-		if($isFlying and !$this->allowFlight and !$this->allowMovementCheats){
-			$this->kick($this->server->getLanguage()->translateString("kick.reason.cheat", ["%ability.flight"]));
-			return true;
-		}
 		if($isFlying !== $this->isFlying()){
 			$ev = new PlayerToggleFlightEvent($this, $isFlying);
+			if($isFlying and !$this->allowFlight){
+				$ev->setCancelled();
+			}
+			
 			$ev->call();
 			if($ev->isCancelled()){
 				$this->sendSettings();

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3134,10 +3134,11 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		$handled = false;
 
 		$isFlying = $packet->getFlag(AdventureSettingsPacket::FLYING);
-		if($isFlying and !$this->allowFlight){
+		if($isFlying and !$this->allowFlight and !$this->allowMovementCheats){
 			$this->kick($this->server->getLanguage()->translateString("kick.reason.cheat", ["%ability.flight"]));
 			return true;
-		}elseif($isFlying !== $this->isFlying()){
+		}
+		if($isFlying !== $this->isFlying()){
 			$ev = new PlayerToggleFlightEvent($this, $isFlying);
 			$ev->call();
 			if($ev->isCancelled()){

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3139,6 +3139,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 			if($isFlying and !$this->allowFlight){
 				$ev->setCancelled();
 			}
+
 			$ev->call();
 			if($ev->isCancelled()){
 				$this->sendSettings();

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3139,7 +3139,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 			if($isFlying and !$this->allowFlight){
 				$ev->setCancelled();
 			}
-			
 			$ev->call();
 			if($ev->isCancelled()){
 				$this->sendSettings();


### PR DESCRIPTION
## Introduction
a lot of people have complained before that they get kicked for flight while the movement cheats is enabled

## Changes

### Behavioural changes
now it will cancel the event instead of kicking the player
