### PR TITLE
Workaround for #4291 fall damage bug

### DIFF
--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1064,6 +1064,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 			$bb = clone $this->boundingBox;
 			$bb->minY = $this->location->y - 0.2;
 			$bb->maxY = $this->location->y + 0.2;
+			$bb->contract(0.00001, 0, 0.00001); // account for floating point precision errors
 
 			$this->onGround = $this->isCollided = count($this->getWorld()->getCollisionBlocks($bb, true)) > 0;
 		}

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1064,7 +1064,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 			$bb = clone $this->boundingBox;
 			$bb->minY = $this->location->y - 0.2;
 			$bb->maxY = $this->location->y + 0.2;
-			$bb->contract(0.00001, 0, 0.00001); // account for floating point precision errors
+			$bb->contract(0.0001, 0, 0.0001); // account for floating point precision errors
 
 			$this->onGround = $this->isCollided = count($this->getWorld()->getCollisionBlocks($bb, true)) > 0;
 		}


### PR DESCRIPTION
## Introduction
This Pull Request simply allows for a `0.0001` margin of error on the sides of the player's bounding box when the server checks for the blocks colliding with the player

### Relevant issues
* Fixes #4291

## Changes
### Behavioural changes
When the server checks for the player's ground state, if the player is not in spectator mode, it will now trim the sides of the bounding box by `0.0001` blocks, in order to account for possible floating point precision errors

## Tests
Without Margin:
https://user-images.githubusercontent.com/17762324/130431606-dfb4d32b-70a6-4293-a161-6fa7ddbd6860.mp4


With margin;
https://user-images.githubusercontent.com/17762324/130431594-8c0036bb-60d5-4435-9ce4-2d9e03255bd9.mp4


