### PR TITLE
Edit PHPDoc for ArmorInventory and EffectManager properties

### DIFF
--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -93,7 +93,7 @@ abstract class Living extends Entity{
 	/** @var EffectManager */
 	protected $effectManager;
 
-	/** @var ArmorInventory */
+	/** @var ?ArmorInventory */
 	protected $armorInventory;
 
 	/** @var bool */

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -90,7 +90,7 @@ abstract class Living extends Entity{
 	/** @var float */
 	protected $jumpVelocity = 0.42;
 
-	/** @var EffectManager */
+	/** @var ?EffectManager */
 	protected $effectManager;
 
 	/** @var ?ArmorInventory */


### PR DESCRIPTION
## Introduction
ArmorInventory and EffectManager can also be null thus the PHPDoc should reflect that

https://github.com/pmmp/PocketMine-MP/blob/master/src/entity/Living.php#L813-L814

## Changes
### API changes
Nope

### Behavioural changes
Nope

## Backwards compatibility
Yes it's BC
