### PR TITLE
the function stringToLegacy gives already null useless to put a defau…

### DIFF
--- a/src/network/mcpe/convert/RuntimeBlockMapping.php
+++ b/src/network/mcpe/convert/RuntimeBlockMapping.php
@@ -87,7 +87,7 @@ final class RuntimeBlockMapping{
 			$idToStatesMap[$state->getString("name")][] = $k;
 		}
 		foreach($legacyStateMap as $pair){
-			$id = $legacyIdMap->stringToLegacy($pair->getId()) ?? null;
+			$id = $legacyIdMap->stringToLegacy($pair->getId());
 			if($id === null){
 				throw new \RuntimeException("No legacy ID matches " . $pair->getId());
 			}


### PR DESCRIPTION
**Small change RuntimeBlockMapping **
I changed the RuntimeBlockMapping because there is a useless thing at line 90 because stringToLegacy returns an int or a null

`$id = $legacyIdMap->stringToLegacy($pair->getId()) ?? null; to $id = $legacyIdMap->stringToLegacy($pair->getId()); `