### PR TITLE
Farmland changes to dirt when jumped on.

### DIFF
--- a/src/block/Block.php
+++ b/src/block/Block.php
@@ -236,8 +236,7 @@ class Block{
 	/**
 	 * Called when an Entity falls on this block.
 	 */
-	public function onEntityFall(Entity $entity, float $fallDistance, Vector3 $fallPos): void
-	{
+	public function onEntityFall(Entity $entity, float $fallDistance, float $jumpVelocity): void{
 
 	}
 

--- a/src/block/Block.php
+++ b/src/block/Block.php
@@ -234,6 +234,14 @@ class Block{
 	}
 
 	/**
+	 * Called when an Entity falls on this block.
+	 */
+	public function onEntityFall(Entity $entity, float $fallDistance, Vector3 $fallPos): void
+	{
+
+	}
+
+	/**
 	 * Returns whether random block updates will be done on this block.
 	 */
 	public function ticksRandomly() : bool{

--- a/src/block/Block.php
+++ b/src/block/Block.php
@@ -236,7 +236,7 @@ class Block{
 	/**
 	 * Called when an Entity falls on this block.
 	 */
-	public function onEntityFall(Entity $entity, float $fallDistance, float $jumpVelocity): void{
+	public function onEntityFall(Entity $entity, float $fallDistance): void{
 
 	}
 

--- a/src/block/Crops.php
+++ b/src/block/Crops.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\block\utils\BlockDataSerializer;
-use pocketmine\entity\Entity;
 use pocketmine\event\block\BlockGrowEvent;
 use pocketmine\item\Fertilizer;
 use pocketmine\item\Item;

--- a/src/block/Crops.php
+++ b/src/block/Crops.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\block\utils\BlockDataSerializer;
+use pocketmine\entity\Entity;
 use pocketmine\event\block\BlockGrowEvent;
 use pocketmine\item\Fertilizer;
 use pocketmine\item\Item;
@@ -109,6 +110,13 @@ abstract class Crops extends Flowable{
 			if(!$ev->isCancelled()){
 				$this->position->getWorld()->setBlock($this->position, $ev->getNewState());
 			}
+		}
+	}
+
+	public function onEntityFall(Entity $entity, float $fallDistance, Vector3 $fallPos) : void{
+		$blockBelow = $this->getSide(Facing::DOWN);
+		if($blockBelow->getId() === BlockLegacyIds::FARMLAND){
+			$blockBelow->onEntityFall($entity, $fallDistance, $fallPos);
 		}
 	}
 }

--- a/src/block/Crops.php
+++ b/src/block/Crops.php
@@ -112,11 +112,4 @@ abstract class Crops extends Flowable{
 			}
 		}
 	}
-
-	public function onEntityFall(Entity $entity, float $fallDistance, Vector3 $fallPos) : void{
-		$blockBelow = $this->getSide(Facing::DOWN);
-		if($blockBelow->getId() === BlockLegacyIds::FARMLAND){
-			$blockBelow->onEntityFall($entity, $fallDistance, $fallPos);
-		}
-	}
 }

