### PR TITLE
Fixed incorrect parameter checking in BlockFactory::get()

### DIFF
--- a/src/block/BlockFactory.php
+++ b/src/block/BlockFactory.php
@@ -952,7 +952,7 @@ class BlockFactory{
 	 * Deserializes a block from the provided legacy ID and legacy meta.
 	 */
 	public function get(int $id, int $meta) : Block{
-		if($meta < 0 or $meta > (1 << Block::INTERNAL_METADATA_BITS)){
+		if($meta < 0 or $meta > Block::INTERNAL_METADATA_MASK){
 			throw new \InvalidArgumentException("Block meta value $meta is out of bounds");
 		}
 

--- a/src/block/BlockFactory.php
+++ b/src/block/BlockFactory.php
@@ -952,7 +952,7 @@ class BlockFactory{
 	 * Deserializes a block from the provided legacy ID and legacy meta.
 	 */
 	public function get(int $id, int $meta) : Block{
-		if($meta < 0 or $meta > Block::INTERNAL_METADATA_MASK){
+		if($meta < 0 or $meta >= (1 << Block::INTERNAL_METADATA_BITS)){
 			throw new \InvalidArgumentException("Block meta value $meta is out of bounds");
 		}
 


### PR DESCRIPTION
## Introduction
Fixed incorrect parameter checking in BlockFactory::get()

https://github.com/pmmp/PocketMine-MP/commit/61c59be299e369878aae00976a970904d7ed8d6b#diff-5ee6ec119d7ba65f7894e25fff09a74933c09607be0e9307011ccbd4cbeffd28R946
<!-- Explain existing problems or why this pull request is necessary -->

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
