### PR TITLE
Implement proper 32x64 skin workaround

### DIFF
--- a/src/network/mcpe/convert/LegacySkinAdapter.php
+++ b/src/network/mcpe/convert/LegacySkinAdapter.php
@@ -32,8 +32,10 @@ use function is_string;
 use function json_decode;
 use function json_encode;
 use function json_last_error_msg;
+use function str_pad;
 use function random_bytes;
 use function str_repeat;
+use function strlen;
 
 class LegacySkinAdapter implements SkinAdapter{
 

--- a/src/network/mcpe/convert/LegacySkinAdapter.php
+++ b/src/network/mcpe/convert/LegacySkinAdapter.php
@@ -99,11 +99,7 @@ class LegacySkinAdapter implements SkinAdapter{
 			$skinData = self::mirroredCopy($skinData, 40, 20, 4, 12, 40, 52);
 			$skinData = self::mirroredCopy($skinData, 52, 20, 4, 12, 44, 52);
 		}
-		return new Skin(
-			$data->getSkinId(),
-			$skinData,
-			$capeData, $geometryName, $data->getGeometryData()
-		);
+		return new Skin($data->getSkinId(), $skinData, $capeData, $geometryName, $data->getGeometryData());
 	}
 
 	private static function mirroredCopy(string $bitmap, int $startX, int $startY, int $width, int $height, int $toX, int $toY) : string{

--- a/src/network/mcpe/convert/LegacySkinAdapter.php
+++ b/src/network/mcpe/convert/LegacySkinAdapter.php
@@ -32,8 +32,8 @@ use function is_string;
 use function json_decode;
 use function json_encode;
 use function json_last_error_msg;
-use function str_pad;
 use function random_bytes;
+use function str_pad;
 use function str_repeat;
 use function strlen;
 

--- a/src/network/mcpe/convert/LegacySkinAdapter.php
+++ b/src/network/mcpe/convert/LegacySkinAdapter.php
@@ -80,24 +80,24 @@ class LegacySkinAdapter implements SkinAdapter{
 			$skinData = str_pad($skinData, 64 * 64 * 4, "\x00\x00\x00\x00"); // pad to 64x64
 
 			// leg tops
-			$skinData = self::copyAndFlipHorizontally($skinData, 4, 16, 4, 4, 20, 48);
-			$skinData = self::copyAndFlipHorizontally($skinData, 8, 16, 4, 4, 24, 48);
+			$skinData = self::mirroredCopy($skinData, 4, 16, 4, 4, 20, 48);
+			$skinData = self::mirroredCopy($skinData, 8, 16, 4, 4, 24, 48);
 
 			// arm tops
-			$skinData = self::copyAndFlipHorizontally($skinData, 44, 16, 4, 4, 36, 48);
-			$skinData = self::copyAndFlipHorizontally($skinData, 48, 16, 4, 4, 40, 48);
+			$skinData = self::mirroredCopy($skinData, 44, 16, 4, 4, 36, 48);
+			$skinData = self::mirroredCopy($skinData, 48, 16, 4, 4, 40, 48);
 
 			// leg pieces
-			$skinData = self::copyAndFlipHorizontally($skinData, 8, 20, 4, 12, 16, 52);
-			$skinData = self::copyAndFlipHorizontally($skinData, 4, 20, 4, 12, 20, 52);
-			$skinData = self::copyAndFlipHorizontally($skinData, 0, 20, 4, 12, 24, 52);
-			$skinData = self::copyAndFlipHorizontally($skinData, 12, 20, 4, 12, 28, 52);
+			$skinData = self::mirroredCopy($skinData, 8, 20, 4, 12, 16, 52);
+			$skinData = self::mirroredCopy($skinData, 4, 20, 4, 12, 20, 52);
+			$skinData = self::mirroredCopy($skinData, 0, 20, 4, 12, 24, 52);
+			$skinData = self::mirroredCopy($skinData, 12, 20, 4, 12, 28, 52);
 
 			// arm pieces
-			$skinData = self::copyAndFlipHorizontally($skinData, 48, 20, 4, 12, 32, 52);
-			$skinData = self::copyAndFlipHorizontally($skinData, 44, 20, 4, 12, 36, 52);
-			$skinData = self::copyAndFlipHorizontally($skinData, 40, 20, 4, 12, 40, 52);
-			$skinData = self::copyAndFlipHorizontally($skinData, 52, 20, 4, 12, 44, 52);
+			$skinData = self::mirroredCopy($skinData, 48, 20, 4, 12, 32, 52);
+			$skinData = self::mirroredCopy($skinData, 44, 20, 4, 12, 36, 52);
+			$skinData = self::mirroredCopy($skinData, 40, 20, 4, 12, 40, 52);
+			$skinData = self::mirroredCopy($skinData, 52, 20, 4, 12, 44, 52);
 		}
 		return new Skin(
 			$data->getSkinId(),
@@ -106,7 +106,7 @@ class LegacySkinAdapter implements SkinAdapter{
 		);
 	}
 
-	private static function copyAndFlipHorizontally(string $bitmap, int $startX, int $startY, int $width, int $height, int $toX, int $toY) : string{
+	private static function mirroredCopy(string $bitmap, int $startX, int $startY, int $width, int $height, int $toX, int $toY) : string{
 		for($x = 0; $x < $width; $x++) {
 			for($y = 0; $y < $height; $y++) {
 				$index = self::toIndex($startX + $x, $startY + $y);


### PR DESCRIPTION
## Introduction
This pull request introduces a workaround to fix the broken rendering of 32x64 skins in MC:Bedrock 1.17 clients formerly without applying a [proper conversion process](https://imgur.com/a/hfaqL) ([source](https://www.reddit.com/r/Minecraft/comments/1vfugk/guide_a_better_guide_to_updating_your_skin_to_the/)), the skins may look glitched or may be [missing the right arm and the right leg](https://twitter.com/dktapps/status/1404067959253909506?s=20).

## Changes
### Behavioural changes
Skins will now be correctly converted with parts mirrored for the 64x64 skin format, and the randomly colored placeholder skin for "persona" skins will now also be rendered properly on 1.17 clients

## Tests
With:
![image](https://user-images.githubusercontent.com/17762324/130103854-100b3269-2bb1-4099-9cdc-c32983781ffa.png)

Without:
![image](https://user-images.githubusercontent.com/17762324/130103915-661eeb82-6e78-467f-969f-dc472db5fcff.png)
