### PR TITLE
Fix dragon egg teleporting in creative

### DIFF
--- a/src/block/DragonEgg.php
+++ b/src/block/DragonEgg.php
@@ -60,8 +60,9 @@ class DragonEgg extends Transparent implements Fallable{
 	public function onAttack(Item $item, int $face, ?Player $player = null) : bool{
 		if($player !== null && !$player->getGamemode()->equals(GameMode::CREATIVE())){
 			$this->teleport();
+			return true;
 		}
-		return true;
+		return false;
 	}
 
 	public function teleport() : void{

--- a/src/block/DragonEgg.php
+++ b/src/block/DragonEgg.php
@@ -29,6 +29,7 @@ use pocketmine\event\block\BlockTeleportEvent;
 use pocketmine\item\Item;
 use pocketmine\item\ToolTier;
 use pocketmine\math\Vector3;
+use pocketmine\player\GameMode;
 use pocketmine\player\Player;
 use pocketmine\world\particle\DragonEggTeleportParticle;
 use pocketmine\world\World;
@@ -57,7 +58,9 @@ class DragonEgg extends Transparent implements Fallable{
 	}
 
 	public function onAttack(Item $item, int $face, ?Player $player = null) : bool{
-		$this->teleport();
+		if($player->getGamemode() !== GameMode::CREATIVE()){
+			$this->teleport();
+		}
 		return true;
 	}
 

--- a/src/block/DragonEgg.php
+++ b/src/block/DragonEgg.php
@@ -58,7 +58,7 @@ class DragonEgg extends Transparent implements Fallable{
 	}
 
 	public function onAttack(Item $item, int $face, ?Player $player = null) : bool{
-		if($player !== null && $player->getGamemode() != GameMode::CREATIVE()){
+		if($player !== null && !$player->getGamemode()->equals(GameMode::CREATIVE())){
 			$this->teleport();
 		}
 		return true;

--- a/src/block/DragonEgg.php
+++ b/src/block/DragonEgg.php
@@ -58,7 +58,7 @@ class DragonEgg extends Transparent implements Fallable{
 	}
 
 	public function onAttack(Item $item, int $face, ?Player $player = null) : bool{
-		if($player->getGamemode() !== GameMode::CREATIVE()){
+		if($player !== null && $player->getGamemode() != GameMode::CREATIVE()){
 			$this->teleport();
 		}
 		return true;


### PR DESCRIPTION
## Introduction
This PR aims to solve https://github.com/pmmp/PocketMine-MP/issues/4179
Dragon eggs should be broken if the player is in gamemode c

### Relevant issues
* Fixes #4179 

## Changes
### API changes
None.

### Behavioural changes
Dragon eggs don't teleport when they're attacked when the player is in creative

## Backwards compatibility
All the changes are BC

## Follow-up
Nope


## Tests
https://streamable.com/c5kj1v (note that I am switching between right and left click in the video)
