### PR TITLE
Farmland turns to dirt when jumped on.

### DIFF
--- a/src/block/Farmland.php
+++ b/src/block/Farmland.php
@@ -30,6 +30,7 @@ use pocketmine\event\entity\EntityTrampleFarmlandEvent;
 use pocketmine\item\Item;
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Facing;
+use function lcg_value;
 
 class Farmland extends Transparent{
 
@@ -89,9 +90,9 @@ class Farmland extends Transparent{
 		}
 	}
 
-	public function onEntityLand(Entity $entity): ?float{
+	public function onEntityLand(Entity $entity) : ?float{
 		if($entity instanceof Living && lcg_value() < $entity->getFallDistance() - 0.5){
-			$ev = new EntityTrampleFarmlandEvent($entity, $this->getPosition()->getWorld()->getBlock($entity->getPosition()->down()));
+			$ev = new EntityTrampleFarmlandEvent($entity, $this);
 			$ev->call();
 			if(!$ev->isCancelled()){
 				$this->getPosition()->getWorld()->setBlock($this->getPosition(), VanillaBlocks::DIRT());

--- a/src/block/Farmland.php
+++ b/src/block/Farmland.php
@@ -24,6 +24,8 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\block\utils\BlockDataSerializer;
+use pocketmine\entity\Entity;
+use pocketmine\entity\Living;
 use pocketmine\item\Item;
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Facing;
@@ -84,6 +86,14 @@ class Farmland extends Transparent{
 			$this->wetness = 7;
 			$this->position->getWorld()->setBlock($this->position, $this, false);
 		}
+	}
+
+	public function onEntityLand(Entity $entity): ?float
+	{
+		if($entity instanceof Living && lcg_value() < $entity->getFallDistance()) {
+			$this->getPosition()->getWorld()->setBlock($this->getPosition(), VanillaBlocks::DIRT(), true);
+		}
+		return null;
 	}
 
 	protected function canHydrate() : bool{

--- a/src/block/Farmland.php
+++ b/src/block/Farmland.php
@@ -90,7 +90,7 @@ class Farmland extends Transparent{
 	}
 
 	public function onEntityLand(Entity $entity): ?float{
-		if($entity instanceof Living && lcg_value() < $entity->getFallDistance()){
+		if($entity instanceof Living && lcg_value() < $entity->getFallDistance() - 0.5){
 			$ev = new EntityTrampleFarmlandEvent($entity, $this->getPosition()->getWorld()->getBlock($entity->getPosition()->down()));
 			$ev->call();
 			if(!$ev->isCancelled()){

--- a/src/block/Farmland.php
+++ b/src/block/Farmland.php
@@ -26,6 +26,7 @@ namespace pocketmine\block;
 use pocketmine\block\utils\BlockDataSerializer;
 use pocketmine\entity\Entity;
 use pocketmine\entity\Living;
+use pocketmine\event\entity\EntityTrampleFarmlandEvent;
 use pocketmine\item\Item;
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Facing;
@@ -88,10 +89,13 @@ class Farmland extends Transparent{
 		}
 	}
 
-	public function onEntityLand(Entity $entity): ?float
-	{
-		if($entity instanceof Living && lcg_value() < $entity->getFallDistance()) {
-			$this->getPosition()->getWorld()->setBlock($this->getPosition(), VanillaBlocks::DIRT(), true);
+	public function onEntityLand(Entity $entity): ?float{
+		if($entity instanceof Living && lcg_value() < $entity->getFallDistance()){
+			$ev = new EntityTrampleFarmlandEvent($entity, $this->getPosition()->getWorld()->getBlock($entity->getPosition()->down()));
+			$ev->call();
+			if(!$ev->isCancelled()){
+				$this->getPosition()->getWorld()->setBlock($this->getPosition(), VanillaBlocks::DIRT());
+			}
 		}
 		return null;
 	}

--- a/src/event/entity/EntityTrampleFarmlandEvent.php
+++ b/src/event/entity/EntityTrampleFarmlandEvent.php
@@ -25,16 +25,20 @@ namespace pocketmine\event\entity;
 
 use pocketmine\block\Block;
 use pocketmine\entity\Entity;
+use pocketmine\entity\Living;
 use pocketmine\event\Cancellable;
 use pocketmine\event\CancellableTrait;
 
+/**
+ * @phpstan-extends EntityEvent<Living>
+ */
 class EntityTrampleFarmlandEvent extends EntityEvent implements Cancellable{
 	use CancellableTrait;
 
 	/** @var Block */
 	private $block;
 
-	public function __construct(Entity $entity, Block $block){
+	public function __construct(Living $entity, Block $block){
 		$this->entity = $entity;
 		$this->block = $block;
 	}
@@ -42,5 +46,4 @@ class EntityTrampleFarmlandEvent extends EntityEvent implements Cancellable{
 	public function getBlock() : Block{
 		return $this->block;
 	}
-
 }

--- a/src/event/entity/EntityTrampleFarmlandEvent.php
+++ b/src/event/entity/EntityTrampleFarmlandEvent.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace pocketmine\event\entity;
 
 use pocketmine\block\Block;
-use pocketmine\entity\Entity;
 use pocketmine\entity\Living;
 use pocketmine\event\Cancellable;
 use pocketmine\event\CancellableTrait;

--- a/src/event/entity/EntityTrampleFarmlandEvent.php
+++ b/src/event/entity/EntityTrampleFarmlandEvent.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\event\entity;
+
+use pocketmine\block\Block;
+use pocketmine\entity\Entity;
+use pocketmine\event\Cancellable;
+use pocketmine\event\CancellableTrait;
+
+class EntityTrampleFarmlandEvent extends EntityEvent implements Cancellable{
+	use CancellableTrait;
+
+	/** @var Block */
+	private $block;
+
+	public function __construct(Entity $entity, Block $block){
+		$this->entity = $entity;
+		$this->block = $block;
+	}
+
+	public function getBlock() : Block{
+		return $this->block;
+	}
+
+}


### PR DESCRIPTION
## Introduction
In vanilla Minecraft, if an entity jumps on farmland, that farmland gets 'trampled' and turns to dirt. This pull request adds this functionality to PocketMine.

### Relevant issues
https://github.com/pmmp/PocketMine-MP/projects/14#card-16053523


## Changes
none

### Behavioural changes
Server replaces the farmland with dirt when 'trampled'.

## Backwards compatibility
none

## Follow-up
none

Requires translations: none

## Tests

Placed farmland block and fell on it from different heights (including jumping), all cases the farmland changed to dirt. Walked across farmland and fell from less than 1 block, all cases the farmland did not change to dirt.

No plugin were installed.