### PR TITLE
Throws an exception if the width/height of the entity is invalid

### DIFF
--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -610,6 +610,10 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 
 		$this->fallDistance = $this->namedtag->getFloat("FallDistance", 0.0);
 
+		if(!isset($this->width) or !isset($this->height)){
+			throw new \InvalidStateException(static::class . " has invalid width/height");
+		}
+
 		$this->propertyManager = new DataPropertyManager();
 
 		$this->propertyManager->setLong(self::DATA_FLAGS, 0);

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -73,7 +73,6 @@ use pocketmine\plugin\Plugin;
 use pocketmine\Server;
 use pocketmine\timings\Timings;
 use pocketmine\timings\TimingsHandler;
-use pocketmine\utils\AssumptionFailedError;
 use function abs;
 use function assert;
 use function cos;

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -73,6 +73,7 @@ use pocketmine\plugin\Plugin;
 use pocketmine\Server;
 use pocketmine\timings\Timings;
 use pocketmine\timings\TimingsHandler;
+use pocketmine\utils\AssumptionFailedError;
 use function abs;
 use function assert;
 use function cos;
@@ -611,7 +612,7 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 		$this->fallDistance = $this->namedtag->getFloat("FallDistance", 0.0);
 
 		if(!isset($this->width) or !isset($this->height)){
-			throw new \InvalidStateException(static::class . " has invalid width/height");
+			throw new AssumptionFailedError(static::class . " has invalid width/height");
 		}
 
 		$this->propertyManager = new DataPropertyManager();

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -612,7 +612,7 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 		$this->fallDistance = $this->namedtag->getFloat("FallDistance", 0.0);
 
 		if(!isset($this->width) or !isset($this->height)){
-			throw new AssumptionFailedError(static::class . " has invalid width/height");
+			throw new \RuntimeException("Entity " . static::class . " must declare the properties height and width and must be a float.");
 		}
 
 		$this->propertyManager = new DataPropertyManager();

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -611,7 +611,7 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 		$this->fallDistance = $this->namedtag->getFloat("FallDistance", 0.0);
 
 		if(!isset($this->width) or !isset($this->height)){
-			throw new \RuntimeException("Entity " . static::class . " must declare the properties height and width and must be a float.");
+			throw new \RuntimeException("Entity " . static::class . " must declare height and width properties and must be a float.");
 		}
 
 		$this->propertyManager = new DataPropertyManager();

