### PR TITLE
Include eye height in Living->lookAt() calculation

### DIFF
--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -772,7 +772,7 @@ abstract class Living extends Entity{
 	 */
 	public function lookAt(Vector3 $target) : void{
 		$horizontal = sqrt(($target->x - $this->location->x) ** 2 + ($target->z - $this->location->z) ** 2);
-		$vertical = $target->y - $this->location->y;
+		$vertical = $target->y - ($this->location->y + $this->getEyeHeight());
 		$this->location->pitch = -atan2($vertical, $horizontal) / M_PI * 180; //negative is up, positive is down
 
 		$xDist = $target->x - $this->location->x;


### PR DESCRIPTION
## Introduction
An entity would turn its head to look at a position, therefore we should calculate the new direction based on eye position, not from feet position.

This change is only logical to prevent copy pasting the same boilerplate code on mob AI plugins just to change one line because it doesn't consider eye position. In addition to this, every entity has an eye position already even if none is provided, PM calculates a default one https://github.com/pmmp/PocketMine-MP/blob/7c943880b24d939514f48b91a3fac91fd103e628/src/entity/EntitySizeInfo.php#L39)

## Changes
### Behavioural changes
`Location->lookAt()` now takes the entity's eye position into account.