### PR TITLE
Possibilities to disable xp orb collecting

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -4207,7 +4207,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 	}
 	
-	public function canCollectXp(): bool {
+	public function canCollectXp() : bool{
 		return !$this->isSpectator();
 	}
 	

--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -4206,7 +4206,11 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 	public function onBlockChanged(Vector3 $block){
 
 	}
-
+	
+	public function canCollectXp(): bool {
+		return !$this->isSpectator();
+	}
+	
 	public function getLoaderId() : int{
 		return $this->loaderId;
 	}

--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -485,7 +485,7 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 	/**
 	 * Returns whether the human should collect experience orbs or not
 	 */
-	public function canCollectXp(): bool {
+	public function canCollectXp() : bool{
 		return true;
 	}
 	

--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -425,7 +425,7 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 
 		return false;
 	}
-	
+
 	private function playLevelUpSound(int $newLevel) : void{
 		$volume = 0x10000000 * (min(30, $newLevel) / 5); //No idea why such odd numbers, but this works...
 		$this->level->broadcastLevelSoundEvent($this, LevelSoundEventPacket::SOUND_LEVELUP, (int) $volume);

--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -425,7 +425,7 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 
 		return false;
 	}
-
+	
 	private function playLevelUpSound(int $newLevel) : void{
 		$volume = 0x10000000 * (min(30, $newLevel) / 5); //No idea why such odd numbers, but this works...
 		$this->level->broadcastLevelSoundEvent($this, LevelSoundEventPacket::SOUND_LEVELUP, (int) $volume);
@@ -481,7 +481,14 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 
 		$this->totalXp = $amount;
 	}
-
+	
+	/**
+	 * Returns whether the human should collect experience orbs or not
+	 */
+	public function canCollectXp(): bool {
+		return true;
+	}
+	
 	/**
 	 * Returns whether the human can pickup XP orbs (checks cooldown time)
 	 */

--- a/src/pocketmine/entity/object/ExperienceOrb.php
+++ b/src/pocketmine/entity/object/ExperienceOrb.php
@@ -168,7 +168,7 @@ class ExperienceOrb extends Entity{
 			if($currentTarget === null){
 				$newTarget = $this->level->getNearestEntity($this, self::MAX_TARGET_DISTANCE, Human::class);
 
-				if($newTarget instanceof Human and !($newTarget instanceof Player and $newTarget->isSpectator())){
+				if($newTarget instanceof Human and $newTarget->canCollectXp()){
 					$currentTarget = $newTarget;
 				}
 			}


### PR DESCRIPTION
## Introduction
Any human (except for Players that are in spectator gamemode) collects xp orbs, which can't be disabled.
So there's no possibility to turn it off in case it's a custom human that basically represents a NPC or something like that

### Relevant issues
Any human collects XP orbs
* This can be turned off via code

-->

## Changes
### API changes
`Human::canCollectXp(): bool`

### Behavioural changes
-

## Backwards compatibility
-

## Follow-up
-

Requires translations:
-

-->

## Tests
Tested, XP orbs are not trying to get collected by the human with disabled collecting, they just lay where they are, players can still collect the orbs.