### PR TITLE
SetDisplayObjectivePacket: added missing constants

### DIFF
--- a/src/pocketmine/network/mcpe/protocol/SetDisplayObjectivePacket.php
+++ b/src/pocketmine/network/mcpe/protocol/SetDisplayObjectivePacket.php
@@ -29,11 +29,11 @@ use pocketmine\network\mcpe\NetworkSession;
 
 class SetDisplayObjectivePacket extends DataPacket{
 	public const NETWORK_ID = ProtocolInfo::SET_DISPLAY_OBJECTIVE_PACKET;
-	
+
 	public const DISPLAY_SLOT_LIST = "list";
 	public const DISPLAY_SLOT_SIDEBAR = "sidebar";
 	public const DISPLAY_SLOT_BELOW_NAME = "belowname";
-	
+
 	public const SORT_ORDER_ASCENDING = 0;
 	public const SORT_ORDER_DESCENDING = 1;
 

--- a/src/pocketmine/network/mcpe/protocol/SetDisplayObjectivePacket.php
+++ b/src/pocketmine/network/mcpe/protocol/SetDisplayObjectivePacket.php
@@ -30,6 +30,10 @@ use pocketmine\network\mcpe\NetworkSession;
 class SetDisplayObjectivePacket extends DataPacket{
 	public const NETWORK_ID = ProtocolInfo::SET_DISPLAY_OBJECTIVE_PACKET;
 	
+	public const DISPLAY_SLOT_LIST = "list";
+	public const DISPLAY_SLOT_SIDEBAR = "sidebar";
+	public const DISPLAY_SLOT_BELOW_NAME = "belowname";
+	
 	public const SORT_ORDER_ASCENDING = 0;
 	public const SORT_ORDER_DESCENDING = 1;
 

--- a/src/pocketmine/network/mcpe/protocol/SetDisplayObjectivePacket.php
+++ b/src/pocketmine/network/mcpe/protocol/SetDisplayObjectivePacket.php
@@ -29,6 +29,9 @@ use pocketmine\network\mcpe\NetworkSession;
 
 class SetDisplayObjectivePacket extends DataPacket{
 	public const NETWORK_ID = ProtocolInfo::SET_DISPLAY_OBJECTIVE_PACKET;
+	
+	public const SORT_ORDER_ASCENDING = 0;
+	public const SORT_ORDER_DESCENDING = 1;
 
 	/** @var string */
 	public $displaySlot;


### PR DESCRIPTION
## Introduction
There were no documented constants for some of the fields in SetDisplayObjectivePacket - these being displaySlot and sortOrder (which are two of the fields that matter in terms of what the client sees). This PR adds constants DISPLAY_SLOT_LIST, DISPLAY_SLOT_SIDEBAR and DISPLAY_SLOT_BELOW_NAME, as well as SORT_ORDER_ASCENDING and SORT_ORDER_DESCENDING.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Five new constants are now available in SetDisplayObjectivePacket - three for the displaySlot field and two for the sortOrder field.
### Behavioural changes
There are no observable behavioral changes.
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
There are no backwards compatibility problems coming from these minor additions.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
N/A

<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
