### PR TITLE
Refactor Tree classes

### DIFF
--- a/src/block/Sapling.php
+++ b/src/block/Sapling.php
@@ -110,7 +110,6 @@ class Sapling extends Flowable{
 
 	private function grow() : void{
 		$random = new Random(mt_rand());
-
 		$tree = Tree::get($random, $this->treeType);
 		$transaction = $tree?->getBlockTransaction($this->position->getWorld(), $this->position->getFloorX(), $this->position->getFloorY(), $this->position->getFloorZ(), $random);
 		if($transaction === null){

--- a/src/block/Sapling.php
+++ b/src/block/Sapling.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\block\utils\TreeType;
+use pocketmine\event\block\StructureGrowEvent;
 use pocketmine\item\Fertilizer;
 use pocketmine\item\Item;
 use pocketmine\math\Facing;
@@ -76,7 +77,7 @@ class Sapling extends Flowable{
 
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
 		if($item instanceof Fertilizer){
-			Tree::growTree($this->position->getWorld(), $this->position->x, $this->position->y, $this->position->z, new Random(mt_rand()), $this->treeType, true);
+			$this->grow();
 
 			$item->pop();
 
@@ -99,12 +100,30 @@ class Sapling extends Flowable{
 	public function onRandomTick() : void{
 		if($this->position->getWorld()->getFullLightAt($this->position->x, $this->position->y, $this->position->z) >= 8 and mt_rand(1, 7) === 1){
 			if($this->ready){
-				Tree::growTree($this->position->getWorld(), $this->position->x, $this->position->y, $this->position->z, new Random(mt_rand()), $this->treeType, true);
+				$this->grow();
 			}else{
 				$this->ready = true;
 				$this->position->getWorld()->setBlock($this->position, $this);
 			}
 		}
+	}
+
+	private function grow() : void{
+		$random = new Random(mt_rand());
+
+		$tree = Tree::get($random, $this->treeType);
+		$transaction = $tree?->getBlockTransaction($this->position->getWorld(), $this->position->x, $this->position->y, $this->position->z, $random);
+		if($transaction === null){
+			return;
+		}
+
+		$ev = new StructureGrowEvent($this, $transaction);
+		$ev->call();
+		if($ev->isCancelled()){
+			return;
+		}
+
+		$transaction->apply();
 	}
 
 	public function getFuelTime() : int{

--- a/src/block/Sapling.php
+++ b/src/block/Sapling.php
@@ -98,7 +98,7 @@ class Sapling extends Flowable{
 	}
 
 	public function onRandomTick() : void{
-		if($this->position->getWorld()->getFullLightAt($this->position->x, $this->position->y, $this->position->z) >= 8 and mt_rand(1, 7) === 1){
+		if($this->position->getWorld()->getFullLightAt($this->position->getFloorX(), $this->position->getFloorY(), $this->position->getFloorZ()) >= 8 and mt_rand(1, 7) === 1){
 			if($this->ready){
 				$this->grow();
 			}else{
@@ -112,7 +112,7 @@ class Sapling extends Flowable{
 		$random = new Random(mt_rand());
 
 		$tree = Tree::get($random, $this->treeType);
-		$transaction = $tree?->getBlockTransaction($this->position->getWorld(), $this->position->x, $this->position->y, $this->position->z, $random);
+		$transaction = $tree?->getBlockTransaction($this->position->getWorld(), $this->position->getFloorX(), $this->position->getFloorY(), $this->position->getFloorZ(), $random);
 		if($transaction === null){
 			return;
 		}

--- a/src/world/generator/object/BirchTree.php
+++ b/src/world/generator/object/BirchTree.php
@@ -30,7 +30,8 @@ use pocketmine\world\ChunkManager;
 
 class BirchTree extends Tree{
 
-	protected bool $superBirch = false;
+	/** @var bool */
+	protected $superBirch = false;
 
 	public function __construct(bool $superBirch = false){
 		parent::__construct(VanillaBlocks::BIRCH_LOG(), VanillaBlocks::BIRCH_LEAVES());

--- a/src/world/generator/object/BirchTree.php
+++ b/src/world/generator/object/BirchTree.php
@@ -25,22 +25,23 @@ namespace pocketmine\world\generator\object;
 
 use pocketmine\block\VanillaBlocks;
 use pocketmine\utils\Random;
+use pocketmine\world\BlockTransaction;
 use pocketmine\world\ChunkManager;
 
 class BirchTree extends Tree{
-	/** @var bool */
-	protected $superBirch = false;
+
+	protected bool $superBirch = false;
 
 	public function __construct(bool $superBirch = false){
 		parent::__construct(VanillaBlocks::BIRCH_LOG(), VanillaBlocks::BIRCH_LEAVES());
 		$this->superBirch = $superBirch;
 	}
 
-	public function placeObject(ChunkManager $world, int $x, int $y, int $z, Random $random, bool $callEvent = false) : void{
+	public function getBlockTransaction(ChunkManager $world, int $x, int $y, int $z, Random $random) : ?BlockTransaction{
 		$this->treeHeight = $random->nextBoundedInt(3) + 5;
 		if($this->superBirch){
 			$this->treeHeight += 5;
 		}
-		parent::placeObject($world, $x, $y, $z, $random, $callEvent);
+		return parent::getBlockTransaction($world, $x, $y, $z, $random);
 	}
 }

--- a/src/world/generator/object/BirchTree.php
+++ b/src/world/generator/object/BirchTree.php
@@ -29,7 +29,6 @@ use pocketmine\world\BlockTransaction;
 use pocketmine\world\ChunkManager;
 
 class BirchTree extends Tree{
-
 	/** @var bool */
 	protected $superBirch = false;
 

--- a/src/world/generator/object/OakTree.php
+++ b/src/world/generator/object/OakTree.php
@@ -25,6 +25,7 @@ namespace pocketmine\world\generator\object;
 
 use pocketmine\block\VanillaBlocks;
 use pocketmine\utils\Random;
+use pocketmine\world\BlockTransaction;
 use pocketmine\world\ChunkManager;
 
 class OakTree extends Tree{
@@ -33,8 +34,8 @@ class OakTree extends Tree{
 		parent::__construct(VanillaBlocks::OAK_LOG(), VanillaBlocks::OAK_LEAVES());
 	}
 
-	public function placeObject(ChunkManager $world, int $x, int $y, int $z, Random $random, bool $callEvent = false) : void{
+	public function getBlockTransaction(ChunkManager $world, int $x, int $y, int $z, Random $random) : ?BlockTransaction{
 		$this->treeHeight = $random->nextBoundedInt(3) + 4;
-		parent::placeObject($world, $x, $y, $z, $random, $callEvent);
+		return parent::getBlockTransaction($world, $x, $y, $z, $random);
 	}
 }

--- a/src/world/generator/object/SpruceTree.php
+++ b/src/world/generator/object/SpruceTree.php
@@ -39,9 +39,9 @@ class SpruceTree extends Tree{
 		return $this->treeHeight - $random->nextBoundedInt(3);
 	}
 
-	public function placeObject(ChunkManager $world, int $x, int $y, int $z, Random $random, bool $callEvent = false) : void{
+	public function getBlockTransaction(ChunkManager $world, int $x, int $y, int $z, Random $random) : ?BlockTransaction{
 		$this->treeHeight = $random->nextBoundedInt(4) + 6;
-		parent::placeObject($world, $x, $y, $z, $random, $callEvent);
+		return parent::getBlockTransaction($world, $x, $y, $z, $random);
 	}
 
 	protected function placeCanopy(int $x, int $y, int $z, Random $random, BlockTransaction $transaction) : void{

--- a/src/world/generator/object/Tree.php
+++ b/src/world/generator/object/Tree.php
@@ -68,10 +68,6 @@ abstract class Tree{
 		return null;
 	}
 
-	protected function generateChunkHeight(Random $random) : int{
-		return $this->treeHeight - 1;
-	}
-
 	public function canPlaceObject(ChunkManager $world, int $x, int $y, int $z, Random $random) : bool{
 		$radiusToCheck = 0;
 		for($yy = 0; $yy < $this->treeHeight + 3; ++$yy){
@@ -104,6 +100,10 @@ abstract class Tree{
 		$this->placeCanopy($x, $y, $z, $random, $transaction);
 
 		return $transaction;
+	}
+
+	protected function generateChunkHeight(Random $random) : int{
+		return $this->treeHeight - 1;
 	}
 
 	protected function placeTrunk(int $x, int $y, int $z, Random $random, int $trunkHeight, BlockTransaction $transaction) : void{

--- a/src/world/generator/object/Tree.php
+++ b/src/world/generator/object/Tree.php
@@ -50,20 +50,27 @@ abstract class Tree{
 	}
 
 	/**
-	 * @param TreeType | null 	$treeType 	default tree type: TreeType::OAK()
+	 * @param TreeType|null $type default oak
 	 */
-	public static function get(Random $random, ?TreeType $treeType = null) : ?self {
-		if($treeType === null || $treeType->equals(TreeType::OAK())){
-			return new OakTree();
-		}elseif($treeType->equals(TreeType::SPRUCE())){
+	public static function get(Random $random, ?TreeType $type = null) : ?self {
+		$type = $type ?? TreeType::OAK();
+		if($type->equals(TreeType::SPRUCE())){
 			return new SpruceTree();
-		}elseif($treeType->equals(TreeType::BIRCH())){
+		}elseif($type->equals(TreeType::BIRCH())){
 			if($random->nextBoundedInt(39) === 0){
 				return new BirchTree(true);
+			}else{
+				return new BirchTree();
 			}
-			return new BirchTree();
-		}elseif($treeType->equals(TreeType::JUNGLE())){
+		}elseif($type->equals(TreeType::JUNGLE())){
 			return new JungleTree();
+		}elseif($type->equals(TreeType::OAK())){ //default
+			return new OakTree();
+			/*if($random->nextRange(0, 9) === 0){
+				$tree = new BigTree();
+			}else{*/
+
+			//}
 		}
 		return null;
 	}

--- a/src/world/generator/object/Tree.php
+++ b/src/world/generator/object/Tree.php
@@ -72,9 +72,6 @@ abstract class Tree{
 		return $this->treeHeight - 1;
 	}
 
-	/*
-	 * check if the tree can be grown at the given coordinates
-	 */
 	public function canPlaceObject(ChunkManager $world, int $x, int $y, int $z, Random $random) : bool{
 		$radiusToCheck = 0;
 		for($yy = 0; $yy < $this->treeHeight + 3; ++$yy){

--- a/src/world/generator/object/Tree.php
+++ b/src/world/generator/object/Tree.php
@@ -34,11 +34,13 @@ use pocketmine\world\ChunkManager;
 use function abs;
 
 abstract class Tree{
+	/** @var Block */
+	protected $trunkBlock;
+	/** @var Block */
+	protected $leafBlock;
 
-	protected Block $trunkBlock;
-	protected Block $leafBlock;
-
-	protected int $treeHeight;
+	/** @var int */
+	protected $treeHeight;
 
 	public function __construct(Block $trunkBlock, Block $leafBlock, int $treeHeight = 7){
 		$this->trunkBlock = $trunkBlock;

--- a/src/world/generator/object/Tree.php
+++ b/src/world/generator/object/Tree.php
@@ -94,8 +94,7 @@ abstract class Tree{
 	}
 
 	/**
-	 * @return BlockTransaction | null
-	 * returns the BlockTransaction containing all the blocks the tree would change upon growing at the given coordinates
+	 * Returns the BlockTransaction containing all the blocks the tree would change upon growing at the given coordinates
 	 * or null if the tree can't be grown
 	 */
 	public function getBlockTransaction(ChunkManager $world, int $x, int $y, int $z, Random $random) : ?BlockTransaction{

--- a/src/world/generator/populator/Tree.php
+++ b/src/world/generator/populator/Tree.php
@@ -62,7 +62,9 @@ class Tree extends Populator{
 			if($y === -1){
 				continue;
 			}
-			ObjectTree::growTree($world, $x, $y, $z, $random, $this->type);
+			$tree = ObjectTree::get($random, $this->type);
+			$transaction = $tree?->getBlockTransaction($world, $x, $y, $z, $random);
+			$transaction?->apply();
 		}
 	}
 


### PR DESCRIPTION
## Introduction
The PR https://github.com/pmmp/PocketMine-MP/pull/4354 introduced the StructureGrowEvent which will be called when structures grow multiple blocks at once. Because of how tree growth is implemented (Sapling class and chunk populator share the same tree placement files) the calling of the event when Sapling grows while it won't be called during chunk population was rather hacky implemented with an $callEvent variable in the Tree classes. But because the PR would have become too big, this issue in coding style wasn't addressed there and it was discussed with @dktapps via. discord that a PR would follow which would refactor the Tree classes (https://discord.com/channels/373199722573201408/551141879123542020/877987305195970581).
This PR aims to refactor the Tree classes to fix this issue in the coding style. 

## Changes
### API changes
- Removed the method  `Tree::growTree(ChunkManager, int, int, int, Random, ?TreeType = null, bool = false) : void`
- Removed the method `Tree::placeObject(ChunkManager, int, int, int, Random, bool= false) : void`
- Added the method `Tree::get(Random, ?TreeType = null) : ?Tree` which returns the corresponding tree to the tree type or null if a tree class was not found for that tree type
- Added the method `Tree::getBlockTransaction(ChunkManager, int, int, int, Random) : ?BlockTransaction` which returns either BlockTransaction containing all the blocks the tree would change upon growing at the given coordinates or null if the tree can't be grown
- Added the method `Sapling::grow() : void` which handles the growth of saplings when using bone meal on them or if they grow during a random tick

## Backwards compatibility
- Any plugins (e.g. world generators) that use PocketMine-MP's implementation of the tree placement will break. To solve breaks in chunk populators following could be changed:
 ```php
// Before the PR 
Tree::growTree($world, $x, $y, $z, $random, $treeType) : void;
```
```php
// After the PR
$tree = Tree::get($random, $this->type);
$transaction = $tree?->getBlockTransaction($world, $x, $y, $z, $random);
$transaction?->apply();
```
## Tests
- This PR was first tested by generating a new world with PocketMine-MP's NORMAL generator and checking for the three tree types this generator populates throughout the world.
  - Oak:
  ![Screenshot (530)](https://user-images.githubusercontent.com/54852588/130872002-7243746c-1690-4788-b626-cbbd3bc634b6.png)
  - Spruce:
  ![Screenshot (531)](https://user-images.githubusercontent.com/54852588/130872053-2ac2d28f-cc2c-4f03-a36b-52a5741e0cda.png)
  - Birch: (both normal birch and superbirch work (right most tree))
  ![Screenshot (532)](https://user-images.githubusercontent.com/54852588/130872094-14a4b19c-29dc-48f3-a84f-e587e42b43d6.png)
- Afterwards, this PR was tested by placing the saplings of the four implemented tree types (oak, spruce, birch, jungle) and using bone meal on them to make them grow: (Because using bone meal and growing during a random tick now use the same method to place the tree, it isn't necessary to explicitly check if these trees also grow during a random tick)
![image](https://user-images.githubusercontent.com/54852588/130872618-ab67beef-d919-44d3-84a7-b4363e38b313.png)
