### PR TITLE
Ignore null items on item-block placement

### DIFF
--- a/src/world/World.php
+++ b/src/world/World.php
@@ -1780,12 +1780,11 @@ class World implements ChunkManager{
 			return true;
 		}
 
-		if($item->canBePlaced()){
-			$hand = $item->getBlock($face);
-			$hand->position($this, $blockReplace->getPosition()->x, $blockReplace->getPosition()->y, $blockReplace->getPosition()->z);
-		}else{
+		if($item->isNull() or !$item->canBePlaced()){
 			return false;
 		}
+		$hand = $item->getBlock($face);
+		$hand->position($this, $blockReplace->getPosition()->x, $blockReplace->getPosition()->y, $blockReplace->getPosition()->z);
 
 		if($hand->canBePlacedAt($blockClicked, $clickVector, $face, true)){
 			$blockReplace = $blockClicked;


### PR DESCRIPTION
## Introduction
With plugins, there may be a possibility of external code reducing the item block's count up-to 0, which would cause the item to be nulled, or supposedly `AIR`, without a check for this in the block placement code, it would cause the next `Item->pop()` call in the block placement logic to throw an `InvalidArgumentException` because of the zero-ed count.

## Changes
### Behavioural changes
The server would now ignore null items when attempting to place them down
