### PR TITLE
Added Minecoin gold textformat

### DIFF
--- a/src/pocketmine/utils/TextFormat.php
+++ b/src/pocketmine/utils/TextFormat.php
@@ -66,6 +66,7 @@ abstract class TextFormat{
 	public const LIGHT_PURPLE = TextFormat::ESCAPE . "d";
 	public const YELLOW = TextFormat::ESCAPE . "e";
 	public const WHITE = TextFormat::ESCAPE . "f";
+	public const MINECOIN_GOLD = TextFormat::ESCAPE . "g";
 
 	public const OBFUSCATED = TextFormat::ESCAPE . "k";
 	public const BOLD = TextFormat::ESCAPE . "l";


### PR DESCRIPTION
## Introduction
I just found out there is a color called: minecoin_gold.
source: https://minecraft.fandom.com/wiki/Formatting_codes
So I added this const to the TextFormat class.
![image](https://user-images.githubusercontent.com/34657342/124797023-16565100-df52-11eb-8143-455f803e0c31.png)
Its a little bit darker then normal yellow.

## Changes
### API changes
* Added MINECOIN_GOLD const to TextFormat

