### PR TITLE
BlockItemPickupEvent

### DIFF
--- a/src/event/block/BlockItemPickupEvent.php
+++ b/src/event/block/BlockItemPickupEvent.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace pocketmine\event\block;
+
+use pocketmine\block\Block;
+use pocketmine\entity\Entity;
+use pocketmine\event\Cancellable;
+use pocketmine\event\CancellableTrait;
+use pocketmine\inventory\Inventory;
+use pocketmine\item\Item;
+
+/**
+ * Called when a block picks up an item, arrow, etc.
+ */
+class BlockItemPickupEvent extends BlockEvent implements Cancellable{
+	use CancellableTrait;
+
+	public function __construct(
+		Block $collector,
+		private Entity $origin,
+		private Item $item,
+		private ?Inventory $inventory
+	){
+		parent::__construct($collector);
+	}
+
+	public function getOrigin() : Entity{
+		return $this->origin;
+	}
+
+	/**
+	 * Items to be received
+	 */
+	public function getItem() : Item{
+		return clone $this->item;
+	}
+
+	/**
+	 * Change the items to receive.
+	 */
+	public function setItem(Item $item) : void{
+		$this->item = clone $item;
+	}
+
+	/**
+	 * Inventory to which received items will be added.
+	 */
+	public function getInventory() : ?Inventory{
+		return $this->inventory;
+	}
+
+	/**
+	 * Change the inventory to which received items are added.
+	 */
+	public function setInventory(?Inventory $inventory) : void{
+		$this->inventory = $inventory;
+	}
+}


### PR DESCRIPTION
## Introduction
With the removal of the InventoryPickupEvent and the addition of the EntityItemPickupEvent through eb9188c30958c8efa4ad8acf1126712a4013d4ca, it became no longer possible to implement event listeners for blocks (that hold inventories) who pick up items, for example in the case of the Hopper.
To allow this addition in a future PR a BlockItemPickupEvent would be needed to implement.

### Relevant issues
* Solves https://github.com/pmmp/PocketMine-MP/issues/4399

## Changes
### API changes
- Adds the BlockItemPickupEvent which is currently never called. It would be called in the future if blocks pick up items, arrows, etc.

## Follow-up
To avoid leaving this event unused for long a PR that would fully implement Hoppers should be also merged to the master branch.

## Tests
Currently, the BlockItemPickupEvent is never called and is basically just dead code.