--- a/src/pocketmine/entity/Entity.php
+++ b/src/pocketmine/entity/Entity.php
@@ -611,7 +611,7 @@ abstract class Entity extends Location implements Metadatable, EntityIds{
 		$this->fallDistance = $this->namedtag->getFloat("FallDistance", 0.0);
 
 		if(!isset($this->width) or !isset($this->height)){
-			throw new \RuntimeException("Entity " . static::class . " must declare height and width properties and must be a float.");
+			throw new \RuntimeException("Entity " . static::class . " must declare height and width properties.");
 		}
 
 		$this->propertyManager = new DataPropertyManager();


### PR DESCRIPTION
## Introduction
> I use google translate and deepl translator.

This pull request adds code to throw an exception if the height / width is undefined when the entity is spawned.
Suppose the developer inadvertently writes the following code without $height and $width.
```php
class testEntity extends Entity{
	const NETWORK_ID = EntityIds::ZOMBIE;

	//Suppose the plugin developer forgot to write the following code.
	//public $height = 1.0;
	//public $width = 1.0;
}
```
Currently, when I generate an entity with the above code, the following error will occur, and if the developer does not submit a backtrace in the forum etc., it is very difficult to identify.
Also, it is difficult for developers who are not yet mature enough to understand the error to determine the cause of the error.
```
TypeError: "Argument 2 passed to pocketmine\entity\DataPropertyManager::setFloat() must be of the type float, null given, called in I:\...\src\...\Entity.php on line 620" (EXCEPTION) in "pmsrc/.../DataPropertyManager" at line 87
#0 pmsrc/.../Entity(620): pocketmine\entity\DataPropertyManager->setFloat(integer 53, NULL )
#1 pmsrc/.../Entity(381): pocketmine\entity\Entity->__construct(object pocketmine\level\Level, object pocketmine\nbt\tag\CompoundTag)
#2 plugins/.../test(17): pocketmine\entity\Entity::createEntity(string[10] testEntity, object pocketmine\level\Level, object pocketmine\nbt\tag\CompoundTag)
```
This pull request throws `RuntimeException` instead.
```
RuntimeException: "Entity test\testEntity must declare height and width properties." (EXCEPTION) in "pmsrc/.../Entity" at line 615
#0 pmsrc/src/pocketmine/entity/Entity(382): pocketmine\entity\Entity->__construct(object pocketmine\...\Level, object pocketmine\...\CompoundTag)
#1 plugins/test/src/test/test(18): pocketmine\...\Entity::createEntity(string[10] testEntity, object pocketmine\...\Level, object pocketmine\...\CompoundTag)
```
### Relevant issues
<!-- List relevant issues here -->
nothing

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
(The Entity class may throw `RuntimeException`.)
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
if width / height attempts to spawn an invalid Entity, it will throw `RuntimeException` instead of TypeError.
## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
nothing
## Follow-up
nothing
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--
Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
- [x] Confirm that the error changes normally
- [x] I have confirmed that I can log in to the server normally.
- [x] I have confirmed that the duplicate code works correctly. (entity spawn)
- [x] I confirmed that the spawn of custom entity works normally.


<details>
<summary>phpstan</summary>

### phpstan
```
.\vendor\bin\phpstan analyze --no-progress --memory-limit=2G
Note: Using configuration file I:\Owner\Desktop\pmmp\PR\PocketMine-MP\phpstan.neon.dist.

 [OK] No errors
 
```
</details>


<details>
<summary>phpunit</summary>

### phpunit
```
.\vendor\bin\phpunit --bootstrap vendor/autoload.php --fail-on-warning tests/phpunit
PHPUnit 9.5.4 by Sebastian Bergmann and contributors.

................................................................. 65 / 71 ( 91%)
......                                                            71 / 71 (100%)

Time: 00:01.605, Memory: 34.00 MB

OK (71 tests, 2918 assertions)
```
</details>

<details>
<summary>Code Style checks</summary>

### Code Style checks
```
php-cs-fixer fix --dry-run --diff --diff-format=udiff
Loaded config default from "I:\Owner\Desktop\pmmp\PR\PocketMine-MP\.php_cs".

Checked all files in 43.458 seconds, 26.000 MB memory used
```
</details>

<details>
<summary>Integration tests</summary>

### Integration tests
using git bash.
```
$ ./tests/travis.sh -t4

Using stub I:\Owner\Desktop\pmmp\PR\PocketMine-MP\tests\plugins\DevTools\stub.php

Adding files...
Added 15 files
Done in 0.061s
Installing dependencies from lock file
Verifying lock file contents can be installed on current platform.
Nothing to install, update or remove
Generating optimized autoload files
1 package you are using is looking for funding.
Use the `composer fund` command to find out more!
> @php -dphar.readonly=0 build/server-phar.php
Git hash detected as 1ebd37e208062138647bfe771411d069414eef73
Creating output file I:\Owner\Desktop\pmmp\PR\PocketMine-MP\PocketMine-MP.phar
Adding files...
Added 1284 files
Compressing files...
Finished compression
Done in 6.194s
Server phar created successfully.
[08:49:28] [Server thread/WARNING]: Xdebug extension is enabled. This has a major impact on performance.
[08:49:28] [Server thread/INFO]: Loading pocketmine.yml...
[08:49:28] [Server thread/INFO]: Loading server properties...
[08:49:28] [Server thread/INFO]: Selected English (eng) as the base language
[08:49:28] [Server thread/INFO]: Starting Minecraft: Bedrock Edition server version v1.16.220
[08:49:28] [Server thread/INFO]: Online mode is enabled. The server will verify that players are authenticated to Xbox Live.
[08:49:28] [Server thread/INFO]: Opening server on 0.0.0.0:19132
[08:49:28] [Server thread/DEBUG]: Server unique id: 49dfa93f-186a-d14a-5ec9-91ff3c5547a1
[08:49:28] [Server thread/DEBUG]: Machine unique id: e8e844ea-a2af-0ddb-f598-570f68bc8ef0
[08:49:28] [Server thread/INFO]: This server is running PocketMine-MP version 3.19.1+dev
[08:49:28] [Server thread/INFO]: PocketMine-MP is distributed under the LGPL License
[08:49:28] [Server thread/DEBUG]: LevelDB support enabled
[08:49:36] [Server thread/DEBUG]: Resource packs path I:\Owner\Desktop\pmmp\PR\PocketMine-MP\test_data\resource_packs\ does not exist, creating directory
[08:49:36] [Server thread/INFO]: Loading resource packs...
[08:49:36] [Server thread/DEBUG]: Successfully loaded 0 resource packs
[08:49:36] [Server thread/INFO]: Loading DevTools v1.14.2
[08:49:36] [Server thread/INFO]: Enabling DevTools v1.14.2
[08:49:36] [Server thread/INFO]: Loading TesterPlugin v0.1.0
[08:49:36] [Server thread/INFO]: [DevTools] Registered folder plugin loader
[08:49:36] [Server thread/NOTICE]: World "world" not found
[08:49:36] [Asynchronous Worker #0 thread/DEBUG]: Set memory limit to 256 MB
[08:49:36] [Server thread/INFO]: Preparing world "world"
[08:49:36] [Server thread/NOTICE]: Spawn terrain for world "world" is being generated in the background
[08:49:36] [Server thread/DEBUG]: Newly loaded chunk 16 16 has no loaders registered, will be unloaded at next available opportunity
[08:49:36] [Server thread/DEBUG]: Newly loaded chunk 13 16 has no loaders registered, will be unloaded at next available opportunity
[08:49:36] [Server thread/DEBUG]: Newly loaded chunk 16 13 has no loaders registered, will be unloaded at next available opportunity
[08:49:36] [Server thread/DEBUG]: Newly loaded chunk 16 19 has no loaders registered, will be unloaded at next available opportunity
[08:49:36] [Server thread/DEBUG]: Newly loaded chunk 19 16 has no loaders registered, will be unloaded at next available opportunity
[08:49:36] [Server thread/DEBUG]: Newly loaded chunk 13 13 has no loaders registered, will be unloaded at next available opportunity
[08:49:36] [Server thread/DEBUG]: Newly loaded chunk 19 13 has no loaders registered, will be unloaded at next available opportunity
[08:49:36] [Server thread/DEBUG]: Newly loaded chunk 13 19 has no loaders registered, will be unloaded at next available opportunity
[08:49:36] [Server thread/DEBUG]: Newly loaded chunk 19 19 has no loaders registered, will be unloaded at next available opportunity
[08:49:36] [Server thread/INFO]: Enabling TesterPlugin v0.1.0
[08:49:36] [Asynchronous Worker #1 thread/DEBUG]: Set memory limit to 256 MB
[08:49:36] [Asynchronous Worker #2 thread/DEBUG]: Set memory limit to 256 MB
[08:49:36] [Asynchronous Worker #3 thread/DEBUG]: Set memory limit to 256 MB
[08:49:36] [Server thread/INFO]: Starting GS4 status listener
[08:49:36] [Server thread/INFO]: Setting query port to 19132
[08:49:36] [Server thread/INFO]: Query running on 0.0.0.0:19132
[08:49:36] [Server thread/INFO]: Default game type: Survival Mode
[08:49:36] [Server thread/INFO]: If you find this project useful, please consider donating to support development: https://patreon.com/pocketminemp
[08:49:36] [Server thread/INFO]: Done (8.546s)! For help, type "help" or "?"
[08:49:36] [Server thread/NOTICE]: [TesterPlugin] Running test #1 (AsyncTask memory leak after completion)
[08:49:36] [Server thread/DEBUG]: [AutoUpdater] Async update check failed due to "Channel not found"
[08:49:51] [Server thread/NOTICE]: [TesterPlugin] Finished test #1 (AsyncTask memory leak after completion): PASS
[08:49:52] [Server thread/NOTICE]: [TesterPlugin] Running test #2 (MainLogger::getLogger() works in AsyncTasks)
[08:49:52] [Asynchronous Worker #0 thread/INFO]: Testing
[08:49:52] [Server thread/NOTICE]: [TesterPlugin] Finished test #2 (MainLogger::getLogger() works in AsyncTasks): PASS
[08:49:53] [Server thread/NOTICE]: [TesterPlugin] Running test #3 (Verify progress updates work as expected when finishing task)
[08:49:53] [Server thread/NOTICE]: [TesterPlugin] Finished test #3 (Verify progress updates work as expected when finishing task): PASS
[08:49:54] [Server thread/NOTICE]: [TesterPlugin] All tests finished, stopping the server
[08:49:54] [Server thread/DEBUG]: Disabling all plugins
[08:49:54] [Server thread/INFO]: Disabling DevTools v1.14.2
[08:49:54] [Server thread/INFO]: Disabling TesterPlugin v0.1.0
[08:49:54] [Server thread/DEBUG]: Unloading all worlds
[08:49:54] [Server thread/INFO]: Unloading world "world"
[08:49:54] [Server thread/DEBUG]: Removing event handlers
[08:49:54] [Server thread/DEBUG]: Shutting down async task worker pool
[08:49:55] [Server thread/DEBUG]: Closing console
[08:49:55] [Server thread/DEBUG]: Stopping network interfaces
[08:49:55] [Server thread/DEBUG]: Stopping network interface pocketmine\network\mcpe\RakLibInterface
[08:49:55] [Server thread/INFO]: Stopping other threads
[08:49:55] [Server thread/DEBUG]: Stopping Console thread
[08:49:56] [Server thread/DEBUG]: Console thread stopped successfully.
[08:49:56] [Server thread/DEBUG]: Stopping Server Killer thread
[08:49:56] [Server thread/DEBUG]: Server Killer thread stopped successfully.

All tests passed
```
</details>

<details>
<summary>php environment</summary>

#### php version
```
php -v
PHP 7.4.10 (cli) (built: Sep 10 2020 22:59:10) ( ZTS Visual C++ 2017 x64 )
Copyright (c) The PHP Group
Zend Engine v3.4.0, Copyright (c) Zend Technologies
    with Xdebug v2.9.6, Copyright (c) 2002-2020, by Derick Rethans
```
#### php modules
```
php -m
[PHP Modules]
bcmath
calendar
com_dotnet
Core
crypto
ctype
curl
date
dom
ds
filter
gd
gmp
hash
iconv
igbinary
json
leveldb
libxml
mbstring
mysqli
mysqlnd
openssl
pcre
PDO
pdo_mysql
pdo_sqlite
Phar
pocketmine_chunkutils
pthreads
recursionguard
Reflection
SimpleXML
sockets
sodium
SPL
sqlite3
standard
tokenizer
vld
xdebug
xml
xmlreader
xmlwriter
yaml
zip
zlib

[Zend Modules]
Xdebug
```
</details>

## Other
#### Special Thanks
We would like to thank [alvin0319](https://github.com/alvin0319) and [brokiem](https://github.com/brokiem) for correcting the code and error text.
<details>
<summary>Open the code that duplicates the error</summary>
<br />

#### src/test/test.php
```php
<?php

namespace test;

use pocketmine\entity\Entity;
use pocketmine\entity\EntityIds;
use pocketmine\math\Vector3;
use pocketmine\plugin\PluginBase;

class test extends PluginBase{
	public function onEnable(){
		Entity::registerEntity(testEntity::class, true);

		$level = $this->getServer()->getDefaultLevel();
		$level->loadChunk(0 >> 4, 0 >> 4);
		$nbt = Entity::createBaseNBT(new Vector3(0, 0, 0));
		$entity = Entity::createEntity("testEntity", $level, $nbt);
	}
}

class testEntity extends Entity{
	const NETWORK_ID = EntityIds::ZOMBIE;

	//Suppose the plugin developer forgot to write the following code.
	//public $height = 1.0;
	//public $width = 1.0;
}

```
#### plugin.yml
```
name: test
main: test\test
version: 1.0
description: "test plugin"
load: POSTWORLD
api: 3.0.0

```
</details>

<details>
<summary>Open error and full backtrace</summary>
<br />

##  Previous error and backtrace
### TypeError
```
TypeError: "Argument 2 passed to pocketmine\entity\DataPropertyManager::setFloat() must be of the type float, null given, called in I:\..\src\...\Entity.php on line 620" (EXCEPTION) in "pmsrc/.../DataPropertyManager" at line 87
#0 pmsrc/src/pocketmine/entity/Entity(620): pocketmine\entity\DataPropertyManager->setFloat(integer 53, NULL )
#1 pmsrc/src/pocketmine/entity/Entity(381): pocketmine\entity\Entity->__construct(object pocketmine\level\Level, object pocketmine\nbt\tag\CompoundTag)
#2 plugins/test/src/test/test(17): pocketmine\entity\Entity::createEntity(string[10] testEntity, object pocketmine\level\Level, object pocketmine\nbt\tag\CompoundTag)
#3 pmsrc/src/pocketmine/plugin/PluginBase(116): test\test->onEnable()
#4 pmsrc/src/pocketmine/plugin/PluginManager(552): pocketmine\plugin\PluginBase->setEnabled(boolean 1)
#5 pmsrc/src/pocketmine/Server(1785): pocketmine\plugin\PluginManager->enablePlugin(object test\test)
#6 pmsrc/src/pocketmine/Server(1771): pocketmine\Server->enablePlugin(object test\test)
#7 pmsrc/src/pocketmine/Server(1584): pocketmine\Server->enablePlugins(integer 1)
#8 pmsrc/src/pocketmine/PocketMine(291): pocketmine\Server->__construct(object BaseClassLoader, object pocketmine\utils\MainLogger, string[39] I:\Owner\Desktop\pmmp\PR\PocketMine-MP\, string[47] I:\Owner\Desktop\pmmp\PR\PocketMine-MP\plugins\)
#9 pmsrc/src/pocketmine/PocketMine(321): pocketmine\server()
```
## Error and backtrace after merging pull request
### RuntimeException
```
RuntimeException: "Entity test\testEntity must declare height and width properties." (EXCEPTION) in "pmsrc/src/pocketmine/entity/Entity" at line 615
#0 pmsrc/src/pocketmine/entity/Entity(382): pocketmine\entity\Entity->__construct(object pocketmine\level\Level, object pocketmine\nbt\tag\CompoundTag)
#1 plugins/test/src/test/test(18): pocketmine\entity\Entity::createEntity(string[10] testEntity, object pocketmine\level\Level, object pocketmine\nbt\tag\CompoundTag)
#2 pmsrc/src/pocketmine/plugin/PluginBase(116): test\test->onEnable()
#3 pmsrc/src/pocketmine/plugin/PluginManager(552): pocketmine\plugin\PluginBase->setEnabled(boolean 1)
#4 pmsrc/src/pocketmine/Server(1785): pocketmine\plugin\PluginManager->enablePlugin(object test\test)
#5 pmsrc/src/pocketmine/Server(1771): pocketmine\Server->enablePlugin(object test\test)
#6 pmsrc/src/pocketmine/Server(1584): pocketmine\Server->enablePlugins(integer 1)
#7 pmsrc/src/pocketmine/PocketMine(291): pocketmine\Server->__construct(object BaseClassLoader, object pocketmine\utils\MainLogger, string[39] I:\Owner\Desktop\pmmp\PR\PocketMine-MP\, string[47] I:\Owner\Desktop\pmmp\PR\PocketMine-MP\plugins\)
#8 pmsrc/src/pocketmine/PocketMine(321): pocketmine\server()
```
### AssumptionFailedError(old)
```
pocketmine\utils\AssumptionFailedError: "test\testEntity has invalid width/height" (EXCEPTION) in "pmsrc/src/pocketmine/entity/Entity" at line 615
#0 pmsrc/src/pocketmine/entity/Entity(382): pocketmine\entity\Entity->__construct(object pocketmine\level\Level, object pocketmine\nbt\tag\CompoundTag)
#1 plugins/test/src/test/test(17): pocketmine\entity\Entity::createEntity(string[10] testEntity, object pocketmine\level\Level, object pocketmine\nbt\tag\CompoundTag)
#2 pmsrc/src/pocketmine/plugin/PluginBase(116): test\test->onEnable()
#3 pmsrc/src/pocketmine/plugin/PluginManager(552): pocketmine\plugin\PluginBase->setEnabled(boolean 1)
#4 pmsrc/src/pocketmine/Server(1785): pocketmine\plugin\PluginManager->enablePlugin(object test\test)
#5 pmsrc/src/pocketmine/Server(1771): pocketmine\Server->enablePlugin(object test\test)
#6 pmsrc/src/pocketmine/Server(1584): pocketmine\Server->enablePlugins(integer 1)
#7 pmsrc/src/pocketmine/PocketMine(291): pocketmine\Server->__construct(object BaseClassLoader, object pocketmine\utils\MainLogger, string[39] I:\Owner\Desktop\pmmp\PR\PocketMine-MP\, string[47] I:\Owner\Desktop\pmmp\PR\PocketMine-MP\plugins\)
#8 pmsrc/src/pocketmine/PocketMine(321): pocketmine\server()
```
### InvalidStateException(old)
```
InvalidStateException: "test\testEntity has invalid width/height" (EXCEPTION) in "pmsrc/src/pocketmine/entity/Entity" at line 614
#0 pmsrc/src/pocketmine/entity/Entity(381): pocketmine\entity\Entity->__construct(object pocketmine\level\Level, object pocketmine\nbt\tag\CompoundTag)
#1 plugins/test/src/test/test(17): pocketmine\entity\Entity::createEntity(string[10] testEntity, object pocketmine\level\Level, object pocketmine\nbt\tag\CompoundTag)
#2 pmsrc/src/pocketmine/plugin/PluginBase(116): test\test->onEnable()
#3 pmsrc/src/pocketmine/plugin/PluginManager(552): pocketmine\plugin\PluginBase->setEnabled(boolean 1)
#4 pmsrc/src/pocketmine/Server(1785): pocketmine\plugin\PluginManager->enablePlugin(object test\test)
#5 pmsrc/src/pocketmine/Server(1771): pocketmine\Server->enablePlugin(object test\test)
#6 pmsrc/src/pocketmine/Server(1584): pocketmine\Server->enablePlugins(integer 1)
#7 pmsrc/src/pocketmine/PocketMine(291): pocketmine\Server->__construct(object BaseClassLoader, object pocketmine\utils\MainLogger, string[39] I:\Owner\Desktop\pmmp\PR\PocketMine-MP\, string[47] I:\Owner\Desktop\pmmp\PR\PocketMine-MP\plugins\)
#8 pmsrc/src/pocketmine/PocketMine(321): pocketmine\server()
```
</details>

<details>
<summary>Open an image about a custom entity</summary>
<br />

![Desktop Screenshot 2021 04 25 - 18 58 08 45](https://user-images.githubusercontent.com/17798680/115989219-51561300-a5f8-11eb-97a6-06eaa23866ad.png)
</details>

<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
