### PR TITLE
Player argument to /transferserver command

### DIFF
--- a/src/pocketmine/command/defaults/TransferServerCommand.php
+++ b/src/pocketmine/command/defaults/TransferServerCommand.php
@@ -26,6 +26,8 @@ namespace pocketmine\command\defaults;
 use pocketmine\command\CommandSender;
 use pocketmine\command\utils\InvalidCommandSyntaxException;
 use pocketmine\Player;
+use pocketmine\utils\TextFormat;
+
 use function count;
 
 class TransferServerCommand extends VanillaCommand{
@@ -53,7 +55,7 @@ class TransferServerCommand extends VanillaCommand{
 		}elseif(count($args) == 3) {
 			$target = $sender->getServer()->getPlayer($args[2]);
 			if (!$target instanceof Player) {
-				throw new InvalidCommandSyntaxException();
+				$sender->sendMessage(TextFormat::RED . "Can't find player " . $args[2]);
 			}
 		}else{
 			$target = $sender;

--- a/src/pocketmine/command/defaults/TransferServerCommand.php
+++ b/src/pocketmine/command/defaults/TransferServerCommand.php
@@ -25,7 +25,6 @@ namespace pocketmine\command\defaults;
 
 use pocketmine\command\CommandSender;
 use pocketmine\command\utils\InvalidCommandSyntaxException;
-use pocketmine\lang\TranslationContainer;
 use pocketmine\Player;
 use pocketmine\utils\TextFormat;
 
@@ -57,7 +56,7 @@ class TransferServerCommand extends VanillaCommand{
 				return true;
 			}
 			$target = $sender->getServer()->getPlayer($args[2]);
-			if (!$target instanceof Player || !$target->isOnline()){
+			if (!$target instanceof Player){
 				$message = $sender->getServer()->getLanguage()->translateString(TextFormat::RED . "%commands.generic.player.notFound");
 				$sender->sendMessage($message);
 
@@ -70,7 +69,7 @@ class TransferServerCommand extends VanillaCommand{
 		}else{
 			$target = $sender;
 		}
-		
+
 		$target->transfer($args[0], (int) ($args[1] ?? 19132));
 
 		return true;

--- a/src/pocketmine/command/defaults/TransferServerCommand.php
+++ b/src/pocketmine/command/defaults/TransferServerCommand.php
@@ -25,6 +25,7 @@ namespace pocketmine\command\defaults;
 
 use pocketmine\command\CommandSender;
 use pocketmine\command\utils\InvalidCommandSyntaxException;
+use pocketmine\lang\TranslationContainer;
 use pocketmine\Player;
 use pocketmine\utils\TextFormat;
 
@@ -38,7 +39,7 @@ class TransferServerCommand extends VanillaCommand{
 			"%pocketmine.command.transferserver.description",
 			"%pocketmine.command.transferserver.usage"
 		);
-		$this->setPermission("pocketmine.command.transferserver");
+		$this->setPermission("pocketmine.command.transferserver;pocketmine.command.transferserver.other");
 	}
 
 	public function execute(CommandSender $sender, string $commandLabel, array $args){
@@ -48,19 +49,28 @@ class TransferServerCommand extends VanillaCommand{
 
 		if(count($args) < 1){
 			throw new InvalidCommandSyntaxException();
-		}elseif(!($sender instanceof Player)){
+		}elseif(count($args) === 3){
+			if (!$sender->hasPermission("pocketmine.command.transferserver.other")){
+				$message = $sender->getServer()->getLanguage()->translateString(TextFormat::RED . "%commands.generic.permission");
+				$sender->sendMessage($message);
+
+				return true;
+			}
+			$target = $sender->getServer()->getPlayer($args[2]);
+			if (!$target instanceof Player || !$target->isOnline()){
+				$message = $sender->getServer()->getLanguage()->translateString(TextFormat::RED . "%commands.generic.player.notFound");
+				$sender->sendMessage($message);
+
+				return true;
+			}
+		}elseif (!$sender instanceof Player){
 			$sender->sendMessage("This command must be executed as a player");
 
-			return false;
-		}elseif(count($args) == 3) {
-			$target = $sender->getServer()->getPlayer($args[2]);
-			if (!$target instanceof Player) {
-				$sender->sendMessage(TextFormat::RED . "Can't find player " . $args[2]);
-			}
+			return true;
 		}else{
 			$target = $sender;
 		}
-
+		
 		$target->transfer($args[0], (int) ($args[1] ?? 19132));
 
 		return true;

--- a/src/pocketmine/command/defaults/TransferServerCommand.php
+++ b/src/pocketmine/command/defaults/TransferServerCommand.php
@@ -50,9 +50,16 @@ class TransferServerCommand extends VanillaCommand{
 			$sender->sendMessage("This command must be executed as a player");
 
 			return false;
+		}elseif(count($args) == 3) {
+			$target = $sender->getServer()->getPlayer($args[2]);
+			if (!$target instanceof Player) {
+				throw new InvalidCommandSyntaxException();
+			}
+		}else{
+			$target = $sender;
 		}
 
-		$sender->transfer($args[0], (int) ($args[1] ?? 19132));
+		$target->transfer($args[0], (int) ($args[1] ?? 19132));
 
 		return true;
 	}

--- a/src/pocketmine/permission/DefaultPermissions.php
+++ b/src/pocketmine/permission/DefaultPermissions.php
@@ -122,6 +122,7 @@ abstract class DefaultPermissions{
 		self::registerPermission(new Permission(self::ROOT . ".command.spawnpoint", "Allows the user to change player's spawnpoint", Permission::DEFAULT_OP), $commands);
 		self::registerPermission(new Permission(self::ROOT . ".command.setworldspawn", "Allows the user to change the world spawn", Permission::DEFAULT_OP), $commands);
 		self::registerPermission(new Permission(self::ROOT . ".command.transferserver", "Allows the user to transfer self to another server", Permission::DEFAULT_OP), $commands);
+		self::registerPermission(new Permission(self::ROOT . ".command.transferserver.other", "Allows the user to transfer another player to another server", Permission::DEFAULT_OP), $commands);
 		self::registerPermission(new Permission(self::ROOT . ".command.title", "Allows the user to send a title to the specified player", Permission::DEFAULT_OP), $commands);
 		self::registerPermission(new Permission(self::ROOT . ".command.difficulty", "Allows the user to change the game difficulty", Permission::DEFAULT_OP), $commands);
 


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
The /transferserver command could only be used by the person himself, and not transferred to any player.
### Relevant issues

Fixes: pmmp/PocketMine-MP#4065

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
N/A
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
N/A
## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
N/A
## Follow-up

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `pocketmine.command.transferserver.description` | `Transfer someone to another server` |
| `pocketmine.command.transferserver.usage` | `/transferserver <server> [port] [player]` |

## Tests
Connect a second account and transfer it to a server of your choice. Works
