### PR TITLE
InventoryHelpersTrait::AddItem() cannot add items with a count greater than maxstack

### DIFF
--- a/src/inventory/InventoryHelpersTrait.php
+++ b/src/inventory/InventoryHelpersTrait.php
@@ -186,7 +186,9 @@ trait InventoryHelpersTrait{
 				$item = clone $slot;
 				$item->setCount($amount);
 				$this->setItem($slotIndex, $item);
-				break;
+				if($slot->getCount() <= 0){
+					break;
+				}
 			}
 		}
 

--- a/tests/phpunit/inventory/BaseInventoryTest.php
+++ b/tests/phpunit/inventory/BaseInventoryTest.php
@@ -85,4 +85,18 @@ class BaseInventoryTest extends TestCase{
 		}
 		self::assertSame(20, $leftoverCount);
 	}
+
+	public function testAddItemWithLargeQuantity() : void{
+		$inventory = new class(10) extends SimpleInventory{
+
+		};
+		$inventory->addItem(VanillaItems::APPLE()->setCount(100));
+
+		$count = 0;
+		foreach($inventory->getContents() as $item){
+			self::assertTrue($item->equals(VanillaItems::APPLE()));
+			$count += $item->getCount();
+		}
+		self::assertSame(100, $count);
+	}
 }

--- a/tests/phpunit/inventory/BaseInventoryTest.php
+++ b/tests/phpunit/inventory/BaseInventoryTest.php
@@ -90,7 +90,8 @@ class BaseInventoryTest extends TestCase{
 		$inventory = new class(10) extends SimpleInventory{
 
 		};
-		$inventory->addItem(VanillaItems::APPLE()->setCount(100));
+		$leftover = $inventory->addItem(VanillaItems::APPLE()->setCount(100));
+		self::assertCount(0, $leftover);
 
 		$count = 0;
 		foreach($inventory->getContents() as $item){

--- a/tests/phpunit/inventory/BaseInventoryTest.php
+++ b/tests/phpunit/inventory/BaseInventoryTest.php
@@ -86,7 +86,7 @@ class BaseInventoryTest extends TestCase{
 		self::assertSame(20, $leftoverCount);
 	}
 
-	public function testAddItemWithLargeQuantity() : void{
+	public function testAddItemWithOversizedCount() : void{
 		$inventory = new class(10) extends SimpleInventory{
 
 		};


### PR DESCRIPTION
## Introduction
Fixed a bug that prevented adding more than 64 items to the inventory even if there was enough space when the following code was executed.

```php
$player->getInventory()->addItem(VanillaItems::APPLE()->setCount(100));
```
### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
