### PR TITLE
Leaves can now be silk touched

### DIFF
--- a/src/block/Leaves.php
+++ b/src/block/Leaves.php
@@ -34,7 +34,6 @@ use pocketmine\math\Vector3;
 use pocketmine\player\Player;
 use pocketmine\world\BlockTransaction;
 use pocketmine\world\World;
-use function count;
 use function mt_rand;
 
 class Leaves extends Transparent{
@@ -137,16 +136,17 @@ class Leaves extends Transparent{
 		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
 	}
 
-	public function getDrops(Item $item) : array{
-		$drops = parent::getDrops($item);
+	public function getDropsForCompatibleTool(Item $item) : array{
+		if(($item->getBlockToolType() & BlockToolType::SHEARS) !== 0){
+			return parent::getDropsForCompatibleTool($item);
+		}
+		$drops = [];
 
-		if(count($drops) < 1){
-			if(mt_rand(1, 20) === 1){ //Saplings
-				$drops[] = ItemFactory::getInstance()->get(ItemIds::SAPLING, $this->treeType->getMagicNumber());
-			}
-			if(($this->treeType->equals(TreeType::OAK()) or $this->treeType->equals(TreeType::DARK_OAK())) and mt_rand(1, 200) === 1){ //Apples
-				$drops[] = VanillaItems::APPLE();
-			}
+		if(mt_rand(1, 20) === 1){ //Saplings
+			$drops[] = ItemFactory::getInstance()->get(ItemIds::SAPLING, $this->treeType->getMagicNumber());
+		}
+		if(($this->treeType->equals(TreeType::OAK()) or $this->treeType->equals(TreeType::DARK_OAK())) and mt_rand(1, 200) === 1){ //Apples
+			$drops[] = VanillaItems::APPLE();
 		}
 
 		return $drops;

--- a/src/block/Leaves.php
+++ b/src/block/Leaves.php
@@ -140,6 +140,7 @@ class Leaves extends Transparent{
 		if(($item->getBlockToolType() & BlockToolType::SHEARS) !== 0){
 			return parent::getDropsForCompatibleTool($item);
 		}
+
 		$drops = [];
 		if(mt_rand(1, 20) === 1){ //Saplings
 			$drops[] = ItemFactory::getInstance()->get(ItemIds::SAPLING, $this->treeType->getMagicNumber());

--- a/src/block/Leaves.php
+++ b/src/block/Leaves.php
@@ -34,6 +34,7 @@ use pocketmine\math\Vector3;
 use pocketmine\player\Player;
 use pocketmine\world\BlockTransaction;
 use pocketmine\world\World;
+use function count;
 use function mt_rand;
 
 class Leaves extends Transparent{

--- a/src/block/Leaves.php
+++ b/src/block/Leaves.php
@@ -141,7 +141,6 @@ class Leaves extends Transparent{
 			return parent::getDropsForCompatibleTool($item);
 		}
 		$drops = [];
-
 		if(mt_rand(1, 20) === 1){ //Saplings
 			$drops[] = ItemFactory::getInstance()->get(ItemIds::SAPLING, $this->treeType->getMagicNumber());
 		}

--- a/src/block/Leaves.php
+++ b/src/block/Leaves.php
@@ -137,19 +137,22 @@ class Leaves extends Transparent{
 	}
 
 	public function getDrops(Item $item) : array{
-		if(($item->getBlockToolType() & BlockToolType::SHEARS) !== 0){
-			return $this->getDropsForCompatibleTool($item);
-		}
+		$drops = parent::getDrops($item);
 
-		$drops = [];
-		if(mt_rand(1, 20) === 1){ //Saplings
-			$drops[] = ItemFactory::getInstance()->get(ItemIds::SAPLING, $this->treeType->getMagicNumber());
-		}
-		if(($this->treeType->equals(TreeType::OAK()) or $this->treeType->equals(TreeType::DARK_OAK())) and mt_rand(1, 200) === 1){ //Apples
-			$drops[] = VanillaItems::APPLE();
+		if(count($drops) < 1){
+			if(mt_rand(1, 20) === 1){ //Saplings
+				$drops[] = ItemFactory::getInstance()->get(ItemIds::SAPLING, $this->treeType->getMagicNumber());
+			}
+			if(($this->treeType->equals(TreeType::OAK()) or $this->treeType->equals(TreeType::DARK_OAK())) and mt_rand(1, 200) === 1){ //Apples
+				$drops[] = VanillaItems::APPLE();
+			}
 		}
 
 		return $drops;
+	}
+
+	public function isAffectedBySilkTouch() : bool{
+		return true;
 	}
 
 	public function getFlameEncouragement() : int{


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Silk touch doesn't work on leaves, but it does in vanilla.

### Relevant issues
<!-- List relevant issues here -->
Fixes #3714

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
N/A

### Behavioral changes
<!-- Any change in how the server behaves, or its performance? -->
N/A

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
N/A

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
N/A

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->

Confirmed leaf blocks can be silk touched in-game.
Confirmed leaf block other drop chances are unaffected.