### PR TITLE
Item/elytra

### DIFF
--- a/src/item/Elytra.php
+++ b/src/item/Elytra.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\item;
+
+class Elytra extends Item{
+
+	public function getMaxStackSize() : int{
+		return 1;
+	}
+}

--- a/src/item/ItemFactory.php
+++ b/src/item/ItemFactory.php
@@ -298,7 +298,6 @@ class ItemFactory{
 		//TODO: minecraft:chest_minecart
 		//TODO: minecraft:command_block_minecart
 		//TODO: minecraft:crossbow
-		//TODO: minecraft:elytra
 		//TODO: minecraft:emptyMap
 		//TODO: minecraft:enchanted_book
 		//TODO: minecraft:end_crystal
@@ -391,6 +390,7 @@ class ItemFactory{
 		$this->register(new Armor(new ItemIdentifier(ItemIds::GOLDEN_CHESTPLATE, 0), "Golden Chestplate", new ArmorTypeInfo(5, 113, ArmorInventory::SLOT_CHEST)));
 		$this->register(new Armor(new ItemIdentifier(ItemIds::IRON_CHESTPLATE, 0), "Iron Chestplate", new ArmorTypeInfo(6, 241, ArmorInventory::SLOT_CHEST)));
 		$this->register(new Armor(new ItemIdentifier(ItemIds::LEATHER_CHESTPLATE, 0), "Leather Tunic", new ArmorTypeInfo(3, 81, ArmorInventory::SLOT_CHEST)));
+		$this->register(new Armor(new ItemIdentifier(ItemIds::ELYTRA, 0), "Elytra", new ArmorTypeInfo(0, 432, ArmorInventory::SLOT_CHEST)));
 		$this->register(new Armor(new ItemIdentifier(ItemIds::CHAIN_HELMET, 0), "Chainmail Helmet", new ArmorTypeInfo(2, 166, ArmorInventory::SLOT_HEAD)));
 		$this->register(new Armor(new ItemIdentifier(ItemIds::DIAMOND_HELMET, 0), "Diamond Helmet", new ArmorTypeInfo(3, 364, ArmorInventory::SLOT_HEAD)));
 		$this->register(new Armor(new ItemIdentifier(ItemIds::GOLDEN_HELMET, 0), "Golden Helmet", new ArmorTypeInfo(2, 78, ArmorInventory::SLOT_HEAD)));


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Adds the elytra item

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
Followup PR to #4446

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
- `minecraft:elytra` is registered, thus plugins have to use `$override = true` when registering their own Elytra now.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
- [ ] Add elytra item check before Player gliding action
- [ ] Implement rocket boost
- [ ] Implement in-flight durability reduction
- [ ] Add firework flight boost

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
- Elytra can be put into the armor slot without transaction mismatch
- Right-clicking the item also equips it
- Damage calculation does not crash the server
- [ ] The elytra should not take damage when armor is damaged.