### PR TITLE
implement temporary bans

### DIFF
--- a/src/command/defaults/BanCommand.php
+++ b/src/command/defaults/BanCommand.php
@@ -23,16 +23,17 @@ declare(strict_types=1);
 
 namespace pocketmine\command\defaults;
 
+use Exception;
 use pocketmine\command\Command;
 use pocketmine\command\CommandSender;
 use pocketmine\command\utils\InvalidCommandSyntaxException;
 use pocketmine\lang\KnownTranslationFactory;
 use pocketmine\lang\KnownTranslationKeys;
+use pocketmine\permission\BanEntry;
 use pocketmine\permission\DefaultPermissionNames;
 use pocketmine\player\Player;
 use function array_shift;
 use function count;
-use function implode;
 
 class BanCommand extends VanillaCommand{
 
@@ -55,9 +56,18 @@ class BanCommand extends VanillaCommand{
 		}
 
 		$name = array_shift($args);
-		$reason = implode(" ", $args);
+		$reason = array_shift($args);
+		$expiration = array_shift($args);
 
-		$sender->getServer()->getNameBans()->addBan($name, $reason, null, $sender->getName());
+		if($expiration){
+			try{
+				$expiration = BanEntry::parseDate($expiration);
+			}catch(Exception){
+				$expiration = null;
+			}
+		}
+
+		$sender->getServer()->getNameBans()->addBan($name, $reason, $expiration, $sender->getName());
 
 		if(($player = $sender->getServer()->getPlayerExact($name)) instanceof Player){
 			$player->kick($reason !== "" ? "Banned by admin. Reason: " . $reason : "Banned by admin.");

--- a/src/command/defaults/BanCommand.php
+++ b/src/command/defaults/BanCommand.php
@@ -28,7 +28,6 @@ use pocketmine\command\CommandSender;
 use pocketmine\command\utils\InvalidCommandSyntaxException;
 use pocketmine\lang\KnownTranslationFactory;
 use pocketmine\lang\KnownTranslationKeys;
-use pocketmine\permission\BanEntry;
 use pocketmine\permission\DefaultPermissionNames;
 use pocketmine\player\Player;
 use function array_shift;
@@ -56,10 +55,9 @@ class BanCommand extends VanillaCommand{
 		}
 
 		$name = array_shift($args);
-		$reason = array_shift($args);
-        $expiration = array_shift($args);
+		$reason = implode(" ", $args);
 
-        $sender->getServer()->getNameBans()->addBan($name, $sender->getName(), $reason, null, $expiration);
+		$sender->getServer()->getNameBans()->addBan($name, $reason, null, $sender->getName());
 
 		if(($player = $sender->getServer()->getPlayerExact($name)) instanceof Player){
 			$player->kick($reason !== "" ? "Banned by admin. Reason: " . $reason : "Banned by admin.");

--- a/src/command/defaults/BanCommand.php
+++ b/src/command/defaults/BanCommand.php
@@ -28,6 +28,7 @@ use pocketmine\command\CommandSender;
 use pocketmine\command\utils\InvalidCommandSyntaxException;
 use pocketmine\lang\KnownTranslationFactory;
 use pocketmine\lang\KnownTranslationKeys;
+use pocketmine\permission\BanEntry;
 use pocketmine\permission\DefaultPermissionNames;
 use pocketmine\player\Player;
 use function array_shift;
@@ -55,9 +56,10 @@ class BanCommand extends VanillaCommand{
 		}
 
 		$name = array_shift($args);
-		$reason = implode(" ", $args);
+		$reason = array_shift($args);
+        $expiration = array_shift($args);
 
-		$sender->getServer()->getNameBans()->addBan($name, $reason, null, $sender->getName());
+        $sender->getServer()->getNameBans()->addBan($name, $sender->getName(), $reason, null, $expiration);
 
 		if(($player = $sender->getServer()->getPlayerExact($name)) instanceof Player){
 			$player->kick($reason !== "" ? "Banned by admin. Reason: " . $reason : "Banned by admin.");

--- a/src/command/defaults/BanIpCommand.php
+++ b/src/command/defaults/BanIpCommand.php
@@ -57,15 +57,16 @@ class BanIpCommand extends VanillaCommand{
 
 		$value = array_shift($args);
 		$reason = implode(" ", $args);
+		$expiration = array_shift($args);
 
 		if(preg_match("/^([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])$/", $value)){
-			$this->processIPBan($value, $sender, $reason);
+			$this->processIPBan($value, $sender, $reason, $expiration);
 
 			Command::broadcastCommandMessage($sender, KnownTranslationFactory::commands_banip_success($value));
 		}else{
 			if(($player = $sender->getServer()->getPlayerByPrefix($value)) instanceof Player){
 				$ip = $player->getNetworkSession()->getIp();
-				$this->processIPBan($ip, $sender, $reason);
+				$this->processIPBan($ip, $sender, $reason, $expiration);
 
 				Command::broadcastCommandMessage($sender, KnownTranslationFactory::commands_banip_success_players($ip, $player->getName()));
 			}else{
@@ -78,8 +79,8 @@ class BanIpCommand extends VanillaCommand{
 		return true;
 	}
 
-	private function processIPBan(string $ip, CommandSender $sender, string $reason) : void{
-		$sender->getServer()->getIPBans()->addBan($ip, $reason, null, $sender->getName());
+	private function processIPBan(string $ip, CommandSender $sender, string $reason, ?string $expiration) : void{
+		$sender->getServer()->getIPBans()->addBan($ip, $sender->getName(), $reason, null, $expiration);
 
 		foreach($sender->getServer()->getOnlinePlayers() as $player){
 			if($player->getNetworkSession()->getIp() === $ip){

--- a/src/command/defaults/BanIpCommand.php
+++ b/src/command/defaults/BanIpCommand.php
@@ -57,16 +57,15 @@ class BanIpCommand extends VanillaCommand{
 
 		$value = array_shift($args);
 		$reason = implode(" ", $args);
-		$expiration = array_shift($args);
 
 		if(preg_match("/^([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])$/", $value)){
-			$this->processIPBan($value, $sender, $reason, $expiration);
+			$this->processIPBan($value, $sender, $reason);
 
 			Command::broadcastCommandMessage($sender, KnownTranslationFactory::commands_banip_success($value));
 		}else{
 			if(($player = $sender->getServer()->getPlayerByPrefix($value)) instanceof Player){
 				$ip = $player->getNetworkSession()->getIp();
-				$this->processIPBan($ip, $sender, $reason, $expiration);
+				$this->processIPBan($ip, $sender, $reason);
 
 				Command::broadcastCommandMessage($sender, KnownTranslationFactory::commands_banip_success_players($ip, $player->getName()));
 			}else{
@@ -79,8 +78,8 @@ class BanIpCommand extends VanillaCommand{
 		return true;
 	}
 
-	private function processIPBan(string $ip, CommandSender $sender, string $reason, ?string $expiration) : void{
-		$sender->getServer()->getIPBans()->addBan($ip, $sender->getName(), $reason, null, $expiration);
+	private function processIPBan(string $ip, CommandSender $sender, string $reason) : void{
+		$sender->getServer()->getIPBans()->addBan($ip, $reason, null, $sender->getName());
 
 		foreach($sender->getServer()->getOnlinePlayers() as $player){
 			if($player->getNetworkSession()->getIp() === $ip){

--- a/src/command/defaults/BanIpCommand.php
+++ b/src/command/defaults/BanIpCommand.php
@@ -23,16 +23,17 @@ declare(strict_types=1);
 
 namespace pocketmine\command\defaults;
 
+use Exception;
 use pocketmine\command\Command;
 use pocketmine\command\CommandSender;
 use pocketmine\command\utils\InvalidCommandSyntaxException;
 use pocketmine\lang\KnownTranslationFactory;
 use pocketmine\lang\KnownTranslationKeys;
+use pocketmine\permission\BanEntry;
 use pocketmine\permission\DefaultPermissionNames;
 use pocketmine\player\Player;
 use function array_shift;
 use function count;
-use function implode;
 use function preg_match;
 
 class BanIpCommand extends VanillaCommand{
@@ -56,16 +57,17 @@ class BanIpCommand extends VanillaCommand{
 		}
 
 		$value = array_shift($args);
-		$reason = implode(" ", $args);
+		$reason = array_shift($args);
+		$expiration = array_shift($args);
 
 		if(preg_match("/^([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])$/", $value)){
-			$this->processIPBan($value, $sender, $reason);
+			$this->processIPBan($value, $sender, $reason, $expiration);
 
 			Command::broadcastCommandMessage($sender, KnownTranslationFactory::commands_banip_success($value));
 		}else{
 			if(($player = $sender->getServer()->getPlayerByPrefix($value)) instanceof Player){
 				$ip = $player->getNetworkSession()->getIp();
-				$this->processIPBan($ip, $sender, $reason);
+				$this->processIPBan($ip, $sender, $reason, $expiration);
 
 				Command::broadcastCommandMessage($sender, KnownTranslationFactory::commands_banip_success_players($ip, $player->getName()));
 			}else{
@@ -78,8 +80,16 @@ class BanIpCommand extends VanillaCommand{
 		return true;
 	}
 
-	private function processIPBan(string $ip, CommandSender $sender, string $reason) : void{
-		$sender->getServer()->getIPBans()->addBan($ip, $reason, null, $sender->getName());
+	private function processIPBan(string $ip, CommandSender $sender, string $reason, ?string $expiration) : void{
+		if($expiration){
+			try{
+				$expiration = BanEntry::parseDate($expiration);
+			}catch(Exception){
+				$expiration = null;
+			}
+		}
+
+		$sender->getServer()->getIPBans()->addBan($ip, $reason, $expiration, $sender->getName());
 
 		foreach($sender->getServer()->getOnlinePlayers() as $player){
 			if($player->getNetworkSession()->getIp() === $ip){

--- a/src/permission/BanEntry.php
+++ b/src/permission/BanEntry.php
@@ -23,160 +23,90 @@ declare(strict_types=1);
 
 namespace pocketmine\permission;
 
-use pocketmine\utils\AssumptionFailedError;
-use function array_shift;
-use function count;
-use function explode;
-use function implode;
-use function strlen;
-use function strtolower;
-use function trim;
+use function strtotime;
+use function time;
 
 class BanEntry{
-	/** @var string */
-	public static $format = "Y-m-d H:i:s O";
+	protected const DATE_FORMAT_STRING = "m/d/Y H:i:s";
 
-	/** @var string */
-	private $name;
-	/** @var \DateTime */
-	private $creationDate;
-	/** @var string */
-	private $source = "(Unknown)";
-	/** @var \DateTime|null */
-	private $expirationDate = null;
-	/** @var string */
-	private $reason = "Banned by an operator.";
+	private string $name;
+	private ?string $source;
+	private ?string $reason;
+	private int $creationTimestamp;
+	private ?int $expirationTimestamp;
 
-	public function __construct(string $name){
-		$this->name = strtolower($name);
-		/** @noinspection PhpUnhandledExceptionInspection */
-		$this->creationDate = new \DateTime();
+	public function __construct(string $name, ?string $source = null, ?string $reason = null, ?int $creationTimestamp = null, ?int $expirationTimestamp = null){
+		$this->name = $name;
+		$this->source = $source;
+		$this->reason = $reason;
+		$this->creationTimestamp = $creationTimestamp ?? time();
+		$this->expirationTimestamp = $expirationTimestamp;
+	}
+
+	public function getSource() : ?string{
+		return $this->source;
+	}
+
+	public function isExpired(): bool{
+		$now = time();
+		return !$this->isPermanent() && $this->getExpirationTimestamp() < $now;
+	}
+
+	public function isPermanent(): bool{
+		return $this->getExpirationTimestamp() === null;
+	}
+
+	public function getCreationTimestamp() : ?int{
+		return $this->creationTimestamp;
+	}
+
+	public function getExpirationTimestamp() : ?int{
+		return $this->expirationTimestamp;
 	}
 
 	public function getName() : string{
 		return $this->name;
 	}
 
-	public function getCreated() : \DateTime{
-		return $this->creationDate;
-	}
-
-	/**
-	 * @throws \InvalidArgumentException
-	 */
-	public function setCreated(\DateTime $date) : void{
-		self::validateDate($date);
-		$this->creationDate = $date;
-	}
-
-	public function getSource() : string{
-		return $this->source;
-	}
-
-	public function setSource(string $source) : void{
-		$this->source = $source;
-	}
-
-	public function getExpires() : ?\DateTime{
-		return $this->expirationDate;
-	}
-
-	/**
-	 * @throws \InvalidArgumentException
-	 */
-	public function setExpires(?\DateTime $date) : void{
-		if($date !== null){
-			self::validateDate($date);
-		}
-		$this->expirationDate = $date;
-	}
-
-	public function hasExpired() : bool{
-		/** @noinspection PhpUnhandledExceptionInspection */
-		$now = new \DateTime();
-
-		return $this->expirationDate === null ? false : $this->expirationDate < $now;
-	}
-
-	public function getReason() : string{
+	public function getReason() : ?string{
 		return $this->reason;
 	}
 
-	public function setReason(string $reason) : void{
+	public static function isValidDateString(string $dateString, ?int $baseTimestamp = null): bool{
+		return strtotime($dateString, $baseTimestamp) !== false;
+	}
+
+	public function setCreationTimestamp(int $creationTimestamp) : void{
+		$this->creationTimestamp = $creationTimestamp;
+	}
+
+	public function setExpirationTimestamp(?int $expirationTimestamp) : void{
+		$this->expirationTimestamp = $expirationTimestamp;
+	}
+
+	public function setName(string $name) : void{
+		$this->name = $name;
+	}
+
+	public function setReason(?string $reason) : void{
 		$this->reason = $reason;
 	}
 
-	public function getString() : string{
-		$str = "";
-		$str .= $this->getName();
-		$str .= "|";
-		$str .= $this->getCreated()->format(self::$format);
+	public function setSource(?string $source) : void{
+		$this->source = $source;
+	}
+
+	public function toString(): string{
+		$str = $this->getName();
 		$str .= "|";
 		$str .= $this->getSource();
 		$str .= "|";
-		$str .= $this->getExpires() === null ? "Forever" : $this->getExpires()->format(self::$format);
-		$str .= "|";
 		$str .= $this->getReason();
+		$str .= "|";
+		$str .= date(self::DATE_FORMAT_STRING, $this->getCreationTimestamp());
+		$str .= "|";
+		$str .= $this->isPermanent() ? "Permanent" : date(self::DATE_FORMAT_STRING, $this->getExpirationTimestamp());
 
 		return $str;
-	}
-
-	/**
-	 * Hacky function to validate \DateTime objects due to a bug in PHP. format() with "Y" can emit years with more than
-	 * 4 digits, but createFromFormat() with "Y" doesn't accept them if they have more than 4 digits on the year.
-	 *
-	 * @link https://bugs.php.net/bug.php?id=75992
-	 *
-	 * @throws \InvalidArgumentException if the argument can't be parsed from a formatted date string
-	 */
-	private static function validateDate(\DateTime $dateTime) : void{
-		try{
-			self::parseDate($dateTime->format(self::$format));
-		}catch(\RuntimeException $e){
-			throw new \InvalidArgumentException($e->getMessage(), 0, $e);
-		}
-	}
-
-	/**
-	 * @throws \RuntimeException
-	 */
-	private static function parseDate(string $date) : \DateTime{
-		$datetime = \DateTime::createFromFormat(self::$format, $date);
-		if(!($datetime instanceof \DateTime)){
-			$lastErrors = \DateTime::getLastErrors();
-			if($lastErrors === false) throw new AssumptionFailedError("DateTime::getLastErrors() should not be returning false in here");
-			throw new \RuntimeException("Corrupted date/time: " . implode(", ", $lastErrors["errors"]));
-		}
-
-		return $datetime;
-	}
-
-	/**
-	 * @throws \RuntimeException
-	 */
-	public static function fromString(string $str) : ?BanEntry{
-		if(strlen($str) < 2){
-			return null;
-		}
-
-		$parts = explode("|", trim($str));
-		$entry = new BanEntry(trim(array_shift($parts)));
-		if(count($parts) > 0){
-			$entry->setCreated(self::parseDate(array_shift($parts)));
-		}
-		if(count($parts) > 0){
-			$entry->setSource(trim(array_shift($parts)));
-		}
-		if(count($parts) > 0){
-			$expire = trim(array_shift($parts));
-			if($expire !== "" and strtolower($expire) !== "forever"){
-				$entry->setExpires(self::parseDate($expire));
-			}
-		}
-		if(count($parts) > 0){
-			$entry->setReason(trim(array_shift($parts)));
-		}
-
-		return $entry;
 	}
 }

--- a/src/permission/BanEntry.php
+++ b/src/permission/BanEntry.php
@@ -23,7 +23,10 @@ declare(strict_types=1);
 
 namespace pocketmine\permission;
 
+use DateTime;
+use InvalidArgumentException;
 use pocketmine\utils\AssumptionFailedError;
+use RuntimeException;
 use function array_shift;
 use function count;
 use function explode;
@@ -38,11 +41,11 @@ class BanEntry{
 
 	/** @var string */
 	private $name;
-	/** @var \DateTime */
+	/** @var DateTime */
 	private $creationDate;
 	/** @var string */
 	private $source = "(Unknown)";
-	/** @var \DateTime|null */
+	/** @var DateTime|null */
 	private $expirationDate = null;
 	/** @var string */
 	private $reason = "Banned by an operator.";
@@ -50,21 +53,21 @@ class BanEntry{
 	public function __construct(string $name){
 		$this->name = strtolower($name);
 		/** @noinspection PhpUnhandledExceptionInspection */
-		$this->creationDate = new \DateTime();
+		$this->creationDate = new DateTime();
 	}
 
 	public function getName() : string{
 		return $this->name;
 	}
 
-	public function getCreated() : \DateTime{
+	public function getCreated() : DateTime{
 		return $this->creationDate;
 	}
 
 	/**
-	 * @throws \InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
-	public function setCreated(\DateTime $date) : void{
+	public function setCreated(DateTime $date) : void{
 		self::validateDate($date);
 		$this->creationDate = $date;
 	}
@@ -77,14 +80,14 @@ class BanEntry{
 		$this->source = $source;
 	}
 
-	public function getExpires() : ?\DateTime{
+	public function getExpires() : ?DateTime{
 		return $this->expirationDate;
 	}
 
 	/**
-	 * @throws \InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
-	public function setExpires(?\DateTime $date) : void{
+	public function setExpires(?DateTime $date) : void{
 		if($date !== null){
 			self::validateDate($date);
 		}
@@ -93,7 +96,7 @@ class BanEntry{
 
 	public function hasExpired() : bool{
 		/** @noinspection PhpUnhandledExceptionInspection */
-		$now = new \DateTime();
+		$now = new DateTime();
 
 		return $this->expirationDate === null ? false : $this->expirationDate < $now;
 	}
@@ -127,32 +130,32 @@ class BanEntry{
 	 *
 	 * @link https://bugs.php.net/bug.php?id=75992
 	 *
-	 * @throws \InvalidArgumentException if the argument can't be parsed from a formatted date string
+	 * @throws InvalidArgumentException if the argument can't be parsed from a formatted date string
 	 */
-	private static function validateDate(\DateTime $dateTime) : void{
+	private static function validateDate(DateTime $dateTime) : void{
 		try{
 			self::parseDate($dateTime->format(self::$format));
-		}catch(\RuntimeException $e){
-			throw new \InvalidArgumentException($e->getMessage(), 0, $e);
+		}catch(RuntimeException $e){
+			throw new InvalidArgumentException($e->getMessage(), 0, $e);
 		}
 	}
 
 	/**
-	 * @throws \RuntimeException
+	 * @throws RuntimeException
 	 */
-	private static function parseDate(string $date) : \DateTime{
-		$datetime = \DateTime::createFromFormat(self::$format, $date);
-		if(!($datetime instanceof \DateTime)){
-			$lastErrors = \DateTime::getLastErrors();
+	public static function parseDate(string $date) : DateTime{
+		$datetime = DateTime::createFromFormat(self::$format, $date);
+		if(!($datetime instanceof DateTime)){
+			$lastErrors = DateTime::getLastErrors();
 			if($lastErrors === false) throw new AssumptionFailedError("DateTime::getLastErrors() should not be returning false in here");
-			throw new \RuntimeException("Corrupted date/time: " . implode(", ", $lastErrors["errors"]));
+			throw new RuntimeException("Corrupted date/time: " . implode(", ", $lastErrors["errors"]));
 		}
 
 		return $datetime;
 	}
 
 	/**
-	 * @throws \RuntimeException
+	 * @throws RuntimeException
 	 */
 	public static function fromString(string $str) : ?BanEntry{
 		if(strlen($str) < 2){

--- a/src/permission/BanEntry.php
+++ b/src/permission/BanEntry.php
@@ -23,90 +23,160 @@ declare(strict_types=1);
 
 namespace pocketmine\permission;
 
-use function strtotime;
-use function time;
+use pocketmine\utils\AssumptionFailedError;
+use function array_shift;
+use function count;
+use function explode;
+use function implode;
+use function strlen;
+use function strtolower;
+use function trim;
 
 class BanEntry{
-	protected const DATE_FORMAT_STRING = "m/d/Y H:i:s";
+	/** @var string */
+	public static $format = "Y-m-d H:i:s O";
 
-	private string $name;
-	private ?string $source;
-	private ?string $reason;
-	private int $creationTimestamp;
-	private ?int $expirationTimestamp;
+	/** @var string */
+	private $name;
+	/** @var \DateTime */
+	private $creationDate;
+	/** @var string */
+	private $source = "(Unknown)";
+	/** @var \DateTime|null */
+	private $expirationDate = null;
+	/** @var string */
+	private $reason = "Banned by an operator.";
 
-	public function __construct(string $name, ?string $source = null, ?string $reason = null, ?int $creationTimestamp = null, ?int $expirationTimestamp = null){
-		$this->name = $name;
-		$this->source = $source;
-		$this->reason = $reason;
-		$this->creationTimestamp = $creationTimestamp ?? time();
-		$this->expirationTimestamp = $expirationTimestamp;
-	}
-
-	public function getSource() : ?string{
-		return $this->source;
-	}
-
-	public function isExpired(): bool{
-		$now = time();
-		return !$this->isPermanent() && $this->getExpirationTimestamp() < $now;
-	}
-
-	public function isPermanent(): bool{
-		return $this->getExpirationTimestamp() === null;
-	}
-
-	public function getCreationTimestamp() : ?int{
-		return $this->creationTimestamp;
-	}
-
-	public function getExpirationTimestamp() : ?int{
-		return $this->expirationTimestamp;
+	public function __construct(string $name){
+		$this->name = strtolower($name);
+		/** @noinspection PhpUnhandledExceptionInspection */
+		$this->creationDate = new \DateTime();
 	}
 
 	public function getName() : string{
 		return $this->name;
 	}
 
-	public function getReason() : ?string{
-		return $this->reason;
+	public function getCreated() : \DateTime{
+		return $this->creationDate;
 	}
 
-	public static function isValidDateString(string $dateString, ?int $baseTimestamp = null): bool{
-		return strtotime($dateString, $baseTimestamp) !== false;
+	/**
+	 * @throws \InvalidArgumentException
+	 */
+	public function setCreated(\DateTime $date) : void{
+		self::validateDate($date);
+		$this->creationDate = $date;
 	}
 
-	public function setCreationTimestamp(int $creationTimestamp) : void{
-		$this->creationTimestamp = $creationTimestamp;
+	public function getSource() : string{
+		return $this->source;
 	}
 
-	public function setExpirationTimestamp(?int $expirationTimestamp) : void{
-		$this->expirationTimestamp = $expirationTimestamp;
-	}
-
-	public function setName(string $name) : void{
-		$this->name = $name;
-	}
-
-	public function setReason(?string $reason) : void{
-		$this->reason = $reason;
-	}
-
-	public function setSource(?string $source) : void{
+	public function setSource(string $source) : void{
 		$this->source = $source;
 	}
 
-	public function toString(): string{
-		$str = $this->getName();
+	public function getExpires() : ?\DateTime{
+		return $this->expirationDate;
+	}
+
+	/**
+	 * @throws \InvalidArgumentException
+	 */
+	public function setExpires(?\DateTime $date) : void{
+		if($date !== null){
+			self::validateDate($date);
+		}
+		$this->expirationDate = $date;
+	}
+
+	public function hasExpired() : bool{
+		/** @noinspection PhpUnhandledExceptionInspection */
+		$now = new \DateTime();
+
+		return $this->expirationDate === null ? false : $this->expirationDate < $now;
+	}
+
+	public function getReason() : string{
+		return $this->reason;
+	}
+
+	public function setReason(string $reason) : void{
+		$this->reason = $reason;
+	}
+
+	public function getString() : string{
+		$str = "";
+		$str .= $this->getName();
+		$str .= "|";
+		$str .= $this->getCreated()->format(self::$format);
 		$str .= "|";
 		$str .= $this->getSource();
 		$str .= "|";
+		$str .= $this->getExpires() === null ? "Forever" : $this->getExpires()->format(self::$format);
+		$str .= "|";
 		$str .= $this->getReason();
-		$str .= "|";
-		$str .= date(self::DATE_FORMAT_STRING, $this->getCreationTimestamp());
-		$str .= "|";
-		$str .= $this->isPermanent() ? "Permanent" : date(self::DATE_FORMAT_STRING, $this->getExpirationTimestamp());
 
 		return $str;
+	}
+
+	/**
+	 * Hacky function to validate \DateTime objects due to a bug in PHP. format() with "Y" can emit years with more than
+	 * 4 digits, but createFromFormat() with "Y" doesn't accept them if they have more than 4 digits on the year.
+	 *
+	 * @link https://bugs.php.net/bug.php?id=75992
+	 *
+	 * @throws \InvalidArgumentException if the argument can't be parsed from a formatted date string
+	 */
+	private static function validateDate(\DateTime $dateTime) : void{
+		try{
+			self::parseDate($dateTime->format(self::$format));
+		}catch(\RuntimeException $e){
+			throw new \InvalidArgumentException($e->getMessage(), 0, $e);
+		}
+	}
+
+	/**
+	 * @throws \RuntimeException
+	 */
+	private static function parseDate(string $date) : \DateTime{
+		$datetime = \DateTime::createFromFormat(self::$format, $date);
+		if(!($datetime instanceof \DateTime)){
+			$lastErrors = \DateTime::getLastErrors();
+			if($lastErrors === false) throw new AssumptionFailedError("DateTime::getLastErrors() should not be returning false in here");
+			throw new \RuntimeException("Corrupted date/time: " . implode(", ", $lastErrors["errors"]));
+		}
+
+		return $datetime;
+	}
+
+	/**
+	 * @throws \RuntimeException
+	 */
+	public static function fromString(string $str) : ?BanEntry{
+		if(strlen($str) < 2){
+			return null;
+		}
+
+		$parts = explode("|", trim($str));
+		$entry = new BanEntry(trim(array_shift($parts)));
+		if(count($parts) > 0){
+			$entry->setCreated(self::parseDate(array_shift($parts)));
+		}
+		if(count($parts) > 0){
+			$entry->setSource(trim(array_shift($parts)));
+		}
+		if(count($parts) > 0){
+			$expire = trim(array_shift($parts));
+			if($expire !== "" and strtolower($expire) !== "forever"){
+				$entry->setExpires(self::parseDate($expire));
+			}
+		}
+		if(count($parts) > 0){
+			$entry->setReason(trim(array_shift($parts)));
+		}
+
+		return $entry;
 	}
 }

--- a/src/permission/BanList.php
+++ b/src/permission/BanList.php
@@ -32,12 +32,15 @@ use function strtolower;
 use function trim;
 
 class BanList{
+
 	/** @var BanEntry[] */
-	private array $list = [];
+	private $list = [];
 
-	private string $file;
+	/** @var string */
+	private $file;
 
-	private bool $enabled = true;
+	/** @var bool */
+	private $enabled = true;
 
 	public function __construct(string $file){
 		$this->file = $file;
@@ -82,32 +85,14 @@ class BanList{
 		$this->save();
 	}
 
-	public function addBanFromString(string $banEntry) : ?BanEntry{
-		$parts = explode("|", trim($banEntry));
-
-		$ban = $this->addBan($parts[0], $parts[1] ?? null, $parts[2] ?? null, $parts[3] ?? null, $parts[4] ?? null, false);
-
-		return $ban->isExpired() ? null : $ban;
-	}
-
-	public function addBan(string $target, ?string $source, ?string $reason = null, ?string $creationDate = null, ?string $expirationDate = null, bool $save = true) : BanEntry{
-		$creation = null;
-		if($creationDate && BanEntry::isValidDateString($creationDate)){
-			$creation = strtotime($creationDate);
-		}
-
-		$expires = null;
-		if($expirationDate && BanEntry::isValidDateString($expirationDate)){
-			$expires = strtotime($expirationDate);
-		}
-
-		$entry = new BanEntry($target, $source, $reason, $creation, $expires);
+	public function addBan(string $target, ?string $reason = null, ?\DateTime $expires = null, ?string $source = null) : BanEntry{
+		$entry = new BanEntry($target);
+		$entry->setSource($source ?? $entry->getSource());
+		$entry->setExpires($expires);
+		$entry->setReason($reason ?? $entry->getReason());
 
 		$this->list[$entry->getName()] = $entry;
-
-		if($save){
-			$this->save();
-		}
+		$this->save();
 
 		return $entry;
 	}
@@ -122,8 +107,8 @@ class BanList{
 
 	public function removeExpired() : void{
 		foreach($this->list as $name => $entry){
-			if($entry->isExpired()){
-				$this->remove($name);
+			if($entry->hasExpired()){
+				unset($this->list[$name]);
 			}
 		}
 	}
@@ -134,12 +119,14 @@ class BanList{
 		if(is_resource($fp)){
 			while(($line = fgets($fp)) !== false){
 				if($line[0] !== "#"){
-					$entry = $this->addBanFromString($line);
-					if($entry !== null){
-						$this->list[$entry->getName()] = $entry;
-					}else{
+					try{
+						$entry = BanEntry::fromString($line);
+						if($entry !== null){
+							$this->list[$entry->getName()] = $entry;
+						}
+					}catch(\RuntimeException $e){
 						$logger = \GlobalLogger::get();
-						$logger->critical("Failed to parse ban entry from string \"" . trim($line) . "\"");
+						$logger->critical("Failed to parse ban entry from string \"" . trim($line) . "\": " . $e->getMessage());
 					}
 
 				}
@@ -151,20 +138,16 @@ class BanList{
 	}
 
 	public function save(bool $writeHeader = true) : void{
+		$this->removeExpired();
 		$fp = @fopen($this->file, "w");
-		$str = "";
-
 		if(is_resource($fp)){
 			if($writeHeader){
-				$str .= "# player | source | reason | creation date | expiration date \n\n";
+				fwrite($fp, "# victim name | ban date | banned by | banned until | reason\n\n");
 			}
 
 			foreach($this->list as $entry){
-				$str .= $entry->toString() . "\n";
+				fwrite($fp, $entry->getString() . "\n");
 			}
-
-			fwrite($fp, $str);
-
 			fclose($fp);
 		}else{
 			\GlobalLogger::get()->error("Could not save ban list");


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This PR aims to implement the missing temporary bans.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
```
public function addBan(string $target, ?string $source, ?string $reason = null, ?string $creationDate = null, ?string $expirationDate = null, bool $save = true) : BanEntry;
```
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
This PR is BC-Breaking as the addBan parameters have been changed and the ban formats have been changed, meaning that any previous bans/ip bans will not load up and might cause a ceash upon loading the ban list. 

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
### Requires translations:

It does not need new translations, however a new translation key can be added to indicate the duration of the ban.

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->

`/ban <player> [reason] [date: 1day]`
`/ban-ip <ip> [reason] [date: 1day]`