### PR TITLE
Save and load arrow critical state with world

### DIFF
--- a/src/entity/EntityFactory.php
+++ b/src/entity/EntityFactory.php
@@ -77,7 +77,7 @@ final class EntityFactory{
 		//TODO: index them by version to allow proper multi-save compatibility
 
 		$this->register(Arrow::class, function(World $world, CompoundTag $nbt) : Arrow{
-			return new Arrow(EntityDataHelper::parseLocation($nbt, $world), null, false, $nbt); //TODO: missing critical flag
+			return new Arrow(EntityDataHelper::parseLocation($nbt, $world), null, $nbt->getByte(Arrow::TAG_CRIT, 0) === 1, $nbt);
 		}, ['Arrow', 'minecraft:arrow'], EntityLegacyIds::ARROW);
 
 		$this->register(Egg::class, function(World $world, CompoundTag $nbt) : Egg{

--- a/src/entity/projectile/Arrow.php
+++ b/src/entity/projectile/Arrow.php
@@ -50,6 +50,7 @@ class Arrow extends Projectile{
 	public const PICKUP_CREATIVE = 2;
 
 	private const TAG_PICKUP = "pickup"; //TAG_Byte
+	private const TAG_CRIT = "crit"; //TAG_Byte
 
 	protected $gravity = 0.05;
 	protected $drag = 0.01;
@@ -80,12 +81,14 @@ class Arrow extends Projectile{
 		parent::initEntity($nbt);
 
 		$this->pickupMode = $nbt->getByte(self::TAG_PICKUP, self::PICKUP_ANY);
+		$this->critical = (bool) $nbt->getByte(self::TAG_CRIT, 0);
 		$this->collideTicks = $nbt->getShort("life", $this->collideTicks);
 	}
 
 	public function saveNBT() : CompoundTag{
 		$nbt = parent::saveNBT();
 		$nbt->setByte(self::TAG_PICKUP, $this->pickupMode);
+		$nbt->setByte(self::TAG_CRIT, (int) $this->critical);
 		$nbt->setShort("life", $this->collideTicks);
 		return $nbt;
 	}

--- a/src/entity/projectile/Arrow.php
+++ b/src/entity/projectile/Arrow.php
@@ -81,14 +81,14 @@ class Arrow extends Projectile{
 		parent::initEntity($nbt);
 
 		$this->pickupMode = $nbt->getByte(self::TAG_PICKUP, self::PICKUP_ANY);
-		$this->critical = (bool) $nbt->getByte(self::TAG_CRIT, 0);
+		$this->critical = $nbt->getByte(self::TAG_CRIT, 0) === 1;
 		$this->collideTicks = $nbt->getShort("life", $this->collideTicks);
 	}
 
 	public function saveNBT() : CompoundTag{
 		$nbt = parent::saveNBT();
 		$nbt->setByte(self::TAG_PICKUP, $this->pickupMode);
-		$nbt->setByte(self::TAG_CRIT, (int) $this->critical);
+		$nbt->setByte(self::TAG_CRIT, $this->critical ? 1 : 0);
 		$nbt->setShort("life", $this->collideTicks);
 		return $nbt;
 	}

--- a/src/entity/projectile/Arrow.php
+++ b/src/entity/projectile/Arrow.php
@@ -50,7 +50,7 @@ class Arrow extends Projectile{
 	public const PICKUP_CREATIVE = 2;
 
 	private const TAG_PICKUP = "pickup"; //TAG_Byte
-	private const TAG_CRIT = "crit"; //TAG_Byte
+	public const TAG_CRIT = "crit"; //TAG_Byte
 
 	protected $gravity = 0.05;
 	protected $drag = 0.01;


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Fixes arrow critical flag not being saved to disk.

### Relevant issues
<!-- List relevant issues here -->
Fixed #3596

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
N/A

### Behavioral changes
<!-- Any change in how the server behaves, or its performance? -->
N/A

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
N/A

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
N/A

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->

Verified NBT data correctly saved on disk during chunk unload.
Verified critical arrow spawned on chunk load.