### PR TITLE
Changed pre-requisites PHP version to 7.4 or newer

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -2,7 +2,7 @@
 ## Pre-requisites
 - A bash shell (git bash is sufficient for Windows)
 - [`git`](https://git-scm.com) available in your shell
-- PHP 7.3 or newer available in your shell
+- PHP 7.4 or newer available in your shell
 - [`composer`](https://getcomposer.org) available in your shell
 
 ## Custom PHP binaries


### PR DESCRIPTION
## Introduction
This pull request aims to change the minimum PHP version in BUILDING.md pre-requisites to version 7.4, because since PocketMine-MP 3.21.0, PHP binary versions below 7.4 are no longer supported.

### Relevant issues
As of PocketMine-MP 3.21.0 or newer, PHP binary versions below 7.4 are no longer supported, however BUILDING.md pre-requisites still stated to use PHP binary version of 7.3 or newer, which is an outdated information.

## Changes
Changed pre-requisites PHP binary version to 7.4 or newer.

## Backwards compatibility
There is no backwards incompatibility issues which is caused by this pull request as it only changes the BUILDING.md and the Files doesn't affect the PocketMine-MP software behavior itself.

## Follow-up
Nothing to follow up.

## Tests
If a user runs `composer make-server` using PHP 7.3 binary to build PocketMine-MP from source as of PocketMine-MP no longer supports PHP binary versions below 7.4, the user will get the following error:
```
Fatal error: Composer detected issues in your platform: Your Composer dependencies require a PHP version ">= 7.4.0". You are running 7.3.19. in C:\KygekDev\PocketMine-MP\vendor\composer\platform_check.php on line 24
```