### PR TITLE
Refactor Block & Tile: getPos() to getPosition()

### DIFF
--- a/src/block/Anvil.php
+++ b/src/block/Anvil.php
@@ -78,7 +78,7 @@ class Anvil extends Transparent implements Fallable{
 
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
 		if($player instanceof Player){
-			$player->setCurrentWindow(new AnvilInventory($this->pos));
+			$player->setCurrentWindow(new AnvilInventory($this->position));
 		}
 
 		return true;

--- a/src/block/Bamboo.php
+++ b/src/block/Bamboo.php
@@ -114,8 +114,8 @@ class Bamboo extends Transparent{
 		return 12 + (self::getOffsetSeed($x, 0, $z) % 5);
 	}
 
-	public function getPosOffset() : ?Vector3{
-		$seed = self::getOffsetSeed($this->pos->getFloorX(), 0, $this->pos->getFloorZ());
+	public function getPositionOffset() : ?Vector3{
+		$seed = self::getOffsetSeed($this->position->getFloorX(), 0, $this->position->getFloorZ());
 		$retX = (($seed % 12) + 1) / 16;
 		$retZ = ((($seed >> 8) % 12) + 1) / 16;
 		return new Vector3($retX, 0, $retZ);
@@ -133,9 +133,9 @@ class Bamboo extends Transparent{
 	}
 
 	private function seekToTop() : Bamboo{
-		$world = $this->pos->getWorld();
+		$world = $this->position->getWorld();
 		$top = $this;
-		while(($next = $world->getBlock($top->pos->up())) instanceof Bamboo && $next->isSameType($this)){
+		while(($next = $world->getBlock($top->position->up())) instanceof Bamboo && $next->isSameType($this)){
 			$top = $next;
 		}
 		return $top;
@@ -144,7 +144,7 @@ class Bamboo extends Transparent{
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
 		if($item instanceof Fertilizer){
 			$top = $this->seekToTop();
-			if($top->grow(self::getMaxHeight($top->pos->getFloorX(), $top->pos->getFloorZ()), mt_rand(1, 2))){
+			if($top->grow(self::getMaxHeight($top->position->getFloorX(), $top->position->getFloorZ()), mt_rand(1, 2))){
 				$item->pop();
 				return true;
 			}
@@ -158,20 +158,20 @@ class Bamboo extends Transparent{
 	}
 
 	public function onNearbyBlockChange() : void{
-		$below = $this->pos->getWorld()->getBlock($this->pos->down());
+		$below = $this->position->getWorld()->getBlock($this->position->down());
 		if(!$this->canBeSupportedBy($below) and !$below->isSameType($this)){
-			$this->pos->getWorld()->useBreakOn($this->pos);
+			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
 
 	private function grow(int $maxHeight, int $growAmount) : bool{
-		$world = $this->pos->getWorld();
-		if(!$world->getBlock($this->pos->up())->canBeReplaced()){
+		$world = $this->position->getWorld();
+		if(!$world->getBlock($this->position->up())->canBeReplaced()){
 			return false;
 		}
 
 		$height = 1;
-		while($world->getBlock($this->pos->subtract(0, $height, 0))->isSameType($this)){
+		while($world->getBlock($this->position->subtract(0, $height, 0))->isSameType($this)){
 			if(++$height >= $maxHeight){
 				return false;
 			}
@@ -206,9 +206,9 @@ class Bamboo extends Transparent{
 			}
 		}
 
-		$tx = new BlockTransaction($this->pos->getWorld());
+		$tx = new BlockTransaction($this->position->getWorld());
 		foreach($newBlocks as $idx => $newBlock){
-			$tx->addBlock($this->pos->subtract(0, $idx - $growAmount, 0), $newBlock);
+			$tx->addBlock($this->position->subtract(0, $idx - $growAmount, 0), $newBlock);
 		}
 		return $tx->apply();
 	}
@@ -218,15 +218,15 @@ class Bamboo extends Transparent{
 	}
 
 	public function onRandomTick() : void{
-		$world = $this->pos->getWorld();
+		$world = $this->position->getWorld();
 		if($this->ready){
 			$this->ready = false;
-			if($world->getFullLight($this->pos) < 9 || !$this->grow(self::getMaxHeight($this->pos->getFloorX(), $this->pos->getFloorZ()), 1)){
-				$world->setBlock($this->pos, $this);
+			if($world->getFullLight($this->position) < 9 || !$this->grow(self::getMaxHeight($this->position->getFloorX(), $this->position->getFloorZ()), 1)){
+				$world->setBlock($this->position, $this);
 			}
-		}elseif($world->getBlock($this->pos->up())->canBeReplaced()){
+		}elseif($world->getBlock($this->position->up())->canBeReplaced()){
 			$this->ready = true;
-			$world->setBlock($this->pos, $this);
+			$world->setBlock($this->position, $this);
 		}
 	}
 }

--- a/src/block/BambooSapling.php
+++ b/src/block/BambooSapling.php
@@ -64,7 +64,7 @@ final class BambooSapling extends Flowable{
 	}
 
 	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		if(!$this->canBeSupportedBy($blockReplace->pos->getWorld()->getBlock($blockReplace->pos->down()))){
+		if(!$this->canBeSupportedBy($blockReplace->position->getWorld()->getBlock($blockReplace->position->down()))){
 			return false;
 		}
 		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
@@ -81,21 +81,21 @@ final class BambooSapling extends Flowable{
 	}
 
 	public function onNearbyBlockChange() : void{
-		if(!$this->canBeSupportedBy($this->pos->getWorld()->getBlock($this->pos->down()))){
-			$this->pos->getWorld()->useBreakOn($this->pos);
+		if(!$this->canBeSupportedBy($this->position->getWorld()->getBlock($this->position->down()))){
+			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
 
 	private function grow() : bool{
-		$world = $this->pos->getWorld();
-		if(!$world->getBlock($this->pos->up())->canBeReplaced()){
+		$world = $this->position->getWorld();
+		if(!$world->getBlock($this->position->up())->canBeReplaced()){
 			return false;
 		}
 
 		$tx = new BlockTransaction($world);
 		$bamboo = VanillaBlocks::BAMBOO();
-		$tx->addBlock($this->pos, $bamboo)
-			->addBlock($this->pos->up(), (clone $bamboo)->setLeafSize(Bamboo::SMALL_LEAVES));
+		$tx->addBlock($this->position, $bamboo)
+			->addBlock($this->position->up(), (clone $bamboo)->setLeafSize(Bamboo::SMALL_LEAVES));
 		return $tx->apply();
 	}
 
@@ -104,15 +104,15 @@ final class BambooSapling extends Flowable{
 	}
 
 	public function onRandomTick() : void{
-		$world = $this->pos->getWorld();
+		$world = $this->position->getWorld();
 		if($this->ready){
 			$this->ready = false;
-			if($world->getFullLight($this->pos) < 9 || !$this->grow()){
-				$world->setBlock($this->pos, $this);
+			if($world->getFullLight($this->position) < 9 || !$this->grow()){
+				$world->setBlock($this->position, $this);
 			}
-		}elseif($world->getBlock($this->pos->up())->canBeReplaced()){
+		}elseif($world->getBlock($this->position->up())->canBeReplaced()){
 			$this->ready = true;
-			$world->setBlock($this->pos, $this);
+			$world->setBlock($this->position, $this);
 		}
 	}
 

--- a/src/block/Barrel.php
+++ b/src/block/Barrel.php
@@ -63,12 +63,12 @@ class Barrel extends Opaque{
 
 	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
 		if($player !== null){
-			if(abs($player->getPosition()->getX() - $this->pos->getX()) < 2 && abs($player->getPosition()->getZ() - $this->pos->getZ()) < 2){
+			if(abs($player->getPosition()->getX() - $this->position->getX()) < 2 && abs($player->getPosition()->getZ() - $this->position->getZ()) < 2){
 				$y = $player->getEyePos()->getY();
 
-				if($y - $this->pos->getY() > 2){
+				if($y - $this->position->getY() > 2){
 					$this->facing = Facing::UP;
-				}elseif($this->pos->getY() - $y > 0){
+				}elseif($this->position->getY() - $y > 0){
 					$this->facing = Facing::DOWN;
 				}else{
 					$this->facing = Facing::opposite($player->getHorizontalFacing());
@@ -83,7 +83,7 @@ class Barrel extends Opaque{
 
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
 		if($player instanceof Player){
-			$barrel = $this->pos->getWorld()->getTile($this->pos);
+			$barrel = $this->position->getWorld()->getTile($this->position);
 			if($barrel instanceof TileBarrel){
 				if(!$barrel->canOpenWith($item->getCustomName())){
 					return true;

--- a/src/block/BaseBanner.php
+++ b/src/block/BaseBanner.php
@@ -54,7 +54,7 @@ abstract class BaseBanner extends Transparent{
 
 	public function readStateFromWorld() : void{
 		parent::readStateFromWorld();
-		$tile = $this->pos->getWorld()->getTile($this->pos);
+		$tile = $this->position->getWorld()->getTile($this->position);
 		if($tile instanceof TileBanner){
 			$this->color = $tile->getBaseColor();
 			$this->setPatterns($tile->getPatterns());
@@ -63,7 +63,7 @@ abstract class BaseBanner extends Transparent{
 
 	public function writeStateToWorld() : void{
 		parent::writeStateToWorld();
-		$tile = $this->pos->getWorld()->getTile($this->pos);
+		$tile = $this->position->getWorld()->getTile($this->position);
 		assert($tile instanceof TileBanner);
 		$tile->setBaseColor($this->color);
 		$tile->setPatterns($this->patterns);
@@ -120,7 +120,7 @@ abstract class BaseBanner extends Transparent{
 
 	public function onNearbyBlockChange() : void{
 		if($this->getSide($this->getSupportingFace())->getId() === BlockLegacyIds::AIR){
-			$this->pos->getWorld()->useBreakOn($this->pos);
+			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
 

--- a/src/block/BaseCoral.php
+++ b/src/block/BaseCoral.php
@@ -54,10 +54,10 @@ abstract class BaseCoral extends Transparent{
 
 	public function onNearbyBlockChange() : void{
 		if(!$this->dead){
-			$world = $this->pos->getWorld();
+			$world = $this->position->getWorld();
 
 			$hasWater = false;
-			foreach($this->pos->sides() as $vector3){
+			foreach($this->position->sides() as $vector3){
 				if($world->getBlock($vector3) instanceof Water){
 					$hasWater = true;
 					break;
@@ -66,7 +66,7 @@ abstract class BaseCoral extends Transparent{
 
 			//TODO: check water inside the block itself (not supported on the API yet)
 			if(!$hasWater){
-				$world->setBlock($this->pos, $this->setDead(true));
+				$world->setBlock($this->position, $this->setDead(true));
 			}
 		}
 	}

--- a/src/block/BaseRail.php
+++ b/src/block/BaseRail.php
@@ -189,7 +189,7 @@ abstract class BaseRail extends Flowable{
 				if(isset($otherPossible[$otherSide])){
 					$otherConnections[] = $otherSide;
 					$other->setConnections($otherConnections);
-					$this->pos->getWorld()->setBlock($other->pos, $other);
+					$this->position->getWorld()->setBlock($other->position, $other);
 
 					$changed = true;
 					$thisConnections[] = $thisSide;
@@ -202,7 +202,7 @@ abstract class BaseRail extends Flowable{
 
 		if($changed){
 			$this->setConnections($thisConnections);
-			$this->pos->getWorld()->setBlock($this->pos, $this);
+			$this->position->getWorld()->setBlock($this->position, $this);
 		}
 	}
 
@@ -221,11 +221,11 @@ abstract class BaseRail extends Flowable{
 
 	public function onNearbyBlockChange() : void{
 		if($this->getSide(Facing::DOWN)->isTransparent()){
-			$this->pos->getWorld()->useBreakOn($this->pos);
+			$this->position->getWorld()->useBreakOn($this->position);
 		}else{
 			foreach($this->getCurrentShapeConnections() as $connection){
 				if(($connection & RailConnectionInfo::FLAG_ASCEND) !== 0 and $this->getSide($connection & ~RailConnectionInfo::FLAG_ASCEND)->isTransparent()){
-					$this->pos->getWorld()->useBreakOn($this->pos);
+					$this->position->getWorld()->useBreakOn($this->position);
 					break;
 				}
 			}

--- a/src/block/BaseSign.php
+++ b/src/block/BaseSign.php
@@ -49,7 +49,7 @@ abstract class BaseSign extends Transparent{
 
 	public function readStateFromWorld() : void{
 		parent::readStateFromWorld();
-		$tile = $this->pos->getWorld()->getTile($this->pos);
+		$tile = $this->position->getWorld()->getTile($this->position);
 		if($tile instanceof TileSign){
 			$this->text = $tile->getText();
 			$this->editorEntityRuntimeId = $tile->getEditorEntityRuntimeId();
@@ -58,7 +58,7 @@ abstract class BaseSign extends Transparent{
 
 	public function writeStateToWorld() : void{
 		parent::writeStateToWorld();
-		$tile = $this->pos->getWorld()->getTile($this->pos);
+		$tile = $this->position->getWorld()->getTile($this->position);
 		assert($tile instanceof TileSign);
 		$tile->setText($this->text);
 		$tile->setEditorEntityRuntimeId($this->editorEntityRuntimeId);
@@ -83,7 +83,7 @@ abstract class BaseSign extends Transparent{
 
 	public function onNearbyBlockChange() : void{
 		if($this->getSide($this->getSupportingFace())->getId() === BlockLegacyIds::AIR){
-			$this->pos->getWorld()->useBreakOn($this->pos);
+			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
 
@@ -130,7 +130,7 @@ abstract class BaseSign extends Transparent{
 		$ev->call();
 		if(!$ev->isCancelled()){
 			$this->setText($ev->getNewText());
-			$this->pos->getWorld()->setBlock($this->pos, $this);
+			$this->position->getWorld()->setBlock($this->position, $this);
 			return true;
 		}
 

--- a/src/block/Bed.php
+++ b/src/block/Bed.php
@@ -70,7 +70,7 @@ class Bed extends Transparent{
 	public function readStateFromWorld() : void{
 		parent::readStateFromWorld();
 		//read extra state information from the tile - this is an ugly hack
-		$tile = $this->pos->getWorld()->getTile($this->pos);
+		$tile = $this->position->getWorld()->getTile($this->position);
 		if($tile instanceof TileBed){
 			$this->color = $tile->getColor();
 		}
@@ -79,7 +79,7 @@ class Bed extends Transparent{
 	public function writeStateToWorld() : void{
 		parent::writeStateToWorld();
 		//extra block properties storage hack
-		$tile = $this->pos->getWorld()->getTile($this->pos);
+		$tile = $this->position->getWorld()->getTile($this->position);
 		if($tile instanceof TileBed){
 			$tile->setColor($this->color);
 		}
@@ -133,12 +133,12 @@ class Bed extends Transparent{
 				$player->sendMessage(TextFormat::GRAY . "This bed is incomplete");
 
 				return true;
-			}elseif($playerPos->distanceSquared($this->pos) > 4 and $playerPos->distanceSquared($other->pos) > 4){
+			}elseif($playerPos->distanceSquared($this->position) > 4 and $playerPos->distanceSquared($other->position) > 4){
 				$player->sendMessage(KnownTranslationFactory::tile_bed_tooFar()->prefix(TextFormat::GRAY));
 				return true;
 			}
 
-			$time = $this->pos->getWorld()->getTimeOfDay();
+			$time = $this->position->getWorld()->getTimeOfDay();
 
 			$isNight = ($time >= World::TIME_NIGHT and $time < World::TIME_SUNRISE);
 
@@ -156,7 +156,7 @@ class Bed extends Transparent{
 				return true;
 			}
 
-			$player->sleepOn($b->pos);
+			$player->sleepOn($b->position);
 		}
 
 		return true;
@@ -166,7 +166,7 @@ class Bed extends Transparent{
 	public function onNearbyBlockChange() : void{
 		if(($other = $this->getOtherHalf()) !== null and $other->occupied !== $this->occupied){
 			$this->occupied = $other->occupied;
-			$this->pos->getWorld()->setBlock($this->pos, $this);
+			$this->position->getWorld()->setBlock($this->position, $this);
 		}
 	}
 
@@ -179,7 +179,7 @@ class Bed extends Transparent{
 			if($next->canBeReplaced() and !$next->getSide(Facing::DOWN)->isTransparent()){
 				$nextState = clone $this;
 				$nextState->head = true;
-				$tx->addBlock($blockReplace->pos, $this)->addBlock($next->pos, $nextState);
+				$tx->addBlock($blockReplace->position, $this)->addBlock($next->position, $nextState);
 				return true;
 			}
 		}

--- a/src/block/Bell.php
+++ b/src/block/Bell.php
@@ -95,7 +95,7 @@ final class Bell extends Transparent{
 
 	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
 		if($face === Facing::UP){
-			if(!$this->canBeSupportedBy($tx->fetchBlock($this->pos->down()))){
+			if(!$this->canBeSupportedBy($tx->fetchBlock($this->position->down()))){
 				return false;
 			}
 			if($player !== null){
@@ -103,18 +103,18 @@ final class Bell extends Transparent{
 			}
 			$this->setAttachmentType(BellAttachmentType::FLOOR());
 		}elseif($face === Facing::DOWN){
-			if(!$this->canBeSupportedBy($tx->fetchBlock($this->pos->up()))){
+			if(!$this->canBeSupportedBy($tx->fetchBlock($this->position->up()))){
 				return false;
 			}
 			$this->setAttachmentType(BellAttachmentType::CEILING());
 		}else{
 			$this->setFacing($face);
-			if($this->canBeSupportedBy($tx->fetchBlock($this->pos->getSide(Facing::opposite($face))))){
+			if($this->canBeSupportedBy($tx->fetchBlock($this->position->getSide(Facing::opposite($face))))){
 				$this->setAttachmentType(BellAttachmentType::ONE_WALL());
 			}else{
 				return false;
 			}
-			if($this->canBeSupportedBy($tx->fetchBlock($this->pos->getSide($face)))){
+			if($this->canBeSupportedBy($tx->fetchBlock($this->position->getSide($face)))){
 				$this->setAttachmentType(BellAttachmentType::TWO_WALLS());
 			}
 		}
@@ -128,7 +128,7 @@ final class Bell extends Transparent{
 			($this->attachmentType->equals(BellAttachmentType::ONE_WALL()) && !$this->canBeSupportedBy($this->getSide(Facing::opposite($this->facing)))) ||
 			($this->attachmentType->equals(BellAttachmentType::TWO_WALLS()) && (!$this->canBeSupportedBy($this->getSide($this->facing)) || !$this->canBeSupportedBy($this->getSide(Facing::opposite($this->facing)))))
 		){
-			$this->pos->getWorld()->useBreakOn($this->pos);
+			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
 
@@ -153,10 +153,10 @@ final class Bell extends Transparent{
 	}
 
 	public function ring(int $faceHit) : void{
-		$this->pos->getWorld()->addSound($this->pos, new BellRingSound());
-		$tile = $this->pos->getWorld()->getTile($this->pos);
+		$this->position->getWorld()->addSound($this->position, new BellRingSound());
+		$tile = $this->position->getWorld()->getTile($this->position);
 		if($tile instanceof TileBell){
-			$this->pos->getWorld()->broadcastPacketToViewers($this->pos, $tile->createFakeUpdatePacket($faceHit));
+			$this->position->getWorld()->broadcastPacketToViewers($this->position, $tile->createFakeUpdatePacket($faceHit));
 		}
 	}
 }

--- a/src/block/BrewingStand.php
+++ b/src/block/BrewingStand.php
@@ -99,7 +99,7 @@ class BrewingStand extends Transparent{
 
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
 		if($player instanceof Player){
-			$stand = $this->pos->getWorld()->getTile($this->pos);
+			$stand = $this->position->getWorld()->getTile($this->position);
 			if($stand instanceof TileBrewingStand and $stand->canOpenWith($item->getCustomName())){
 				$player->setCurrentWindow($stand->getInventory());
 			}

--- a/src/block/Button.php
+++ b/src/block/Button.php
@@ -71,9 +71,9 @@ abstract class Button extends Flowable{
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
 		if(!$this->pressed){
 			$this->pressed = true;
-			$this->pos->getWorld()->setBlock($this->pos, $this);
-			$this->pos->getWorld()->scheduleDelayedBlockUpdate($this->pos, $this->getActivationTime());
-			$this->pos->getWorld()->addSound($this->pos->add(0.5, 0.5, 0.5), new RedstonePowerOnSound());
+			$this->position->getWorld()->setBlock($this->position, $this);
+			$this->position->getWorld()->scheduleDelayedBlockUpdate($this->position, $this->getActivationTime());
+			$this->position->getWorld()->addSound($this->position->add(0.5, 0.5, 0.5), new RedstonePowerOnSound());
 		}
 
 		return true;
@@ -82,8 +82,8 @@ abstract class Button extends Flowable{
 	public function onScheduledUpdate() : void{
 		if($this->pressed){
 			$this->pressed = false;
-			$this->pos->getWorld()->setBlock($this->pos, $this);
-			$this->pos->getWorld()->addSound($this->pos->add(0.5, 0.5, 0.5), new RedstonePowerOffSound());
+			$this->position->getWorld()->setBlock($this->position, $this);
+			$this->position->getWorld()->addSound($this->position->add(0.5, 0.5, 0.5), new RedstonePowerOffSound());
 		}
 	}
 }

--- a/src/block/Cactus.php
+++ b/src/block/Cactus.php
@@ -83,12 +83,12 @@ class Cactus extends Transparent{
 	public function onNearbyBlockChange() : void{
 		$down = $this->getSide(Facing::DOWN);
 		if($down->getId() !== BlockLegacyIds::SAND and !$down->isSameType($this)){
-			$this->pos->getWorld()->useBreakOn($this->pos);
+			$this->position->getWorld()->useBreakOn($this->position);
 		}else{
 			foreach(Facing::HORIZONTAL as $side){
 				$b = $this->getSide($side);
 				if($b->isSolid()){
-					$this->pos->getWorld()->useBreakOn($this->pos);
+					$this->position->getWorld()->useBreakOn($this->position);
 					break;
 				}
 			}
@@ -103,26 +103,26 @@ class Cactus extends Transparent{
 		if(!$this->getSide(Facing::DOWN)->isSameType($this)){
 			if($this->age === 15){
 				for($y = 1; $y < 3; ++$y){
-					if(!$this->pos->getWorld()->isInWorld($this->pos->x, $this->pos->y + $y, $this->pos->z)){
+					if(!$this->position->getWorld()->isInWorld($this->position->x, $this->position->y + $y, $this->position->z)){
 						break;
 					}
-					$b = $this->pos->getWorld()->getBlockAt($this->pos->x, $this->pos->y + $y, $this->pos->z);
+					$b = $this->position->getWorld()->getBlockAt($this->position->x, $this->position->y + $y, $this->position->z);
 					if($b->getId() === BlockLegacyIds::AIR){
 						$ev = new BlockGrowEvent($b, VanillaBlocks::CACTUS());
 						$ev->call();
 						if($ev->isCancelled()){
 							break;
 						}
-						$this->pos->getWorld()->setBlock($b->pos, $ev->getNewState());
+						$this->position->getWorld()->setBlock($b->position, $ev->getNewState());
 					}else{
 						break;
 					}
 				}
 				$this->age = 0;
-				$this->pos->getWorld()->setBlock($this->pos, $this);
+				$this->position->getWorld()->setBlock($this->position, $this);
 			}else{
 				++$this->age;
-				$this->pos->getWorld()->setBlock($this->pos, $this);
+				$this->position->getWorld()->setBlock($this->position, $this);
 			}
 		}
 	}

--- a/src/block/Cake.php
+++ b/src/block/Cake.php
@@ -84,7 +84,7 @@ class Cake extends Transparent implements FoodSource{
 
 	public function onNearbyBlockChange() : void{
 		if($this->getSide(Facing::DOWN)->getId() === BlockLegacyIds::AIR){ //Replace with common break method
-			$this->pos->getWorld()->setBlock($this->pos, VanillaBlocks::AIR());
+			$this->position->getWorld()->setBlock($this->position, VanillaBlocks::AIR());
 		}
 	}
 
@@ -133,6 +133,6 @@ class Cake extends Transparent implements FoodSource{
 	}
 
 	public function onConsume(Living $consumer) : void{
-		$this->pos->getWorld()->setBlock($this->pos, $this->getResidue());
+		$this->position->getWorld()->setBlock($this->position, $this->getResidue());
 	}
 }

--- a/src/block/Carpet.php
+++ b/src/block/Carpet.php
@@ -62,7 +62,7 @@ class Carpet extends Flowable{
 
 	public function onNearbyBlockChange() : void{
 		if($this->getSide(Facing::DOWN)->getId() === BlockLegacyIds::AIR){
-			$this->pos->getWorld()->useBreakOn($this->pos);
+			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
 

--- a/src/block/Chest.php
+++ b/src/block/Chest.php
@@ -45,7 +45,7 @@ class Chest extends Transparent{
 	}
 
 	public function onPostPlace() : void{
-		$tile = $this->pos->getWorld()->getTile($this->pos);
+		$tile = $this->position->getWorld()->getTile($this->position);
 		if($tile instanceof TileChest){
 			foreach([
 				Facing::rotateY($this->facing, true),
@@ -53,7 +53,7 @@ class Chest extends Transparent{
 			] as $side){
 				$c = $this->getSide($side);
 				if($c instanceof Chest and $c->isSameType($this) and $c->facing === $this->facing){
-					$pair = $this->pos->getWorld()->getTile($c->pos);
+					$pair = $this->position->getWorld()->getTile($c->position);
 					if($pair instanceof TileChest and !$pair->isPaired()){
 						$pair->pairWith($tile);
 						$tile->pairWith($pair);
@@ -67,7 +67,7 @@ class Chest extends Transparent{
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
 		if($player instanceof Player){
 
-			$chest = $this->pos->getWorld()->getTile($this->pos);
+			$chest = $this->position->getWorld()->getTile($this->position);
 			if($chest instanceof TileChest){
 				if(
 					!$this->getSide(Facing::UP)->isTransparent() or

--- a/src/block/CocoaBlock.php
+++ b/src/block/CocoaBlock.php
@@ -96,7 +96,7 @@ class CocoaBlock extends Transparent{
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
 		if($this->age < 2 and $item instanceof Fertilizer){
 			$this->age++;
-			$this->pos->getWorld()->setBlock($this->pos, $this);
+			$this->position->getWorld()->setBlock($this->position, $this);
 
 			$item->pop();
 
@@ -108,7 +108,7 @@ class CocoaBlock extends Transparent{
 
 	public function onNearbyBlockChange() : void{
 		if(!$this->canAttachTo($this->getSide(Facing::opposite($this->facing)))){
-			$this->pos->getWorld()->useBreakOn($this->pos);
+			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
 
@@ -119,7 +119,7 @@ class CocoaBlock extends Transparent{
 	public function onRandomTick() : void{
 		if($this->age < 2 and mt_rand(1, 5) === 1){
 			$this->age++;
-			$this->pos->getWorld()->setBlock($this->pos, $this);
+			$this->position->getWorld()->setBlock($this->position, $this);
 		}
 	}
 

--- a/src/block/ConcretePowder.php
+++ b/src/block/ConcretePowder.php
@@ -42,7 +42,7 @@ class ConcretePowder extends Opaque implements Fallable{
 
 	public function onNearbyBlockChange() : void{
 		if(($block = $this->checkAdjacentWater()) !== null){
-			$this->pos->getWorld()->setBlock($this->pos, $block);
+			$this->position->getWorld()->setBlock($this->position, $block);
 		}else{
 			$this->startFalling();
 		}

--- a/src/block/Coral.php
+++ b/src/block/Coral.php
@@ -54,9 +54,9 @@ final class Coral extends BaseCoral{
 
 	public function readStateFromWorld() : void{
 		//TODO: this hack ensures correct state of coral plants, because they don't retain their dead flag in metadata
-		$world = $this->pos->getWorld();
+		$world = $this->position->getWorld();
 		$this->dead = true;
-		foreach($this->pos->sides() as $vector3){
+		foreach($this->position->sides() as $vector3){
 			if($world->getBlock($vector3) instanceof Water){
 				$this->dead = false;
 				break;
@@ -65,16 +65,16 @@ final class Coral extends BaseCoral{
 	}
 
 	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		if(!$tx->fetchBlock($blockReplace->getPos()->down())->isSolid()){
+		if(!$tx->fetchBlock($blockReplace->getPosition()->down())->isSolid()){
 			return false;
 		}
 		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
 	}
 
 	public function onNearbyBlockChange() : void{
-		$world = $this->pos->getWorld();
-		if(!$world->getBlock($this->pos->down())->isSolid()){
-			$world->useBreakOn($this->pos);
+		$world = $this->position->getWorld();
+		if(!$world->getBlock($this->position->down())->isSolid()){
+			$world->useBreakOn($this->position);
 		}else{
 			parent::onNearbyBlockChange();
 		}

--- a/src/block/CoralBlock.php
+++ b/src/block/CoralBlock.php
@@ -78,23 +78,23 @@ final class CoralBlock extends Opaque{
 
 	public function onNearbyBlockChange() : void{
 		if(!$this->dead){
-			$this->pos->getWorld()->scheduleDelayedBlockUpdate($this->pos, mt_rand(40, 200));
+			$this->position->getWorld()->scheduleDelayedBlockUpdate($this->position, mt_rand(40, 200));
 		}
 	}
 
 	public function onScheduledUpdate() : void{
 		if(!$this->dead){
-			$world = $this->pos->getWorld();
+			$world = $this->position->getWorld();
 
 			$hasWater = false;
-			foreach($this->pos->sides() as $vector3){
+			foreach($this->position->sides() as $vector3){
 				if($world->getBlock($vector3) instanceof Water){
 					$hasWater = true;
 					break;
 				}
 			}
 			if(!$hasWater){
-				$world->setBlock($this->pos, $this->setDead(true));
+				$world->setBlock($this->position, $this->setDead(true));
 			}
 		}
 	}

--- a/src/block/Crops.php
+++ b/src/block/Crops.php
@@ -79,7 +79,7 @@ abstract class Crops extends Flowable{
 			$ev = new BlockGrowEvent($this, $block);
 			$ev->call();
 			if(!$ev->isCancelled()){
-				$this->pos->getWorld()->setBlock($this->pos, $ev->getNewState());
+				$this->position->getWorld()->setBlock($this->position, $ev->getNewState());
 			}
 
 			$item->pop();
@@ -92,7 +92,7 @@ abstract class Crops extends Flowable{
 
 	public function onNearbyBlockChange() : void{
 		if($this->getSide(Facing::DOWN)->getId() !== BlockLegacyIds::FARMLAND){
-			$this->pos->getWorld()->useBreakOn($this->pos);
+			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
 
@@ -107,7 +107,7 @@ abstract class Crops extends Flowable{
 			$ev = new BlockGrowEvent($this, $block);
 			$ev->call();
 			if(!$ev->isCancelled()){
-				$this->pos->getWorld()->setBlock($this->pos, $ev->getNewState());
+				$this->position->getWorld()->setBlock($this->position, $ev->getNewState());
 			}
 		}
 	}

--- a/src/block/DaylightSensor.php
+++ b/src/block/DaylightSensor.php
@@ -90,7 +90,7 @@ class DaylightSensor extends Transparent{
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
 		$this->inverted = !$this->inverted;
 		$this->signalStrength = $this->recalculateSignalStrength();
-		$this->pos->getWorld()->setBlock($this->pos, $this);
+		$this->position->getWorld()->setBlock($this->position, $this);
 		return true;
 	}
 
@@ -98,18 +98,18 @@ class DaylightSensor extends Transparent{
 		$signalStrength = $this->recalculateSignalStrength();
 		if($this->signalStrength !== $signalStrength){
 			$this->signalStrength = $signalStrength;
-			$this->pos->getWorld()->setBlock($this->pos, $this);
+			$this->position->getWorld()->setBlock($this->position, $this);
 		}
-		$this->pos->getWorld()->scheduleDelayedBlockUpdate($this->pos, 20);
+		$this->position->getWorld()->scheduleDelayedBlockUpdate($this->position, 20);
 	}
 
 	private function recalculateSignalStrength() : int{
-		$lightLevel = $this->pos->getWorld()->getRealBlockSkyLightAt($this->pos->x, $this->pos->y, $this->pos->z);
+		$lightLevel = $this->position->getWorld()->getRealBlockSkyLightAt($this->position->x, $this->position->y, $this->position->z);
 		if($this->inverted){
 			return 15 - $lightLevel;
 		}
 
-		$sunAngle = $this->pos->getWorld()->getSunAnglePercentage();
+		$sunAngle = $this->position->getWorld()->getSunAnglePercentage();
 		return max(0, (int) round($lightLevel * cos(($sunAngle + ((($sunAngle < 0.5 ? 0 : 1) - $sunAngle) / 5)) * 2 * M_PI)));
 	}
 

--- a/src/block/DeadBush.php
+++ b/src/block/DeadBush.php
@@ -43,7 +43,7 @@ class DeadBush extends Flowable{
 
 	public function onNearbyBlockChange() : void{
 		if($this->getSide(Facing::DOWN)->isTransparent()){
-			$this->pos->getWorld()->useBreakOn($this->pos);
+			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
 

--- a/src/block/Dirt.php
+++ b/src/block/Dirt.php
@@ -60,7 +60,7 @@ class Dirt extends Opaque{
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
 		if($face === Facing::UP and $item instanceof Hoe){
 			$item->applyDamage(1);
-			$this->pos->getWorld()->setBlock($this->pos, $this->coarse ? VanillaBlocks::DIRT() : VanillaBlocks::FARMLAND());
+			$this->position->getWorld()->setBlock($this->position, $this->coarse ? VanillaBlocks::DIRT() : VanillaBlocks::FARMLAND());
 
 			return true;
 		}

--- a/src/block/Door.php
+++ b/src/block/Door.php
@@ -121,7 +121,7 @@ class Door extends Transparent{
 
 	public function onNearbyBlockChange() : void{
 		if($this->getSide(Facing::DOWN)->getId() === BlockLegacyIds::AIR){ //Replace with common break method
-			$this->pos->getWorld()->useBreakOn($this->pos); //this will delete both halves if they exist
+			$this->position->getWorld()->useBreakOn($this->position); //this will delete both halves if they exist
 		}
 	}
 
@@ -147,7 +147,7 @@ class Door extends Transparent{
 			$topHalf = clone $this;
 			$topHalf->top = true;
 
-			$tx->addBlock($blockReplace->pos, $this)->addBlock($blockUp->pos, $topHalf);
+			$tx->addBlock($blockReplace->position, $this)->addBlock($blockUp->position, $topHalf);
 			return true;
 		}
 
@@ -160,11 +160,11 @@ class Door extends Transparent{
 		$other = $this->getSide($this->top ? Facing::DOWN : Facing::UP);
 		if($other instanceof Door and $other->isSameType($this)){
 			$other->open = $this->open;
-			$this->pos->getWorld()->setBlock($other->pos, $other);
+			$this->position->getWorld()->setBlock($other->position, $other);
 		}
 
-		$this->pos->getWorld()->setBlock($this->pos, $this);
-		$this->pos->getWorld()->addSound($this->pos, new DoorSound());
+		$this->position->getWorld()->setBlock($this->position, $this);
+		$this->position->getWorld()->addSound($this->position, new DoorSound());
 
 		return true;
 	}

--- a/src/block/DoublePlant.php
+++ b/src/block/DoublePlant.php
@@ -58,7 +58,7 @@ class DoublePlant extends Flowable{
 		if(($id === BlockLegacyIds::GRASS or $id === BlockLegacyIds::DIRT) and $blockReplace->getSide(Facing::UP)->canBeReplaced()){
 			$top = clone $this;
 			$top->top = true;
-			$tx->addBlock($blockReplace->pos, $this)->addBlock($blockReplace->pos->getSide(Facing::UP), $top);
+			$tx->addBlock($blockReplace->position, $this)->addBlock($blockReplace->position->getSide(Facing::UP), $top);
 			return true;
 		}
 
@@ -80,7 +80,7 @@ class DoublePlant extends Flowable{
 
 	public function onNearbyBlockChange() : void{
 		if(!$this->isValidHalfPlant() or (!$this->top and $this->getSide(Facing::DOWN)->isTransparent())){
-			$this->pos->getWorld()->useBreakOn($this->pos);
+			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
 

--- a/src/block/DragonEgg.php
+++ b/src/block/DragonEgg.php
@@ -62,22 +62,22 @@ class DragonEgg extends Transparent implements Fallable{
 
 	public function teleport() : void{
 		for($tries = 0; $tries < 16; ++$tries){
-			$block = $this->pos->getWorld()->getBlockAt(
-				$this->pos->x + mt_rand(-16, 16),
-				max(World::Y_MIN, min(World::Y_MAX - 1, $this->pos->y + mt_rand(-8, 8))),
-				$this->pos->z + mt_rand(-16, 16)
+			$block = $this->position->getWorld()->getBlockAt(
+				$this->position->x + mt_rand(-16, 16),
+				max(World::Y_MIN, min(World::Y_MAX - 1, $this->position->y + mt_rand(-8, 8))),
+				$this->position->z + mt_rand(-16, 16)
 			);
 			if($block instanceof Air){
-				$ev = new BlockTeleportEvent($this, $block->pos);
+				$ev = new BlockTeleportEvent($this, $block->position);
 				$ev->call();
 				if($ev->isCancelled()){
 					break;
 				}
 
 				$blockPos = $ev->getTo();
-				$this->pos->getWorld()->addParticle($this->pos, new DragonEggTeleportParticle($this->pos->x - $blockPos->x, $this->pos->y - $blockPos->y, $this->pos->z - $blockPos->z));
-				$this->pos->getWorld()->setBlock($this->pos, VanillaBlocks::AIR());
-				$this->pos->getWorld()->setBlock($blockPos, $this);
+				$this->position->getWorld()->addParticle($this->position, new DragonEggTeleportParticle($this->position->x - $blockPos->x, $this->position->y - $blockPos->y, $this->position->z - $blockPos->z));
+				$this->position->getWorld()->setBlock($this->position, VanillaBlocks::AIR());
+				$this->position->getWorld()->setBlock($blockPos, $this);
 				break;
 			}
 		}

--- a/src/block/EnchantingTable.php
+++ b/src/block/EnchantingTable.php
@@ -43,7 +43,7 @@ class EnchantingTable extends Transparent{
 		if($player instanceof Player){
 			//TODO lock
 
-			$player->setCurrentWindow(new EnchantInventory($this->pos));
+			$player->setCurrentWindow(new EnchantInventory($this->position));
 		}
 
 		return true;

--- a/src/block/EnderChest.php
+++ b/src/block/EnderChest.php
@@ -51,10 +51,10 @@ class EnderChest extends Transparent{
 
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
 		if($player instanceof Player){
-			$enderChest = $this->pos->getWorld()->getTile($this->pos);
+			$enderChest = $this->position->getWorld()->getTile($this->position);
 			if($enderChest instanceof TileEnderChest and $this->getSide(Facing::UP)->isTransparent()){
 				$enderChest->setViewerCount($enderChest->getViewerCount() + 1);
-				$player->setCurrentWindow(new EnderChestInventory($this->pos, $player->getEnderInventory()));
+				$player->setCurrentWindow(new EnderChestInventory($this->position, $player->getEnderInventory()));
 			}
 		}
 

--- a/src/block/Farmland.php
+++ b/src/block/Farmland.php
@@ -64,7 +64,7 @@ class Farmland extends Transparent{
 
 	public function onNearbyBlockChange() : void{
 		if($this->getSide(Facing::UP)->isSolid()){
-			$this->pos->getWorld()->setBlock($this->pos, VanillaBlocks::DIRT());
+			$this->position->getWorld()->setBlock($this->position, VanillaBlocks::DIRT());
 		}
 	}
 
@@ -76,24 +76,24 @@ class Farmland extends Transparent{
 		if(!$this->canHydrate()){
 			if($this->wetness > 0){
 				$this->wetness--;
-				$this->pos->getWorld()->setBlock($this->pos, $this, false);
+				$this->position->getWorld()->setBlock($this->position, $this, false);
 			}else{
-				$this->pos->getWorld()->setBlock($this->pos, VanillaBlocks::DIRT());
+				$this->position->getWorld()->setBlock($this->position, VanillaBlocks::DIRT());
 			}
 		}elseif($this->wetness < 7){
 			$this->wetness = 7;
-			$this->pos->getWorld()->setBlock($this->pos, $this, false);
+			$this->position->getWorld()->setBlock($this->position, $this, false);
 		}
 	}
 
 	protected function canHydrate() : bool{
 		//TODO: check rain
-		$start = $this->pos->add(-4, 0, -4);
-		$end = $this->pos->add(4, 1, 4);
+		$start = $this->position->add(-4, 0, -4);
+		$end = $this->position->add(4, 1, 4);
 		for($y = $start->y; $y <= $end->y; ++$y){
 			for($z = $start->z; $z <= $end->z; ++$z){
 				for($x = $start->x; $x <= $end->x; ++$x){
-					if($this->pos->getWorld()->getBlockAt($x, $y, $z) instanceof Water){
+					if($this->position->getWorld()->getBlockAt($x, $y, $z) instanceof Water){
 						return true;
 					}
 				}

--- a/src/block/FenceGate.php
+++ b/src/block/FenceGate.php
@@ -99,7 +99,7 @@ class FenceGate extends Transparent{
 		$inWall = $this->checkInWall();
 		if($inWall !== $this->inWall){
 			$this->inWall = $inWall;
-			$this->pos->getWorld()->setBlock($this->pos, $this);
+			$this->position->getWorld()->setBlock($this->position, $this);
 		}
 	}
 
@@ -112,8 +112,8 @@ class FenceGate extends Transparent{
 			}
 		}
 
-		$this->pos->getWorld()->setBlock($this->pos, $this);
-		$this->pos->getWorld()->addSound($this->pos, new DoorSound());
+		$this->position->getWorld()->setBlock($this->position, $this);
+		$this->position->getWorld()->addSound($this->position, new DoorSound());
 		return true;
 	}
 

--- a/src/block/Fire.php
+++ b/src/block/Fire.php
@@ -95,9 +95,9 @@ class Fire extends Flowable{
 
 	public function onNearbyBlockChange() : void{
 		if(!$this->getSide(Facing::DOWN)->isSolid() and !$this->hasAdjacentFlammableBlocks()){
-			$this->pos->getWorld()->setBlock($this->pos, VanillaBlocks::AIR());
+			$this->position->getWorld()->setBlock($this->position, VanillaBlocks::AIR());
 		}else{
-			$this->pos->getWorld()->scheduleDelayedBlockUpdate($this->pos, mt_rand(30, 40));
+			$this->position->getWorld()->scheduleDelayedBlockUpdate($this->position, mt_rand(30, 40));
 		}
 	}
 
@@ -131,10 +131,10 @@ class Fire extends Flowable{
 		}
 
 		if($result !== null){
-			$this->pos->getWorld()->setBlock($this->pos, $result);
+			$this->position->getWorld()->setBlock($this->position, $result);
 		}
 
-		$this->pos->getWorld()->scheduleDelayedBlockUpdate($this->pos, mt_rand(30, 40));
+		$this->position->getWorld()->scheduleDelayedBlockUpdate($this->position, mt_rand(30, 40));
 
 		if($canSpread){
 			//TODO: raise upper bound for chance in humid biomes
@@ -175,9 +175,9 @@ class Fire extends Flowable{
 				if(mt_rand(0, $this->age + 9) < 5){ //TODO: check rain
 					$fire = clone $this;
 					$fire->age = min(15, $fire->age + (mt_rand(0, 4) >> 2));
-					$this->pos->getWorld()->setBlock($block->pos, $fire);
+					$this->position->getWorld()->setBlock($block->position, $fire);
 				}else{
-					$this->pos->getWorld()->setBlock($block->pos, VanillaBlocks::AIR());
+					$this->position->getWorld()->setBlock($block->position, VanillaBlocks::AIR());
 				}
 			}
 		}

--- a/src/block/FloorCoralFan.php
+++ b/src/block/FloorCoralFan.php
@@ -93,12 +93,12 @@ final class FloorCoralFan extends BaseCoral{
 	}
 
 	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		if(!$tx->fetchBlock($blockReplace->getPos()->down())->isSolid()){
+		if(!$tx->fetchBlock($blockReplace->getPosition()->down())->isSolid()){
 			return false;
 		}
 		if($player !== null){
 			$playerBlockPos = $player->getPosition()->floor();
-			$directionVector = $blockReplace->getPos()->subtractVector($playerBlockPos)->normalize();
+			$directionVector = $blockReplace->getPosition()->subtractVector($playerBlockPos)->normalize();
 			$angle = rad2deg(atan2($directionVector->getZ(), $directionVector->getX()));
 
 			if($angle <= 45 || 315 <= $angle || (135 <= $angle && $angle <= 225)){
@@ -111,9 +111,9 @@ final class FloorCoralFan extends BaseCoral{
 	}
 
 	public function onNearbyBlockChange() : void{
-		$world = $this->pos->getWorld();
-		if(!$world->getBlock($this->pos->down())->isSolid()){
-			$world->useBreakOn($this->pos);
+		$world = $this->position->getWorld();
+		if(!$world->getBlock($this->position->down())->isSolid()){
+			$world->useBreakOn($this->position);
 		}else{
 			parent::onNearbyBlockChange();
 		}

--- a/src/block/Flower.php
+++ b/src/block/Flower.php
@@ -42,7 +42,7 @@ class Flower extends Flowable{
 
 	public function onNearbyBlockChange() : void{
 		if($this->getSide(Facing::DOWN)->isTransparent()){
-			$this->pos->getWorld()->useBreakOn($this->pos);
+			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
 

--- a/src/block/FlowerPot.php
+++ b/src/block/FlowerPot.php
@@ -47,7 +47,7 @@ class FlowerPot extends Flowable{
 
 	public function readStateFromWorld() : void{
 		parent::readStateFromWorld();
-		$tile = $this->pos->getWorld()->getTile($this->pos);
+		$tile = $this->position->getWorld()->getTile($this->position);
 		if($tile instanceof TileFlowerPot){
 			$this->setPlant($tile->getPlant());
 		}else{
@@ -58,7 +58,7 @@ class FlowerPot extends Flowable{
 	public function writeStateToWorld() : void{
 		parent::writeStateToWorld();
 
-		$tile = $this->pos->getWorld()->getTile($this->pos);
+		$tile = $this->position->getWorld()->getTile($this->position);
 		assert($tile instanceof TileFlowerPot);
 		$tile->setPlant($this->plant);
 	}
@@ -109,7 +109,7 @@ class FlowerPot extends Flowable{
 
 	public function onNearbyBlockChange() : void{
 		if($this->getSide(Facing::DOWN)->isTransparent()){
-			$this->pos->getWorld()->useBreakOn($this->pos);
+			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
 
@@ -121,7 +121,7 @@ class FlowerPot extends Flowable{
 
 		$this->setPlant($plant);
 		$item->pop();
-		$this->pos->getWorld()->setBlock($this->pos, $this);
+		$this->position->getWorld()->setBlock($this->position, $this);
 
 		return true;
 	}

--- a/src/block/FrostedIce.php
+++ b/src/block/FrostedIce.php
@@ -55,15 +55,15 @@ class FrostedIce extends Ice{
 
 	public function onNearbyBlockChange() : void{
 		if(!$this->checkAdjacentBlocks(2)){
-			$this->pos->getWorld()->useBreakOn($this->pos);
+			$this->position->getWorld()->useBreakOn($this->position);
 		}else{
-			$this->pos->getWorld()->scheduleDelayedBlockUpdate($this->pos, mt_rand(20, 40));
+			$this->position->getWorld()->scheduleDelayedBlockUpdate($this->position, mt_rand(20, 40));
 		}
 	}
 
 	public function onRandomTick() : void{
 		if((!$this->checkAdjacentBlocks(4) or mt_rand(0, 2) === 0) and
-			$this->pos->getWorld()->getHighestAdjacentFullLightAt($this->pos->x, $this->pos->y, $this->pos->z) >= 12 - $this->age){
+			$this->position->getWorld()->getHighestAdjacentFullLightAt($this->position->x, $this->position->y, $this->position->z) >= 12 - $this->age){
 			if($this->tryMelt()){
 				foreach($this->getAllSides() as $block){
 					if($block instanceof FrostedIce){
@@ -72,7 +72,7 @@ class FrostedIce extends Ice{
 				}
 			}
 		}else{
-			$this->pos->getWorld()->scheduleDelayedBlockUpdate($this->pos, mt_rand(20, 40));
+			$this->position->getWorld()->scheduleDelayedBlockUpdate($this->position, mt_rand(20, 40));
 		}
 	}
 
@@ -88,7 +88,7 @@ class FrostedIce extends Ice{
 					continue;
 				}
 				if(
-					$this->pos->getWorld()->getBlockAt($this->pos->x + $x, $this->pos->y, $this->pos->z + $z) instanceof FrostedIce and
+					$this->position->getWorld()->getBlockAt($this->position->x + $x, $this->position->y, $this->position->z + $z) instanceof FrostedIce and
 					++$found >= $requirement
 				){
 					return true;
@@ -105,13 +105,13 @@ class FrostedIce extends Ice{
 	 */
 	private function tryMelt() : bool{
 		if($this->age >= 3){
-			$this->pos->getWorld()->useBreakOn($this->pos);
+			$this->position->getWorld()->useBreakOn($this->position);
 			return true;
 		}
 
 		$this->age++;
-		$this->pos->getWorld()->setBlock($this->pos, $this);
-		$this->pos->getWorld()->scheduleDelayedBlockUpdate($this->pos, mt_rand(20, 40));
+		$this->position->getWorld()->setBlock($this->position, $this);
+		$this->position->getWorld()->scheduleDelayedBlockUpdate($this->position, mt_rand(20, 40));
 		return false;
 	}
 }

--- a/src/block/Furnace.php
+++ b/src/block/Furnace.php
@@ -72,7 +72,7 @@ class Furnace extends Opaque{
 
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
 		if($player instanceof Player){
-			$furnace = $this->pos->getWorld()->getTile($this->pos);
+			$furnace = $this->position->getWorld()->getTile($this->position);
 			if($furnace instanceof TileFurnace and $furnace->canOpenWith($item->getCustomName())){
 				$player->setCurrentWindow($furnace->getInventory());
 			}
@@ -82,9 +82,9 @@ class Furnace extends Opaque{
 	}
 
 	public function onScheduledUpdate() : void{
-		$furnace = $this->pos->getWorld()->getTile($this->pos);
+		$furnace = $this->position->getWorld()->getTile($this->position);
 		if($furnace instanceof TileFurnace and $furnace->onUpdate()){
-			$this->pos->getWorld()->scheduleDelayedBlockUpdate($this->pos, 1); //TODO: check this
+			$this->position->getWorld()->scheduleDelayedBlockUpdate($this->position, 1); //TODO: check this
 		}
 	}
 }

--- a/src/block/Grass.php
+++ b/src/block/Grass.php
@@ -52,27 +52,27 @@ class Grass extends Opaque{
 	}
 
 	public function onRandomTick() : void{
-		$lightAbove = $this->pos->getWorld()->getFullLightAt($this->pos->x, $this->pos->y + 1, $this->pos->z);
-		if($lightAbove < 4 and $this->pos->getWorld()->getBlockAt($this->pos->x, $this->pos->y + 1, $this->pos->z)->getLightFilter() >= 2){
+		$lightAbove = $this->position->getWorld()->getFullLightAt($this->position->x, $this->position->y + 1, $this->position->z);
+		if($lightAbove < 4 and $this->position->getWorld()->getBlockAt($this->position->x, $this->position->y + 1, $this->position->z)->getLightFilter() >= 2){
 			//grass dies
 			$ev = new BlockSpreadEvent($this, $this, VanillaBlocks::DIRT());
 			$ev->call();
 			if(!$ev->isCancelled()){
-				$this->pos->getWorld()->setBlock($this->pos, $ev->getNewState(), false);
+				$this->position->getWorld()->setBlock($this->position, $ev->getNewState(), false);
 			}
 		}elseif($lightAbove >= 9){
 			//try grass spread
 			for($i = 0; $i < 4; ++$i){
-				$x = mt_rand($this->pos->x - 1, $this->pos->x + 1);
-				$y = mt_rand($this->pos->y - 3, $this->pos->y + 1);
-				$z = mt_rand($this->pos->z - 1, $this->pos->z + 1);
+				$x = mt_rand($this->position->x - 1, $this->position->x + 1);
+				$y = mt_rand($this->position->y - 3, $this->position->y + 1);
+				$z = mt_rand($this->position->z - 1, $this->position->z + 1);
 
-				$b = $this->pos->getWorld()->getBlockAt($x, $y, $z);
+				$b = $this->position->getWorld()->getBlockAt($x, $y, $z);
 				if(
 					!($b instanceof Dirt) or
 					$b->isCoarse() or
-					$this->pos->getWorld()->getFullLightAt($x, $y + 1, $z) < 4 or
-					$this->pos->getWorld()->getBlockAt($x, $y + 1, $z)->getLightFilter() >= 2
+					$this->position->getWorld()->getFullLightAt($x, $y + 1, $z) < 4 or
+					$this->position->getWorld()->getBlockAt($x, $y + 1, $z)->getLightFilter() >= 2
 				){
 					continue;
 				}
@@ -80,7 +80,7 @@ class Grass extends Opaque{
 				$ev = new BlockSpreadEvent($b, $this, VanillaBlocks::GRASS());
 				$ev->call();
 				if(!$ev->isCancelled()){
-					$this->pos->getWorld()->setBlock($b->pos, $ev->getNewState(), false);
+					$this->position->getWorld()->setBlock($b->position, $ev->getNewState(), false);
 				}
 			}
 		}
@@ -92,17 +92,17 @@ class Grass extends Opaque{
 		}
 		if($item instanceof Fertilizer){
 			$item->pop();
-			TallGrassObject::growGrass($this->pos->getWorld(), $this->pos, new Random(mt_rand()), 8, 2);
+			TallGrassObject::growGrass($this->position->getWorld(), $this->position, new Random(mt_rand()), 8, 2);
 
 			return true;
 		}elseif($item instanceof Hoe){
 			$item->applyDamage(1);
-			$this->pos->getWorld()->setBlock($this->pos, VanillaBlocks::FARMLAND());
+			$this->position->getWorld()->setBlock($this->position, VanillaBlocks::FARMLAND());
 
 			return true;
 		}elseif($item instanceof Shovel and $this->getSide(Facing::UP)->getId() === BlockLegacyIds::AIR){
 			$item->applyDamage(1);
-			$this->pos->getWorld()->setBlock($this->pos, VanillaBlocks::GRASS_PATH());
+			$this->position->getWorld()->setBlock($this->position, VanillaBlocks::GRASS_PATH());
 
 			return true;
 		}

--- a/src/block/GrassPath.php
+++ b/src/block/GrassPath.php
@@ -38,7 +38,7 @@ class GrassPath extends Transparent{
 
 	public function onNearbyBlockChange() : void{
 		if($this->getSide(Facing::UP)->isSolid()){
-			$this->pos->getWorld()->setBlock($this->pos, VanillaBlocks::DIRT());
+			$this->position->getWorld()->setBlock($this->position, VanillaBlocks::DIRT());
 		}
 	}
 

--- a/src/block/Hopper.php
+++ b/src/block/Hopper.php
@@ -86,7 +86,7 @@ class Hopper extends Transparent{
 
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
 		if($player !== null){
-			$tile = $this->pos->getWorld()->getTile($this->pos);
+			$tile = $this->position->getWorld()->getTile($this->position);
 			if($tile instanceof TileHopper){ //TODO: find a way to have inventories open on click without this boilerplate in every block
 				$player->setCurrentWindow($tile->getInventory());
 			}

--- a/src/block/Ice.php
+++ b/src/block/Ice.php
@@ -39,7 +39,7 @@ class Ice extends Transparent{
 
 	public function onBreak(Item $item, ?Player $player = null) : bool{
 		if(($player === null or $player->isSurvival()) and !$item->hasEnchantment(VanillaEnchantments::SILK_TOUCH())){
-			$this->pos->getWorld()->setBlock($this->pos, VanillaBlocks::WATER());
+			$this->position->getWorld()->setBlock($this->position, VanillaBlocks::WATER());
 			return true;
 		}
 		return parent::onBreak($item, $player);
@@ -50,8 +50,8 @@ class Ice extends Transparent{
 	}
 
 	public function onRandomTick() : void{
-		if($this->pos->getWorld()->getHighestAdjacentBlockLight($this->pos->x, $this->pos->y, $this->pos->z) >= 12){
-			$this->pos->getWorld()->useBreakOn($this->pos);
+		if($this->position->getWorld()->getHighestAdjacentBlockLight($this->position->x, $this->position->y, $this->position->z) >= 12){
+			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
 

--- a/src/block/ItemFrame.php
+++ b/src/block/ItemFrame.php
@@ -55,7 +55,7 @@ class ItemFrame extends Flowable{
 
 	public function readStateFromWorld() : void{
 		parent::readStateFromWorld();
-		$tile = $this->pos->getWorld()->getTile($this->pos);
+		$tile = $this->position->getWorld()->getTile($this->position);
 		if($tile instanceof TileItemFrame){
 			$this->framedItem = $tile->getItem();
 			if($this->framedItem->isNull()){
@@ -68,7 +68,7 @@ class ItemFrame extends Flowable{
 
 	public function writeStateToWorld() : void{
 		parent::writeStateToWorld();
-		$tile = $this->pos->getWorld()->getTile($this->pos);
+		$tile = $this->position->getWorld()->getTile($this->position);
 		if($tile instanceof TileItemFrame){
 			$tile->setItem($this->framedItem);
 			$tile->setItemRotation($this->itemRotation);
@@ -137,7 +137,7 @@ class ItemFrame extends Flowable{
 			return true;
 		}
 
-		$this->pos->getWorld()->setBlock($this->pos, $this);
+		$this->position->getWorld()->setBlock($this->position, $this);
 
 		return true;
 	}
@@ -147,16 +147,16 @@ class ItemFrame extends Flowable{
 			return false;
 		}
 		if(lcg_value() <= $this->itemDropChance){
-			$this->pos->getWorld()->dropItem($this->pos->add(0.5, 0.5, 0.5), clone $this->framedItem);
+			$this->position->getWorld()->dropItem($this->position->add(0.5, 0.5, 0.5), clone $this->framedItem);
 		}
 		$this->setFramedItem(null);
-		$this->pos->getWorld()->setBlock($this->pos, $this);
+		$this->position->getWorld()->setBlock($this->position, $this);
 		return true;
 	}
 
 	public function onNearbyBlockChange() : void{
 		if(!$this->getSide(Facing::opposite($this->facing))->isSolid()){
-			$this->pos->getWorld()->useBreakOn($this->pos);
+			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
 

--- a/src/block/Jukebox.php
+++ b/src/block/Jukebox.php
@@ -49,7 +49,7 @@ class Jukebox extends Opaque{
 			}
 		}
 
-		$this->pos->getWorld()->setBlock($this->pos, $this);
+		$this->position->getWorld()->setBlock($this->position, $this);
 
 		return true;
 	}
@@ -60,7 +60,7 @@ class Jukebox extends Opaque{
 
 	public function ejectRecord() : void{
 		if($this->record !== null){
-			$this->getPos()->getWorld()->dropItem($this->getPos()->add(0.5, 1, 0.5), $this->record);
+			$this->getPosition()->getWorld()->dropItem($this->getPosition()->add(0.5, 1, 0.5), $this->record);
 			$this->record = null;
 			$this->stopSound();
 		}
@@ -75,12 +75,12 @@ class Jukebox extends Opaque{
 
 	public function startSound() : void{
 		if($this->record !== null){
-			$this->getPos()->getWorld()->addSound($this->getPos(), new RecordSound($this->record->getRecordType()));
+			$this->getPosition()->getWorld()->addSound($this->getPosition(), new RecordSound($this->record->getRecordType()));
 		}
 	}
 
 	public function stopSound() : void{
-		$this->getPos()->getWorld()->addSound($this->getPos(), new RecordStopSound());
+		$this->getPosition()->getWorld()->addSound($this->getPosition(), new RecordStopSound());
 	}
 
 	public function onBreak(Item $item, ?Player $player = null) : bool{
@@ -98,7 +98,7 @@ class Jukebox extends Opaque{
 
 	public function readStateFromWorld() : void{
 		parent::readStateFromWorld();
-		$jukebox = $this->pos->getWorld()->getTile($this->pos);
+		$jukebox = $this->position->getWorld()->getTile($this->position);
 		if($jukebox instanceof JukeboxTile){
 			$this->record = $jukebox->getRecord();
 		}
@@ -106,7 +106,7 @@ class Jukebox extends Opaque{
 
 	public function writeStateToWorld() : void{
 		parent::writeStateToWorld();
-		$jukebox = $this->pos->getWorld()->getTile($this->pos);
+		$jukebox = $this->position->getWorld()->getTile($this->position);
 		if($jukebox instanceof JukeboxTile){
 			$jukebox->setRecord($this->record);
 		}

--- a/src/block/Ladder.php
+++ b/src/block/Ladder.php
@@ -50,7 +50,7 @@ class Ladder extends Transparent{
 	}
 
 	public function onEntityInside(Entity $entity) : bool{
-		if($entity instanceof Living && $entity->getPosition()->floor()->distanceSquared($this->pos) < 1){ //entity coordinates must be inside block
+		if($entity instanceof Living && $entity->getPosition()->floor()->distanceSquared($this->position) < 1){ //entity coordinates must be inside block
 			$entity->resetFallDistance();
 			$entity->onGround = true;
 		}
@@ -75,7 +75,7 @@ class Ladder extends Transparent{
 
 	public function onNearbyBlockChange() : void{
 		if(!$this->getSide(Facing::opposite($this->facing))->isSolid()){ //Replace with common break method
-			$this->pos->getWorld()->useBreakOn($this->pos);
+			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
 }

--- a/src/block/Lantern.php
+++ b/src/block/Lantern.php
@@ -77,17 +77,17 @@ class Lantern extends Transparent{
 	}
 
 	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		if(!$this->canAttachTo($this->pos->getWorld()->getBlock($blockReplace->getPos()->up())) and !$this->canAttachTo($this->pos->getWorld()->getBlock($blockReplace->getPos()->down()))){
+		if(!$this->canAttachTo($this->position->getWorld()->getBlock($blockReplace->getPosition()->up())) and !$this->canAttachTo($this->position->getWorld()->getBlock($blockReplace->getPosition()->down()))){
 			return false;
 		}
 
-		$this->hanging = ($face === Facing::DOWN or !$this->canAttachTo($this->pos->getWorld()->getBlock($blockReplace->getPos()->down())));
+		$this->hanging = ($face === Facing::DOWN or !$this->canAttachTo($this->position->getWorld()->getBlock($blockReplace->getPosition()->down())));
 		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
 	}
 
 	public function onNearbyBlockChange() : void{
-		if(!$this->canAttachTo($this->pos->getWorld()->getBlock($this->hanging ? $this->pos->up() : $this->pos->down()))){
-			$this->pos->getWorld()->useBreakOn($this->pos);
+		if(!$this->canAttachTo($this->position->getWorld()->getBlock($this->hanging ? $this->position->up() : $this->position->down()))){
+			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
 }

--- a/src/block/Leaves.php
+++ b/src/block/Leaves.php
@@ -91,7 +91,7 @@ class Leaves extends Transparent{
 		}
 		$visited[$index] = true;
 
-		$block = $this->pos->getWorld()->getBlock($pos);
+		$block = $this->position->getWorld()->getBlock($pos);
 		if($block instanceof Wood){ //type doesn't matter
 			return true;
 		}
@@ -110,7 +110,7 @@ class Leaves extends Transparent{
 	public function onNearbyBlockChange() : void{
 		if(!$this->noDecay and !$this->checkDecay){
 			$this->checkDecay = true;
-			$this->pos->getWorld()->setBlock($this->pos, $this, false);
+			$this->position->getWorld()->setBlock($this->position, $this, false);
 		}
 	}
 
@@ -122,11 +122,11 @@ class Leaves extends Transparent{
 		if(!$this->noDecay and $this->checkDecay){
 			$ev = new LeavesDecayEvent($this);
 			$ev->call();
-			if($ev->isCancelled() or $this->findLog($this->pos)){
+			if($ev->isCancelled() or $this->findLog($this->position)){
 				$this->checkDecay = false;
-				$this->pos->getWorld()->setBlock($this->pos, $this, false);
+				$this->position->getWorld()->setBlock($this->position, $this, false);
 			}else{
-				$this->pos->getWorld()->useBreakOn($this->pos);
+				$this->position->getWorld()->useBreakOn($this->position);
 			}
 		}
 	}

--- a/src/block/Lever.php
+++ b/src/block/Lever.php
@@ -101,15 +101,15 @@ class Lever extends Flowable{
 		}
 
 		if(!$this->getSide($face)->isSolid()){
-			$this->pos->getWorld()->useBreakOn($this->pos);
+			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
 
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
 		$this->powered = !$this->powered;
-		$this->pos->getWorld()->setBlock($this->pos, $this);
-		$this->pos->getWorld()->addSound(
-			$this->pos->add(0.5, 0.5, 0.5),
+		$this->position->getWorld()->setBlock($this->position, $this);
+		$this->position->getWorld()->addSound(
+			$this->position->add(0.5, 0.5, 0.5),
 			$this->powered ? new RedstonePowerOnSound() : new RedstonePowerOffSound()
 		);
 		return true;

--- a/src/block/Liquid.php
+++ b/src/block/Liquid.php
@@ -184,13 +184,13 @@ abstract class Liquid extends Transparent{
 
 		$decay = $this->getEffectiveFlowDecay($this);
 
-		$world = $this->pos->getWorld();
+		$world = $this->position->getWorld();
 
 		for($j = 0; $j < 4; ++$j){
 
-			$x = $this->pos->x;
-			$y = $this->pos->y;
-			$z = $this->pos->z;
+			$x = $this->position->x;
+			$y = $this->position->y;
+			$z = $this->position->z;
 
 			if($j === 0){
 				--$x;
@@ -214,17 +214,17 @@ abstract class Liquid extends Transparent{
 
 				if($blockDecay >= 0){
 					$realDecay = $blockDecay - ($decay - 8);
-					$vX += ($x - $this->pos->x) * $realDecay;
-					$vY += ($y - $this->pos->y) * $realDecay;
-					$vZ += ($z - $this->pos->z) * $realDecay;
+					$vX += ($x - $this->position->x) * $realDecay;
+					$vY += ($y - $this->position->y) * $realDecay;
+					$vZ += ($z - $this->position->z) * $realDecay;
 				}
 
 				continue;
 			}else{
 				$realDecay = $blockDecay - $decay;
-				$vX += ($x - $this->pos->x) * $realDecay;
-				$vY += ($y - $this->pos->y) * $realDecay;
-				$vZ += ($z - $this->pos->z) * $realDecay;
+				$vX += ($x - $this->position->x) * $realDecay;
+				$vY += ($y - $this->position->y) * $realDecay;
+				$vZ += ($z - $this->position->z) * $realDecay;
 			}
 		}
 
@@ -232,14 +232,14 @@ abstract class Liquid extends Transparent{
 
 		if($this->falling){
 			if(
-				!$this->canFlowInto($world->getBlockAt($this->pos->x, $this->pos->y, $this->pos->z - 1)) or
-				!$this->canFlowInto($world->getBlockAt($this->pos->x, $this->pos->y, $this->pos->z + 1)) or
-				!$this->canFlowInto($world->getBlockAt($this->pos->x - 1, $this->pos->y, $this->pos->z)) or
-				!$this->canFlowInto($world->getBlockAt($this->pos->x + 1, $this->pos->y, $this->pos->z)) or
-				!$this->canFlowInto($world->getBlockAt($this->pos->x, $this->pos->y + 1, $this->pos->z - 1)) or
-				!$this->canFlowInto($world->getBlockAt($this->pos->x, $this->pos->y + 1, $this->pos->z + 1)) or
-				!$this->canFlowInto($world->getBlockAt($this->pos->x - 1, $this->pos->y + 1, $this->pos->z)) or
-				!$this->canFlowInto($world->getBlockAt($this->pos->x + 1, $this->pos->y + 1, $this->pos->z))
+				!$this->canFlowInto($world->getBlockAt($this->position->x, $this->position->y, $this->position->z - 1)) or
+				!$this->canFlowInto($world->getBlockAt($this->position->x, $this->position->y, $this->position->z + 1)) or
+				!$this->canFlowInto($world->getBlockAt($this->position->x - 1, $this->position->y, $this->position->z)) or
+				!$this->canFlowInto($world->getBlockAt($this->position->x + 1, $this->position->y, $this->position->z)) or
+				!$this->canFlowInto($world->getBlockAt($this->position->x, $this->position->y + 1, $this->position->z - 1)) or
+				!$this->canFlowInto($world->getBlockAt($this->position->x, $this->position->y + 1, $this->position->z + 1)) or
+				!$this->canFlowInto($world->getBlockAt($this->position->x - 1, $this->position->y + 1, $this->position->z)) or
+				!$this->canFlowInto($world->getBlockAt($this->position->x + 1, $this->position->y + 1, $this->position->z))
 			){
 				$vector = $vector->normalize()->add(0, -6, 0);
 			}
@@ -266,7 +266,7 @@ abstract class Liquid extends Transparent{
 
 	public function onNearbyBlockChange() : void{
 		if(!$this->checkForHarden()){
-			$this->pos->getWorld()->scheduleDelayedBlockUpdate($this->pos, $this->tickRate());
+			$this->position->getWorld()->scheduleDelayedBlockUpdate($this->position, $this->tickRate());
 		}
 	}
 
@@ -276,10 +276,10 @@ abstract class Liquid extends Transparent{
 		if(!$this->isSource()){
 			$smallestFlowDecay = -100;
 			$this->adjacentSources = 0;
-			$smallestFlowDecay = $this->getSmallestFlowDecay($this->pos->getWorld()->getBlockAt($this->pos->x, $this->pos->y, $this->pos->z - 1), $smallestFlowDecay);
-			$smallestFlowDecay = $this->getSmallestFlowDecay($this->pos->getWorld()->getBlockAt($this->pos->x, $this->pos->y, $this->pos->z + 1), $smallestFlowDecay);
-			$smallestFlowDecay = $this->getSmallestFlowDecay($this->pos->getWorld()->getBlockAt($this->pos->x - 1, $this->pos->y, $this->pos->z), $smallestFlowDecay);
-			$smallestFlowDecay = $this->getSmallestFlowDecay($this->pos->getWorld()->getBlockAt($this->pos->x + 1, $this->pos->y, $this->pos->z), $smallestFlowDecay);
+			$smallestFlowDecay = $this->getSmallestFlowDecay($this->position->getWorld()->getBlockAt($this->position->x, $this->position->y, $this->position->z - 1), $smallestFlowDecay);
+			$smallestFlowDecay = $this->getSmallestFlowDecay($this->position->getWorld()->getBlockAt($this->position->x, $this->position->y, $this->position->z + 1), $smallestFlowDecay);
+			$smallestFlowDecay = $this->getSmallestFlowDecay($this->position->getWorld()->getBlockAt($this->position->x - 1, $this->position->y, $this->position->z), $smallestFlowDecay);
+			$smallestFlowDecay = $this->getSmallestFlowDecay($this->position->getWorld()->getBlockAt($this->position->x + 1, $this->position->y, $this->position->z), $smallestFlowDecay);
 
 			$newDecay = $smallestFlowDecay + $multiplier;
 			$falling = false;
@@ -288,12 +288,12 @@ abstract class Liquid extends Transparent{
 				$newDecay = -1;
 			}
 
-			if($this->getEffectiveFlowDecay($this->pos->getWorld()->getBlockAt($this->pos->x, $this->pos->y + 1, $this->pos->z)) >= 0){
+			if($this->getEffectiveFlowDecay($this->position->getWorld()->getBlockAt($this->position->x, $this->position->y + 1, $this->position->z)) >= 0){
 				$falling = true;
 			}
 
 			if($this->adjacentSources >= 2 and $this instanceof Water){
-				$bottomBlock = $this->pos->getWorld()->getBlockAt($this->pos->x, $this->pos->y - 1, $this->pos->z);
+				$bottomBlock = $this->position->getWorld()->getBlockAt($this->position->x, $this->position->y - 1, $this->position->z);
 				if($bottomBlock->isSolid() or ($bottomBlock instanceof Water and $bottomBlock->isSource())){
 					$newDecay = 0;
 					$falling = false;
@@ -302,17 +302,17 @@ abstract class Liquid extends Transparent{
 
 			if($falling !== $this->falling or (!$falling and $newDecay !== $this->decay)){
 				if(!$falling and $newDecay < 0){
-					$this->pos->getWorld()->setBlock($this->pos, VanillaBlocks::AIR());
+					$this->position->getWorld()->setBlock($this->position, VanillaBlocks::AIR());
 					return;
 				}
 
 				$this->falling = $falling;
 				$this->decay = $falling ? 0 : $newDecay;
-				$this->pos->getWorld()->setBlock($this->pos, $this); //local block update will cause an update to be scheduled
+				$this->position->getWorld()->setBlock($this->position, $this); //local block update will cause an update to be scheduled
 			}
 		}
 
-		$bottomBlock = $this->pos->getWorld()->getBlockAt($this->pos->x, $this->pos->y - 1, $this->pos->z);
+		$bottomBlock = $this->position->getWorld()->getBlockAt($this->position->x, $this->position->y - 1, $this->position->z);
 
 		$this->flowIntoBlock($bottomBlock, 0, true);
 
@@ -327,19 +327,19 @@ abstract class Liquid extends Transparent{
 				$flags = $this->getOptimalFlowDirections();
 
 				if($flags[0]){
-					$this->flowIntoBlock($this->pos->getWorld()->getBlockAt($this->pos->x - 1, $this->pos->y, $this->pos->z), $adjacentDecay, false);
+					$this->flowIntoBlock($this->position->getWorld()->getBlockAt($this->position->x - 1, $this->position->y, $this->position->z), $adjacentDecay, false);
 				}
 
 				if($flags[1]){
-					$this->flowIntoBlock($this->pos->getWorld()->getBlockAt($this->pos->x + 1, $this->pos->y, $this->pos->z), $adjacentDecay, false);
+					$this->flowIntoBlock($this->position->getWorld()->getBlockAt($this->position->x + 1, $this->position->y, $this->position->z), $adjacentDecay, false);
 				}
 
 				if($flags[2]){
-					$this->flowIntoBlock($this->pos->getWorld()->getBlockAt($this->pos->x, $this->pos->y, $this->pos->z - 1), $adjacentDecay, false);
+					$this->flowIntoBlock($this->position->getWorld()->getBlockAt($this->position->x, $this->position->y, $this->position->z - 1), $adjacentDecay, false);
 				}
 
 				if($flags[3]){
-					$this->flowIntoBlock($this->pos->getWorld()->getBlockAt($this->pos->x, $this->pos->y, $this->pos->z + 1), $adjacentDecay, false);
+					$this->flowIntoBlock($this->position->getWorld()->getBlockAt($this->position->x, $this->position->y, $this->position->z + 1), $adjacentDecay, false);
 				}
 			}
 		}
@@ -357,10 +357,10 @@ abstract class Liquid extends Transparent{
 			$ev->call();
 			if(!$ev->isCancelled()){
 				if($block->getId() > 0){
-					$this->pos->getWorld()->useBreakOn($block->pos);
+					$this->position->getWorld()->useBreakOn($block->position);
 				}
 
-				$this->pos->getWorld()->setBlock($block->pos, $ev->getNewState());
+				$this->position->getWorld()->setBlock($block->position, $ev->getNewState());
 			}
 		}
 	}
@@ -388,10 +388,10 @@ abstract class Liquid extends Transparent{
 			}
 
 			if(!isset($this->flowCostVisited[$hash = World::blockHash($x, $y, $z)])){
-				$blockSide = $this->pos->getWorld()->getBlockAt($x, $y, $z);
+				$blockSide = $this->position->getWorld()->getBlockAt($x, $y, $z);
 				if(!$this->canFlowInto($blockSide)){
 					$this->flowCostVisited[$hash] = self::BLOCKED;
-				}elseif($this->pos->getWorld()->getBlockAt($x, $y - 1, $z)->canBeFlowedInto()){
+				}elseif($this->position->getWorld()->getBlockAt($x, $y - 1, $z)->canBeFlowedInto()){
 					$this->flowCostVisited[$hash] = self::CAN_FLOW_DOWN;
 				}else{
 					$this->flowCostVisited[$hash] = self::CAN_FLOW;
@@ -427,9 +427,9 @@ abstract class Liquid extends Transparent{
 		$flowCost = array_fill(0, 4, 1000);
 		$maxCost = intdiv(4, $this->getFlowDecayPerBlock());
 		for($j = 0; $j < 4; ++$j){
-			$x = $this->pos->x;
-			$y = $this->pos->y;
-			$z = $this->pos->z;
+			$x = $this->position->x;
+			$y = $this->position->y;
+			$z = $this->position->z;
 
 			if($j === 0){
 				--$x;
@@ -440,12 +440,12 @@ abstract class Liquid extends Transparent{
 			}elseif($j === 3){
 				++$z;
 			}
-			$block = $this->pos->getWorld()->getBlockAt($x, $y, $z);
+			$block = $this->position->getWorld()->getBlockAt($x, $y, $z);
 
 			if(!$this->canFlowInto($block)){
 				$this->flowCostVisited[World::blockHash($x, $y, $z)] = self::BLOCKED;
 				continue;
-			}elseif($this->pos->getWorld()->getBlockAt($x, $y - 1, $z)->canBeFlowedInto()){
+			}elseif($this->position->getWorld()->getBlockAt($x, $y - 1, $z)->canBeFlowedInto()){
 				$this->flowCostVisited[World::blockHash($x, $y, $z)] = self::CAN_FLOW_DOWN;
 				$flowCost[$j] = $maxCost = 0;
 			}elseif($maxCost > 0){
@@ -493,13 +493,13 @@ abstract class Liquid extends Transparent{
 		$ev = new BlockFormEvent($this, $result);
 		$ev->call();
 		if(!$ev->isCancelled()){
-			$this->pos->getWorld()->setBlock($this->pos, $ev->getNewState());
-			$this->pos->getWorld()->addSound($this->pos->add(0.5, 0.5, 0.5), new FizzSound(2.6 + (lcg_value() - lcg_value()) * 0.8));
+			$this->position->getWorld()->setBlock($this->position, $ev->getNewState());
+			$this->position->getWorld()->addSound($this->position->add(0.5, 0.5, 0.5), new FizzSound(2.6 + (lcg_value() - lcg_value()) * 0.8));
 		}
 		return true;
 	}
 
 	protected function canFlowInto(Block $block) : bool{
-		return $this->pos->getWorld()->isInWorld($block->pos->x, $block->pos->y, $block->pos->z) and $block->canBeFlowedInto() and !($block instanceof Liquid and $block->isSource()); //TODO: I think this should only be liquids of the same type
+		return $this->position->getWorld()->isInWorld($block->position->x, $block->position->y, $block->position->z) and $block->canBeFlowedInto() and !($block instanceof Liquid and $block->isSource()); //TODO: I think this should only be liquids of the same type
 	}
 }

--- a/src/block/Loom.php
+++ b/src/block/Loom.php
@@ -49,7 +49,7 @@ final class Loom extends Opaque{
 
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
 		if($player !== null){
-			$player->setCurrentWindow(new LoomInventory($this->pos));
+			$player->setCurrentWindow(new LoomInventory($this->position));
 			return true;
 		}
 		return false;

--- a/src/block/Mycelium.php
+++ b/src/block/Mycelium.php
@@ -46,16 +46,16 @@ class Mycelium extends Opaque{
 
 	public function onRandomTick() : void{
 		//TODO: light levels
-		$x = mt_rand($this->pos->x - 1, $this->pos->x + 1);
-		$y = mt_rand($this->pos->y - 2, $this->pos->y + 2);
-		$z = mt_rand($this->pos->z - 1, $this->pos->z + 1);
-		$block = $this->pos->getWorld()->getBlockAt($x, $y, $z);
+		$x = mt_rand($this->position->x - 1, $this->position->x + 1);
+		$y = mt_rand($this->position->y - 2, $this->position->y + 2);
+		$z = mt_rand($this->position->z - 1, $this->position->z + 1);
+		$block = $this->position->getWorld()->getBlockAt($x, $y, $z);
 		if($block->getId() === BlockLegacyIds::DIRT){
 			if($block->getSide(Facing::UP) instanceof Transparent){
 				$ev = new BlockSpreadEvent($block, $this, VanillaBlocks::MYCELIUM());
 				$ev->call();
 				if(!$ev->isCancelled()){
-					$this->pos->getWorld()->setBlock($block->pos, $ev->getNewState());
+					$this->position->getWorld()->setBlock($block->position, $ev->getNewState());
 				}
 			}
 		}

--- a/src/block/NetherWartPlant.php
+++ b/src/block/NetherWartPlant.php
@@ -70,7 +70,7 @@ class NetherWartPlant extends Flowable{
 
 	public function onNearbyBlockChange() : void{
 		if($this->getSide(Facing::DOWN)->getId() !== BlockLegacyIds::SOUL_SAND){
-			$this->pos->getWorld()->useBreakOn($this->pos);
+			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
 
@@ -85,7 +85,7 @@ class NetherWartPlant extends Flowable{
 			$ev = new BlockGrowEvent($this, $block);
 			$ev->call();
 			if(!$ev->isCancelled()){
-				$this->pos->getWorld()->setBlock($this->pos, $ev->getNewState());
+				$this->position->getWorld()->setBlock($this->position, $ev->getNewState());
 			}
 		}
 	}

--- a/src/block/Note.php
+++ b/src/block/Note.php
@@ -34,7 +34,7 @@ class Note extends Opaque{
 
 	public function readStateFromWorld() : void{
 		parent::readStateFromWorld();
-		$tile = $this->pos->getWorld()->getTile($this->pos);
+		$tile = $this->position->getWorld()->getTile($this->position);
 		if($tile instanceof TileNote){
 			$this->pitch = $tile->getPitch();
 		}else{
@@ -44,7 +44,7 @@ class Note extends Opaque{
 
 	public function writeStateToWorld() : void{
 		parent::writeStateToWorld();
-		$tile = $this->pos->getWorld()->getTile($this->pos);
+		$tile = $this->position->getWorld()->getTile($this->position);
 		assert($tile instanceof TileNote);
 		$tile->setPitch($this->pitch);
 	}

--- a/src/block/RedMushroom.php
+++ b/src/block/RedMushroom.php
@@ -37,7 +37,7 @@ class RedMushroom extends Flowable{
 
 	public function onNearbyBlockChange() : void{
 		if($this->getSide(Facing::DOWN)->isTransparent()){
-			$this->pos->getWorld()->useBreakOn($this->pos);
+			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
 

--- a/src/block/RedstoneComparator.php
+++ b/src/block/RedstoneComparator.php
@@ -72,7 +72,7 @@ class RedstoneComparator extends Flowable{
 
 	public function readStateFromWorld() : void{
 		parent::readStateFromWorld();
-		$tile = $this->pos->getWorld()->getTile($this->pos);
+		$tile = $this->position->getWorld()->getTile($this->position);
 		if($tile instanceof Comparator){
 			$this->signalStrength = $tile->getSignalStrength();
 		}
@@ -80,7 +80,7 @@ class RedstoneComparator extends Flowable{
 
 	public function writeStateToWorld() : void{
 		parent::writeStateToWorld();
-		$tile = $this->pos->getWorld()->getTile($this->pos);
+		$tile = $this->position->getWorld()->getTile($this->position);
 		assert($tile instanceof Comparator);
 		$tile->setSignalStrength($this->signalStrength);
 	}
@@ -115,13 +115,13 @@ class RedstoneComparator extends Flowable{
 
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
 		$this->isSubtractMode = !$this->isSubtractMode;
-		$this->pos->getWorld()->setBlock($this->pos, $this);
+		$this->position->getWorld()->setBlock($this->position, $this);
 		return true;
 	}
 
 	public function onNearbyBlockChange() : void{
 		if($this->getSide(Facing::DOWN)->isTransparent()){
-			$this->pos->getWorld()->useBreakOn($this->pos);
+			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
 

--- a/src/block/RedstoneOre.php
+++ b/src/block/RedstoneOre.php
@@ -67,7 +67,7 @@ class RedstoneOre extends Opaque{
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
 		if(!$this->lit){
 			$this->lit = true;
-			$this->pos->getWorld()->setBlock($this->pos, $this); //no return here - this shouldn't prevent block placement
+			$this->position->getWorld()->setBlock($this->position, $this); //no return here - this shouldn't prevent block placement
 		}
 		return false;
 	}
@@ -75,7 +75,7 @@ class RedstoneOre extends Opaque{
 	public function onNearbyBlockChange() : void{
 		if(!$this->lit){
 			$this->lit = true;
-			$this->pos->getWorld()->setBlock($this->pos, $this);
+			$this->position->getWorld()->setBlock($this->position, $this);
 		}
 	}
 
@@ -86,7 +86,7 @@ class RedstoneOre extends Opaque{
 	public function onRandomTick() : void{
 		if($this->lit){
 			$this->lit = false;
-			$this->pos->getWorld()->setBlock($this->pos, $this);
+			$this->position->getWorld()->setBlock($this->position, $this);
 		}
 	}
 

--- a/src/block/RedstoneRepeater.php
+++ b/src/block/RedstoneRepeater.php
@@ -98,13 +98,13 @@ class RedstoneRepeater extends Flowable{
 		if(++$this->delay > 4){
 			$this->delay = 1;
 		}
-		$this->pos->getWorld()->setBlock($this->pos, $this);
+		$this->position->getWorld()->setBlock($this->position, $this);
 		return true;
 	}
 
 	public function onNearbyBlockChange() : void{
 		if($this->getSide(Facing::DOWN)->isTransparent()){
-			$this->pos->getWorld()->useBreakOn($this->pos);
+			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
 

--- a/src/block/Sapling.php
+++ b/src/block/Sapling.php
@@ -76,7 +76,7 @@ class Sapling extends Flowable{
 
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
 		if($item instanceof Fertilizer){
-			Tree::growTree($this->pos->getWorld(), $this->pos->x, $this->pos->y, $this->pos->z, new Random(mt_rand()), $this->treeType);
+			Tree::growTree($this->position->getWorld(), $this->position->x, $this->position->y, $this->position->z, new Random(mt_rand()), $this->treeType);
 
 			$item->pop();
 
@@ -88,7 +88,7 @@ class Sapling extends Flowable{
 
 	public function onNearbyBlockChange() : void{
 		if($this->getSide(Facing::DOWN)->isTransparent()){
-			$this->pos->getWorld()->useBreakOn($this->pos);
+			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
 
@@ -97,12 +97,12 @@ class Sapling extends Flowable{
 	}
 
 	public function onRandomTick() : void{
-		if($this->pos->getWorld()->getFullLightAt($this->pos->x, $this->pos->y, $this->pos->z) >= 8 and mt_rand(1, 7) === 1){
+		if($this->position->getWorld()->getFullLightAt($this->position->x, $this->position->y, $this->position->z) >= 8 and mt_rand(1, 7) === 1){
 			if($this->ready){
-				Tree::growTree($this->pos->getWorld(), $this->pos->x, $this->pos->y, $this->pos->z, new Random(mt_rand()), $this->treeType);
+				Tree::growTree($this->position->getWorld(), $this->position->x, $this->position->y, $this->position->z, new Random(mt_rand()), $this->treeType);
 			}else{
 				$this->ready = true;
-				$this->pos->getWorld()->setBlock($this->pos, $this);
+				$this->position->getWorld()->setBlock($this->position, $this);
 			}
 		}
 	}

--- a/src/block/ShulkerBox.php
+++ b/src/block/ShulkerBox.php
@@ -35,7 +35,7 @@ class ShulkerBox extends Opaque{
 
 	public function writeStateToWorld() : void{
 		parent::writeStateToWorld();
-		$shulker = $this->pos->getWorld()->getTile($this->pos);
+		$shulker = $this->position->getWorld()->getTile($this->position);
 		if($shulker instanceof TileShulkerBox){
 			$shulker->setFacing($this->facing);
 		}
@@ -43,7 +43,7 @@ class ShulkerBox extends Opaque{
 
 	public function readStateFromWorld() : void{
 		parent::readStateFromWorld();
-		$shulker = $this->pos->getWorld()->getTile($this->pos);
+		$shulker = $this->position->getWorld()->getTile($this->position);
 		if($shulker instanceof TileShulkerBox){
 			$this->facing = $shulker->getFacing();
 		}
@@ -71,7 +71,7 @@ class ShulkerBox extends Opaque{
 
 	public function getDropsForCompatibleTool(Item $item) : array{
 		$drop = $this->asItem();
-		if(($tile = $this->pos->getWorld()->getTile($this->pos)) instanceof TileShulkerBox){
+		if(($tile = $this->position->getWorld()->getTile($this->position)) instanceof TileShulkerBox){
 			$this->addDataFromTile($tile, $drop);
 		}
 		return [$drop];
@@ -79,7 +79,7 @@ class ShulkerBox extends Opaque{
 
 	public function getPickedItem(bool $addUserData = false) : Item{
 		$result = parent::getPickedItem($addUserData);
-		if($addUserData && ($tile = $this->pos->getWorld()->getTile($this->pos)) instanceof TileShulkerBox){
+		if($addUserData && ($tile = $this->position->getWorld()->getTile($this->position)) instanceof TileShulkerBox){
 			$this->addDataFromTile($tile, $result);
 		}
 		return $result;
@@ -88,7 +88,7 @@ class ShulkerBox extends Opaque{
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
 		if($player instanceof Player){
 
-			$shulker = $this->pos->getWorld()->getTile($this->pos);
+			$shulker = $this->position->getWorld()->getTile($this->position);
 			if($shulker instanceof TileShulkerBox){
 				if(
 					$this->getSide($this->facing)->getId() !== BlockLegacyIds::AIR or

--- a/src/block/Skull.php
+++ b/src/block/Skull.php
@@ -64,7 +64,7 @@ class Skull extends Flowable{
 
 	public function readStateFromWorld() : void{
 		parent::readStateFromWorld();
-		$tile = $this->pos->getWorld()->getTile($this->pos);
+		$tile = $this->position->getWorld()->getTile($this->position);
 		if($tile instanceof TileSkull){
 			$this->skullType = $tile->getSkullType();
 			$this->rotation = $tile->getRotation();
@@ -74,7 +74,7 @@ class Skull extends Flowable{
 	public function writeStateToWorld() : void{
 		parent::writeStateToWorld();
 		//extra block properties storage hack
-		$tile = $this->pos->getWorld()->getTile($this->pos);
+		$tile = $this->position->getWorld()->getTile($this->position);
 		assert($tile instanceof TileSkull);
 		$tile->setRotation($this->rotation);
 		$tile->setSkullType($this->skullType);

--- a/src/block/SnowLayer.php
+++ b/src/block/SnowLayer.php
@@ -99,8 +99,8 @@ class SnowLayer extends Flowable implements Fallable{
 	}
 
 	public function onRandomTick() : void{
-		if($this->pos->getWorld()->getBlockLightAt($this->pos->x, $this->pos->y, $this->pos->z) >= 12){
-			$this->pos->getWorld()->setBlock($this->pos, VanillaBlocks::AIR(), false);
+		if($this->position->getWorld()->getBlockLightAt($this->position->x, $this->position->y, $this->position->z) >= 12){
+			$this->position->getWorld()->setBlock($this->position, VanillaBlocks::AIR(), false);
 		}
 	}
 

--- a/src/block/Stem.php
+++ b/src/block/Stem.php
@@ -41,7 +41,7 @@ abstract class Stem extends Crops{
 				$ev = new BlockGrowEvent($this, $block);
 				$ev->call();
 				if(!$ev->isCancelled()){
-					$this->pos->getWorld()->setBlock($this->pos, $ev->getNewState());
+					$this->position->getWorld()->setBlock($this->position, $ev->getNewState());
 				}
 			}else{
 				$grow = $this->getPlant();
@@ -57,7 +57,7 @@ abstract class Stem extends Crops{
 					$ev = new BlockGrowEvent($side, $grow);
 					$ev->call();
 					if(!$ev->isCancelled()){
-						$this->pos->getWorld()->setBlock($side->pos, $ev->getNewState());
+						$this->position->getWorld()->setBlock($side->position, $ev->getNewState());
 					}
 				}
 			}

--- a/src/block/Sugarcane.php
+++ b/src/block/Sugarcane.php
@@ -50,23 +50,23 @@ class Sugarcane extends Flowable{
 
 	private function grow() : void{
 		for($y = 1; $y < 3; ++$y){
-			if(!$this->pos->getWorld()->isInWorld($this->pos->x, $this->pos->y + $y, $this->pos->z)){
+			if(!$this->position->getWorld()->isInWorld($this->position->x, $this->position->y + $y, $this->position->z)){
 				break;
 			}
-			$b = $this->pos->getWorld()->getBlockAt($this->pos->x, $this->pos->y + $y, $this->pos->z);
+			$b = $this->position->getWorld()->getBlockAt($this->position->x, $this->position->y + $y, $this->position->z);
 			if($b->getId() === BlockLegacyIds::AIR){
 				$ev = new BlockGrowEvent($b, VanillaBlocks::SUGARCANE());
 				$ev->call();
 				if($ev->isCancelled()){
 					break;
 				}
-				$this->pos->getWorld()->setBlock($b->pos, $ev->getNewState());
+				$this->position->getWorld()->setBlock($b->position, $ev->getNewState());
 			}else{
 				break;
 			}
 		}
 		$this->age = 0;
-		$this->pos->getWorld()->setBlock($this->pos, $this);
+		$this->position->getWorld()->setBlock($this->position, $this);
 	}
 
 	public function getAge() : int{ return $this->age; }
@@ -97,7 +97,7 @@ class Sugarcane extends Flowable{
 	public function onNearbyBlockChange() : void{
 		$down = $this->getSide(Facing::DOWN);
 		if($down->isTransparent() and !$down->isSameType($this)){
-			$this->pos->getWorld()->useBreakOn($this->pos);
+			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
 
@@ -111,7 +111,7 @@ class Sugarcane extends Flowable{
 				$this->grow();
 			}else{
 				++$this->age;
-				$this->pos->getWorld()->setBlock($this->pos, $this);
+				$this->position->getWorld()->setBlock($this->position, $this);
 			}
 		}
 	}

--- a/src/block/SweetBerryBush.php
+++ b/src/block/SweetBerryBush.php
@@ -98,13 +98,13 @@ class SweetBerryBush extends Flowable{
 			$ev->call();
 
 			if(!$ev->isCancelled()){
-				$this->pos->getWorld()->setBlock($this->pos, $ev->getNewState());
+				$this->position->getWorld()->setBlock($this->position, $ev->getNewState());
 			}
 
 			$item->pop();
 		}elseif(($dropAmount = $this->getBerryDropAmount()) > 0){
-			$this->pos->getWorld()->setBlock($this->pos, $this->setAge(self::STAGE_BUSH_NO_BERRIES));
-			$this->pos->getWorld()->dropItem($this->pos, $this->asItem()->setCount($dropAmount));
+			$this->position->getWorld()->setBlock($this->position, $this->setAge(self::STAGE_BUSH_NO_BERRIES));
+			$this->position->getWorld()->dropItem($this->position, $this->asItem()->setCount($dropAmount));
 		}
 
 		return true;
@@ -126,7 +126,7 @@ class SweetBerryBush extends Flowable{
 
 	public function onNearbyBlockChange() : void{
 		if(!$this->canBeSupportedBy($this->getSide(Facing::DOWN))){
-			$this->pos->getWorld()->useBreakOn($this->pos);
+			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
 
@@ -141,7 +141,7 @@ class SweetBerryBush extends Flowable{
 			$ev = new BlockGrowEvent($this, $block);
 			$ev->call();
 			if(!$ev->isCancelled()){
-				$this->pos->getWorld()->setBlock($this->pos, $ev->getNewState());
+				$this->position->getWorld()->setBlock($this->position, $ev->getNewState());
 			}
 		}
 	}

--- a/src/block/TNT.php
+++ b/src/block/TNT.php
@@ -110,11 +110,11 @@ class TNT extends Opaque{
 	}
 
 	public function ignite(int $fuse = 80) : void{
-		$this->pos->getWorld()->setBlock($this->pos, VanillaBlocks::AIR());
+		$this->position->getWorld()->setBlock($this->position, VanillaBlocks::AIR());
 
 		$mot = (new Random())->nextSignedFloat() * M_PI * 2;
 
-		$tnt = new PrimedTNT(Location::fromObject($this->pos->add(0.5, 0, 0.5), $this->pos->getWorld()));
+		$tnt = new PrimedTNT(Location::fromObject($this->position->add(0.5, 0, 0.5), $this->position->getWorld()));
 		$tnt->setFuse($fuse);
 		$tnt->setWorksUnderwater($this->worksUnderwater);
 		$tnt->setMotion(new Vector3(-sin($mot) * 0.02, 0.2, -cos($mot) * 0.02));

--- a/src/block/TallGrass.php
+++ b/src/block/TallGrass.php
@@ -48,7 +48,7 @@ class TallGrass extends Flowable{
 
 	public function onNearbyBlockChange() : void{
 		if($this->getSide(Facing::DOWN)->isTransparent()){ //Replace with common break method
-			$this->pos->getWorld()->useBreakOn($this->pos);
+			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
 

--- a/src/block/Torch.php
+++ b/src/block/Torch.php
@@ -67,7 +67,7 @@ class Torch extends Flowable{
 		$face = Facing::opposite($this->facing);
 
 		if($this->getSide($face)->isTransparent() and !($face === Facing::DOWN and ($below->getId() === BlockLegacyIds::FENCE or $below->getId() === BlockLegacyIds::COBBLESTONE_WALL))){
-			$this->pos->getWorld()->useBreakOn($this->pos);
+			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
 

--- a/src/block/Trapdoor.php
+++ b/src/block/Trapdoor.php
@@ -91,8 +91,8 @@ class Trapdoor extends Transparent{
 
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
 		$this->open = !$this->open;
-		$this->pos->getWorld()->setBlock($this->pos, $this);
-		$this->pos->getWorld()->addSound($this->pos, new DoorSound());
+		$this->position->getWorld()->setBlock($this->position, $this);
+		$this->position->getWorld()->addSound($this->position, new DoorSound());
 		return true;
 	}
 }

--- a/src/block/Vine.php
+++ b/src/block/Vine.php
@@ -142,9 +142,9 @@ class Vine extends Flowable{
 
 		if($changed){
 			if(count($this->faces) === 0){
-				$this->pos->getWorld()->useBreakOn($this->pos);
+				$this->position->getWorld()->useBreakOn($this->position);
 			}else{
-				$this->pos->getWorld()->setBlock($this->pos, $this);
+				$this->position->getWorld()->setBlock($this->position, $this);
 			}
 		}
 	}

--- a/src/block/WallCoralFan.php
+++ b/src/block/WallCoralFan.php
@@ -121,9 +121,9 @@ final class WallCoralFan extends BaseCoral{
 	}
 
 	public function onNearbyBlockChange() : void{
-		$world = $this->pos->getWorld();
-		if(!$world->getBlock($this->pos->getSide(Facing::opposite($this->facing)))->isSolid()){
-			$world->useBreakOn($this->pos);
+		$world = $this->position->getWorld();
+		if(!$world->getBlock($this->position->getSide(Facing::opposite($this->facing)))->isSolid()){
+			$world->useBreakOn($this->position);
 		}else{
 			parent::onNearbyBlockChange();
 		}

--- a/src/block/WaterLily.php
+++ b/src/block/WaterLily.php
@@ -52,7 +52,7 @@ class WaterLily extends Flowable{
 
 	public function onNearbyBlockChange() : void{
 		if(!($this->getSide(Facing::DOWN) instanceof Water)){
-			$this->pos->getWorld()->useBreakOn($this->pos);
+			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
 }

--- a/src/block/tile/Barrel.php
+++ b/src/block/tile/Barrel.php
@@ -37,7 +37,7 @@ class Barrel extends Spawnable implements Container, Nameable{
 
 	public function __construct(World $world, Vector3 $pos){
 		parent::__construct($world, $pos);
-		$this->inventory = new BarrelInventory($this->pos);
+		$this->inventory = new BarrelInventory($this->position);
 	}
 
 	public function readSaveData(CompoundTag $nbt) : void{

--- a/src/block/tile/Bell.php
+++ b/src/block/tile/Bell.php
@@ -81,6 +81,6 @@ final class Bell extends Spawnable{
 		$nbt->setByte(self::TAG_RINGING, 1);
 		$nbt->setInt(self::TAG_DIRECTION, BlockDataSerializer::writeLegacyHorizontalFacing($bellHitFace));
 		$nbt->setInt(self::TAG_TICKS, 0);
-		return BlockActorDataPacket::create($this->pos->getFloorX(), $this->pos->getFloorY(), $this->pos->getFloorZ(), new CacheableNbt($nbt));
+		return BlockActorDataPacket::create($this->position->getFloorX(), $this->position->getFloorY(), $this->position->getFloorZ(), new CacheableNbt($nbt));
 	}
 }

--- a/src/block/tile/BrewingStand.php
+++ b/src/block/tile/BrewingStand.php
@@ -53,7 +53,7 @@ class BrewingStand extends Spawnable implements Container, Nameable{
 
 	public function __construct(World $world, Vector3 $pos){
 		parent::__construct($world, $pos);
-		$this->inventory = new BrewingStandInventory($this->pos);
+		$this->inventory = new BrewingStandInventory($this->position);
 		$this->inventory->getListeners()->add(CallbackInventoryListener::onAnyChange(static function(Inventory $unused) use ($world, $pos) : void{
 			$world->scheduleDelayedBlockUpdate($pos, 1);
 		}));

--- a/src/block/tile/Chest.php
+++ b/src/block/tile/Chest.php
@@ -55,7 +55,7 @@ class Chest extends Spawnable implements Container, Nameable{
 
 	public function __construct(World $world, Vector3 $pos){
 		parent::__construct($world, $pos);
-		$this->inventory = new ChestInventory($this->pos);
+		$this->inventory = new ChestInventory($this->position);
 	}
 
 	public function readSaveData(CompoundTag $nbt) : void{
@@ -63,8 +63,8 @@ class Chest extends Spawnable implements Container, Nameable{
 			$pairX = $pairXTag->getValue();
 			$pairZ = $pairZTag->getValue();
 			if(
-				($this->pos->x === $pairX and abs($this->pos->z - $pairZ) === 1) or
-				($this->pos->z === $pairZ and abs($this->pos->x - $pairX) === 1)
+				($this->position->x === $pairX and abs($this->position->z - $pairZ) === 1) or
+				($this->position->z === $pairZ and abs($this->position->x - $pairX) === 1)
 			){
 				$this->pairX = $pairX;
 				$this->pairZ = $pairZ;
@@ -99,7 +99,7 @@ class Chest extends Spawnable implements Container, Nameable{
 			$this->inventory->removeAllViewers();
 
 			if($this->doubleInventory !== null){
-				if($this->isPaired() and $this->pos->getWorld()->isChunkLoaded($this->pairX >> 4, $this->pairZ >> 4)){
+				if($this->isPaired() and $this->position->getWorld()->isChunkLoaded($this->pairX >> 4, $this->pairZ >> 4)){
 					$this->doubleInventory->removeAllViewers();
 					if(($pair = $this->getPair()) !== null){
 						$pair->doubleInventory = null;
@@ -135,7 +135,7 @@ class Chest extends Spawnable implements Container, Nameable{
 	}
 
 	protected function checkPairing() : void{
-		if($this->isPaired() and !$this->pos->getWorld()->isInLoadedTerrain(new Vector3($this->pairX, $this->pos->y, $this->pairZ))){
+		if($this->isPaired() and !$this->position->getWorld()->isInLoadedTerrain(new Vector3($this->pairX, $this->position->y, $this->pairZ))){
 			//paired to a tile in an unloaded chunk
 			$this->doubleInventory = null;
 
@@ -148,7 +148,7 @@ class Chest extends Spawnable implements Container, Nameable{
 				if($pair->doubleInventory !== null){
 					$this->doubleInventory = $pair->doubleInventory;
 				}else{
-					if(($pair->getPos()->x + ($pair->getPos()->z << 15)) > ($this->pos->x + ($this->pos->z << 15))){ //Order them correctly
+					if(($pair->getPosition()->x + ($pair->getPosition()->z << 15)) > ($this->position->x + ($this->position->z << 15))){ //Order them correctly
 						$this->doubleInventory = $pair->doubleInventory = new DoubleChestInventory($pair->inventory, $this->inventory);
 					}else{
 						$this->doubleInventory = $pair->doubleInventory = new DoubleChestInventory($this->inventory, $pair->inventory);
@@ -171,7 +171,7 @@ class Chest extends Spawnable implements Container, Nameable{
 
 	public function getPair() : ?Chest{
 		if($this->isPaired()){
-			$tile = $this->pos->getWorld()->getTileAt($this->pairX, $this->pos->y, $this->pairZ);
+			$tile = $this->position->getWorld()->getTileAt($this->pairX, $this->position->y, $this->pairZ);
 			if($tile instanceof Chest){
 				return $tile;
 			}
@@ -195,11 +195,11 @@ class Chest extends Spawnable implements Container, Nameable{
 	}
 
 	private function createPair(Chest $tile) : void{
-		$this->pairX = $tile->getPos()->x;
-		$this->pairZ = $tile->getPos()->z;
+		$this->pairX = $tile->getPosition()->x;
+		$this->pairZ = $tile->getPosition()->z;
 
-		$tile->pairX = $this->getPos()->x;
-		$tile->pairZ = $this->getPos()->z;
+		$tile->pairX = $this->getPosition()->x;
+		$tile->pairZ = $this->getPosition()->z;
 	}
 
 	public function unpair() : bool{

--- a/src/block/tile/ContainerTrait.php
+++ b/src/block/tile/ContainerTrait.php
@@ -84,14 +84,14 @@ trait ContainerTrait{
 	/**
 	 * @see Position::asPosition()
 	 */
-	abstract protected function getPos() : Position;
+	abstract protected function getPosition() : Position;
 
 	/**
 	 * @see Tile::onBlockDestroyedHook()
 	 */
 	protected function onBlockDestroyedHook() : void{
 		$inv = $this->getRealInventory();
-		$pos = $this->getPos();
+		$pos = $this->getPosition();
 
 		foreach($inv->getContents() as $k => $item){
 			$pos->getWorld()->dropItem($pos->add(0.5, 0.5, 0.5), $item);

--- a/src/block/tile/Furnace.php
+++ b/src/block/tile/Furnace.php
@@ -59,7 +59,7 @@ abstract class Furnace extends Spawnable implements Container, Nameable{
 
 	public function __construct(World $world, Vector3 $pos){
 		parent::__construct($world, $pos);
-		$this->inventory = new FurnaceInventory($this->pos, $this->getFurnaceType());
+		$this->inventory = new FurnaceInventory($this->position, $this->getFurnaceType());
 		$this->inventory->getListeners()->add(CallbackInventoryListener::onAnyChange(
 			static function(Inventory $unused) use ($world, $pos) : void{
 				$world->scheduleDelayedBlockUpdate($pos, 1);
@@ -137,7 +137,7 @@ abstract class Furnace extends Spawnable implements Container, Nameable{
 		$block = $this->getBlock();
 		if($block instanceof BlockFurnace and !$block->isLit()){
 			$block->setLit(true);
-			$this->pos->getWorld()->setBlock($block->getPos(), $block);
+			$this->position->getWorld()->setBlock($block->getPosition(), $block);
 		}
 	}
 
@@ -145,7 +145,7 @@ abstract class Furnace extends Spawnable implements Container, Nameable{
 		$block = $this->getBlock();
 		if($block instanceof BlockFurnace and $block->isLit()){
 			$block->setLit(false);
-			$this->pos->getWorld()->setBlock($block->getPos(), $block);
+			$this->position->getWorld()->setBlock($block->getPosition(), $block);
 		}
 	}
 
@@ -170,7 +170,7 @@ abstract class Furnace extends Spawnable implements Container, Nameable{
 		$product = $this->inventory->getResult();
 
 		$furnaceType = $this->getFurnaceType();
-		$smelt = $this->pos->getWorld()->getServer()->getCraftingManager()->getFurnaceRecipeManager($furnaceType)->match($raw);
+		$smelt = $this->position->getWorld()->getServer()->getCraftingManager()->getFurnaceRecipeManager($furnaceType)->match($raw);
 		$canSmelt = ($smelt instanceof FurnaceRecipe and $raw->getCount() > 0 and (($smelt->getResult()->equals($product) and $product->getCount() < $product->getMaxStackSize()) or $product->isNull()));
 
 		if($this->remainingFuelTime <= 0 and $canSmelt and $fuel->getFuelTime() > 0 and $fuel->getCount() > 0){

--- a/src/block/tile/Hopper.php
+++ b/src/block/tile/Hopper.php
@@ -43,7 +43,7 @@ class Hopper extends Spawnable implements Container, Nameable{
 
 	public function __construct(World $world, Vector3 $pos){
 		parent::__construct($world, $pos);
-		$this->inventory = new HopperInventory($this->pos);
+		$this->inventory = new HopperInventory($this->position);
 	}
 
 	public function readSaveData(CompoundTag $nbt) : void{

--- a/src/block/tile/ShulkerBox.php
+++ b/src/block/tile/ShulkerBox.php
@@ -46,7 +46,7 @@ class ShulkerBox extends Spawnable implements Container, Nameable{
 
 	public function __construct(World $world, Vector3 $pos){
 		parent::__construct($world, $pos);
-		$this->inventory = new ShulkerBoxInventory($this->pos);
+		$this->inventory = new ShulkerBoxInventory($this->position);
 	}
 
 	public function readSaveData(CompoundTag $nbt) : void{

--- a/src/block/tile/Spawnable.php
+++ b/src/block/tile/Spawnable.php
@@ -67,9 +67,9 @@ abstract class Spawnable extends Tile{
 	final public function getSpawnCompound() : CompoundTag{
 		$nbt = CompoundTag::create()
 			->setString(self::TAG_ID, TileFactory::getInstance()->getSaveId(get_class($this))) //TODO: disassociate network ID from save ID
-			->setInt(self::TAG_X, $this->pos->x)
-			->setInt(self::TAG_Y, $this->pos->y)
-			->setInt(self::TAG_Z, $this->pos->z);
+			->setInt(self::TAG_X, $this->position->x)
+			->setInt(self::TAG_Y, $this->position->y)
+			->setInt(self::TAG_Z, $this->position->z);
 		$this->addAdditionalSpawnData($nbt);
 		return $nbt;
 	}

--- a/src/block/tile/Tile.php
+++ b/src/block/tile/Tile.php
@@ -46,14 +46,14 @@ abstract class Tile{
 	public const TAG_Z = "z";
 
 	/** @var Position */
-	protected $pos;
+	protected $position;
 	/** @var bool */
 	public $closed = false;
 	/** @var TimingsHandler */
 	protected $timings;
 
 	public function __construct(World $world, Vector3 $pos){
-		$this->pos = Position::fromObject($pos, $world);
+		$this->position = Position::fromObject($pos, $world);
 		$this->timings = Timings::getTileEntityTimings($this);
 	}
 
@@ -72,9 +72,9 @@ abstract class Tile{
 	public function saveNBT() : CompoundTag{
 		$nbt = CompoundTag::create()
 			->setString(self::TAG_ID, TileFactory::getInstance()->getSaveId(get_class($this)))
-			->setInt(self::TAG_X, $this->pos->getFloorX())
-			->setInt(self::TAG_Y, $this->pos->getFloorY())
-			->setInt(self::TAG_Z, $this->pos->getFloorZ());
+			->setInt(self::TAG_X, $this->position->getFloorX())
+			->setInt(self::TAG_Y, $this->position->getFloorY())
+			->setInt(self::TAG_Z, $this->position->getFloorZ());
 		$this->writeSaveData($nbt);
 
 		return $nbt;
@@ -97,11 +97,11 @@ abstract class Tile{
 	}
 
 	public function getBlock() : Block{
-		return $this->pos->getWorld()->getBlock($this->pos);
+		return $this->position->getWorld()->getBlock($this->position);
 	}
 
-	public function getPos() : Position{
-		return $this->pos;
+	public function getPosition() : Position{
+		return $this->position;
 	}
 
 	public function isClosed() : bool{
@@ -131,8 +131,8 @@ abstract class Tile{
 		if(!$this->closed){
 			$this->closed = true;
 
-			if($this->pos->isValid()){
-				$this->pos->getWorld()->removeTile($this);
+			if($this->position->isValid()){
+				$this->position->getWorld()->removeTile($this);
 			}
 		}
 	}

--- a/src/block/utils/FallableTrait.php
+++ b/src/block/utils/FallableTrait.php
@@ -41,14 +41,14 @@ use pocketmine\world\Position;
  */
 trait FallableTrait{
 
-	abstract protected function getPos() : Position;
+	abstract protected function getPosition() : Position;
 
 	abstract protected function getId() : int;
 
 	abstract protected function getMeta() : int;
 
 	public function onNearbyBlockChange() : void{
-		$pos = $this->getPos();
+		$pos = $this->getPosition();
 		$down = $pos->getWorld()->getBlock($pos->getSide(Facing::DOWN));
 		if($down->getId() === BlockLegacyIds::AIR or $down instanceof Liquid or $down instanceof Fire){
 			$pos->getWorld()->setBlock($pos, VanillaBlocks::AIR());

--- a/src/entity/projectile/Projectile.php
+++ b/src/entity/projectile/Projectile.php
@@ -141,7 +141,7 @@ abstract class Projectile extends Entity{
 		$nbt->setDouble("damage", $this->damage);
 
 		if($this->blockHit !== null){
-			$pos = $this->blockHit->getPos();
+			$pos = $this->blockHit->getPosition();
 			$nbt->setInt("tileX", $pos->x);
 			$nbt->setInt("tileY", $pos->y);
 			$nbt->setInt("tileZ", $pos->z);
@@ -159,7 +159,7 @@ abstract class Projectile extends Entity{
 	}
 
 	public function onNearbyBlockChange() : void{
-		if($this->blockHit !== null and $this->getWorld()->isInLoadedTerrain($this->blockHit->getPos()) and !$this->blockHit->isSameState($this->getWorld()->getBlock($this->blockHit->getPos()))){
+		if($this->blockHit !== null and $this->getWorld()->isInLoadedTerrain($this->blockHit->getPosition()) and !$this->blockHit->isSameState($this->getWorld()->getBlock($this->blockHit->getPosition()))){
 			$this->blockHit = null;
 		}
 

--- a/src/entity/projectile/SplashPotion.php
+++ b/src/entity/projectile/SplashPotion.php
@@ -133,11 +133,11 @@ class SplashPotion extends Throwable{
 			$blockIn = $event->getBlockHit()->getSide($event->getRayTraceResult()->getHitFace());
 
 			if($blockIn->getId() === BlockLegacyIds::FIRE){
-				$this->getWorld()->setBlock($blockIn->getPos(), VanillaBlocks::AIR());
+				$this->getWorld()->setBlock($blockIn->getPosition(), VanillaBlocks::AIR());
 			}
 			foreach($blockIn->getHorizontalSides() as $horizontalSide){
 				if($horizontalSide->getId() === BlockLegacyIds::FIRE){
-					$this->getWorld()->setBlock($horizontalSide->getPos(), VanillaBlocks::AIR());
+					$this->getWorld()->setBlock($horizontalSide->getPosition(), VanillaBlocks::AIR());
 				}
 			}
 		}

--- a/src/item/Bucket.php
+++ b/src/item/Bucket.php
@@ -46,8 +46,8 @@ class Bucket extends Item{
 			$ev = new PlayerBucketFillEvent($player, $blockReplace, $face, $this, $resultItem);
 			$ev->call();
 			if(!$ev->isCancelled()){
-				$player->getWorld()->setBlock($blockClicked->getPos(), VanillaBlocks::AIR());
-				$player->getWorld()->addSound($blockClicked->getPos()->add(0.5, 0.5, 0.5), $blockClicked->getBucketFillSound());
+				$player->getWorld()->setBlock($blockClicked->getPosition(), VanillaBlocks::AIR());
+				$player->getWorld()->addSound($blockClicked->getPosition()->add(0.5, 0.5, 0.5), $blockClicked->getBucketFillSound());
 				if($player->hasFiniteResources()){
 					if($stack->getCount() === 0){
 						$player->getInventory()->setItemInHand($ev->getItem());

--- a/src/item/FlintSteel.php
+++ b/src/item/FlintSteel.php
@@ -35,8 +35,8 @@ class FlintSteel extends Tool{
 	public function onInteractBlock(Player $player, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector) : ItemUseResult{
 		if($blockReplace->getId() === BlockLegacyIds::AIR){
 			$world = $player->getWorld();
-			$world->setBlock($blockReplace->getPos(), VanillaBlocks::FIRE());
-			$world->addSound($blockReplace->getPos()->add(0.5, 0.5, 0.5), new FlintSteelSound());
+			$world->setBlock($blockReplace->getPosition(), VanillaBlocks::FIRE());
+			$world->addSound($blockReplace->getPosition()->add(0.5, 0.5, 0.5), new FlintSteelSound());
 
 			$this->applyDamage(1);
 

--- a/src/item/LiquidBucket.php
+++ b/src/item/LiquidBucket.php
@@ -67,8 +67,8 @@ class LiquidBucket extends Item{
 		$ev = new PlayerBucketEmptyEvent($player, $blockReplace, $face, $this, VanillaItems::BUCKET());
 		$ev->call();
 		if(!$ev->isCancelled()){
-			$player->getWorld()->setBlock($blockReplace->getPos(), $resultBlock->getFlowingForm());
-			$player->getWorld()->addSound($blockReplace->getPos()->add(0.5, 0.5, 0.5), $resultBlock->getBucketEmptySound());
+			$player->getWorld()->setBlock($blockReplace->getPosition(), $resultBlock->getFlowingForm());
+			$player->getWorld()->addSound($blockReplace->getPosition()->add(0.5, 0.5, 0.5), $resultBlock->getBucketEmptySound());
 
 			if($player->hasFiniteResources()){
 				$player->getInventory()->setItemInHand($ev->getItem());

--- a/src/item/PaintingItem.php
+++ b/src/item/PaintingItem.php
@@ -51,7 +51,7 @@ class PaintingItem extends Item{
 				continue;
 			}
 
-			if(Painting::canFit($player->getWorld(), $blockReplace->getPos(), $face, true, $motive)){
+			if(Painting::canFit($player->getWorld(), $blockReplace->getPosition(), $face, true, $motive)){
 				if($currentTotalDimension > $totalDimension){
 					$totalDimension = $currentTotalDimension;
 					/*
@@ -73,8 +73,8 @@ class PaintingItem extends Item{
 		/** @var PaintingMotive $motive */
 		$motive = $motives[array_rand($motives)];
 
-		$replacePos = $blockReplace->getPos();
-		$clickedPos = $blockClicked->getPos();
+		$replacePos = $blockReplace->getPosition();
+		$clickedPos = $blockClicked->getPosition();
 
 		$entity = new Painting(Location::fromObject($replacePos, $replacePos->getWorld()), $clickedPos, $face, $motive);
 		$this->pop();

--- a/src/item/SpawnEgg.php
+++ b/src/item/SpawnEgg.php
@@ -35,7 +35,7 @@ abstract class SpawnEgg extends Item{
 	abstract protected function createEntity(World $world, Vector3 $pos, float $yaw, float $pitch) : Entity;
 
 	public function onInteractBlock(Player $player, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector) : ItemUseResult{
-		$entity = $this->createEntity($player->getWorld(), $blockReplace->getPos()->add(0.5, 0, 0.5), lcg_value() * 360, 0);
+		$entity = $this->createEntity($player->getWorld(), $blockReplace->getPosition()->add(0.5, 0, 0.5), lcg_value() * 360, 0);
 
 		if($this->hasCustomName()){
 			$entity->setNameTag($this->getCustomName());

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1526,8 +1526,8 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 
 		$block = $target->getSide($face);
 		if($block->getId() === BlockLegacyIds::FIRE){
-			$this->getWorld()->setBlock($block->getPos(), VanillaBlocks::AIR());
-			$this->getWorld()->addSound($block->getPos()->add(0.5, 0.5, 0.5), new FireExtinguishSound());
+			$this->getWorld()->setBlock($block->getPosition(), VanillaBlocks::AIR());
+			$this->getWorld()->addSound($block->getPosition()->add(0.5, 0.5, 0.5), new FireExtinguishSound());
 			return true;
 		}
 

--- a/src/world/Explosion.php
+++ b/src/world/Explosion.php
@@ -138,7 +138,7 @@ class Explosion{
 										$_block = $blockFactory->fromFullBlock($state);
 										$_block->position($this->world, $vBlockX, $vBlockY, $vBlockZ);
 										foreach($_block->getAffectedBlocks() as $_affectedBlock){
-											$_affectedBlockPos = $_affectedBlock->getPos();
+											$_affectedBlockPos = $_affectedBlock->getPosition();
 											$this->affectedBlocks[World::blockHash($_affectedBlockPos->x, $_affectedBlockPos->y, $_affectedBlockPos->z)] = $_affectedBlock;
 										}
 									}
@@ -214,7 +214,7 @@ class Explosion{
 		$airBlock = VanillaBlocks::AIR();
 
 		foreach($this->affectedBlocks as $block){
-			$pos = $block->getPos();
+			$pos = $block->getPosition();
 			if($block instanceof TNT){
 				$block->ignite(mt_rand(10, 30));
 			}else{
@@ -232,7 +232,7 @@ class Explosion{
 		}
 
 		foreach($this->affectedBlocks as $block){
-			$pos = $block->getPos();
+			$pos = $block->getPosition();
 			foreach(Facing::ALL as $side){
 				$sideBlock = $pos->getSide($side);
 				if(!$this->world->isInWorld($sideBlock->x, $sideBlock->y, $sideBlock->z)){

--- a/src/world/World.php
+++ b/src/world/World.php
@@ -1563,7 +1563,7 @@ class World implements ChunkManager{
 
 		$block->position($this, $x, $y, $z);
 		$block->writeStateToWorld();
-		$pos = $block->getPos();
+		$pos = $block->getPosition();
 
 		$chunkHash = World::chunkHash($x >> 4, $z >> 4);
 		$relativeBlockHash = World::chunkBlockHash($x, $y, $z);
@@ -1718,12 +1718,12 @@ class World implements ChunkManager{
 
 	private function destroyBlockInternal(Block $target, Item $item, ?Player $player = null, bool $createParticles = false) : void{
 		if($createParticles){
-			$this->addParticle($target->getPos()->add(0.5, 0.5, 0.5), new BlockBreakParticle($target));
+			$this->addParticle($target->getPosition()->add(0.5, 0.5, 0.5), new BlockBreakParticle($target));
 		}
 
 		$target->onBreak($item, $player);
 
-		$tile = $this->getTile($target->getPos());
+		$tile = $this->getTile($target->getPosition());
 		if($tile !== null){
 			$tile->onBlockDestroyed();
 		}
@@ -1743,12 +1743,12 @@ class World implements ChunkManager{
 			$clickVector = new Vector3(0.0, 0.0, 0.0);
 		}
 
-		if(!$this->isInWorld($blockReplace->getPos()->x, $blockReplace->getPos()->y, $blockReplace->getPos()->z)){
+		if(!$this->isInWorld($blockReplace->getPosition()->x, $blockReplace->getPosition()->y, $blockReplace->getPosition()->z)){
 			//TODO: build height limit messages for custom world heights and mcregion cap
 			return false;
 		}
-		$chunkX = $blockReplace->getPos()->getFloorX() >> 4;
-		$chunkZ = $blockReplace->getPos()->getFloorZ() >> 4;
+		$chunkX = $blockReplace->getPosition()->getFloorX() >> 4;
+		$chunkZ = $blockReplace->getPosition()->getFloorZ() >> 4;
 		if(!$this->isChunkLoaded($chunkX, $chunkZ) || !$this->isChunkGenerated($chunkX, $chunkZ) || $this->isChunkLocked($chunkX, $chunkZ)){
 			return false;
 		}
@@ -1782,14 +1782,14 @@ class World implements ChunkManager{
 
 		if($item->canBePlaced()){
 			$hand = $item->getBlock($face);
-			$hand->position($this, $blockReplace->getPos()->x, $blockReplace->getPos()->y, $blockReplace->getPos()->z);
+			$hand->position($this, $blockReplace->getPosition()->x, $blockReplace->getPosition()->y, $blockReplace->getPosition()->z);
 		}else{
 			return false;
 		}
 
 		if($hand->canBePlacedAt($blockClicked, $clickVector, $face, true)){
 			$blockReplace = $blockClicked;
-			$hand->position($this, $blockReplace->getPos()->x, $blockReplace->getPos()->y, $blockReplace->getPos()->z);
+			$hand->position($this, $blockReplace->getPosition()->x, $blockReplace->getPosition()->y, $blockReplace->getPosition()->z);
 		}elseif(!$hand->canBePlacedAt($blockReplace, $clickVector, $face, false)){
 			return false;
 		}
@@ -1850,7 +1850,7 @@ class World implements ChunkManager{
 		}
 
 		if($playSound){
-			$this->addSound($hand->getPos(), new BlockPlaceSound($hand));
+			$this->addSound($hand->getPosition(), new BlockPlaceSound($hand));
 		}
 
 		$item->pop();
@@ -2367,7 +2367,7 @@ class World implements ChunkManager{
 		if($tile->isClosed()){
 			throw new \InvalidArgumentException("Attempted to add a garbage closed Tile to world");
 		}
-		$pos = $tile->getPos();
+		$pos = $tile->getPosition();
 		if(!$pos->isValid() || $pos->getWorld() !== $this){
 			throw new \InvalidArgumentException("Invalid Tile world");
 		}
@@ -2390,7 +2390,7 @@ class World implements ChunkManager{
 	 * @throws \InvalidArgumentException
 	 */
 	public function removeTile(Tile $tile) : void{
-		$pos = $tile->getPos();
+		$pos = $tile->getPosition();
 		if(!$pos->isValid() || $pos->getWorld() !== $this){
 			throw new \InvalidArgumentException("Invalid Tile world");
 		}
@@ -2507,7 +2507,7 @@ class World implements ChunkManager{
 				}
 				if($tile === null){
 					$this->getLogger()->warning("Chunk $chunkX $chunkZ: Deleted unknown tile entity type " . $nbt->getString("id", "<unknown>"));
-				}elseif(!$this->isChunkLoaded($tile->getPos()->getFloorX() >> 4, $tile->getPos()->getFloorZ() >> 4)){
+				}elseif(!$this->isChunkLoaded($tile->getPosition()->getFloorX() >> 4, $tile->getPosition()->getFloorZ() >> 4)){
 					$this->logger->error("Chunk $chunkX $chunkZ: Found tile saved on wrong chunk - unable to fix due to correct chunk not loaded");
 				}else{
 					$this->addTile($tile);

--- a/src/world/format/Chunk.php
+++ b/src/world/format/Chunk.php
@@ -228,7 +228,7 @@ class Chunk{
 			throw new \InvalidArgumentException("Attempted to add a garbage closed Tile to a chunk");
 		}
 
-		$pos = $tile->getPos();
+		$pos = $tile->getPosition();
 		if(isset($this->tiles[$index = Chunk::blockHash($pos->x, $pos->y, $pos->z)]) and $this->tiles[$index] !== $tile){
 			throw new \InvalidArgumentException("Another tile is already at this location");
 		}
@@ -237,7 +237,7 @@ class Chunk{
 	}
 
 	public function removeTile(Tile $tile) : void{
-		$pos = $tile->getPos();
+		$pos = $tile->getPosition();
 		unset($this->tiles[Chunk::blockHash($pos->x, $pos->y, $pos->z)]);
 		$this->dirtyFlags |= self::DIRTY_FLAG_TILES;
 	}


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
The purpose of this pull request is to establish more consistency in the naming scheme of position getters in PM4 by adjusting them in the Block and Tile classes, as well as their usages within the codebase, in order to correspond to the getPosition() method in the Entity class as well as the name of the Position class.

Furthermore, the class property 'pos' has been renamed to 'position' in hope of reducing additional guesswork for developers and as stated already, for the sake of consistency. However, the scope of this pull request hasn't been broadened up to local variables, hence they remain unchanged.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
I am not aware of any relevant issues.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

Changed method signatures:
- `Block->getPos()` -> `Block->getPosition()`
- `Block->getPosOffset()` -> `Block->getPositionOffset()`
- `Tile->getPos()` -> `Tile->getPosition()`

Changed class properties:
- `Block->pos` -> `Block->position`
- `Tile->pos` -> `Tile->position`

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
No behavioural changes are intended nor expected.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
All API changes as stated above are heavily backwards-incompatible and will cause many plugins to break. I'd argue the impact on PM3 plugins is acceptable since they would have faced breaking changes anyway, making the additional cost to maintain consistency negligible.
On the other hand, it might not be worth it to break existing plugins for PM4 over this change.
For this reason, I'm also still ambivalent about this pull request and kindly ask for more opinions on this matter.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
No follow-ups planned so far.

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Besides manually going through the changes via git and testing various gameplay mechanics within the game no further intensive testing has been done. I'd be glad for more pairs of eyes to take a look at the changes and point out any flaws to me.