### PR TITLE
Fix item losing when player disconnect

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -3705,6 +3705,8 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 			$this->stopSleep();
 
 			if($this->spawned){
+				$this->doCloseInventory();
+
 				$ev = new PlayerQuitEvent($this, $message, $reason);
 				$ev->call();
 				if($ev->getQuitMessage() != ""){


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
When the player disconnect, the items in crafting grid and cursor inventory were returned to the player's inventory before PlayerQuitEvent.  
### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
* Fixes #4318
* Fixes #4315

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
