### PR TITLE
BaseInventory->removeItem() now alway check item NamedTag

### DIFF
--- a/src/inventory/BaseInventory.php
+++ b/src/inventory/BaseInventory.php
@@ -266,7 +266,7 @@ abstract class BaseInventory implements Inventory{
 			}
 
 			foreach($itemSlots as $index => $slot){
-				if($slot->equals($item, !$slot->hasAnyDamageValue(), $slot->hasNamedTag())){
+				if($slot->equals($item, !$slot->hasAnyDamageValue(), true)){
 					$amount = min($item->getCount(), $slot->getCount());
 					$slot->setCount($slot->getCount() - $amount);
 					$item->setCount($item->getCount() - $amount);


### PR DESCRIPTION
## Introduction
* Due to original item dont have NamedTag, so removeItem() can remove item that have same type but have different NamedTag. 
### Relevant issues
* Fixes #4233 
## Tests
*  Try to remove item like #4233, now it only remove original item.