### PR TITLE
The top of blocks are now collided with correctly

### DIFF
--- a/src/entity/Entity.php
+++ b/src/entity/Entity.php
@@ -1247,7 +1247,7 @@ abstract class Entity{
 			$inset = 0.001; //Offset against floating-point errors
 
 			$minX = (int) floor($this->boundingBox->minX + $inset);
-			$minY = (int) floor($this->boundingBox->minY + $inset);
+			$minY = (int) floor($this->boundingBox->minY + $inset - (($this->boundingBox->minY - ((int) $this->boundingBox->minY)) > 2 / 16 ? 0 : 1));
 			$minZ = (int) floor($this->boundingBox->minZ + $inset);
 			$maxX = (int) floor($this->boundingBox->maxX - $inset);
 			$maxY = (int) floor($this->boundingBox->maxY - $inset);


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Block collisions for the blocks directly below the player will now take effect when the player is within 3/16 of the block.

### Relevant issues
<!-- List relevant issues here -->
* Fixes #2731
* Fixes #2041

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
N/A

### Behavioral changes
<!-- Any change in how the server behaves, or its performance? -->
N/A

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
N/A

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
N/A

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->

In-game testing shows standing on cactus and magma blocks damages the player.
Standing on trapdoors and half slabs does not damage the player.
Standing on carpets will damage the player, matching vanilla.