### PR TITLE
Fix offhand pickup

### DIFF
--- a/src/entity/object/ItemEntity.php
+++ b/src/entity/object/ItemEntity.php
@@ -227,7 +227,7 @@ class ItemEntity extends Entity{
 
 		$item = $this->getItem();
 		$playerInventory = match(true){
-			$player->getOffHandInventory()->getItem(0)->canStackWith($item) => $player->getOffHandInventory(),
+			$player->getOffHandInventory()->getItem(0)->canStackWith($item) and $player->getOffHandInventory()->canAddItem($item) => $player->getOffHandInventory(),
 			$player->getInventory()->canAddItem($item) => $player->getInventory(),
 			default => null
 		};

--- a/src/entity/object/ItemEntity.php
+++ b/src/entity/object/ItemEntity.php
@@ -226,16 +226,14 @@ class ItemEntity extends Entity{
 		}
 
 		$item = $this->getItem();
-		$playerOffHandInventory = $player->getOffHandInventory();
-		$playerInventory = $player->getInventory();
-		$inventory = match(true){
-			$playerOffHandInventory->getItem(0)->canStackWith($item) and $playerOffHandInventory->canAddItem($item) => $playerOffHandInventory,
-			$playerInventory->canAddItem($item) => $playerInventory,
+		$playerInventory = match(true){
+			$player->getOffHandInventory()->getItem(0)->canStackWith($item) and $player->getOffHandInventory()->canAddItem($item) => $player->getOffHandInventory(),
+			$player->getInventory()->canAddItem($item) => $player->getInventory(),
 			default => null
 		};
 
-		$ev = new EntityItemPickupEvent($player, $this, $item, $inventory);
-		if($player->hasFiniteResources() and $inventory === null){
+		$ev = new EntityItemPickupEvent($player, $this, $item, $playerInventory);
+		if($player->hasFiniteResources() and $playerInventory === null){
 			$ev->cancel();
 		}
 

--- a/src/entity/object/ItemEntity.php
+++ b/src/entity/object/ItemEntity.php
@@ -226,14 +226,16 @@ class ItemEntity extends Entity{
 		}
 
 		$item = $this->getItem();
-		$playerInventory = match(true){
-			$player->getOffHandInventory()->getItem(0)->canStackWith($item) and $player->getOffHandInventory()->canAddItem($item) => $player->getOffHandInventory(),
-			$player->getInventory()->canAddItem($item) => $player->getInventory(),
+		$playerOffHandInventory = $player->getOffHandInventory();
+		$playerInventory = $player->getInventory();
+		$inventory = match(true){
+			$playerOffHandInventory->getItem(0)->canStackWith($item) and $playerOffHandInventory->canAddItem($item) => $playerOffHandInventory,
+			$playerInventory->canAddItem($item) => $playerInventory,
 			default => null
 		};
 
-		$ev = new EntityItemPickupEvent($player, $this, $item, $playerInventory);
-		if($player->hasFiniteResources() and $playerInventory === null){
+		$ev = new EntityItemPickupEvent($player, $this, $item, $inventory);
+		if($player->hasFiniteResources() and $inventory === null){
 			$ev->cancel();
 		}
 

--- a/src/entity/projectile/Arrow.php
+++ b/src/entity/projectile/Arrow.php
@@ -175,7 +175,7 @@ class Arrow extends Projectile{
 
 		$item = VanillaItems::ARROW();
 		$playerInventory = match(true){
-			$player->getOffHandInventory()->getItem(0)->canStackWith($item) => $player->getOffHandInventory(),
+			$player->getOffHandInventory()->getItem(0)->canStackWith($item) and $player->getOffHandInventory()->canAddItem($item) => $player->getOffHandInventory(),
 			$player->getInventory()->canAddItem($item) => $player->getInventory(),
 			default => null
 		};

--- a/src/entity/projectile/Arrow.php
+++ b/src/entity/projectile/Arrow.php
@@ -174,14 +174,16 @@ class Arrow extends Projectile{
 		}
 
 		$item = VanillaItems::ARROW();
-		$playerInventory = match(true){
-			$player->getOffHandInventory()->getItem(0)->canStackWith($item) and $player->getOffHandInventory()->canAddItem($item) => $player->getOffHandInventory(),
-			$player->getInventory()->canAddItem($item) => $player->getInventory(),
+		$playerOffHandInventory = $player->getOffHandInventory();
+		$playerInventory = $player->getInventory();
+		$inventory = match(true){
+			$playerOffHandInventory->getItem(0)->canStackWith($item) and $playerOffHandInventory->canAddItem($item) => $playerOffHandInventory,
+			$playerInventory->canAddItem($item) => $playerInventory,
 			default => null
 		};
 
-		$ev = new EntityItemPickupEvent($player, $this, $item, $playerInventory);
-		if($player->hasFiniteResources() and $playerInventory === null){
+		$ev = new EntityItemPickupEvent($player, $this, $item, $inventory);
+		if($player->hasFiniteResources() and $inventory === null){
 			$ev->cancel();
 		}
 		if($this->pickupMode === self::PICKUP_NONE or ($this->pickupMode === self::PICKUP_CREATIVE and !$player->isCreative())){

--- a/src/entity/projectile/Arrow.php
+++ b/src/entity/projectile/Arrow.php
@@ -174,16 +174,14 @@ class Arrow extends Projectile{
 		}
 
 		$item = VanillaItems::ARROW();
-		$playerOffHandInventory = $player->getOffHandInventory();
-		$playerInventory = $player->getInventory();
-		$inventory = match(true){
-			$playerOffHandInventory->getItem(0)->canStackWith($item) and $playerOffHandInventory->canAddItem($item) => $playerOffHandInventory,
-			$playerInventory->canAddItem($item) => $playerInventory,
+		$playerInventory = match(true){
+			$player->getOffHandInventory()->getItem(0)->canStackWith($item) and $player->getOffHandInventory()->canAddItem($item) => $player->getOffHandInventory(),
+			$player->getInventory()->canAddItem($item) => $player->getInventory(),
 			default => null
 		};
 
-		$ev = new EntityItemPickupEvent($player, $this, $item, $inventory);
-		if($player->hasFiniteResources() and $inventory === null){
+		$ev = new EntityItemPickupEvent($player, $this, $item, $playerInventory);
+		if($player->hasFiniteResources() and $playerInventory === null){
 			$ev->cancel();
 		}
 		if($this->pickupMode === self::PICKUP_NONE or ($this->pickupMode === self::PICKUP_CREATIVE and !$player->isCreative())){


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Currently, the offhand check in the PlayerItemPickupEvent is not strictly enforced, so there is a possibility that items will disappear.
### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
before:

https://user-images.githubusercontent.com/76860328/131239826-cbc21e26-c15c-420f-870c-239903eda1aa.mp4

after:

https://user-images.githubusercontent.com/76860328/131239828-ab1f2515-32c2-4d29-ada6-7dc609ffee98.mp4

