### PR TITLE
Implemented TextFormat::POP (&p) custom formatting code

### DIFF
--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1733,21 +1733,21 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		if($subtitle !== ""){
 			$this->sendSubTitle($subtitle);
 		}
-		$this->getNetworkSession()->onTitle($title);
+		$this->getNetworkSession()->onTitle(TextFormat::toVanilla($title));
 	}
 
 	/**
 	 * Sets the subtitle message, without sending a title.
 	 */
 	public function sendSubTitle(string $subtitle) : void{
-		$this->getNetworkSession()->onSubTitle($subtitle);
+		$this->getNetworkSession()->onSubTitle(TextFormat::toVanilla($subtitle));
 	}
 
 	/**
 	 * Adds small text to the user's screen.
 	 */
 	public function sendActionBarMessage(string $message) : void{
-		$this->getNetworkSession()->onActionBar($message);
+		$this->getNetworkSession()->onActionBar(TextFormat::toVanilla($message));
 	}
 
 	/**
@@ -1786,7 +1786,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 			return;
 		}
 
-		$this->getNetworkSession()->onRawChatMessage($this->getLanguage()->translateString($message));
+		$this->getNetworkSession()->onRawChatMessage(TextFormat::toVanilla($this->getLanguage()->translateString($message)));
 	}
 
 	/**
@@ -1795,11 +1795,11 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 	public function sendTranslation(string $message, array $parameters = []) : void{
 		if(!$this->server->isLanguageForced()){
 			foreach($parameters as $i => $p){
-				$parameters[$i] = $this->getLanguage()->translateString($p, [], "pocketmine.");
+				$parameters[$i] = TextFormat::toVanilla($this->getLanguage()->translateString($p, [], "pocketmine."));
 			}
-			$this->getNetworkSession()->onTranslatedChatMessage($this->getLanguage()->translateString($message, $parameters, "pocketmine."), $parameters);
+			$this->getNetworkSession()->onTranslatedChatMessage(TextFormat::toVanilla($this->getLanguage()->translateString($message, $parameters, "pocketmine.")), $parameters);
 		}else{
-			$this->sendMessage($this->getLanguage()->translateString($message, $parameters));
+			$this->sendMessage(TextFormat::toVanilla($this->getLanguage()->translateString($message, $parameters)));
 		}
 	}
 
@@ -1816,11 +1816,11 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 	 * TODO: add translation type popups
 	 */
 	public function sendPopup(string $message) : void{
-		$this->getNetworkSession()->onPopup($message);
+		$this->getNetworkSession()->onPopup(TextFormat::toVanilla($message));
 	}
 
 	public function sendTip(string $message) : void{
-		$this->getNetworkSession()->onTip($message);
+		$this->getNetworkSession()->onTip(TextFormat::toVanilla($message));
 	}
 
 	/**

--- a/src/utils/Terminal.php
+++ b/src/utils/Terminal.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\utils;
 
+use function assert;
 use function fclose;
 use function fopen;
 use function function_exists;
@@ -204,7 +205,7 @@ abstract class Terminal{
 	 */
 	public static function toANSI($string) : string{
 		if(!is_array($string)){
-			$string = TextFormat::tokenize($string);
+			$string = TextFormat::tokenize(TextFormat::toVanilla($string));
 		}
 
 		$newString = "";
@@ -277,6 +278,9 @@ abstract class Terminal{
 					break;
 				case TextFormat::WHITE:
 					$newString .= Terminal::$COLOR_WHITE;
+					break;
+				case TextFormat::POP:
+					assert(false);
 					break;
 				default:
 					$newString .= $token;


### PR DESCRIPTION
## Introduction
Log messages have been plagued for a long time by the difficulty of inserting coloured words into them without doing one of two things:
1) Assuming the colour of the log output
2) Breaking the colour of the text after the coloured word

This is particularly inconvenient for translations. Some non-English translations parameters don't have proper colour termination (and the word order is different to English), but even if they did, the colour would get stripped instead of being correctly applied.

TextFormat::RESET is not suitable for this, since it strips _all_ formatting since the start of the string, which causes this kind of problem for log messages:
![image](https://user-images.githubusercontent.com/14214667/129200891-006ff86e-39d3-4100-9428-b02709a4a551.png)

TextFormat::POP is a little like RESET, except that instead of removing _all_ formatting codes used to that point, it removes only the most recent one.

## Note
This formatting code does NOT exist in vanilla Minecraft. It is not supported by Minecraft, nor is it supported for chat. It is only usable on the server side by plugins (or PM itself).

### Relevant issues
#4116 

## Changes
### API changes
- Introduced `TextFormat::POP` constant.
- Introduced `TextFormat::toVanilla()` function, which takes a string possibly containing &p formatting codes and converts them into pure Minecraft formatting.

### Behavioural changes
Text has to be preprocessed before sending to the client if it contains POP formatting codes, so that the client will see the correct formatting. This has a very slight impact on performance, but the usability advantages should outweigh that by a lot.

## Backwards compatibility
Anything that had §p in their strings to be sent to the client or console, or used in ::colorize(), will now be treated as a POP code, instead of just two unrelated characters.

## Alternatives
- It's been suggested to instead implement two additional codes `§(` and `§)` to enclose formatting blocks, instead of this PR. While this has some advantages, it's a lot more complicated to implement and will take more time to have ready for a feature proposal.

## Tests
Tests are TBD, but local testing with plugins has been done and everything seems to work so far.