### PR TITLE
small inventory bug fix

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2843,9 +2843,9 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		}
 
 		$target = $this->level->getEntity($packet->target);
-		if($packet->action !== InteractPacket::ACTION_OPEN_INVENTORY){
-			$this->doCloseInventory();
-		}
+		if(($inventoryClosed = !array_key_exists($windowId = self::HARDCODED_INVENTORY_WINDOW_ID,$this->openHardcodedWindows)) or $packet->action !== InteractPacket::ACTION_MOUSEOVER){
+            $this->doCloseInventory();
+        }
 
 		if($target === null){
 			return false;
@@ -2856,7 +2856,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 			case InteractPacket::ACTION_MOUSEOVER:
 				break; //TODO: handle these
 			case InteractPacket::ACTION_OPEN_INVENTORY:
-				if($target === $this && !array_key_exists($windowId = self::HARDCODED_INVENTORY_WINDOW_ID, $this->openHardcodedWindows)){
+				if($target === $this && $inventoryClosed){
 					//TODO: HACK! this restores 1.14ish behaviour, but this should be able to be listened to and
 					//controlled by plugins. However, the player is always a subscriber to their own inventory so it
 					//doesn't integrate well with the regular container system right now.

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2843,7 +2843,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		}
 
 		$target = $this->level->getEntity($packet->target);
-		if($packet->action !== InteractPacket::ACTION_OPEN_INVENTORY or $target !== $this){
+		if($packet->action !== InteractPacket::ACTION_OPEN_INVENTORY){
 			$this->doCloseInventory();
 		}
 

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2844,8 +2844,8 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 		$target = $this->level->getEntity($packet->target);
 		if(($inventoryClosed = !array_key_exists($windowId = self::HARDCODED_INVENTORY_WINDOW_ID,$this->openHardcodedWindows)) or $packet->action !== InteractPacket::ACTION_MOUSEOVER){
-            $this->doCloseInventory();
-        }
+			$this->doCloseInventory();
+		}
 
 		if($target === null){
 			return false;

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2842,9 +2842,11 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 			return true;
 		}
 
-		$this->doCloseInventory();
-
 		$target = $this->level->getEntity($packet->target);
+		if($packet->action !== InteractPacket::ACTION_OPEN_INVENTORY or $target !== $this){
+			$this->doCloseInventory();
+		}
+
 		if($target === null){
 			return false;
 		}


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
#4140 

### Relevant issues
<!-- List relevant issues here -->
<!--

Fixes #4140 

-->

## Changes

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
now InteractPacket will only run doCloseInventory if the player doesn't have his inventory open or the action isn't InteractPacket::ACTION_MOUSEOVER 