### PR TITLE
Remove "ench" tag when all enchantments are removed from an item (Fixes #4144)

### DIFF
--- a/src/pocketmine/item/Item.php
+++ b/src/pocketmine/item/Item.php
@@ -339,7 +339,11 @@ class Item implements ItemIds, \JsonSerializable{
 			}
 		}
 
-		$this->setNamedTagEntry($ench);
+		if($ench->getCount() > 0){
+			$this->setNamedTagEntry($ench);
+		}else{
+			$this->removeNamedTagEntry(self::TAG_ENCH);
+		}
 	}
 
 	public function removeEnchantments() : void{

--- a/tests/phpstan/configs/l8-baseline.neon
+++ b/tests/phpstan/configs/l8-baseline.neon
@@ -1606,6 +1606,11 @@ parameters:
 			path: ../../../src/pocketmine/utils/Utils.php
 
 		-
+			message: "#^Parameter \\#1 \\$enchantment of class pocketmine\\\\item\\\\enchantment\\\\EnchantmentInstance constructor expects pocketmine\\\\item\\\\enchantment\\\\Enchantment, pocketmine\\\\item\\\\enchantment\\\\Enchantment\\|null given\\.$#"
+			count: 2
+			path: ../../phpunit/item/ItemTest.php
+
+		-
 			message: "#^Cannot call method cancel\\(\\) on pocketmine\\\\scheduler\\\\TaskHandler\\|null\\.$#"
 			count: 1
 			path: ../../plugins/TesterPlugin/src/pmmp/TesterPlugin/CheckTestCompletionTask.php

--- a/tests/phpstan/configs/l8-baseline.neon
+++ b/tests/phpstan/configs/l8-baseline.neon
@@ -1607,7 +1607,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$enchantment of class pocketmine\\\\item\\\\enchantment\\\\EnchantmentInstance constructor expects pocketmine\\\\item\\\\enchantment\\\\Enchantment, pocketmine\\\\item\\\\enchantment\\\\Enchantment\\|null given\\.$#"
-			count: 2
+			count: 1
 			path: ../../phpunit/item/ItemTest.php
 
 		-

--- a/tests/phpunit/item/ItemTest.php
+++ b/tests/phpunit/item/ItemTest.php
@@ -72,7 +72,7 @@ class ItemTest extends TestCase{
 		$item = ItemFactory::get(Item::DIAMOND_SWORD);
 		$item->addEnchantment(new EnchantmentInstance(Enchantment::getEnchantment(Enchantment::SHARPNESS)));
 		$item->removeEnchantment(Enchantment::SHARPNESS);
-		self::assertFalse($item->getNamedTag()->hasTag(Item::TAG_ENCH, ListTag::class));
+		self::assertNull($item->getNamedTag()->getTag(Item::TAG_ENCH));
 	}
 
 	/**

--- a/tests/phpunit/item/ItemTest.php
+++ b/tests/phpunit/item/ItemTest.php
@@ -25,12 +25,16 @@ namespace pocketmine\item;
 
 use PHPUnit\Framework\TestCase;
 use pocketmine\block\BlockFactory;
+use pocketmine\item\enchantment\Enchantment;
+use pocketmine\item\enchantment\EnchantmentInstance;
+use pocketmine\nbt\tag\ListTag;
 
 class ItemTest extends TestCase{
 
 	public function setUp() : void{
 		BlockFactory::init();
 		ItemFactory::init();
+		Enchantment::init();
 	}
 
 	/**
@@ -59,6 +63,19 @@ class ItemTest extends TestCase{
 		for($id = 0; $id < 256; ++$id){
 			self::assertEquals(BlockFactory::isRegistered($id), ItemFactory::isRegistered($id));
 		}
+	}
+
+	/**
+	 * Tests that when all enchantments are removed from an item, the "ench" tag is removed as well
+	 */
+	public function testEnchantmentRemoval() : void{
+		$item = ItemFactory::get(Item::DIAMOND_SWORD);
+		$item->addEnchantment(new EnchantmentInstance(Enchantment::getEnchantment(Enchantment::SHARPNESS)));
+		$item->addEnchantment(new EnchantmentInstance(Enchantment::getEnchantment(Enchantment::UNBREAKING)));
+		$item->removeEnchantment(Enchantment::SHARPNESS);
+		self::assertTrue($item->getNamedTag()->hasTag(Item::TAG_ENCH, ListTag::class));
+		$item->removeEnchantment(Enchantment::UNBREAKING);
+		self::assertFalse($item->getNamedTag()->hasTag(Item::TAG_ENCH, ListTag::class));
 	}
 
 	/**

--- a/tests/phpunit/item/ItemTest.php
+++ b/tests/phpunit/item/ItemTest.php
@@ -71,10 +71,7 @@ class ItemTest extends TestCase{
 	public function testEnchantmentRemoval() : void{
 		$item = ItemFactory::get(Item::DIAMOND_SWORD);
 		$item->addEnchantment(new EnchantmentInstance(Enchantment::getEnchantment(Enchantment::SHARPNESS)));
-		$item->addEnchantment(new EnchantmentInstance(Enchantment::getEnchantment(Enchantment::UNBREAKING)));
 		$item->removeEnchantment(Enchantment::SHARPNESS);
-		self::assertTrue($item->getNamedTag()->hasTag(Item::TAG_ENCH, ListTag::class));
-		$item->removeEnchantment(Enchantment::UNBREAKING);
 		self::assertFalse($item->getNamedTag()->hasTag(Item::TAG_ENCH, ListTag::class));
 	}
 

--- a/tests/phpunit/item/ItemTest.php
+++ b/tests/phpunit/item/ItemTest.php
@@ -27,7 +27,6 @@ use PHPUnit\Framework\TestCase;
 use pocketmine\block\BlockFactory;
 use pocketmine\item\enchantment\Enchantment;
 use pocketmine\item\enchantment\EnchantmentInstance;
-use pocketmine\nbt\tag\ListTag;
 
 class ItemTest extends TestCase{
 


### PR DESCRIPTION
## Introduction
As reported in #4144, Item->removeEnchantment() doesn't remove the "ench" tag when there are no more enchantments left on the item.
This PR fixes this issue by checking if, after the enchantment has been removed, there are no other ones left and acting accordingly.

### Relevant issues
<!-- List relevant issues here -->
* Fixes #4144 

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
None

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
Now the shining effect won't be shown on items which don't have any enchantments but previously did.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Yes

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
None

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
I added a phpunit test to verify that the "ench" tag is being correctly removed when there is the need to do so.
I also confirmed that the reproducing code provided in the issue does not reproduce anymore.