### PR TITLE
Implemented Hopper pushing, pulling and picking up items logic

### DIFF
--- a/src/block/Hopper.php
+++ b/src/block/Hopper.php
@@ -163,7 +163,7 @@ class Hopper extends Transparent{
 			//TODO: Brewing Stand
 			//TODO: Jukebox (improve)
 			if($destination instanceof TileFurnace){
-				// If the hopper is facing down, it will push every item to the furnace's smelting slot, even items that aren't smeltable.
+				// If the hopper is facing down, it will push every item to the furnace's input slot, even items that aren't smeltable.
 				// If the hopper is facing in any other direction, it will only push items that can be used as fuel to the furnace's fuel slot.
 				if($this->facing === Facing::DOWN){
 					$slotInFurnace = FurnaceInventory::SLOT_INPUT;

--- a/src/block/Hopper.php
+++ b/src/block/Hopper.php
@@ -129,6 +129,7 @@ class Hopper extends Transparent{
 		}
 
 		$success = $this->push($tile);
+		// Hoppers that have a container above them, won't try to pick up items.
 		$origin = $this->position->getWorld()->getTile($this->position->getSide(Facing::UP));
 		if($origin instanceof Container){
 			$success |= $this->pull($tile, $origin);

--- a/src/block/Hopper.php
+++ b/src/block/Hopper.php
@@ -116,13 +116,7 @@ class Hopper extends Transparent{
 			$tile->setTransferCooldown($transferCooldown);
 		}
 
-		if($this->isPowered()){
-			// If a hopper is powered it is deactivated and won't push, pull or pick up items.
-			return;
-		}
-
-		if($transferCooldown > 0){
-			// Skipping this tick because the hopper is still on cooldown of 8 ticks.
+		if($this->isPowered() || $transferCooldown > 0){
 			return;
 		}
 

--- a/src/block/Hopper.php
+++ b/src/block/Hopper.php
@@ -27,7 +27,6 @@ use pocketmine\block\tile\Container;
 use pocketmine\block\tile\Furnace as TileFurnace;
 use pocketmine\block\tile\Hopper as TileHopper;
 use pocketmine\block\tile\Jukebox as TileJukebox;
-use pocketmine\block\tile\ShulkerBox as TileShulkerBox;
 use pocketmine\block\utils\BlockDataSerializer;
 use pocketmine\block\utils\InvalidBlockStateException;
 use pocketmine\block\utils\PoweredByRedstoneTrait;
@@ -229,16 +228,6 @@ class Hopper extends Transparent{
 					$tile->getInventory()->setItem($slot, $item);
 				}
 				return true;
-
-			}elseif($destination instanceof TileShulkerBox){
-				// Hoppers can't push a shulkerbox into another shulkerbox.
-				if($item->getBlock() instanceof ShulkerBox){
-					continue;
-				}
-				$itemToPush = $item->pop();
-				if(!$destination->getInventory()->canAddItem($itemToPush)){
-					continue;
-				}
 
 			}elseif($destination instanceof Container){
 				$itemToPush = $item->pop();

--- a/src/block/Hopper.php
+++ b/src/block/Hopper.php
@@ -227,6 +227,7 @@ class Hopper extends Transparent{
 				if($jukeboxBlock instanceof Jukebox){
 					$jukeboxBlock->insertRecord($item->pop());
 					$jukeboxBlock->getPosition()->getWorld()->setBlock($jukeboxBlock->getPosition(), $jukeboxBlock);
+					$tile->getInventory()->setItem($slot, $item->isNull() ? ItemFactory::air() : $item);
 				}
 				return true;
 

--- a/src/block/Hopper.php
+++ b/src/block/Hopper.php
@@ -170,14 +170,14 @@ class Hopper extends Transparent{
 				// If the hopper is facing in any other direction, it will only push items that can be used as fuel to the furnace's fuel slot.
 				if($this->facing === Facing::DOWN){
 					// ID of the smelting slot
-					$slot = 0;
+					$slotInFurnace = 0;
 					$itemInFurnace = $destination->getInventory()->getSmelting();
 				}else{
 					if($item->getFuelTime() === 0){
 						continue;
 					}
 					// ID of the fuel slot
-					$slot = 1;
+					$slotInFurnace = 1;
 					$itemInFurnace = $destination->getInventory()->getFuel();
 				}
 				if(!$itemInFurnace->isNull()){
@@ -195,7 +195,7 @@ class Hopper extends Transparent{
 
 				// TODO event on item inventory switch
 
-				$destination->getInventory()->setItem($slot, $itemInFurnace);
+				$destination->getInventory()->setItem($slotInFurnace, $itemInFurnace);
 				$tile->getInventory()->setItem($slot, $item->isNull() ? ItemFactory::air() : $item);
 				return true;
 

--- a/src/block/Hopper.php
+++ b/src/block/Hopper.php
@@ -128,9 +128,9 @@ class Hopper extends Transparent{
 		}else{
 			$success |= $this->pickup($tile);
 		}
-		// The cooldown is only set back to 8 ticks if the hopper has done anything.
+		// The cooldown is only set back to the default amount of ticks if the hopper has done anything.
 		if((bool) $success){
-			$tile->setTransferCooldown(8);
+			$tile->setTransferCooldown(TileHopper::DEFAULT_TRANSFER_COOLDOWN);
 		}
 	}
 
@@ -196,9 +196,9 @@ class Hopper extends Transparent{
 				if(!$destination->getInventory()->canAddItem($itemToPush)){
 					continue;
 				}
-				// Hoppers pushing into empty hoppers set the empty hoppers transfer cooldown back to 8 ticks.
+				// Hoppers pushing into empty hoppers set the empty hoppers transfer cooldown back to the default amount of ticks.
 				if(count($destination->getInventory()->getContents()) === 0){
-					$destination->setTransferCooldown(8);
+					$destination->setTransferCooldown(TileHopper::DEFAULT_TRANSFER_COOLDOWN);
 				}
 
 			}elseif($destination instanceof TileJukebox){

--- a/src/block/Hopper.php
+++ b/src/block/Hopper.php
@@ -221,8 +221,9 @@ class Hopper extends Transparent{
 					$jukeboxBlock->insertRecord($item->pop());
 					$jukeboxBlock->getPosition()->getWorld()->setBlock($jukeboxBlock->getPosition(), $jukeboxBlock);
 					$inventory->setItem($slot, $item);
+					return true;
 				}
-				return true;
+				return false;
 
 			}elseif($destination instanceof Container){
 				$itemToPush = $item->pop();

--- a/src/block/Hopper.php
+++ b/src/block/Hopper.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\block\inventory\FurnaceInventory;
 use pocketmine\block\inventory\HopperInventory;
 use pocketmine\block\tile\Container;
 use pocketmine\block\tile\Furnace as TileFurnace;
@@ -32,6 +33,7 @@ use pocketmine\block\utils\BlockDataSerializer;
 use pocketmine\block\utils\InvalidBlockStateException;
 use pocketmine\block\utils\PoweredByRedstoneTrait;
 use pocketmine\entity\object\ItemEntity;
+use pocketmine\inventory\Inventory;
 use pocketmine\item\Bucket;
 use pocketmine\item\Item;
 use pocketmine\item\Record;
@@ -248,22 +250,22 @@ class Hopper extends Transparent{
 	 * This function handles pulling items by the hopper from a container above.
 	 * Returns true if an item was successfully pulled or false on failure.
 	 */
-	private function pull(HopperInventory $inventory, Container $origin) : bool{
+	private function pull(HopperInventory $inventory, Inventory $origin) : bool{
 		// Hoppers interact differently when pulling from different kinds of tiles.
 		//TODO: Composter
 		//TODO: Brewing Stand
 		//TODO: Jukebox
-		if($origin instanceof TileFurnace){
+		if($origin instanceof FurnaceInventory){
 			// Hoppers either pull empty buckets from the furnace's fuel slot or pull from its result slot.
 			// They prioritise pulling from the fuel slot over the result slot.
-			$item = $origin->getInventory()->getFuel();
+			$item = $origin->getFuel();
 			if($item instanceof Bucket){
 				// ID of the fuel slot
 				$slot = 1;
 			}else{
 				// ID of the result slot
 				$slot = 2;
-				$item = $origin->getInventory()->getResult();
+				$item = $origin->getResult();
 				if($item->isNull()){
 					return false;
 				}
@@ -272,13 +274,13 @@ class Hopper extends Transparent{
 
 			//TODO: event on item inventory switch
 
-			$origin->getInventory()->setItem($slot, $item);
+			$origin->setItem($slot, $item);
 			$inventory->addItem($itemToPull);
 			return true;
 
 		}else{
-			for($slot = 0; $slot < $origin->getInventory()->getSize(); $slot++){
-				$item = $origin->getInventory()->getItem($slot);
+			for($slot = 0; $slot < $origin->getSize(); $slot++){
+				$item = $origin->getItem($slot);
 				if($item->isNull()){
 					continue;
 				}
@@ -289,7 +291,7 @@ class Hopper extends Transparent{
 
 				//TODO: event on item inventory switch
 
-				$origin->getInventory()->setItem($slot, $item);
+				$origin->setItem($slot, $item);
 				$inventory->addItem($itemToPull);
 				return true;
 			}

--- a/src/block/Hopper.php
+++ b/src/block/Hopper.php
@@ -34,7 +34,6 @@ use pocketmine\block\utils\PoweredByRedstoneTrait;
 use pocketmine\entity\object\ItemEntity;
 use pocketmine\item\Bucket;
 use pocketmine\item\Item;
-use pocketmine\item\ItemFactory;
 use pocketmine\item\Record;
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Facing;

--- a/src/block/Hopper.php
+++ b/src/block/Hopper.php
@@ -41,6 +41,7 @@ use pocketmine\math\Facing;
 use pocketmine\math\Vector3;
 use pocketmine\player\Player;
 use pocketmine\world\BlockTransaction;
+use function count;
 
 class Hopper extends Transparent{
 	use PoweredByRedstoneTrait;

--- a/src/block/Hopper.php
+++ b/src/block/Hopper.php
@@ -196,7 +196,7 @@ class Hopper extends Transparent{
 				// TODO event on item inventory switch
 
 				$destination->getInventory()->setItem($slotInFurnace, $itemInFurnace);
-				$tile->getInventory()->setItem($slot, $item->isNull() ? ItemFactory::air() : $item);
+				$tile->getInventory()->setItem($slot, $item);
 				return true;
 
 			}elseif($destination instanceof TileHopper){
@@ -227,7 +227,7 @@ class Hopper extends Transparent{
 				if($jukeboxBlock instanceof Jukebox){
 					$jukeboxBlock->insertRecord($item->pop());
 					$jukeboxBlock->getPosition()->getWorld()->setBlock($jukeboxBlock->getPosition(), $jukeboxBlock);
-					$tile->getInventory()->setItem($slot, $item->isNull() ? ItemFactory::air() : $item);
+					$tile->getInventory()->setItem($slot, $item);
 				}
 				return true;
 
@@ -253,7 +253,7 @@ class Hopper extends Transparent{
 
 			// TODO event on item inventory switch
 
-			$tile->getInventory()->setItem($slot, $item->isNull() ? ItemFactory::air() : $item);
+			$tile->getInventory()->setItem($slot, $item);
 			$destination->getInventory()->addItem($itemToPush);
 			return true;
 		}
@@ -288,7 +288,7 @@ class Hopper extends Transparent{
 
 			// TODO event on item inventory switch
 
-			$origin->getInventory()->setItem($slot, $item->isNull() ? ItemFactory::air() : $item);
+			$origin->getInventory()->setItem($slot, $item);
 			$tile->getInventory()->addItem($itemToPull);
 			return true;
 
@@ -305,7 +305,7 @@ class Hopper extends Transparent{
 
 				// TODO event on item inventory switch
 
-				$origin->getInventory()->setItem($slot, $item->isNull() ? ItemFactory::air() : $item);
+				$origin->getInventory()->setItem($slot, $item);
 				$tile->getInventory()->addItem($itemToPull);
 				return true;
 			}

--- a/src/block/Hopper.php
+++ b/src/block/Hopper.php
@@ -129,12 +129,12 @@ class Hopper extends Transparent{
 		$origin = $this->position->getWorld()->getTile($this->position->getSide(Facing::UP));
 		//TODO: Not all blocks a hopper can pull from have an inventory (for example: Jukebox).
 		if($origin instanceof Container){
-			$success |= $this->pull($inventory, $origin->getInventory());
+			$success = $this->pull($inventory, $origin->getInventory()) || $success;
 		}else{
-			$success |= $this->pickup($inventory);
+			$success = $this->pickup($inventory) || $success;
 		}
 		// The cooldown is only set back to the default amount of ticks if the hopper has done anything.
-		if((bool) $success){
+		if($success){
 			$tile->setTransferCooldown(TileHopper::DEFAULT_TRANSFER_COOLDOWN);
 		}
 	}

--- a/src/block/Hopper.php
+++ b/src/block/Hopper.php
@@ -23,11 +23,19 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\block\tile\Container;
+use pocketmine\block\tile\Furnace as TileFurnace;
 use pocketmine\block\tile\Hopper as TileHopper;
+use pocketmine\block\tile\Jukebox as TileJukebox;
+use pocketmine\block\tile\ShulkerBox as TileShulkerBox;
 use pocketmine\block\utils\BlockDataSerializer;
 use pocketmine\block\utils\InvalidBlockStateException;
 use pocketmine\block\utils\PoweredByRedstoneTrait;
+use pocketmine\entity\object\ItemEntity;
+use pocketmine\item\Bucket;
 use pocketmine\item\Item;
+use pocketmine\item\ItemFactory;
+use pocketmine\item\Record;
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Facing;
 use pocketmine\math\Vector3;
@@ -96,8 +104,246 @@ class Hopper extends Transparent{
 	}
 
 	public function onScheduledUpdate() : void{
-		//TODO
+		$this->position->getWorld()->scheduleDelayedBlockUpdate($this->position, 1);
+
+		$tile = $this->position->getWorld()->getTile($this->position);
+		if(!$tile instanceof TileHopper){
+			return;
+		}
+
+		$transferCooldown = $tile->getTransferCooldown();
+		if($transferCooldown > 0){
+			$transferCooldown--;
+			$tile->setTransferCooldown($transferCooldown);
+		}
+
+		if($this->isPowered()){
+			// If a hopper is powered it is deactivated and won't push, pull or pick up items.
+			return;
+		}
+
+		if($transferCooldown > 0){
+			// Skipping this tick because the hopper is still on cooldown of 8 ticks.
+			return;
+		}
+
+		$success = $this->push($tile);
+		$origin = $this->position->getWorld()->getTile($this->position->getSide(Facing::UP));
+		if($origin instanceof Container){
+			$success |= $this->pull($tile, $origin);
+		}else{
+			$success |= $this->pickup($tile);
+		}
+		// The cooldown is only set back to 8 ticks if the hopper has done anything.
+		if((bool) $success){
+			$tile->setTransferCooldown(8);
+		}
 	}
 
-	//TODO: redstone logic, sucking logic
+	/**
+	 * This function handles pushing items from the hopper to a tile in the direction the hopper is facing.
+	 * Returns true if an item was successfully pushed or false on failure.
+	 */
+	private function push(TileHopper $tile) : bool{
+		if(count($tile->getInventory()->getContents()) === 0){
+			return false;
+		}
+		$destination = $this->position->getWorld()->getTile($this->position->getSide($this->facing));
+		if($destination === null){
+			return false;
+		}
+
+		for($slot = 0; $slot < $tile->getInventory()->getSize(); $slot++){
+			$item = $tile->getInventory()->getItem($slot);
+			if($item->isNull()){
+				continue;
+			}
+
+			// Hoppers interact differently when pushing into different kinds of tiles.
+			// TODO Composter
+			// TODO Brewing Stand
+			// TODO Jukebox (improve)
+			if($destination instanceof TileFurnace){
+				// If the hopper is facing down, it will push every item to the furnace's smelting slot, even items that aren't smeltable.
+				// If the hopper is facing in any other direction, it will only push items that can be used as fuel to the furnace's fuel slot.
+				if($this->facing === Facing::DOWN){
+					// ID of the smelting slot
+					$slot = 0;
+					$itemInFurnace = $destination->getInventory()->getSmelting();
+				}else{
+					if($item->getFuelTime() === 0){
+						continue;
+					}
+					// ID of the fuel slot
+					$slot = 1;
+					$itemInFurnace = $destination->getInventory()->getFuel();
+				}
+				if(!$itemInFurnace->isNull()){
+					if($itemInFurnace->getCount() >= $itemInFurnace->getMaxStackSize()){
+						return false;
+					}
+					if(!$itemInFurnace->canStackWith($item)){
+						continue;
+					}
+					$item->pop();
+					$itemInFurnace->setCount($itemInFurnace->getCount() + 1);
+				}else{
+					$itemInFurnace = $item->pop();
+				}
+
+				// TODO event on item inventory switch
+
+				$destination->getInventory()->setItem($slot, $itemInFurnace);
+				$tile->getInventory()->setItem($slot, $item->isNull() ? ItemFactory::air() : $item);
+				return true;
+
+			}elseif($destination instanceof TileHopper){
+				$itemToPush = $item->pop();
+				if(!$destination->getInventory()->canAddItem($itemToPush)){
+					continue;
+				}
+				// Hoppers pushing into empty hoppers set the empty hoppers transfer cooldown back to 8 ticks.
+				if(count($destination->getInventory()->getContents()) === 0){
+					$destination->setTransferCooldown(8);
+				}
+
+			}elseif($destination instanceof TileJukebox){
+				if(!$item instanceof Record){
+					continue;
+				}
+				// TODO
+				// Jukeboxes actually emit a redstone signal when playing a record so nearby hoppers are blocked and
+				// prevented from inserting another disk. Because neither does redstone work properly nor can we check if
+				// a jukebox is still playing a record or has already finished it, we can just check if it has already a
+				// record inserted.
+				if($destination->getRecord() !== null){
+					return false;
+				}
+
+				// The Jukebox block is handling the playing of records, so we need to get it here and can't use TileJukebox::setRecord().
+				$jukeboxBlock = $destination->getBlock();
+				if($jukeboxBlock instanceof Jukebox){
+					$jukeboxBlock->insertRecord($item->pop());
+					$jukeboxBlock->getPosition()->getWorld()->setBlock($jukeboxBlock->getPosition(), $jukeboxBlock);
+				}
+				return true;
+
+			}elseif($destination instanceof TileShulkerBox){
+				// Hoppers can't push a shulkerbox into another shulkerbox.
+				if($item->getBlock() instanceof ShulkerBox){
+					continue;
+				}
+				$itemToPush = $item->pop();
+				if(!$destination->getInventory()->canAddItem($itemToPush)){
+					continue;
+				}
+
+			}elseif($destination instanceof Container){
+				$itemToPush = $item->pop();
+				if(!$destination->getInventory()->canAddItem($itemToPush)){
+					continue;
+				}
+
+			}else{
+				return false;
+			}
+
+			// TODO event on item inventory switch
+
+			$tile->getInventory()->setItem($slot, $item->isNull() ? ItemFactory::air() : $item);
+			$destination->getInventory()->addItem($itemToPush);
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * This function handles pulling items by the hopper from a container above.
+	 * Returns true if an item was successfully pulled or false on failure.
+	 */
+	private function pull(TileHopper $tile, Container $origin) : bool{
+		// Hoppers interact differently when pulling from different kinds of tiles.
+		// TODO Composter
+		// TODO Brewing Stand
+		// TODO Jukebox
+		if($origin instanceof TileFurnace){
+			// Hoppers either pull empty buckets from the furnace's fuel slot or pull from its result slot.
+			// They prioritise pulling from the fuel slot over the result slot.
+			$item = $origin->getInventory()->getFuel();
+			if($item instanceof Bucket){
+				// ID of the fuel slot
+				$slot = 1;
+			}else{
+				// ID of the result slot
+				$slot = 2;
+				$item = $origin->getInventory()->getResult();
+				if($item->isNull()){
+					return false;
+				}
+			}
+			$itemToPull = $item->pop();
+
+			// TODO event on item inventory switch
+
+			$origin->getInventory()->setItem($slot, $item->isNull() ? ItemFactory::air() : $item);
+			$tile->getInventory()->addItem($itemToPull);
+			return true;
+
+		}else{
+			for($slot = 0; $slot < $origin->getInventory()->getSize(); $slot++){
+				$item = $origin->getInventory()->getItem($slot);
+				if($item->isNull()){
+					continue;
+				}
+				$itemToPull = $item->pop();
+				if(!$tile->getInventory()->canAddItem($itemToPull)){
+					continue;
+				}
+
+				// TODO event on item inventory switch
+
+				$origin->getInventory()->setItem($slot, $item->isNull() ? ItemFactory::air() : $item);
+				$tile->getInventory()->addItem($itemToPull);
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * This function handles picking up items by the hopper.
+	 * Returns true if an item was successfully picked up or false on failure.
+	 */
+	private function pickup(TileHopper $tile) : bool{
+		// In Bedrock Edition hoppers collect from the lower 3/4 of the block space above them.
+		$pickupCollisionBox = new AxisAlignedBB(
+			$this->position->getX(),
+			$this->position->getY() + 1,
+			$this->position->getZ(),
+			$this->position->getX() + 1,
+			$this->position->getY() + 1.75,
+			$this->position->getZ() + 1
+		);
+
+		foreach($this->position->getWorld()->getNearbyEntities($pickupCollisionBox) as $entity){
+			if($entity->isClosed() || $entity->isFlaggedForDespawn() || !$entity instanceof ItemEntity){
+				continue;
+			}
+			// Unlike Java Edition, Bedrock Edition's hoppers don't save in which order item entities landed on top of them to collect them in that order.
+			// In Bedrock Edition hoppers collect item entities in the order in which they entered the chunk.
+			// Because of how entities are saved by PocketMine-MP the first entities of this loop are also the first ones who were saved.
+			// That's why we don't need to implement any sorting mechanism.
+			$item = $entity->getItem();
+			if(!$tile->getInventory()->canAddItem($item)){
+				continue;
+			}
+
+			// TODO event on block picking up an item
+
+			$tile->getInventory()->addItem($item);
+			$entity->flagForDespawn();
+			return true;
+		}
+		return false;
+	}
 }

--- a/src/block/Hopper.php
+++ b/src/block/Hopper.php
@@ -154,9 +154,9 @@ class Hopper extends Transparent{
 			}
 
 			// Hoppers interact differently when pushing into different kinds of tiles.
-			// TODO Composter
-			// TODO Brewing Stand
-			// TODO Jukebox (improve)
+			//TODO: Composter
+			//TODO: Brewing Stand
+			//TODO: Jukebox (improve)
 			if($destination instanceof TileFurnace){
 				// If the hopper is facing down, it will push every item to the furnace's smelting slot, even items that aren't smeltable.
 				// If the hopper is facing in any other direction, it will only push items that can be used as fuel to the furnace's fuel slot.
@@ -185,7 +185,7 @@ class Hopper extends Transparent{
 					$itemInFurnace = $item->pop();
 				}
 
-				// TODO event on item inventory switch
+				//TODO: event on item inventory switch
 
 				$destination->getInventory()->setItem($slotInFurnace, $itemInFurnace);
 				$tile->getInventory()->setItem($slot, $item);
@@ -205,7 +205,7 @@ class Hopper extends Transparent{
 				if(!$item instanceof Record){
 					continue;
 				}
-				// TODO
+				//TODO:
 				// Jukeboxes actually emit a redstone signal when playing a record so nearby hoppers are blocked and
 				// prevented from inserting another disk. Because neither does redstone work properly nor can we check if
 				// a jukebox is still playing a record or has already finished it, we can just check if it has already a
@@ -233,7 +233,7 @@ class Hopper extends Transparent{
 				return false;
 			}
 
-			// TODO event on item inventory switch
+			//TODO: event on item inventory switch
 
 			$tile->getInventory()->setItem($slot, $item);
 			$destination->getInventory()->addItem($itemToPush);
@@ -248,9 +248,9 @@ class Hopper extends Transparent{
 	 */
 	private function pull(TileHopper $tile, Container $origin) : bool{
 		// Hoppers interact differently when pulling from different kinds of tiles.
-		// TODO Composter
-		// TODO Brewing Stand
-		// TODO Jukebox
+		//TODO: Composter
+		//TODO: Brewing Stand
+		//TODO: Jukebox
 		if($origin instanceof TileFurnace){
 			// Hoppers either pull empty buckets from the furnace's fuel slot or pull from its result slot.
 			// They prioritise pulling from the fuel slot over the result slot.
@@ -268,7 +268,7 @@ class Hopper extends Transparent{
 			}
 			$itemToPull = $item->pop();
 
-			// TODO event on item inventory switch
+			//TODO: event on item inventory switch
 
 			$origin->getInventory()->setItem($slot, $item);
 			$tile->getInventory()->addItem($itemToPull);
@@ -285,7 +285,7 @@ class Hopper extends Transparent{
 					continue;
 				}
 
-				// TODO event on item inventory switch
+				//TODO: event on item inventory switch
 
 				$origin->getInventory()->setItem($slot, $item);
 				$tile->getInventory()->addItem($itemToPull);
@@ -323,7 +323,7 @@ class Hopper extends Transparent{
 				continue;
 			}
 
-			// TODO event on block picking up an item
+			//TODO: event on block picking up an item
 
 			$tile->getInventory()->addItem($item);
 			$entity->flagForDespawn();

--- a/src/block/Hopper.php
+++ b/src/block/Hopper.php
@@ -123,13 +123,14 @@ class Hopper extends Transparent{
 			return;
 		}
 
-		$success = $this->push($tile->getInventory());
+		$inventory = $tile->getInventory();
+		$success = $this->push($inventory);
 		// Hoppers that have a container above them, won't try to pick up items.
 		$origin = $this->position->getWorld()->getTile($this->position->getSide(Facing::UP));
 		if($origin instanceof Container){
-			$success |= $this->pull($tile, $origin);
+			$success |= $this->pull($inventory, $origin->getInventory());
 		}else{
-			$success |= $this->pickup($tile);
+			$success |= $this->pickup($inventory);
 		}
 		// The cooldown is only set back to the default amount of ticks if the hopper has done anything.
 		if((bool) $success){

--- a/src/block/Hopper.php
+++ b/src/block/Hopper.php
@@ -202,7 +202,7 @@ class Hopper extends Transparent{
 				}
 
 			}elseif($destination instanceof TileJukebox){
-				if(!$item instanceof Record){
+				if(!($item instanceof Record)){
 					continue;
 				}
 				//TODO:

--- a/src/block/Hopper.php
+++ b/src/block/Hopper.php
@@ -166,15 +166,13 @@ class Hopper extends Transparent{
 				// If the hopper is facing down, it will push every item to the furnace's smelting slot, even items that aren't smeltable.
 				// If the hopper is facing in any other direction, it will only push items that can be used as fuel to the furnace's fuel slot.
 				if($this->facing === Facing::DOWN){
-					// ID of the smelting slot
-					$slotInFurnace = 0;
+					$slotInFurnace = FurnaceInventory::SLOT_INPUT;
 					$itemInFurnace = $destination->getInventory()->getSmelting();
 				}else{
 					if($item->getFuelTime() === 0){
 						continue;
 					}
-					// ID of the fuel slot
-					$slotInFurnace = 1;
+					$slotInFurnace = FurnaceInventory::SLOT_FUEL;
 					$itemInFurnace = $destination->getInventory()->getFuel();
 				}
 				if(!$itemInFurnace->isNull()){
@@ -262,11 +260,9 @@ class Hopper extends Transparent{
 			// They prioritise pulling from the fuel slot over the result slot.
 			$item = $origin->getFuel();
 			if($item instanceof Bucket){
-				// ID of the fuel slot
-				$slot = 1;
+				$slot = FurnaceInventory::SLOT_FUEL;
 			}else{
-				// ID of the result slot
-				$slot = 2;
+				$slot = FurnaceInventory::SLOT_RESULT;
 				$item = $origin->getResult();
 				if($item->isNull()){
 					return false;

--- a/src/block/Hopper.php
+++ b/src/block/Hopper.php
@@ -127,6 +127,7 @@ class Hopper extends Transparent{
 		$success = $this->push($inventory);
 		// Hoppers that have a container above them, won't try to pick up items.
 		$origin = $this->position->getWorld()->getTile($this->position->getSide(Facing::UP));
+		//TODO: Not all blocks a hopper can pull from have an inventory (for example: Jukebox).
 		if($origin instanceof Container){
 			$success |= $this->pull($inventory, $origin->getInventory());
 		}else{

--- a/src/block/tile/Hopper.php
+++ b/src/block/tile/Hopper.php
@@ -34,6 +34,7 @@ class Hopper extends Spawnable implements Container, Nameable{
 	use NameableTrait;
 
 	private const TAG_TRANSFER_COOLDOWN = "TransferCooldown";
+	public const DEFAULT_TRANSFER_COOLDOWN = 8;
 
 	/** @var HopperInventory */
 	private $inventory;

--- a/src/block/tile/Hopper.php
+++ b/src/block/tile/Hopper.php
@@ -85,4 +85,12 @@ class Hopper extends Spawnable implements Container, Nameable{
 	public function getRealInventory(){
 		return $this->inventory;
 	}
+
+	public function getTransferCooldown() : int{
+		return $this->transferCooldown;
+	}
+
+	public function setTransferCooldown(int $transferCooldown) : void{
+		$this->transferCooldown = $transferCooldown;
+	}
 }

--- a/src/block/tile/Hopper.php
+++ b/src/block/tile/Hopper.php
@@ -44,6 +44,7 @@ class Hopper extends Spawnable implements Container, Nameable{
 	public function __construct(World $world, Vector3 $pos){
 		parent::__construct($world, $pos);
 		$this->inventory = new HopperInventory($this->position);
+		$this->position->getWorld()->scheduleDelayedBlockUpdate($this->position, 1);
 	}
 
 	public function readSaveData(CompoundTag $nbt) : void{


### PR DESCRIPTION
## Introduction
In pm4 hopper blocks were implemented to have an inventory. But the logic for pushing, pulling and picking up items was missing nonetheless.
This PR aims to add this logic to the hopper.
**This PR contains many comments because the hopper logic is very complex. To prevent future developers from getting confused about how certain things were done, most parts were commented to explain what was done and why.**

### Relevant issues
- Fixes https://github.com/pmmp/PocketMine-MP/blob/master/src/block/Hopper.php#L98-L102

### Sources
- https://minecraft.fandom.com/wiki/Hopper
  - https://static.wikia.nocookie.net/minecraft_gamepedia/images/3/38/Hopper_logic_flowchart.png/revision/latest?cb=20210518094503

## Changes
### API changes
- Added private function in block class `Hopper::push(HopperInventory) : bool` which handles pushing items from the hopper to a tile in the direction the hopper is facing.
- Added private function in block class `Hopper::pull(HopperInventory, Container) : bool` which handles pulling items by the hopper from a container above.
- Added private function in block class `Hopper::pickup(HopperInventory) : bool` which handles picking up items by the hopper.
- Added getter in tile class `Hopper::getTransferCooldown() : int` to get the transfer cooldown of that hopper.
- Added setter in tile class `Hopper::setTransferCooldown(int)` to set the transfer cooldown of that hopper.

### Behavioural changes
- Because hoppers need to be updated every tick, it could impact the server's performance if a large amount of hoppers is loaded.

### TODOs
- Pushing to specific blocks couldn't be implemented because these blocks aren't implemented at the moment. This includes the Composter, the Brewing Stand and the Jukebox (not working as in vanilla).
- Pulling from specific blocks couldn't be implemented because these blocks aren't implemented at the moment. This includes the Composter, the Brewing Stand and the Jukebox.
- Calling an event when a hopper moves an item between its own and another inventory.
- Calling an event when a hopper picks up an item.

## Backwards compatibility
- This PR is fully backwards compatible. Already placed hoppers should also work without any problems when updating to a version of pm4 which merged these changes.

## Tests
- Functionality tests
  - Every block a hopper can push items into was tested if it works as explained in the sources.
  https://www.youtube.com/watch?v=4gSyuViaPaU
  - Every block a hopper can pull items from was tested if it works as explained in the sources.
  https://www.youtube.com/watch?v=6NWvr6Kv88E
  - The collision box of the area where the hopper should pick up items was checked and works as explained in the sources.
  https://www.youtube.com/watch?v=hVEPiK9KWkA

- "Performance" tests
  - 128 hoppers pushing 27 * 64 dirt from one chest to another:
    https://timings.pmmp.io/?id=158627
    ![Screenshot (543)](https://user-images.githubusercontent.com/54852588/131256515-3611c594-08e1-45a1-8bd2-3ebbaf141c8a.png)

    