### PR TITLE
Better sorting of items in InventoryHelpersTrait::addItem()

### DIFF
--- a/src/inventory/InventoryHelpersTrait.php
+++ b/src/inventory/InventoryHelpersTrait.php
@@ -144,6 +144,22 @@ trait InventoryHelpersTrait{
 			}
 		}
 
+		foreach($itemSlots as $key1 => $slot1){
+			foreach($itemSlots as $key2 => $slot2){
+				if($key1 !== $key2 and $slot1->equals($slot2) and $slot1->getCount() < $slot1->getMaxStackSize()){
+					$amount = min($slot1->getMaxStackSize() - $slot1->getCount(), $slot2->getCount(), $this->getMaxStackSize());
+					if($amount > 0){
+						$slot2->setCount($slot2->getCount() - $amount);
+						$slot1->setCount($slot1->getCount() + $amount);
+						$itemSlots[$key1] = $slot1;
+						if($slot2->getCount() <= 0){
+							unset($itemSlots[$key2]);
+						}
+					}
+				}
+			}
+		}
+
 		$emptySlots = [];
 
 		for($i = 0, $size = $this->getSize(); $i < $size; ++$i){

--- a/src/inventory/InventoryHelpersTrait.php
+++ b/src/inventory/InventoryHelpersTrait.php
@@ -178,7 +178,6 @@ trait InventoryHelpersTrait{
 
 		if(count($emptySlots) > 0){
 			foreach($emptySlots as $slotIndex){
-				//This loop only gets the first item, then goes to the next empty slot
 				$amount = min($slot->getMaxStackSize(), $slot->getCount(), $this->getMaxStackSize());
 				$slot->setCount($slot->getCount() - $amount);
 				$item = clone $slot;

--- a/src/inventory/InventoryHelpersTrait.php
+++ b/src/inventory/InventoryHelpersTrait.php
@@ -148,7 +148,10 @@ trait InventoryHelpersTrait{
 		$returnSlots = [];
 
 		foreach($itemSlots as $item){
-			$returnSlots[] = $this->internalAddItem($item);
+			$leftover = $this->internalAddItem($item);
+			if(!$leftover->isNull()){
+				$returnSlots[] = $leftover;
+			}
 		}
 
 		return $returnSlots;


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Dylan posted an issue on it, so its getting changed.

### Relevant issues
<!-- List relevant issues here -->
Fixes #1412

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
`InventoryHelpersTrait::addItem()` will now stack items together even when provided separately as parameters.

### Behavioral changes
<!-- Any change in how the server behaves, or its performance? -->
N/A

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
N/A

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
N/A

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->

```php
$inventory->addItem(
	VanillaBlocks::OAK_PLANKS()->asItem()->setCount(16),
	VanillaBlocks::OAK_PLANKS()->asItem()->setCount(16),
	VanillaBlocks::OAK_PLANKS()->asItem()->setCount(16),
	VanillaBlocks::OAK_PLANKS()->asItem()->setCount(16)
);
```

![image](https://user-images.githubusercontent.com/16521025/120718746-c8a08180-c497-11eb-8e16-4dd30db1e54d.png)
