### PR TITLE
Use the correct Skull Item ID

### DIFF
--- a/src/block/BlockFactory.php
+++ b/src/block/BlockFactory.php
@@ -322,7 +322,7 @@ class BlockFactory{
 		$this->register(new Sand(new BID(Ids::SAND, 1), "Red Sand", $sandBreakInfo));
 		$this->register(new SeaLantern(new BID(Ids::SEALANTERN, 0), "Sea Lantern", new BlockBreakInfo(0.3)));
 		$this->register(new SeaPickle(new BID(Ids::SEA_PICKLE, 0), "Sea Pickle", BlockBreakInfo::instant()));
-		$this->register(new Skull(new BID(Ids::MOB_HEAD_BLOCK, 0, null, TileSkull::class), "Mob Head", new BlockBreakInfo(1.0)));
+		$this->register(new Skull(new BID(Ids::MOB_HEAD_BLOCK, 0, ItemIds::SKULL, TileSkull::class), "Mob Head", new BlockBreakInfo(1.0)));
 
 		$this->register(new Snow(new BID(Ids::SNOW, 0), "Snow Block", new BlockBreakInfo(0.2, BlockToolType::SHOVEL, ToolTier::WOOD()->getHarvestLevel())));
 		$this->register(new SnowLayer(new BID(Ids::SNOW_LAYER, 0), "Snow Layer", new BlockBreakInfo(0.1, BlockToolType::SHOVEL, ToolTier::WOOD()->getHarvestLevel())));


### PR DESCRIPTION
## Introduction
This pull request fixes `VanillaBlocks::MOB_HEAD()->asItem()` returning an item with the original `mob_head_block` ID instead of the correct item ID, causing an incorrect render client-side, and the wrong skull type to be used when placed.

## Tests
Give a skull to the player, even with a different skull type, for example... a player:
`VanillaBlocks::MOB_HEAD()->setSkullType(SkullType::PLAYER())->asItem()`

What would be received is: 
![image](https://user-images.githubusercontent.com/17762324/129607154-6b312e2e-2bf8-40ae-ac80-3b8743443919.png)

Expected item:
![image](https://user-images.githubusercontent.com/17762324/129607183-2bcfec0e-ad38-4c4d-aa63-4305e559855a.png)

