### PR TITLE
call InventoryCloseEvent on removeWindow()

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -4134,15 +4134,12 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	public function removeWindow(Inventory $inventory, bool $force = false){
 		$id = $this->windows[$hash = spl_object_hash($inventory)] ?? null;
 
-		if($id !== null){
-			(new InventoryCloseEvent($inventory, $this))->call();
-		}
-
 		if($id !== null and !$force and isset($this->permanentWindows[$id])){
 			throw new \InvalidArgumentException("Cannot remove fixed window $id (" . get_class($inventory) . ") from " . $this->getName());
 		}
 
 		if($id !== null){
+			(new InventoryCloseEvent($inventory, $this))->call();
 			$inventory->close($this);
 			unset($this->windows[$hash], $this->windowIndex[$id], $this->permanentWindows[$id]);
 		}

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -4134,7 +4134,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	public function removeWindow(Inventory $inventory, bool $force = false){
 		$id = $this->windows[$hash = spl_object_hash($inventory)] ?? null;
 
-		if(id !== null){
+		if($id !== null){
 			(new InventoryCloseEvent($inventory, $this))->call();
 		}
 

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3116,7 +3116,6 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		}
 		if(isset($this->windowIndex[$packet->windowId])){
 			$this->closingWindowId = $packet->windowId;
-			(new InventoryCloseEvent($this->windowIndex[$packet->windowId], $this))->call();
 			$this->removeWindow($this->windowIndex[$packet->windowId]);
 			$this->closingWindowId = null;
 			//removeWindow handles sending the appropriate
@@ -4134,6 +4133,8 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	 */
 	public function removeWindow(Inventory $inventory, bool $force = false){
 		$id = $this->windows[$hash = spl_object_hash($inventory)] ?? null;
+
+		(new InventoryCloseEvent($inventory, $this))->call();
 
 		if($id !== null and !$force and isset($this->permanentWindows[$id])){
 			throw new \InvalidArgumentException("Cannot remove fixed window $id (" . get_class($inventory) . ") from " . $this->getName());

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -4134,7 +4134,9 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	public function removeWindow(Inventory $inventory, bool $force = false){
 		$id = $this->windows[$hash = spl_object_hash($inventory)] ?? null;
 
-		(new InventoryCloseEvent($inventory, $this))->call();
+		if(id !== null){
+			(new InventoryCloseEvent($inventory, $this))->call();
+		}
 
 		if($id !== null and !$force and isset($this->permanentWindows[$id])){
 			throw new \InvalidArgumentException("Cannot remove fixed window $id (" . get_class($inventory) . ") from " . $this->getName());


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
as explained in #4130 the server depend on ContainerClosePacket to call InventoryCloseEvent, this is problematic cause it will break plugins depending on that event if the client didn't send ContainerClosePacket.

* Fixes #4130 

-->

## Changes

### Behavioural changes
now InventoryCloseEvent will be called whenever the inventory is closed from the server side