### PR TITLE
Added the consts that were removed, which wasn't in the previous README for PM4

### DIFF
--- a/changelogs/4.0.md
+++ b/changelogs/4.0.md
@@ -897,6 +897,9 @@ However, if we add `src-namespace-prefix: pmmp\TesterPlugin` to the `plugin.yml`
 - `PluginManager->registerEvent()` now has a simpler signature: `registerEvent(string $event, \Closure $handler, int $priority, Plugin $plugin, bool $handleCancelled = false)`. The provided closure must accept the specified event class as its only parameter. See [Event API changes](#event) for more details.
 - The following classes have been removed:
   - `PluginLogger`
+- The following constants have been removed:
+  - `PluginLoadOrder::STARTUP` - use `PluginEnableOrder::STARTUP()` 
+  - `PluginLoadOrder::POSTWORLD` - use `PluginEnableOrder::POSTWORLD()`
 - The following interface requirements have been removed:
   - `Plugin->onEnable()`: this is now internalized inside `PluginBase`
   - `Plugin->onDisable()`: same as above


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Added the consts that were removed, which wasn't in the previous README for PM4:
PluginLoadOrder::STARTUP - PluginEnableOrder::STARTUP()
PluginLoadOrder::POSTWORLD - PluginEnableOrder::POSTWORLD()

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
NONE

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
NONE

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
No

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
NONE

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
NONE
