### PR TITLE
Remove movement workaround from 1.14.30

### DIFF
--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -51,7 +51,6 @@ use pocketmine\network\mcpe\protocol\ActorEventPacket;
 use pocketmine\network\mcpe\protocol\AddPlayerPacket;
 use pocketmine\network\mcpe\protocol\LevelEventPacket;
 use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
-use pocketmine\network\mcpe\protocol\MovePlayerPacket;
 use pocketmine\network\mcpe\protocol\PlayerListPacket;
 use pocketmine\network\mcpe\protocol\PlayerSkinPacket;
 use pocketmine\network\mcpe\protocol\types\inventory\ItemStackWrapper;
@@ -829,23 +828,6 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 			$pk->entries = [PlayerListEntry::createRemovalEntry($this->uuid)];
 			$player->dataPacket($pk);
 		}
-	}
-
-	public function broadcastMovement(bool $teleport = false) : void{
-		//TODO: workaround 1.14.30 bug: MoveActor(Absolute|Delta)Packet don't work on players anymore :(
-		$pk = new MovePlayerPacket();
-		$pk->entityRuntimeId = $this->getId();
-		$pk->position = $this->getOffsetPosition($this);
-		$pk->yaw = $this->yaw;
-		$pk->pitch = $this->pitch;
-		$pk->headYaw = $this->yaw;
-		$pk->mode = $teleport ? MovePlayerPacket::MODE_TELEPORT : MovePlayerPacket::MODE_NORMAL;
-
-		//we can't assume that everyone who is using our chunk wants to see this movement,
-		//because this human might be a player who shouldn't be receiving his own movement.
-		//this didn't matter when we were able to use MoveActorPacket because
-		//the client just ignored MoveActor for itself, but it doesn't ignore MovePlayer for itself.
-		$this->server->broadcastPacket($this->hasSpawned, $pk);
 	}
 
 	public function close() : void{


### PR DESCRIPTION
## Introduction
This pull request removes the movement workaround from 1.14.30 where the packets MoveActorAbsolute and MoveActorDelta no longer worked on players. I do not know when this was fixed but this was tested on 1.16.221 and it works fine. It is said that the MoveActor packets are smoother over the MovePlayer counterparts and I do believe this myself, but it could also be a case of the placebo effect in my own testing.

## Changes
Human->broadcastMovement() was removed, using Entity->broadcastMovement() instead.

## Tests
https://user-images.githubusercontent.com/17461354/120941860-2381e500-c6f3-11eb-9125-ecdfa1df8632.mp4
