### PR TITLE
Misleading Chunk methods in World class

### DIFF
--- a/src/command/defaults/GarbageCollectorCommand.php
+++ b/src/command/defaults/GarbageCollectorCommand.php
@@ -54,10 +54,10 @@ class GarbageCollectorCommand extends VanillaCommand{
 		$memory = memory_get_usage();
 
 		foreach($sender->getServer()->getWorldManager()->getWorlds() as $world){
-			$diff = [count($world->getChunks()), count($world->getEntities())];
+			$diff = [count($world->getLoadedChunks()), count($world->getEntities())];
 			$world->doChunkGarbageCollection();
 			$world->unloadChunks(true);
-			$chunksCollected += $diff[0] - count($world->getChunks());
+			$chunksCollected += $diff[0] - count($world->getLoadedChunks());
 			$entitiesCollected += $diff[1] - count($world->getEntities());
 			$world->clearCache(true);
 		}

--- a/src/command/defaults/StatusCommand.php
+++ b/src/command/defaults/StatusCommand.php
@@ -113,7 +113,7 @@ class StatusCommand extends VanillaCommand{
 			$worldName = $world->getFolderName() !== $world->getDisplayName() ? " (" . $world->getDisplayName() . ")" : "";
 			$timeColor = $world->getTickRateTime() > 40 ? TextFormat::RED : TextFormat::YELLOW;
 			$sender->sendMessage(TextFormat::GOLD . "World \"{$world->getFolderName()}\"$worldName: " .
-				TextFormat::RED . number_format(count($world->getChunks())) . TextFormat::GREEN . " chunks, " .
+				TextFormat::RED . number_format(count($world->getLoadedChunks())) . TextFormat::GREEN . " chunks, " .
 				TextFormat::RED . number_format(count($world->getEntities())) . TextFormat::GREEN . " entities. " .
 				"Time $timeColor" . round($world->getTickRateTime(), 2) . "ms"
 			);

--- a/src/world/World.php
+++ b/src/world/World.php
@@ -2035,7 +2035,7 @@ class World implements ChunkManager{
 	/**
 	 * @return Chunk[]
 	 */
-	public function getChunks() : array{
+	public function getLoadedChunks() : array{
 		return $this->chunks;
 	}
 


### PR DESCRIPTION
## Introduction
As pointed out by @dktapps via. discord (https://discord.com/channels/373199722573201408/373214753147060235/878764690526830592) the method getChunks() in the World class which returns all loaded chunks from that world is misleading.

### Relevant issues
https://discord.com/channels/373199722573201408/373214753147060235/878764690526830592

## Changes
### API changes
The method name was changed from getChunks() to getLoadedChunks() so it is less misleading and indicates that not every existing but just every currently loaded chunk will be returned.

## Backwards compatibility
Any plugins that use this method would need to rename it.

## Tests
The method is only used in the GarbageCollectorCommand class and the StatusCommand class as can be seen through PhpStorm's and GitHub's usage search and should therefore not require any additional tests because just the name was changed and not the method itself
![image](https://user-images.githubusercontent.com/54852588/130336810-538af2c2-a928-4432-8e8d-6ab805ce4fae.png)
![image](https://user-images.githubusercontent.com/54852588/130336820-866fc909-07cf-4985-ac31-dc9e9a80ec50.png)

