### PR TITLE
Added Type NBT data for illager banners

### DIFF
--- a/src/block/BaseBanner.php
+++ b/src/block/BaseBanner.php
@@ -47,6 +47,8 @@ abstract class BaseBanner extends Transparent{
 	 */
 	protected array $patterns = [];
 
+	private bool $illagerPattern = false;
+
 	public function __construct(BlockIdentifier $idInfo, string $name, BlockBreakInfo $breakInfo){
 		$this->color = DyeColor::BLACK();
 		parent::__construct($idInfo, $name, $breakInfo);
@@ -58,6 +60,7 @@ abstract class BaseBanner extends Transparent{
 		if($tile instanceof TileBanner){
 			$this->color = $tile->getBaseColor();
 			$this->setPatterns($tile->getPatterns());
+			$this->illagerPattern = $tile->isIllagerPattern();
 		}
 	}
 
@@ -67,6 +70,7 @@ abstract class BaseBanner extends Transparent{
 		assert($tile instanceof TileBanner);
 		$tile->setBaseColor($this->color);
 		$tile->setPatterns($this->patterns);
+		$tile->setIllagerPattern($this->illagerPattern);
 	}
 
 	public function isSolid() : bool{
@@ -98,6 +102,14 @@ abstract class BaseBanner extends Transparent{
 		}
 		$this->patterns = $checked;
 		return $this;
+	}
+
+	public function isIllagerPattern() : bool{
+		return $this->illagerPattern;
+	}
+
+	public function setIllagerPattern(bool $illagerPattern) : void{
+		$this->illagerPattern = $illagerPattern;
 	}
 
 	/**

--- a/src/block/BaseBanner.php
+++ b/src/block/BaseBanner.php
@@ -151,7 +151,7 @@ abstract class BaseBanner extends Transparent{
 
 	public function getPickedItem(bool $addUserData = false) : Item{
 		$result = $this->asItem();
-		if($result instanceof ItemBanner) {
+		if($result instanceof ItemBanner){
 			$result->setPatterns($this->patterns);
 			$result->setIllagerPattern($this->illagerPattern);
 		}

--- a/src/block/BaseBanner.php
+++ b/src/block/BaseBanner.php
@@ -151,8 +151,9 @@ abstract class BaseBanner extends Transparent{
 
 	public function getPickedItem(bool $addUserData = false) : Item{
 		$result = $this->asItem();
-		if($addUserData && $result instanceof ItemBanner && count($this->patterns) > 0){
+		if($result instanceof ItemBanner) {
 			$result->setPatterns($this->patterns);
+			$result->setIllagerPattern($this->illagerPattern);
 		}
 		return $result;
 	}

--- a/src/block/tile/Banner.php
+++ b/src/block/tile/Banner.php
@@ -40,6 +40,7 @@ use pocketmine\world\World;
 class Banner extends Spawnable{
 
 	public const TAG_BASE = "Base";
+	public const TAG_TYPE = "Type"; // IntTag
 	public const TAG_PATTERNS = "Patterns";
 	public const TAG_PATTERN_COLOR = "Color";
 	public const TAG_PATTERN_NAME = "Pattern";
@@ -52,6 +53,8 @@ class Banner extends Spawnable{
 	 * @phpstan-var list<BannerPatternLayer>
 	 */
 	private $patterns = [];
+
+	private bool $illagerPattern = false;
 
 	public function __construct(World $world, Vector3 $pos){
 		$this->baseColor = DyeColor::BLACK();
@@ -83,6 +86,8 @@ class Banner extends Spawnable{
 				$this->patterns[] = new BannerPatternLayer($patternType, $patternColor);
 			}
 		}
+
+		$this->illagerPattern = (bool) $nbt->getInt(self::TAG_TYPE, 0);
 	}
 
 	protected function writeSaveData(CompoundTag $nbt) : void{
@@ -97,6 +102,7 @@ class Banner extends Spawnable{
 			);
 		}
 		$nbt->setTag(self::TAG_PATTERNS, $patterns);
+		$nbt->setInt(self::TAG_TYPE, (int) $this->illagerPattern);
 	}
 
 	protected function addAdditionalSpawnData(CompoundTag $nbt) : void{
@@ -111,6 +117,7 @@ class Banner extends Spawnable{
 			);
 		}
 		$nbt->setTag(self::TAG_PATTERNS, $patterns);
