### PR TITLE
Reverse the order of plugin disabling

### DIFF
--- a/src/plugin/PluginManager.php
+++ b/src/plugin/PluginManager.php
@@ -43,6 +43,7 @@ use pocketmine\utils\Utils;
 use Webmozart\PathUtil\Path;
 use function array_intersect;
 use function array_merge;
+use function array_reverse;
 use function class_exists;
 use function count;
 use function dirname;
@@ -407,7 +408,7 @@ class PluginManager{
 	}
 
 	public function disablePlugins() : void{
-		foreach($this->getPlugins() as $plugin){
+		foreach(array_reverse($this->getPlugins()) as $plugin){
 			$this->disablePlugin($plugin);
 		}
 	}


### PR DESCRIPTION
## Introduction
The order in which plugins are loaded is ensured by settings such as `depend`, but the order in which they are disabled is not.
This causes the problem that dependent plugins are disabled first.
By reversing the order in which plugins are disabled, this problem is solved.

### Relevant issues
none

## Changes
### API changes
none

### Behavioural changes
The order in which plugins are disabled when the server is shut down has been reversed.

## Backwards compatibility
none

## Follow-up
none


## Tests
I created two plugins and tested.
```php
/**
 * @name ParentPlugin
 * @main MyPlugin\ParentPlugin
 * @version 1.0.0
 * @api 4.0.0
 */
namespace MyPlugin{
	class ParentPlugin extends \pocketmine\plugin\PluginBase{
	}
}
```
```php
/**
 * @name ChildPlugin
 * @main MyPlugin\ChildPlugin
 * @version 1.0.0
 * @api 4.0.0
 * @depend ParentPlugin
 */
namespace MyPlugin{
	class ChildPlugin extends \pocketmine\plugin\PluginBase{
	}
}
```
server log:
```
2021-09-18 [17:50:12.786] [Server thread/INFO]: This server is running PocketMine-MP version 4.0.0-BETA3+dev
2021-09-18 [17:50:12.786] [Server thread/INFO]: PocketMine-MP is distributed under the LGPL License
2021-09-18 [17:50:17.521] [Server thread/INFO]: Loading resource packs...
2021-09-18 [17:50:18.062] [Server thread/INFO]: Loading DevTools v1.15.0+dev
2021-09-18 [17:50:18.191] [Server thread/INFO]: Loading ParentPlugin v1.0.0
2021-09-18 [17:50:18.192] [Server thread/INFO]: Loading ChildPlugin v1.0.0
2021-09-18 [17:50:18.192] [Server thread/INFO]: Enabling DevTools v1.15.0+dev
2021-09-18 [17:50:18.193] [Server thread/INFO]: [DevTools] Registered folder plugin loader
2021-09-18 [17:50:18.457] [Server thread/INFO]: Preparing world "world"
2021-09-18 [17:50:18.536] [Server thread/INFO]: Enabling ParentPlugin v1.0.0
2021-09-18 [17:50:18.536] [Server thread/INFO]: Enabling ChildPlugin v1.0.0
2021-09-18 [17:50:19.043] [Server thread/INFO]: Minecraft network interface running on 0.0.0.0:19132
2021-09-18 [17:50:19.057] [Server thread/INFO]: Default game type: Creative Mode
2021-09-18 [17:50:19.057] [Server thread/INFO]: If you find this project useful, please consider donating to support development: https://patreon.com/pocketminemp
2021-09-18 [17:50:19.058] [Server thread/INFO]: Done (7.398s)! For help, type "help" or "?"
2021-09-18 [17:50:35.501] [Server thread/INFO]: [CONSOLE: Stopping the server]
2021-09-18 [17:50:35.502] [Server thread/INFO]: Disabling ChildPlugin v1.0.0
2021-09-18 [17:50:35.599] [Server thread/INFO]: Disabling ParentPlugin v1.0.0
2021-09-18 [17:50:35.600] [Server thread/INFO]: Disabling DevTools v1.15.0+dev
2021-09-18 [17:50:35.610] [Server thread/INFO]: Unloading world "world"
2021-09-18 [17:50:36.407] [Server thread/INFO]: Stopping other threads
```