### PR TITLE
Workaround for offhand sync

### DIFF
--- a/src/network/mcpe/InventoryManager.php
+++ b/src/network/mcpe/InventoryManager.php
@@ -209,7 +209,12 @@ class InventoryManager{
 			$currentItem = $inventory->getItem($slot);
 			$clientSideItem = $this->initiatedSlotChanges[$windowId][$slot] ?? null;
 			if($clientSideItem === null or !$clientSideItem->equalsExact($currentItem)){
-				$this->session->sendDataPacket(InventorySlotPacket::create($windowId, $slot, ItemStackWrapper::legacy(TypeConverter::getInstance()->coreItemStackToNet($currentItem))));
+				$typeConverter = TypeConverter::getInstance();
+				if($windowId === ContainerIds::OFFHAND){
+					$this->session->sendDataPacket(InventoryContentPacket::create($windowId, [ItemStackWrapper::legacy($typeConverter->coreItemStackToNet($currentItem))]));
+				}else{
+					$this->session->sendDataPacket(InventorySlotPacket::create($windowId, $slot, ItemStackWrapper::legacy($typeConverter->coreItemStackToNet($currentItem))));
+				}
 			}
 			unset($this->initiatedSlotChanges[$windowId][$slot]);
 		}

--- a/src/network/mcpe/InventoryManager.php
+++ b/src/network/mcpe/InventoryManager.php
@@ -211,6 +211,11 @@ class InventoryManager{
 			if($clientSideItem === null or !$clientSideItem->equalsExact($currentItem)){
 				$itemStackWrapper = ItemStackWrapper::legacy(TypeConverter::getInstance()->coreItemStackToNet($currentItem));
 				if($windowId === ContainerIds::OFFHAND){
+					//TODO: HACK!
+					//The client may sometimes ignore the InventorySlotPacket for the offhand slot.
+					//This can cause a lot of problems (totems, arrows, and more...).
+					//The workaround is to send an InventoryContentPacket instead
+					//BDS (Bedrock Dedicated Server) also seems to work this way.
 					$this->session->sendDataPacket(InventoryContentPacket::create($windowId, [$itemStackWrapper]));
 				}else{
 					$this->session->sendDataPacket(InventorySlotPacket::create($windowId, $slot, $itemStackWrapper));

--- a/src/network/mcpe/InventoryManager.php
+++ b/src/network/mcpe/InventoryManager.php
@@ -209,11 +209,11 @@ class InventoryManager{
 			$currentItem = $inventory->getItem($slot);
 			$clientSideItem = $this->initiatedSlotChanges[$windowId][$slot] ?? null;
 			if($clientSideItem === null or !$clientSideItem->equalsExact($currentItem)){
-				$typeConverter = TypeConverter::getInstance();
+				$itemStackWrapper = ItemStackWrapper::legacy(TypeConverter::getInstance()->coreItemStackToNet($currentItem));
 				if($windowId === ContainerIds::OFFHAND){
-					$this->session->sendDataPacket(InventoryContentPacket::create($windowId, [ItemStackWrapper::legacy($typeConverter->coreItemStackToNet($currentItem))]));
+					$this->session->sendDataPacket(InventoryContentPacket::create($windowId, [$itemStackWrapper]));
 				}else{
-					$this->session->sendDataPacket(InventorySlotPacket::create($windowId, $slot, ItemStackWrapper::legacy($typeConverter->coreItemStackToNet($currentItem))));
+					$this->session->sendDataPacket(InventorySlotPacket::create($windowId, $slot, $itemStackWrapper));
 				}
 			}
 			unset($this->initiatedSlotChanges[$windowId][$slot]);


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Offhand slots sometimes ignore Inventory Slot Packets.
### Relevant issues
<!-- List relevant issues here -->
* Fix #4231 
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
Send InventoryContentPacket as a workaround.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
https://user-images.githubusercontent.com/76860328/128989052-edf5584e-eef4-4803-b312-219732f14299.mp4