### PR TITLE
API method for clearing block cache per chunk (#4171 for master)

### DIFF
--- a/src/world/World.php
+++ b/src/world/World.php
@@ -948,7 +948,13 @@ class World implements ChunkManager{
 	}
 
 	public function clearBlockCache(int $chunkX, int $chunkZ) : void{
+		$chunk = $this->getChunk($chunkX, $chunkZ);
 		unset($this->blockCache[World::chunkHash($chunkX, $chunkZ)]);
+		if($chunk !== null){
+			foreach($this->getChunkPlayers($chunkX, $chunkZ) as $p){
+				$p->onChunkChanged($chunkX, $chunkZ, $chunk);
+			}
+		}
 	}
 
 	/**

--- a/src/world/World.php
+++ b/src/world/World.php
@@ -947,6 +947,10 @@ class World implements ChunkManager{
 		}
 	}
 
+	public function clearBlockCache(int $chunkX, int $chunkZ) : void{
+		unset($this->blockCache[World::chunkHash($chunkX, $chunkZ)]);
+	}
+
 	/**
 	 * @return bool[] fullID => bool
 	 */

--- a/src/world/World.php
+++ b/src/world/World.php
@@ -951,7 +951,7 @@ class World implements ChunkManager{
 		$chunk = $this->getChunk($chunkX, $chunkZ);
 		unset($this->blockCache[World::chunkHash($chunkX, $chunkZ)]);
 		if($chunk !== null){
-			foreach($this->getChunkPlayers($chunkX, $chunkZ) as $p){
+			foreach($this->getChunkListeners($chunkX, $chunkZ) as $p){
 				$p->onChunkChanged($chunkX, $chunkZ, $chunk);
 			}
 		}


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This is a pull request that rewrites #4171 for the master.
Please see #4171.

> Plugins whose use SubChunkIteratorManager for filling needs to send chunks to player afterwards. It is also needed to clear chunk caches to avoid sending outdated blocks. Currently there is method to clear Level->chunkCache, whilst there is no way to clear Level->blockCache (per chunk). Although there is method Level->clearCache(true), developers could not use it to clear cache in certain chunks, whose were changed.
### Relevant issues
<!-- List relevant issues here -->
> Nothing
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
> Added method Level->clearBlockCache(int $chunkX, int $chunkZ)
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
> Nothing
## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
> Any backwards incompatible changes
## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
> Nothing
<!--
Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
I ran the following code and confirmed that "worked" was displayed normally.
```php
<?php

namespace test;

use pocketmine\command\Command;
use pocketmine\command\CommandSender;
use pocketmine\player\Player;
use pocketmine\plugin\PluginBase;

class main extends PluginBase{
	public function onCommand(CommandSender $sender, Command $command, string $label, array $args): bool{
		if(!$sender instanceof Player){
			return true;
		}
		if($label === "test"){
			$pos = $sender->getPosition();
			$sender->getWorld()->clearBlockCache($pos->x >> 4, $pos->z >> 4);
			$sender->sendMessage("worked");
		}
		return true;
	}
}
```
