### PR TITLE
Fixed action stopping when needing to build PHP

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Compile PHP
         if: steps.php-build-cache.outputs.cache-hit != 'true'
-        run: ./tests/gh-actions/build.sh "${{ matrix.php }}"
+        run: chmod +x ./tests/gh-actions/build.sh && ./tests/gh-actions/build.sh "${{ matrix.php }}"
 
   phpstan:
     name: PHPStan analysis


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Fixed action stopping when needing to build PHP with insufficient permissions.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
none

## Changes
<!-- Any additions to the API that should be documented in release notes? -->
- You will be able to build PHP

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