+		$nbt->setInt(self::TAG_TYPE, (int) $this->illagerPattern);
 	}
 
 	/**
@@ -142,6 +149,14 @@ class Banner extends Spawnable{
 	 */
 	public function setPatterns(array $patterns) : void{
 		$this->patterns = $patterns;
+	}
+
+	public function isIllagerPattern() : bool{
+		return $this->illagerPattern;
+	}
+
+	public function setIllagerPattern(bool $illagerPattern) : void{
+		$this->illagerPattern = $illagerPattern;
 	}
 
 	public function getDefaultName() : string{

--- a/src/block/tile/Banner.php
+++ b/src/block/tile/Banner.php
@@ -27,6 +27,7 @@ use pocketmine\block\utils\BannerPatternLayer;
 use pocketmine\block\utils\DyeColor;
 use pocketmine\data\bedrock\BannerPatternTypeIdMap;
 use pocketmine\data\bedrock\DyeColorIdMap;
+use pocketmine\item\Banner as BannerItem;
 use pocketmine\item\Item;
 use pocketmine\math\Vector3;
 use pocketmine\nbt\tag\CompoundTag;
@@ -123,8 +124,9 @@ class Banner extends Spawnable{
 
 	public function copyDataFromItem(Item $item) : void{
 		parent::copyDataFromItem($item);
-		/** @var \pocketmine\item\Banner $item */
-		$this->illagerPattern = $item->isIllagerPattern();
+		if($item instanceof BannerItem){
+			$this->illagerPattern = $item->isIllagerPattern();
+		}
 	}
 
 	/**

--- a/src/block/tile/Banner.php
+++ b/src/block/tile/Banner.php
@@ -27,6 +27,7 @@ use pocketmine\block\utils\BannerPatternLayer;
 use pocketmine\block\utils\DyeColor;
 use pocketmine\data\bedrock\BannerPatternTypeIdMap;
 use pocketmine\data\bedrock\DyeColorIdMap;
+use pocketmine\item\Item;
 use pocketmine\math\Vector3;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\IntTag;
@@ -118,6 +119,12 @@ class Banner extends Spawnable{
 		}
 		$nbt->setTag(self::TAG_PATTERNS, $patterns);
 		$nbt->setInt(self::TAG_TYPE, $this->illagerPattern ? 1 : 0);
+	}
+
+	public function copyDataFromItem(Item $item) : void{
+		parent::copyDataFromItem($item);
+		/** @var \pocketmine\item\Banner $item */
+		$this->illagerPattern = $item->isIllagerPattern();
 	}
 
 	/**

--- a/src/block/tile/Banner.php
+++ b/src/block/tile/Banner.php
@@ -87,7 +87,7 @@ class Banner extends Spawnable{
 			}
 		}
 
-		$this->illagerPattern = (bool) $nbt->getInt(self::TAG_TYPE, 0);
+		$this->illagerPattern = $nbt->getInt(self::TAG_TYPE, 0) !== 0;
 	}
 
 	protected function writeSaveData(CompoundTag $nbt) : void{
@@ -102,7 +102,7 @@ class Banner extends Spawnable{
 			);
 		}
 		$nbt->setTag(self::TAG_PATTERNS, $patterns);
-		$nbt->setInt(self::TAG_TYPE, (int) $this->illagerPattern);
+		$nbt->setInt(self::TAG_TYPE, $this->illagerPattern ? 1 : 0);
 	}
 
 	protected function addAdditionalSpawnData(CompoundTag $nbt) : void{
@@ -117,7 +117,7 @@ class Banner extends Spawnable{
 			);
 		}
 		$nbt->setTag(self::TAG_PATTERNS, $patterns);
-		$nbt->setInt(self::TAG_TYPE, (int) $this->illagerPattern);
+		$nbt->setInt(self::TAG_TYPE, $this->illagerPattern ? 1 : 0);
 	}
 
 	/**

--- a/src/item/Banner.php
+++ b/src/item/Banner.php
@@ -95,7 +95,6 @@ class Banner extends ItemBlockWallOrFloor{
 
 	public function setIllagerPattern(bool $illagerPattern) : self{
 		$this->illagerPattern = $illagerPattern;
-		$this->color = DyeColor::WHITE(); // meta 15 matches vanilla
 		return $this;
 	}
 

--- a/src/item/Banner.php
+++ b/src/item/Banner.php
@@ -34,6 +34,7 @@ use pocketmine\nbt\tag\ListTag;
 use function count;
 
 class Banner extends ItemBlockWallOrFloor{
+	public const TAG_TYPE = TileBanner::TAG_TYPE; // IntTag
 	public const TAG_PATTERNS = TileBanner::TAG_PATTERNS;
 	public const TAG_PATTERN_COLOR = TileBanner::TAG_PATTERN_COLOR;
 	public const TAG_PATTERN_NAME = TileBanner::TAG_PATTERN_NAME;
@@ -46,6 +47,8 @@ class Banner extends ItemBlockWallOrFloor{
 	 * @phpstan-var list<BannerPatternLayer>
 	 */
 	private $patterns = [];
+
+	private bool $illagerPattern = false;
 
 	public function __construct(ItemIdentifier $identifier, Block $floorVariant, Block $wallVariant){
 		parent::__construct($identifier, $floorVariant, $wallVariant);
@@ -86,6 +89,15 @@ class Banner extends ItemBlockWallOrFloor{
 		return $this;
 	}
 
+	public function isIllagerPattern() : bool{
+		return $this->illagerPattern;
+	}
+
+	public function setIllagerPattern(bool $illagerPattern) : self{
+		$this->illagerPattern = $illagerPattern;
+		return $this;
+	}
+
 	public function getFuelTime() : int{
 		return 300;
 	}
@@ -109,6 +121,7 @@ class Banner extends ItemBlockWallOrFloor{
 				$this->patterns[] = new BannerPatternLayer($patternType, $patternColor);
 			}
 		}
+		$this->illagerPattern = (bool) $tag->getInt(self::TAG_TYPE, 0);
 	}
 
 	protected function serializeCompoundTag(CompoundTag $tag) : void{
@@ -129,5 +142,6 @@ class Banner extends ItemBlockWallOrFloor{
 		}else{
 			$tag->removeTag(self::TAG_PATTERNS);
 		}
+		$tag->setInt(self::TAG_TYPE, (int) $this->illagerPattern);
 	}
 }

