### PR TITLE
API method to clear block cache per chunk

### DIFF
--- a/src/pocketmine/level/Level.php
+++ b/src/pocketmine/level/Level.php
@@ -1047,6 +1047,15 @@ class Level implements ChunkManager, Metadatable{
 	/**
 	 * @return void
 	 */
+	public function clearBlockCache(int $chunkX, int $chunkZ){
+		if(isset($this->blockCache[$hash = Level::chunkHash($chunkX, $chunkZ)])) {
+			unset($this->blockCache[$hash]);
+		}
+	}
+
+	/**
+	 * @return void
+	 */
 	public function clearChunkCache(int $chunkX, int $chunkZ){
 		unset($this->chunkCache[Level::chunkHash($chunkX, $chunkZ)]);
 	}


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Plugins whose use SubChunkIteratorManager for filling needs to send chunks to player afterwards.  It is also needed to clear chunk caches to avoid sending outdated blocks. Currently there is method to clear `Level->chunkCache`, whilst there is no way to clear `Level->blockCache` (per chunk). Although there is method `Level->clearCache(true)`, developers could not use it to clear cache in certain chunks, whose were changed.

### Relevant issues
- Nothing
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
- Added method `Level->clearBlockCache(int $chunkX, int $chunkZ)`
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
- Nothing
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
- Any backwards incompatible changes
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
- Nothing
<!-- Suggest any actions to be done before/after merging this pull request -->

<!--
Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |
-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
- Tested with [BuilderTools plugin](https://github.com/CzechPMDevs/BuilderTools/tree/feature/pm-fork)
