### PR TITLE
Apply damage items even if it is broken

### DIFF
--- a/src/pocketmine/item/Durable.php
+++ b/src/pocketmine/item/Durable.php
@@ -52,7 +52,7 @@ abstract class Durable extends Item{
 	 * @return bool if any damage was applied to the item
 	 */
 	public function applyDamage(int $amount) : bool{
-		if($this->isUnbreakable() or $this->isBroken()){
+		if($this->isUnbreakable()){
 			return false;
 		}
 


### PR DESCRIPTION
## Introduction
Broken items that is created by give command or plugins will be taken damage when called ```Item -> applyDamage()```.
Currently, broken items will not be removed.

### Relevant issues
nothing

## Changes
### API changes
nothing

### Behavioural changes
Broken items cannot be used for a number of times.

## Backwards compatibility
nothing

## Follow-up
nothing

## Tests
* I have confirmed that players can be logged in normally.
* I have confirmed that durable items can use normally.
* I have confirmed that broken durable items was removed when use without any errors