### PR TITLE
Fixed bug that never lets mountainous terrain generate

### DIFF
--- a/src/pocketmine/level/generator/normal/Normal.php
+++ b/src/pocketmine/level/generator/normal/Normal.php
@@ -147,7 +147,7 @@ class Normal extends Generator{
 					//According to the wiki, mountains have a temperature of 0.2-0.3,
 					//so substituting rainfall for temperature was actually pretty accurate
 					//These are all the best estimates for mountain temperature
-				    if($temperature < 0.20){
+					if($temperature < 0.20){
 						return Biome::MOUNTAINS;
 					}elseif($temperature < 0.40){
 						return Biome::SMALL_MOUNTAINS;

--- a/src/pocketmine/level/generator/normal/Normal.php
+++ b/src/pocketmine/level/generator/normal/Normal.php
@@ -144,12 +144,12 @@ class Normal extends Generator{
 						return Biome::BIRCH_FOREST;
 					}
 				}else{
-					//FIXME: This will always cause River to be used since the rainfall is always greater than 0.8 if we
-					//reached this branch. However I don't think that substituting temperature for rainfall is correct given
-					//that mountain biomes are supposed to be pretty cold.
-					if($rainfall < 0.25){
+					//According to the wiki, mountains have a temperature of 0.2-0.3,
+					//so substituting rainfall for temperature was actually pretty accurate
+					//These are all the best estimates for mountain temperature
+				    if($temperature < 0.20){
 						return Biome::MOUNTAINS;
-					}elseif($rainfall < 0.70){
+					}elseif($temperature < 0.40){
 						return Biome::SMALL_MOUNTAINS;
 					}else{
 						return Biome::RIVER;

--- a/src/pocketmine/level/generator/normal/Normal.php
+++ b/src/pocketmine/level/generator/normal/Normal.php
@@ -144,9 +144,6 @@ class Normal extends Generator{
 						return Biome::BIRCH_FOREST;
 					}
 				}else{
-					//According to the wiki, mountains have a temperature of 0.2-0.3,
-					//so substituting rainfall for temperature was actually pretty accurate
-					//These are all the best estimates for mountain temperature
 					if($temperature < 0.20){
 						return Biome::MOUNTAINS;
 					}elseif($temperature < 0.40){


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
As of now the BiomeSelector class has a bug that prevents mountains from generating in the world, left unfixed for several concerns about a possible fix being inaccurate. This pull request attempts to create a decent fix for this issue

This PR message is still currently a WIP 

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
No relevant issues

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
None
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
Mountains and Small Mountains now generate in the world naturally
## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
No backwards incompatibility, this merely changes the terrain generator, which is entirely server side and currently untouchable by plugins
## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
Unlikely to require any follow up after merge

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Generated mountains:
![image](https://user-images.githubusercontent.com/32636402/114510407-3a630880-9c69-11eb-9cd2-8b455b8cfb7e.png)

