### PR TITLE
Update bow sound

### DIFF
--- a/src/item/Bow.php
+++ b/src/item/Bow.php
@@ -31,6 +31,7 @@ use pocketmine\event\entity\ProjectileLaunchEvent;
 use pocketmine\item\enchantment\VanillaEnchantments;
 use pocketmine\player\Player;
 use pocketmine\world\sound\BowShootSound;
+use pocketmine\world\sound\ItemBreakSound;
 use function intdiv;
 use function min;
 
@@ -119,6 +120,10 @@ class Bow extends Tool implements Releasable{
 				$inventory?->removeItem($arrow);
 			}
 			$this->applyDamage(1);
+			
+			if($this->isBroken()){
+				$location->getWorld()->addSound($location, new ItemBreakSound());
+			}
 		}
 
 		return ItemUseResult::SUCCESS();


### PR DESCRIPTION
## Introduction
When the durability is exhausted, the bow does not emit Item Break Sound. 

## Follow-up
Make sure the breakable objects in the game make a sound when they break.

## Tests
Use a bow until it breaks.