--- a/src/item/Banner.php
+++ b/src/item/Banner.php
@@ -93,8 +93,10 @@ class Banner extends ItemBlockWallOrFloor{
 		return $this->illagerPattern;
 	}
 
-	public function setIllagerPattern(bool $illagerPattern) : void{
+	public function setIllagerPattern(bool $illagerPattern) : self{
 		$this->illagerPattern = $illagerPattern;
+		$this->color = DyeColor::WHITE(); // meta 15 matches vanilla
+		return $this;
 	}
 
 	public function getFuelTime() : int{

--- a/src/item/Banner.php
+++ b/src/item/Banner.php
@@ -93,9 +93,8 @@ class Banner extends ItemBlockWallOrFloor{
 		return $this->illagerPattern;
 	}
 
-	public function setIllagerPattern(bool $illagerPattern) : self{
+	public function setIllagerPattern(bool $illagerPattern) : void{
 		$this->illagerPattern = $illagerPattern;
-		return $this;
 	}
 
 	public function getFuelTime() : int{
@@ -121,7 +120,7 @@ class Banner extends ItemBlockWallOrFloor{
 				$this->patterns[] = new BannerPatternLayer($patternType, $patternColor);
 			}
 		}
-		$this->illagerPattern = (bool) $tag->getInt(self::TAG_TYPE, 0);
+		$this->illagerPattern = $tag->getInt(self::TAG_TYPE, 0) !== 0;
 	}
 
 	protected function serializeCompoundTag(CompoundTag $tag) : void{
@@ -142,6 +141,6 @@ class Banner extends ItemBlockWallOrFloor{
 		}else{
 			$tag->removeTag(self::TAG_PATTERNS);
 		}
-		$tag->setInt(self::TAG_TYPE, (int) $this->illagerPattern);
+		$tag->setInt(self::TAG_TYPE, $this->illagerPattern ? 1 : 0);
 	}
 }


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Banners can now be set and used as the illager type.

### Relevant issues
<!-- List relevant issues here -->
Fixes #2951

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
6 new functions:
`item\Banner::isIllagerPattern()`
`item\Banner::setIllagerPattern(bool)`
`tile\Banner::isIllagerPattern()`
`tile\Banner::setIllagerPattern(bool)`
`block\BaseBanner::isIllagerPattern()`
`block\BaseBanner::setIllagerPattern(bool)`

### Behavioral changes
<!-- Any change in how the server behaves, or its performance? -->
N/A

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
N/A

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
WIP

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Pending Tests