### PR TITLE
Bows can now use offhand arrows

### DIFF
--- a/src/item/Bow.php
+++ b/src/item/Bow.php
@@ -46,8 +46,16 @@ class Bow extends Tool implements Releasable{
 
 	public function onReleaseUsing(Player $player) : ItemUseResult{
 		$arrow = VanillaItems::ARROW();
-		if($player->hasFiniteResources() and !$player->getInventory()->contains($arrow)){
-			return ItemUseResult::FAIL();
+
+		$inventory = null;
+		if($player->hasFiniteResources()){
+			if($player->getOffHandInventory()->contains($arrow)){ // Receives a Mismatch Transaction. why???
+				$inventory = $player->getOffHandInventory();
+			}elseif($player->getInventory()->contains($arrow)){
+				$inventory = $player->getInventory();
+			}else{
+				return ItemUseResult::FAIL();
+			}
 		}
 
 		$location = $player->getLocation();
@@ -110,7 +118,7 @@ class Bow extends Tool implements Releasable{
 
 		if($player->hasFiniteResources()){
 			if(!$infinity){ //TODO: tipped arrows are still consumed when Infinity is applied
-				$player->getInventory()->removeItem($arrow);
+				$inventory?->removeItem($arrow);
 			}
 			$this->applyDamage(1);
 		}

--- a/src/item/Bow.php
+++ b/src/item/Bow.php
@@ -46,9 +46,13 @@ class Bow extends Tool implements Releasable{
 
 	public function onReleaseUsing(Player $player) : ItemUseResult{
 		$arrow = VanillaItems::ARROW();
+		$inventory = match(true){
+			$player->getOffHandInventory()->contains($arrow) => $player->getOffHandInventory(),
+			$player->getInventory()->contains($arrow) => $player->getInventory(),
+			default => null
+		};
 
-		$inventory = $player->getOffHandInventory();
-		if($player->hasFiniteResources() and !($inventory->contains($arrow) or ($inventory = $player->getInventory())->contains($arrow))){// Receives a Mismatch Transaction when using offhand arrows. why???
+		if($player->hasFiniteResources() and $inventory === null){// Receives a Mismatch Transaction when using offhand arrows. why???
 			return ItemUseResult::FAIL();
 		}
 

--- a/src/item/Bow.php
+++ b/src/item/Bow.php
@@ -52,7 +52,7 @@ class Bow extends Tool implements Releasable{
 			default => null
 		};
 
-		if($player->hasFiniteResources() and $inventory === null){// Receives a Mismatch Transaction when using offhand arrows. why???
+		if($player->hasFiniteResources() and $inventory === null){
 			return ItemUseResult::FAIL();
 		}
 

--- a/src/item/Bow.php
+++ b/src/item/Bow.php
@@ -47,15 +47,9 @@ class Bow extends Tool implements Releasable{
 	public function onReleaseUsing(Player $player) : ItemUseResult{
 		$arrow = VanillaItems::ARROW();
 
-		$inventory = null;
-		if($player->hasFiniteResources()){
-			if($player->getOffHandInventory()->contains($arrow)){ // Receives a Mismatch Transaction. why???
-				$inventory = $player->getOffHandInventory();
-			}elseif($player->getInventory()->contains($arrow)){
-				$inventory = $player->getInventory();
-			}else{
-				return ItemUseResult::FAIL();
-			}
+		$inventory = $player->getOffHandInventory();
+		if($player->hasFiniteResources() and !($inventory->contains($arrow) or ($inventory = $player->getInventory())->contains($arrow))){// Receives a Mismatch Transaction when using offhand arrows. why???
+			return ItemUseResult::FAIL();
 		}
 
 		$location = $player->getLocation();


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Bows currently do not use offhand arrows
### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->

https://user-images.githubusercontent.com/76860328/128688083-ee1081de-3755-4c85-8b3e-6de5d21c6318.mp4


