### PR TITLE
Effect: implement slowfall

### DIFF
--- a/src/data/bedrock/EffectIdMap.php
+++ b/src/data/bedrock/EffectIdMap.php
@@ -70,7 +70,7 @@ final class EffectIdMap{
 		$this->register(EffectIds::LEVITATION, VanillaEffects::LEVITATION());
 		$this->register(EffectIds::FATAL_POISON, VanillaEffects::FATAL_POISON());
 		$this->register(EffectIds::CONDUIT_POWER, VanillaEffects::CONDUIT_POWER());
-		//TODO: SLOW_FALLING
+		$this->register(EffectIds::SLOW_FALLING, VanillaEffects::SLOW_FALLING());
 		//TODO: BAD_OMEN
 		//TODO: VILLAGE_HERO
 	}

--- a/src/entity/Entity.php
+++ b/src/entity/Entity.php
@@ -778,6 +778,10 @@ abstract class Entity{
 		$this->server->broadcastPackets($this->hasSpawned, [SetActorMotionPacket::create($this->id, $this->getMotion())]);
 	}
 
+	public function getGravity() : float{
+		return $this->gravity;
+	}
+
 	public function hasGravity() : bool{
 		return $this->gravityEnabled;
 	}
@@ -800,7 +804,7 @@ abstract class Entity{
 		}
 
 		if($this->gravityEnabled){
-			$mY -= $this->gravity;
+			$mY -= $this->getGravity();
 		}
 
 		if(!$this->applyDragBeforeGravity()){

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -188,6 +188,13 @@ abstract class Living extends Entity{
 		}
 	}
 
+	public function getGravity() : float{
+		if($this->effectManager->has(VanillaEffects::SLOW_FALLING())){
+			return $this->effectManager->get(VanillaEffects::SLOW_FALLING())->getType()->getGravity();
+		}
+		return $this->gravity;
+	}
+
 	public function getMaxHealth() : int{
 		return (int) $this->healthAttr->getMaxValue();
 	}

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -190,7 +190,7 @@ abstract class Living extends Entity{
 
 	public function getGravity() : float{
 		if($this->effectManager->has(VanillaEffects::SLOW_FALLING())){
-			return $this->effectManager->get(VanillaEffects::SLOW_FALLING())->getType()->getGravity();
+			return VanillaEffects::SLOW_FALLING()->getGravity();
 		}
 		return $this->gravity;
 	}

--- a/src/entity/effect/SlowFallEffect.php
+++ b/src/entity/effect/SlowFallEffect.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\entity\effect;
+
+use pocketmine\entity\Entity;
+use pocketmine\entity\Living;
+
+class SlowFallEffect extends Effect{
+	public function getGravity() : float{
+		return 0.01;
+	}
+
+	public function canTick(EffectInstance $instance) : bool{
+		return true;
+	}
+
+	public function applyEffect(Living $entity, EffectInstance $instance, float $potency = 1.0, ?Entity $source = null) : void{
+		$entity->resetFallDistance();
+	}
+}

--- a/src/entity/effect/VanillaEffects.php
+++ b/src/entity/effect/VanillaEffects.php
@@ -53,6 +53,7 @@ use function assert;
  * @method static Effect RESISTANCE()
  * @method static SaturationEffect SATURATION()
  * @method static SlownessEffect SLOWNESS()
+ * @method static SlowFallEffect SLOW_FALLING()
  * @method static SpeedEffect SPEED()
  * @method static Effect STRENGTH()
  * @method static Effect WATER_BREATHING()
@@ -84,7 +85,7 @@ final class VanillaEffects{
 		self::register("regeneration", new RegenerationEffect(10, "%potion.regeneration", new Color(0xcd, 0x5c, 0xab)));
 		self::register("resistance", new Effect(11, "%potion.resistance", new Color(0x99, 0x45, 0x3a)));
 		self::register("saturation", new SaturationEffect(23, "%potion.saturation", new Color(0xf8, 0x24, 0x23), false));
-		//TODO: slow_falling
+		self::register("slow_falling", new SlowFallEffect(27, "%potion.slowFalling", new Color(0xce, 0xff, 0xff), false));
 		self::register("slowness", new SlownessEffect(2, "%potion.moveSlowdown", new Color(0x5a, 0x6c, 0x81), true));
 		self::register("speed", new SpeedEffect(1, "%potion.moveSpeed", new Color(0x7c, 0xaf, 0xc6)));
 		self::register("strength", new Effect(5, "%potion.damageBoost", new Color(0x93, 0x24, 0x23)));

--- a/src/item/PotionType.php
+++ b/src/item/PotionType.php
@@ -195,10 +195,10 @@ final class PotionType{
 				//TODO
 			]),
 			new self("slow_falling", "Slow Falling", fn() => [
-				//TODO
+				new EffectInstance(VanillaEffects::SLOW_FALLING(), 1800)
 			]),
 			new self("long_slow_falling", "Long Slow Falling", fn() => [
-				//TODO
+				new EffectInstance(VanillaEffects::SLOW_FALLING(), 4800)
 			])
 		);
 	}


### PR DESCRIPTION
## Introduction

Implement vanilla snowfall effect(according to Minecraft Java Edition 1.16.2 source)

## Changes
### API changes

[+] Entity::getGravity() : float

This method return the gravity that need in caculate (default $this->gravity for compactibility)

Reason:
 https://github.com/Blackjack200/minecraft_client_1_16_2/blob/c7f87b96efaeb477d9604354aa23ada0eb637ec6/net/minecraft/world/entity/LivingEntity.java#L1795-L1796

### Behavioural changes

The living entity will fall slowly when get slowfall effect

## Backwards compatibility

the plugins that override tryChangeMovement or manipluate gravity.

## Follow-up

I think we don't have a system to implement this very well

## Requires translations:

```ini
potion.slowFalling=Slow Falling
```

(according to Minecraft Bedrock Edition 1.17.11 language file en_US.lang)

## Tests
1. Player get slow fall like vanilla did.
2. Living Entities get slow fall like vanilla did(i test with Zombie)
3. The potions let entites get effect correctly
4. Test video: https://youtu.be/g-Ysi97rRsQ