### PR TITLE
Anvil Damage Implementation

### DIFF
--- a/src/block/Anvil.php
+++ b/src/block/Anvil.php
@@ -38,6 +38,7 @@ use pocketmine\math\Facing;
 use pocketmine\math\Vector3;
 use pocketmine\player\Player;
 use pocketmine\world\BlockTransaction;
+use function min;
 
 class Anvil extends Transparent implements Fallable{
 	use FallableTrait;

--- a/src/block/Anvil.php
+++ b/src/block/Anvil.php
@@ -29,6 +29,9 @@ use pocketmine\block\utils\BlockDataSerializer;
 use pocketmine\block\utils\Fallable;
 use pocketmine\block\utils\FallableTrait;
 use pocketmine\block\utils\HorizontalFacingTrait;
+use pocketmine\entity\Living;
+use pocketmine\event\entity\EntityDamageByBlockEvent;
+use pocketmine\event\entity\EntityDamageEvent;
 use pocketmine\item\Item;
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Facing;
@@ -94,5 +97,14 @@ class Anvil extends Transparent implements Fallable{
 
 	public function tickFalling() : ?Block{
 		return null;
+	}
+
+	public function onHitGround(int $fallDistance, int $fallTime, AxisAlignedBB $boundsOnDespawn) : void{
+		foreach($this->position->getWorld()->getCollidingEntities($boundsOnDespawn) as $ent){
+			if($ent instanceof Living){
+				$damageSource = new EntityDamageByBlockEvent($this, $ent, EntityDamageEvent::CAUSE_FALLING_BLOCK, min($fallDistance * 2, 40));
+				$ent->attack($damageSource);
+			}
+		}
 	}
 }

--- a/src/block/Anvil.php
+++ b/src/block/Anvil.php
@@ -102,11 +102,22 @@ class Anvil extends Transparent implements Fallable{
 	}
 
 	public function onHitGround(FallingBlock $blockEntity) : void{
-		foreach($this->position->getWorld()->getCollidingEntities($blockEntity->getBoundingBox()) as $ent){
-			if($ent instanceof Living){
-				if($blockEntity->fallDistance > 1) {
-					$damageSource = new EntityDamageByEntityEvent($blockEntity, $ent, EntityDamageEvent::CAUSE_FALLING_BLOCK, min($blockEntity->fallDistance * 2, 40));
-					$ent->attack($damageSource);
+		if($this->position->isValid()){
+			foreach($this->position->getWorld()->getCollidingEntities($blockEntity->getBoundingBox()) as $ent){
+				if($ent instanceof Living){
+					if($blockEntity->fallDistance > 1){
+						//If player has helmet do 1/4 the normal damage
+						$helmet = $ent->getArmorInventory()->getHelmet();
+						if($helmet !== null && !$helmet->isNull()){
+							$damageDone = $blockEntity->fallDistance * 0.5;
+							$ent->damageItem($helmet, (int) $damageDone);
+						}else{
+							$damageDone = $blockEntity->fallDistance * 2;
+						}
+
+						$damageSource = new EntityDamageByEntityEvent($blockEntity, $ent, EntityDamageEvent::CAUSE_FALLING_BLOCK, min($damageDone, 40));
+						$ent->attack($damageSource);
+					}
 				}
 			}
 		}

--- a/src/block/Anvil.php
+++ b/src/block/Anvil.php
@@ -104,8 +104,10 @@ class Anvil extends Transparent implements Fallable{
 	public function onHitGround(FallingBlock $blockEntity) : void{
 		foreach($this->position->getWorld()->getCollidingEntities($blockEntity->getBoundingBox()) as $ent){
 			if($ent instanceof Living){
-				$damageSource = new EntityDamageByEntityEvent($blockEntity, $ent, EntityDamageEvent::CAUSE_FALLING_BLOCK, min($blockEntity->fallDistance * 2, 40));
-				$ent->attack($damageSource);
+				if($blockEntity->fallDistance > 1) {
+					$damageSource = new EntityDamageByEntityEvent($blockEntity, $ent, EntityDamageEvent::CAUSE_FALLING_BLOCK, min($blockEntity->fallDistance * 2, 40));
+					$ent->attack($damageSource);
+				}
 			}
 		}
 	}

--- a/src/block/Anvil.php
+++ b/src/block/Anvil.php
@@ -30,7 +30,8 @@ use pocketmine\block\utils\Fallable;
 use pocketmine\block\utils\FallableTrait;
 use pocketmine\block\utils\HorizontalFacingTrait;
 use pocketmine\entity\Living;
-use pocketmine\event\entity\EntityDamageByBlockEvent;
+use pocketmine\entity\object\FallingBlock;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
 use pocketmine\event\entity\EntityDamageEvent;
 use pocketmine\item\Item;
 use pocketmine\math\AxisAlignedBB;
@@ -100,10 +101,10 @@ class Anvil extends Transparent implements Fallable{
 		return null;
 	}
 
-	public function onHitGround(int $fallDistance, int $fallTime, AxisAlignedBB $boundsOnDespawn) : void{
-		foreach($this->position->getWorld()->getCollidingEntities($boundsOnDespawn) as $ent){
+	public function onHitGround(FallingBlock $blockEntity) : void{
+		foreach($this->position->getWorld()->getCollidingEntities($blockEntity->getBoundingBox()) as $ent){
 			if($ent instanceof Living){
-				$damageSource = new EntityDamageByBlockEvent($this, $ent, EntityDamageEvent::CAUSE_FALLING_BLOCK, min($fallDistance * 2, 40));
+				$damageSource = new EntityDamageByEntityEvent($blockEntity, $ent, EntityDamageEvent::CAUSE_FALLING_BLOCK, min($blockEntity->fallDistance * 2, 40));
 				$ent->attack($damageSource);
 			}
 		}

--- a/src/block/Anvil.php
+++ b/src/block/Anvil.php
@@ -33,6 +33,7 @@ use pocketmine\entity\Living;
 use pocketmine\entity\object\FallingBlock;
 use pocketmine\event\entity\EntityDamageByEntityEvent;
 use pocketmine\event\entity\EntityDamageEvent;
+use pocketmine\event\Durable;
 use pocketmine\item\Item;
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Facing;
@@ -108,7 +109,7 @@ class Anvil extends Transparent implements Fallable{
 					if($blockEntity->fallDistance > 1){
 						//If player has helmet do 1/4 the normal damage
 						$helmet = $ent->getArmorInventory()->getHelmet();
-						if($helmet !== null && !$helmet->isNull()){
+						if($helmet != null && !$helmet->isNull() && $helmet instanceof Durable){
 							$damageDone = $blockEntity->fallDistance * 0.5;
 							$ent->damageItem($helmet, (int) $damageDone);
 						}else{

--- a/src/block/Anvil.php
+++ b/src/block/Anvil.php
@@ -109,15 +109,19 @@ class Anvil extends Transparent implements Fallable{
 					if($blockEntity->fallDistance > 1){
 						//If player has helmet do 1/4 the normal damage
 						$helmet = $ent->getArmorInventory()->getHelmet();
+
 						if(!$helmet->isNull() && $helmet instanceof Durable){
-							$damageDone = $blockEntity->fallDistance * 0.5;
-							$ent->damageItem($helmet, (int) $damageDone);
+							$damageDone = $blockEntity->fallDistance * 1.5;
 						}else{
 							$damageDone = $blockEntity->fallDistance * 2;
 						}
 
 						$damageSource = new EntityDamageByEntityEvent($blockEntity, $ent, EntityDamageEvent::CAUSE_FALLING_BLOCK, min($damageDone, 40));
 						$ent->attack($damageSource);
+
+						if(!$damageSource->isCancelled() && !$helmet->isNull() && $helmet instanceof Durable) {
+							$ent->damageItem($helmet, (int) $damageDone);
+						}
 					}
 				}
 			}

--- a/src/block/Anvil.php
+++ b/src/block/Anvil.php
@@ -33,7 +33,7 @@ use pocketmine\entity\Living;
 use pocketmine\entity\object\FallingBlock;
 use pocketmine\event\entity\EntityDamageByEntityEvent;
 use pocketmine\event\entity\EntityDamageEvent;
-use pocketmine\event\Durable;
+use pocketmine\item\Durable;
 use pocketmine\item\Item;
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Facing;
@@ -109,7 +109,7 @@ class Anvil extends Transparent implements Fallable{
 					if($blockEntity->fallDistance > 1){
 						//If player has helmet do 1/4 the normal damage
 						$helmet = $ent->getArmorInventory()->getHelmet();
-						if($helmet != null && !$helmet->isNull() && $helmet instanceof Durable){
+						if(!$helmet->isNull() && $helmet instanceof Durable){
 							$damageDone = $blockEntity->fallDistance * 0.5;
 							$ent->damageItem($helmet, (int) $damageDone);
 						}else{

--- a/src/block/Anvil.php
+++ b/src/block/Anvil.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use InvalidArgumentException;
 use pocketmine\block\inventory\AnvilInventory;
 use pocketmine\block\utils\BlockDataSerializer;
 use pocketmine\block\utils\Fallable;
@@ -63,7 +64,7 @@ class Anvil extends Transparent implements Fallable{
 	/** @return $this */
 	public function setDamage(int $damage) : self{
 		if($damage < 0 || $damage > 2){
-			throw new \InvalidArgumentException("Damage must be in range 0-2");
+			throw new InvalidArgumentException("Damage must be in range 0-2");
 		}
 		$this->damage = $damage;
 		return $this;

--- a/src/block/ConcretePowder.php
+++ b/src/block/ConcretePowder.php
@@ -27,7 +27,7 @@ use pocketmine\block\utils\ColorInMetadataTrait;
 use pocketmine\block\utils\DyeColor;
 use pocketmine\block\utils\Fallable;
 use pocketmine\block\utils\FallableTrait;
-use pocketmine\math\AxisAlignedBB;
+use pocketmine\entity\object\FallingBlock;
 use pocketmine\math\Facing;
 
 class ConcretePowder extends Opaque implements Fallable{
@@ -66,5 +66,5 @@ class ConcretePowder extends Opaque implements Fallable{
 		return null;
 	}
 
-	public function onHitGround(int $fallDistance, int $fallTime, AxisAlignedBB $boundsOnDespawn) : void{}
+	public function onHitGround(FallingBlock $blockEntity) : void{}
 }

--- a/src/block/ConcretePowder.php
+++ b/src/block/ConcretePowder.php
@@ -27,6 +27,7 @@ use pocketmine\block\utils\ColorInMetadataTrait;
 use pocketmine\block\utils\DyeColor;
 use pocketmine\block\utils\Fallable;
 use pocketmine\block\utils\FallableTrait;
+use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Facing;
 
 class ConcretePowder extends Opaque implements Fallable{
@@ -64,4 +65,6 @@ class ConcretePowder extends Opaque implements Fallable{
 
 		return null;
 	}
+
+	public function onHitGround(int $fallDistance, int $fallTime, AxisAlignedBB $boundsOnDespawn) : void{}
 }

--- a/src/block/DragonEgg.php
+++ b/src/block/DragonEgg.php
@@ -25,9 +25,9 @@ namespace pocketmine\block;
 
 use pocketmine\block\utils\Fallable;
 use pocketmine\block\utils\FallableTrait;
+use pocketmine\entity\object\FallingBlock;
 use pocketmine\event\block\BlockTeleportEvent;
 use pocketmine\item\Item;
-use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Vector3;
 use pocketmine\player\GameMode;
 use pocketmine\player\Player;
@@ -84,5 +84,5 @@ class DragonEgg extends Transparent implements Fallable{
 		}
 	}
 
-	public function onHitGround(int $fallDistance, int $fallTime, AxisAlignedBB $boundsOnDespawn) : void{}
+	public function onHitGround(FallingBlock $blockEntity) : void{}
 }

--- a/src/block/DragonEgg.php
+++ b/src/block/DragonEgg.php
@@ -27,6 +27,7 @@ use pocketmine\block\utils\Fallable;
 use pocketmine\block\utils\FallableTrait;
 use pocketmine\event\block\BlockTeleportEvent;
 use pocketmine\item\Item;
+use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Vector3;
 use pocketmine\player\GameMode;
 use pocketmine\player\Player;
@@ -82,4 +83,6 @@ class DragonEgg extends Transparent implements Fallable{
 			}
 		}
 	}
+
+	public function onHitGround(int $fallDistance, int $fallTime, AxisAlignedBB $boundsOnDespawn) : void{}
 }

--- a/src/block/Gravel.php
+++ b/src/block/Gravel.php
@@ -27,6 +27,7 @@ use pocketmine\block\utils\Fallable;
 use pocketmine\block\utils\FallableTrait;
 use pocketmine\item\Item;
 use pocketmine\item\VanillaItems;
+use pocketmine\math\AxisAlignedBB;
 use function mt_rand;
 
 class Gravel extends Opaque implements Fallable{
@@ -49,4 +50,6 @@ class Gravel extends Opaque implements Fallable{
 	public function tickFalling() : ?Block{
 		return null;
 	}
+
+	public function onHitGround(int $fallDistance, int $fallTime, AxisAlignedBB $boundsOnDespawn) : void {}
 }

--- a/src/block/Gravel.php
+++ b/src/block/Gravel.php
@@ -25,9 +25,9 @@ namespace pocketmine\block;
 
 use pocketmine\block\utils\Fallable;
 use pocketmine\block\utils\FallableTrait;
+use pocketmine\entity\object\FallingBlock;
 use pocketmine\item\Item;
 use pocketmine\item\VanillaItems;
-use pocketmine\math\AxisAlignedBB;
 use function mt_rand;
 
 class Gravel extends Opaque implements Fallable{
@@ -51,5 +51,5 @@ class Gravel extends Opaque implements Fallable{
 		return null;
 	}
 
-	public function onHitGround(int $fallDistance, int $fallTime, AxisAlignedBB $boundsOnDespawn) : void {}
+	public function onHitGround(FallingBlock $blockEntity) : void {}
 }

--- a/src/block/Sand.php
+++ b/src/block/Sand.php
@@ -25,7 +25,7 @@ namespace pocketmine\block;
 
 use pocketmine\block\utils\Fallable;
 use pocketmine\block\utils\FallableTrait;
-use pocketmine\math\AxisAlignedBB;
+use pocketmine\entity\object\FallingBlock;
 
 class Sand extends Opaque implements Fallable{
 	use FallableTrait;
@@ -34,5 +34,5 @@ class Sand extends Opaque implements Fallable{
 		return null;
 	}
 
-	public function onHitGround(int $fallDistance, int $fallTime, AxisAlignedBB $boundsOnDespawn) : void{}
+	public function onHitGround(FallingBlock $blockEntity) : void{}
 }

--- a/src/block/Sand.php
+++ b/src/block/Sand.php
@@ -25,6 +25,7 @@ namespace pocketmine\block;
 
 use pocketmine\block\utils\Fallable;
 use pocketmine\block\utils\FallableTrait;
+use pocketmine\math\AxisAlignedBB;
 
 class Sand extends Opaque implements Fallable{
 	use FallableTrait;
@@ -32,4 +33,6 @@ class Sand extends Opaque implements Fallable{
 	public function tickFalling() : ?Block{
 		return null;
 	}
+
+	public function onHitGround(int $fallDistance, int $fallTime, AxisAlignedBB $boundsOnDespawn) : void{}
 }

--- a/src/block/SnowLayer.php
+++ b/src/block/SnowLayer.php
@@ -113,4 +113,6 @@ class SnowLayer extends Flowable implements Fallable{
 			VanillaItems::SNOWBALL()->setCount(max(1, (int) floor($this->layers / 2)))
 		];
 	}
+
+	public function onHitGround(int $fallDistance, int $fallTime, AxisAlignedBB $boundsOnDespawn) : void{}
 }

--- a/src/block/SnowLayer.php
+++ b/src/block/SnowLayer.php
@@ -26,6 +26,7 @@ namespace pocketmine\block;
 use pocketmine\block\utils\BlockDataSerializer;
 use pocketmine\block\utils\Fallable;
 use pocketmine\block\utils\FallableTrait;
+use pocketmine\entity\object\FallingBlock;
 use pocketmine\item\Item;
 use pocketmine\item\VanillaItems;
 use pocketmine\math\AxisAlignedBB;
@@ -114,5 +115,5 @@ class SnowLayer extends Flowable implements Fallable{
 		];
 	}
 
-	public function onHitGround(int $fallDistance, int $fallTime, AxisAlignedBB $boundsOnDespawn) : void{}
+	public function onHitGround(FallingBlock $blockEntity) : void{}
 }

--- a/src/block/utils/Fallable.php
+++ b/src/block/utils/Fallable.php
@@ -37,7 +37,6 @@ interface Fallable{
 
 	/**
 	 * Called just before entity destroys itself.
-	 *
 	 */
 	public function onHitGround(int $fallDistance, int $fallTime, AxisAlignedBB $boundsOnDespawn) : void;
 }

--- a/src/block/utils/Fallable.php
+++ b/src/block/utils/Fallable.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace pocketmine\block\utils;
 
 use pocketmine\block\Block;
-use pocketmine\math\AxisAlignedBB;
+use pocketmine\entity\object\FallingBlock;
 
 interface Fallable{
 
@@ -36,7 +36,7 @@ interface Fallable{
 	public function tickFalling() : ?Block;
 
 	/**
-	 * Called just before entity destroys itself.
+	 * Called just before entity destroys itself and creates a block.
 	 */
-	public function onHitGround(int $fallDistance, int $fallTime, AxisAlignedBB $boundsOnDespawn) : void;
+	public function onHitGround(FallingBlock $blockEntity) : void;
 }

--- a/src/block/utils/Fallable.php
+++ b/src/block/utils/Fallable.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace pocketmine\block\utils;
 
 use pocketmine\block\Block;
+use pocketmine\math\AxisAlignedBB;
 
 interface Fallable{
 
@@ -33,4 +34,10 @@ interface Fallable{
 	 * Return null if you don't want to change the usual behaviour.
 	 */
 	public function tickFalling() : ?Block;
+
+	/**
+	 * Called just before entity destroys itself.
+	 *
+	 */
+	public function onHitGround(int $fallDistance, int $fallTime, AxisAlignedBB $boundsOnDespawn) : void;
 }

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -446,7 +446,7 @@ abstract class Living extends Entity{
 		$this->armorInventory->setContents($armor);
 	}
 
-	private function damageItem(Durable $item, int $durabilityRemoved) : void{
+	public function damageItem(Durable $item, int $durabilityRemoved) : void{
 		$item->applyDamage($durabilityRemoved);
 		if($item->isBroken()){
 			$this->broadcastSound(new ItemBreakSound());

--- a/src/entity/object/FallingBlock.php
+++ b/src/entity/object/FallingBlock.php
@@ -26,13 +26,10 @@ namespace pocketmine\entity\object;
 use pocketmine\block\Block;
 use pocketmine\block\BlockFactory;
 use pocketmine\block\utils\Fallable;
-use pocketmine\block\VanillaBlocks;
 use pocketmine\entity\Entity;
 use pocketmine\entity\EntitySizeInfo;
-use pocketmine\entity\Living;
 use pocketmine\entity\Location;
 use pocketmine\event\entity\EntityBlockChangeEvent;
-use pocketmine\event\entity\EntityDamageByBlockEvent;
 use pocketmine\event\entity\EntityDamageEvent;
 use pocketmine\math\Vector3;
 use pocketmine\nbt\tag\ByteTag;
@@ -44,7 +41,6 @@ use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataCollection;
 use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataProperties;
 use UnexpectedValueException;
 use function abs;
-use function min;
 
 class FallingBlock extends Entity{
 
@@ -162,16 +158,8 @@ class FallingBlock extends Entity{
 	}
 
 	protected function onHitGround() : ?float{
-		if($this->getBlock()->getId() === VanillaBlocks::ANVIL()->getId()) {
-			foreach($this->getWorld()->getCollidingEntities($this->getBoundingBox()) as $ent){
-				if($ent instanceof Living){
-					$lastCause = $ent->lastDamageCause;
-					if(!($lastCause instanceof EntityDamageByBlockEvent) || $lastCause->getDamager() !== $this->getBlock()){
-						$damageSource = new EntityDamageByBlockEvent($this->getBlock(), $ent, EntityDamageEvent::CAUSE_FALLING_BLOCK, min($this->fallTime / 2, 40));
-						$ent->attack($damageSource);
-					}
-				}
-			}
+		if($this->block instanceof Fallable){
+			$this->block->onHitGround((int) $this->fallDistance, $this->fallTime, $this->getBoundingBox());
 		}
 		return parent::onHitGround();
 	}

--- a/src/entity/object/FallingBlock.php
+++ b/src/entity/object/FallingBlock.php
@@ -51,7 +51,7 @@ class FallingBlock extends Entity{
 
 	protected $gravity = 0.04;
 	protected $drag = 0.02;
-	
+
 	/** @var int */
 	private $fallTime = 0;
 

--- a/src/entity/object/FallingBlock.php
+++ b/src/entity/object/FallingBlock.php
@@ -51,7 +51,8 @@ class FallingBlock extends Entity{
 
 	protected $gravity = 0.04;
 	protected $drag = 0.02;
-	private int $fallTime = 0;
+	/** @var int */
+	private $fallTime = 0;
 
 	/** @var Block */
 	protected $block;

--- a/src/entity/object/FallingBlock.php
+++ b/src/entity/object/FallingBlock.php
@@ -101,7 +101,7 @@ class FallingBlock extends Entity{
 		if($this->closed){
 			return false;
 		}
-		$this->fallTime+=1;
+		$this->fallTime++;
 
 		$hasUpdate = parent::entityBaseTick($tickDiff);
 
@@ -110,14 +110,14 @@ class FallingBlock extends Entity{
 			$pos = $this->location->add(-$this->size->getWidth() / 2, $this->size->getHeight(), -$this->size->getWidth() / 2)->floor();
 
 
-			if($this->getBlock()->getId() == VanillaBlocks::ANVIL()->GetId()) {
+			if($this->getBlock()->getId() === VanillaBlocks::ANVIL()->getId()) {
 
 				$collidedEntities = $world->getCollidingEntities($this->getBoundingBox());
 				foreach($collidedEntities as $ent)
 					if($ent instanceof Living) {
 						$lastCause = $ent->lastDamageCause;
 						if(!($lastCause instanceof EntityDamageByBlockEvent) || $lastCause->getDamager() !== $this->getBlock()) {
-							$ev = new EntityDamageByBlockEvent($this->getBlock(), $ent, EntityDamageEvent::CAUSE_FALLING_ANVIL, min($this->fallTime, 40));
+							$ev = new EntityDamageByBlockEvent($this->getBlock(), $ent, EntityDamageEvent::CAUSE_FALLING_BLOCK, min($this->fallTime, 40));
 							$ent->attack($ev);
 						}
 					}
@@ -173,5 +173,4 @@ class FallingBlock extends Entity{
 	public function getOffsetPosition(Vector3 $vector3) : Vector3{
 		return $vector3->add(0, 0.49, 0); //TODO: check if height affects this
 	}
-
 }

--- a/src/entity/object/FallingBlock.php
+++ b/src/entity/object/FallingBlock.php
@@ -26,11 +26,11 @@ namespace pocketmine\entity\object;
 use pocketmine\block\Block;
 use pocketmine\block\BlockFactory;
 use pocketmine\block\utils\Fallable;
+use pocketmine\block\VanillaBlocks;
 use pocketmine\entity\Entity;
 use pocketmine\entity\EntitySizeInfo;
 use pocketmine\entity\Living;
 use pocketmine\entity\Location;
-use pocketmine\block\VanillaBlocks;
 use pocketmine\event\entity\EntityBlockChangeEvent;
 use pocketmine\event\entity\EntityDamageByBlockEvent;
 use pocketmine\event\entity\EntityDamageEvent;
@@ -43,6 +43,7 @@ use pocketmine\network\mcpe\protocol\types\entity\EntityIds;
 use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataCollection;
 use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataProperties;
 use function abs;
+use function min;
 
 class FallingBlock extends Entity{
 
@@ -109,7 +110,6 @@ class FallingBlock extends Entity{
 			$world = $this->getWorld();
 			$pos = $this->location->add(-$this->size->getWidth() / 2, $this->size->getHeight(), -$this->size->getWidth() / 2)->floor();
 
-
 			if($this->getBlock()->getId() === VanillaBlocks::ANVIL()->getId()) {
 
 				$collidedEntities = $world->getCollidingEntities($this->getBoundingBox());
@@ -122,7 +122,6 @@ class FallingBlock extends Entity{
 						}
 					}
 			}
-
 
 			$this->block->position($world, $pos->x, $pos->y, $pos->z);
 

--- a/src/entity/object/FallingBlock.php
+++ b/src/entity/object/FallingBlock.php
@@ -159,7 +159,7 @@ class FallingBlock extends Entity{
 
 	protected function onHitGround() : ?float{
 		if($this->block instanceof Fallable){
-			$this->block->onHitGround((int) $this->fallDistance, $this->fallTime, $this->getBoundingBox());
+			$this->block->onHitGround($this);
 		}
 		return parent::onHitGround();
 	}

--- a/src/entity/object/FallingBlock.php
+++ b/src/entity/object/FallingBlock.php
@@ -53,10 +53,8 @@ class FallingBlock extends Entity{
 	protected $gravity = 0.04;
 	protected $drag = 0.02;
 
-	/** @var int */
 	private int $fallTime = 0;
 
-	/** @var Block */
 	protected Block $block;
 
 	public $canCollide = false;

--- a/src/entity/object/FallingBlock.php
+++ b/src/entity/object/FallingBlock.php
@@ -51,6 +51,7 @@ class FallingBlock extends Entity{
 
 	protected $gravity = 0.04;
 	protected $drag = 0.02;
+	
 	/** @var int */
 	private $fallTime = 0;
 

--- a/src/entity/object/FallingBlock.php
+++ b/src/entity/object/FallingBlock.php
@@ -50,7 +50,7 @@ class FallingBlock extends Entity{
 
 	protected $gravity = 0.04;
 	protected $drag = 0.02;
-	private $fallTime = 0;
+	private int $fallTime = 0;
 
 	/** @var Block */
 	protected $block;

--- a/src/event/entity/EntityDamageEvent.php
+++ b/src/event/entity/EntityDamageEvent.php
@@ -63,7 +63,7 @@ class EntityDamageEvent extends EntityEvent implements Cancellable{
 	public const CAUSE_MAGIC = 13;
 	public const CAUSE_CUSTOM = 14;
 	public const CAUSE_STARVATION = 15;
-	public const CAUSE_FALLING_ANVIL = 16;
+	public const CAUSE_FALLING_BLOCK = 16;
 
 	/** @var int */
 	private $cause;

--- a/src/event/entity/EntityDamageEvent.php
+++ b/src/event/entity/EntityDamageEvent.php
@@ -63,6 +63,7 @@ class EntityDamageEvent extends EntityEvent implements Cancellable{
 	public const CAUSE_MAGIC = 13;
 	public const CAUSE_CUSTOM = 14;
 	public const CAUSE_STARVATION = 15;
+	public const CAUSE_FALLING_ANVIL = 16;
 
 	/** @var int */
 	private $cause;

--- a/src/event/player/PlayerDeathEvent.php
+++ b/src/event/player/PlayerDeathEvent.php
@@ -129,6 +129,9 @@ class PlayerDeathEvent extends EntityDeathEvent{
 			case EntityDamageEvent::CAUSE_DROWNING:
 				return KnownTranslationFactory::death_attack_drown($name);
 
+			Case EntityDamageEvent::CAUSE_FALLING_ANVIL:
+				return KnownTranslationFactory::death_attack_anvil($name);
+
 			case EntityDamageEvent::CAUSE_CONTACT:
 				if($deathCause instanceof EntityDamageByBlockEvent){
 					if($deathCause->getDamager()->getId() === BlockLegacyIds::CACTUS){

--- a/src/event/player/PlayerDeathEvent.php
+++ b/src/event/player/PlayerDeathEvent.php
@@ -129,7 +129,7 @@ class PlayerDeathEvent extends EntityDeathEvent{
 			case EntityDamageEvent::CAUSE_DROWNING:
 				return KnownTranslationFactory::death_attack_drown($name);
 
-			Case EntityDamageEvent::CAUSE_FALLING_ANVIL:
+			case EntityDamageEvent::CAUSE_FALLING_BLOCK:
 				return KnownTranslationFactory::death_attack_anvil($name);
 
 			case EntityDamageEvent::CAUSE_CONTACT:

--- a/src/lang/KnownTranslationFactory.php
+++ b/src/lang/KnownTranslationFactory.php
@@ -569,11 +569,9 @@ final class KnownTranslationFactory{
 		return new Translatable(KnownTranslationKeys::COMMANDS_WHITELIST_REMOVE_USAGE, []);
 	}
 
-
 	public static function commands_whitelist_usage() : Translatable{
 		return new Translatable(KnownTranslationKeys::COMMANDS_WHITELIST_USAGE, []);
 	}
-
 
 	public static function death_attack_anvil(Translatable|string $param0) : Translatable{
 		return new Translatable(KnownTranslationKeys::DEATH_ATTACK_ANVIL, [

--- a/src/lang/KnownTranslationFactory.php
+++ b/src/lang/KnownTranslationFactory.php
@@ -569,8 +569,16 @@ final class KnownTranslationFactory{
 		return new Translatable(KnownTranslationKeys::COMMANDS_WHITELIST_REMOVE_USAGE, []);
 	}
 
+
 	public static function commands_whitelist_usage() : Translatable{
 		return new Translatable(KnownTranslationKeys::COMMANDS_WHITELIST_USAGE, []);
+	}
+
+
+	public static function death_attack_anvil(Translatable|string $param0) : Translatable{
+		return new Translatable(KnownTranslationKeys::DEATH_ATTACK_ANVIL, [
+			0 => $param0,
+		]);
 	}
 
 	public static function death_attack_arrow(Translatable|string $param0, Translatable|string $param1) : Translatable{

--- a/src/lang/KnownTranslationKeys.php
+++ b/src/lang/KnownTranslationKeys.php
@@ -128,6 +128,7 @@ final class KnownTranslationKeys{
 	public const COMMANDS_WHITELIST_REMOVE_SUCCESS = "commands.whitelist.remove.success";
 	public const COMMANDS_WHITELIST_REMOVE_USAGE = "commands.whitelist.remove.usage";
 	public const COMMANDS_WHITELIST_USAGE = "commands.whitelist.usage";
+	public const DEATH_ATTACK_ANVIL = "death.attack.anvil";
 	public const DEATH_ATTACK_ARROW = "death.attack.arrow";
 	public const DEATH_ATTACK_ARROW_ITEM = "death.attack.arrow.item";
 	public const DEATH_ATTACK_CACTUS = "death.attack.cactus";


### PR DESCRIPTION
## Introduction

When a player or an entity has an anvil drop on them no damage is applied to same entity.

### Relevant issues

[Issues 4437](https://github.com/pmmp/PocketMine-MP/issues/4437)

## Changes
### API changes

No API Changes.

### Behavioural changes

- Anvils now create falling damage at a max of 40HP.  The damage is linked to the tick rate so odd behavior is limited.  
- EntityDamageEvent has been updated to contain "CAUSE_FALLING_ANVIL" 
- PlayerDeathEvent translation factory now has anvil death message.

_Nathan was squashed by an anvil_

## Backwards compatibility

Unlikely to have any issues.

## Follow-up

- Falling Block types could benefit to having an event to handle collisions for plugins.
- Sound when anvil finishes falling.
- Anvil functionality.
- Anvil piston behavior.

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `death.attack.anvil` | `{%a} was squashed by an anvil` |


## Tests

Game Implementation so no PHPUnit test used. I tested it by dropping anvils at various heights on me and all mobs implemented.