--- a/src/block/Farmland.php
+++ b/src/block/Farmland.php
@@ -24,9 +24,11 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\block\utils\BlockDataSerializer;
+use pocketmine\entity\Entity;
 use pocketmine\item\Item;
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Facing;
+use pocketmine\math\Vector3;
 
 class Farmland extends Transparent{
 
@@ -111,5 +113,11 @@ class Farmland extends Transparent{
 
 	public function getPickedItem(bool $addUserData = false) : Item{
 		return VanillaBlocks::DIRT()->asItem();
+	}
+
+	public function onEntityFall(Entity $entity, float $fallDistance, Vector3 $fallPos) : void{
+		if($fallDistance > 0.99) {
+			$this->getPosition()->getWorld()->setBlock($this->getPosition(), BlockFactory::getInstance()->get(BlockLegacyIds::DIRT, 0));
+		}
 	}
 }

--- a/src/block/Farmland.php
+++ b/src/block/Farmland.php
@@ -115,8 +115,8 @@ class Farmland extends Transparent{
 		return VanillaBlocks::DIRT()->asItem();
 	}
 
-	public function onEntityFall(Entity $entity, float $fallDistance, Vector3 $fallPos) : void{
-		if($fallDistance > 0.5) {
+	public function onEntityFall(Entity $entity, float $fallDistance, float $jumpVelocity) : void{
+		if($fallDistance > 0.5){
 			$this->getPosition()->getWorld()->setBlock($this->getPosition(), VanillaBlocks::DIRT());
 		}
 	}

--- a/src/block/Farmland.php
+++ b/src/block/Farmland.php
@@ -28,7 +28,6 @@ use pocketmine\entity\Entity;
 use pocketmine\item\Item;
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Facing;
-use pocketmine\math\Vector3;
 
 class Farmland extends Transparent{
 
@@ -115,7 +114,7 @@ class Farmland extends Transparent{
 		return VanillaBlocks::DIRT()->asItem();
 	}
 
-	public function onEntityFall(Entity $entity, float $fallDistance, float $jumpVelocity) : void{
+	public function onEntityFall(Entity $entity, float $fallDistance) : void{
 		if($fallDistance > 0.5){
 			$this->getPosition()->getWorld()->setBlock($this->getPosition(), VanillaBlocks::DIRT());
 		}

--- a/src/block/Farmland.php
+++ b/src/block/Farmland.php
@@ -116,8 +116,8 @@ class Farmland extends Transparent{
 	}
 
 	public function onEntityFall(Entity $entity, float $fallDistance, Vector3 $fallPos) : void{
-		if($fallDistance > 0.99) {
-			$this->getPosition()->getWorld()->setBlock($this->getPosition(), BlockFactory::getInstance()->get(BlockLegacyIds::DIRT, 0));
+		if($fallDistance > 0.5) {
+			$this->getPosition()->getWorld()->setBlock($this->getPosition(), VanillaBlocks::DIRT());
 		}
 	}
 }

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -327,7 +327,7 @@ abstract class Living extends Entity{
 				$this->broadcastSound(new EntityLandSound($this, $fallBlock));
 			}
 		}
-		if($fallBlock->getId() === BlockLegacyIds::FARMLAND) {
+		if($fallDistance > 0.99 && $fallBlock->getId() === BlockLegacyIds::FARMLAND) {
 			$this->getWorld()->setBlock($fallBlockPos, BlockFactory::getInstance()->get(BlockLegacyIds::DIRT, 0));
 		}
 	}

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -310,6 +310,11 @@ abstract class Living extends Entity{
 		$damage = ceil($fallDistance - 3 - (($jumpBoost = $this->effectManager->get(VanillaEffects::JUMP_BOOST())) !== null ? $jumpBoost->getEffectLevel() : 0));
 		$fallBlockPos = $this->location->floor();
 		$fallBlock = $this->getWorld()->getBlock($fallBlockPos);
+		if($fallBlock->getId() === BlockLegacyIds::AIR){
+			$fallBlockPos = $fallBlockPos->subtract(0, 1, 0);
+			$fallBlock = $this->getWorld()->getBlock($fallBlockPos);
+		}
+
 		if($damage > 0){
 			$ev = new EntityDamageEvent($this, EntityDamageEvent::CAUSE_FALL, $damage);
 			$this->attack($ev);
@@ -319,17 +324,12 @@ abstract class Living extends Entity{
 				new EntityShortFallSound($this)
 			);
 		}else{
-			if($fallBlock->getId() === BlockLegacyIds::AIR){
-				$fallBlockPos = $fallBlockPos->subtract(0, 1, 0);
-				$fallBlock = $this->getWorld()->getBlock($fallBlockPos);
-			}
 			if($fallBlock->getId() !== BlockLegacyIds::AIR){
 				$this->broadcastSound(new EntityLandSound($this, $fallBlock));
 			}
 		}
-		if($fallDistance > 0.99 && $fallBlock->getId() === BlockLegacyIds::FARMLAND) {
-			$this->getWorld()->setBlock($fallBlockPos, BlockFactory::getInstance()->get(BlockLegacyIds::DIRT, 0));
-		}
+
+		$fallBlock->onEntityFall($this, $fallDistance, $fallBlockPos);
 	}
 
 	/**

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -333,7 +333,7 @@ abstract class Living extends Entity{
 			$fallBlockPos = $fallBlockPos->subtract(0, 1, 0);
 			$fallBlock = $this->getWorld()->getBlock($fallBlockPos);
 		}
-		$fallBlock->onEntityFall($this, $fallDistance, $this->getJumpVelocity());
+		$fallBlock->onEntityFall($this, $fallDistance);
 	}
 
 	/**

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -24,8 +24,8 @@ declare(strict_types=1);
 namespace pocketmine\entity;
 
 use pocketmine\block\Block;
-use pocketmine\block\BlockFactory;
 use pocketmine\block\BlockLegacyIds;
+use pocketmine\block\Flowable;
 use pocketmine\data\bedrock\EffectIdMap;
 use pocketmine\entity\animation\DeathAnimation;
 use pocketmine\entity\animation\HurtAnimation;
@@ -329,7 +329,11 @@ abstract class Living extends Entity{
 			}
 		}
 
-		$fallBlock->onEntityFall($this, $fallDistance, $fallBlockPos);
+		if ($fallBlock instanceof Flowable ){
+			$fallBlockPos = $fallBlockPos->subtract(0, 1, 0);
+			$fallBlock = $this->getWorld()->getBlock($fallBlockPos);
+		}
+		$fallBlock->onEntityFall($this, $fallDistance, $this->getJumpVelocity());
 	}
 
 	/**

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace pocketmine\entity;
 
 use pocketmine\block\Block;
+use pocketmine\block\BlockFactory;
 use pocketmine\block\BlockLegacyIds;
 use pocketmine\data\bedrock\EffectIdMap;
 use pocketmine\entity\animation\DeathAnimation;
@@ -307,6 +308,8 @@ abstract class Living extends Entity{
 
 	public function fall(float $fallDistance) : void{
 		$damage = ceil($fallDistance - 3 - (($jumpBoost = $this->effectManager->get(VanillaEffects::JUMP_BOOST())) !== null ? $jumpBoost->getEffectLevel() : 0));
+		$fallBlockPos = $this->location->floor();
+		$fallBlock = $this->getWorld()->getBlock($fallBlockPos);
 		if($damage > 0){
 			$ev = new EntityDamageEvent($this, EntityDamageEvent::CAUSE_FALL, $damage);
 			$this->attack($ev);
@@ -316,8 +319,6 @@ abstract class Living extends Entity{
 				new EntityShortFallSound($this)
 			);
 		}else{
-			$fallBlockPos = $this->location->floor();
-			$fallBlock = $this->getWorld()->getBlock($fallBlockPos);
 			if($fallBlock->getId() === BlockLegacyIds::AIR){
 				$fallBlockPos = $fallBlockPos->subtract(0, 1, 0);
 				$fallBlock = $this->getWorld()->getBlock($fallBlockPos);
@@ -325,6 +326,9 @@ abstract class Living extends Entity{
 			if($fallBlock->getId() !== BlockLegacyIds::AIR){
 				$this->broadcastSound(new EntityLandSound($this, $fallBlock));
 			}
+		}
+		if($fallBlock->getId() === BlockLegacyIds::FARMLAND) {
+			$this->getWorld()->setBlock($fallBlockPos, BlockFactory::getInstance()->get(BlockLegacyIds::DIRT, 0));
 		}
 	}
 


### PR DESCRIPTION
## Introduction
In vanilla Minecraft, if an entity jumps on farmland, that farmland gets 'trampled' and turns to dirt. This pull request adds this functionality to PocketMine.

### Relevant issues
https://github.com/pmmp/PocketMine-MP/projects/14#card-16053523


## Changes
none

### Behavioural changes
Server replaces the farmland with dirt when 'trampled'.

## Backwards compatibility
none

## Follow-up
none

Requires translations: none

## Tests

Placed farmland block and fell on it from different heights (including jumping), all cases the farmland changed to dirt. Walked across farmland and fell from less than 1 block, all cases the farmland did not change to dirt.

No plugin were installed.