### PR TITLE
Add armor slot transaction item validation

### DIFF
--- a/src/inventory/transaction/action/SlotChangeAction.php
+++ b/src/inventory/transaction/action/SlotChangeAction.php
@@ -73,7 +73,7 @@ class SlotChangeAction extends InventoryAction{
 			throw new TransactionValidationException("Slot does not contain expected original item");
 		}
 		if(!$this->sourceItem->isValidSlot($this->inventory, $this->inventorySlot)){
-			throw new TransactionValidationException("Slot {$this->inventorySlot} in inventory of type ".get_class($this->inventory)." does not accept this item");
+			throw new TransactionValidationException("Slot {$this->inventorySlot} in inventory of type " . get_class($this->inventory) . " does not accept this item");
 		}
 	}
 

--- a/src/inventory/transaction/action/SlotChangeAction.php
+++ b/src/inventory/transaction/action/SlotChangeAction.php
@@ -28,6 +28,7 @@ use pocketmine\inventory\transaction\InventoryTransaction;
 use pocketmine\inventory\transaction\TransactionValidationException;
 use pocketmine\item\Item;
 use pocketmine\player\Player;
+use function get_class;
 
 /**
  * Represents an action causing a change in an inventory slot.
@@ -70,6 +71,9 @@ class SlotChangeAction extends InventoryAction{
 		}
 		if(!$this->inventory->getItem($this->inventorySlot)->equalsExact($this->sourceItem)){
 			throw new TransactionValidationException("Slot does not contain expected original item");
+		}
+		if(!$this->sourceItem->isValidSlot($this->inventory, $this->inventorySlot)){
+			throw new TransactionValidationException("Slot {$this->inventorySlot} in inventory of type ".get_class($this->inventory)." does not accept this item");
 		}
 	}
 

--- a/src/item/Armor.php
+++ b/src/item/Armor.php
@@ -153,6 +153,6 @@ class Armor extends Durable{
 	}
 
 	public function isValidSlot(Inventory $inventory, int $slot) : bool{
-		return $inventory instanceof ArmorInventory && $this->getArmorSlot() === $slot;
+		return ($inventory instanceof ArmorInventory && $this->getArmorSlot() === $slot) || parent::isValidSlot($inventory, $slot);
 	}
 }

--- a/src/item/Armor.php
+++ b/src/item/Armor.php
@@ -26,6 +26,7 @@ namespace pocketmine\item;
 use pocketmine\color\Color;
 use pocketmine\event\entity\EntityDamageEvent;
 use pocketmine\inventory\ArmorInventory;
+use pocketmine\inventory\Inventory;
 use pocketmine\item\enchantment\ProtectionEnchantment;
 use pocketmine\item\enchantment\VanillaEnchantments;
 use pocketmine\math\Vector3;
@@ -149,5 +150,9 @@ class Armor extends Durable{
 		$this->customColor !== null ?
 			$tag->setInt(self::TAG_CUSTOM_COLOR, Binary::signInt($this->customColor->toARGB())) :
 			$tag->removeTag(self::TAG_CUSTOM_COLOR);
+	}
+
+	public function isValidSlot(Inventory $inventory, int $slot) : bool{
+		return $inventory instanceof ArmorInventory && $this->getArmorSlot() === $slot;
 	}
 }

--- a/src/item/Item.php
+++ b/src/item/Item.php
@@ -32,6 +32,7 @@ use pocketmine\block\BlockToolType;
 use pocketmine\block\VanillaBlocks;
 use pocketmine\data\bedrock\EnchantmentIdMap;
 use pocketmine\entity\Entity;
+use pocketmine\inventory\Inventory;
 use pocketmine\item\enchantment\EnchantmentInstance;
 use pocketmine\math\Vector3;
 use pocketmine\nbt\LittleEndianNbtSerializer;
@@ -571,6 +572,10 @@ class Item implements \JsonSerializable{
 	 */
 	final public function canStackWith(Item $other) : bool{
 		return $this->equals($other, true, true);
+	}
+
+	public function isValidSlot(Inventory $inventory, int $slot) : bool{
+		return true;
 	}
 
 	/**

--- a/src/item/ItemBlock.php
+++ b/src/item/ItemBlock.php
@@ -25,6 +25,9 @@ namespace pocketmine\item;
 
 use pocketmine\block\Block;
 use pocketmine\block\BlockFactory;
+use pocketmine\block\VanillaBlocks;
+use pocketmine\inventory\ArmorInventory;
+use pocketmine\inventory\Inventory;
 
 /**
  * Class used for Items that can be Blocks
@@ -48,5 +51,15 @@ class ItemBlock extends Item{
 
 	public function getMaxStackSize() : int{
 		return $this->getBlock()->getMaxStackSize();
+	}
+
+	public function isValidSlot(Inventory $inventory, int $slot) : bool{
+		return match ($inventory instanceof ArmorInventory) {//TODO test
+			$slot === ArmorInventory::SLOT_HEAD => match (true) {
+				$this->blockFullId === VanillaBlocks::CARVED_PUMPKIN()->getFullId() => true,
+				default => false
+			},
+			default => parent::isValidSlot($inventory, $slot)
+		};
 	}
 }

--- a/src/item/ItemBlock.php
+++ b/src/item/ItemBlock.php
@@ -54,12 +54,12 @@ class ItemBlock extends Item{
 	}
 
 	public function isValidSlot(Inventory $inventory, int $slot) : bool{
-		return match ($inventory instanceof ArmorInventory) {//TODO test
+		return $inventory instanceof ArmorInventory && match (true) {
 			$slot === ArmorInventory::SLOT_HEAD => match (true) {
 				$this->blockFullId === VanillaBlocks::CARVED_PUMPKIN()->getFullId() => true,
 				default => false
 			},
 			default => parent::isValidSlot($inventory, $slot)
-		};
+		} || parent::isValidSlot($inventory, $slot);
 	}
 }

--- a/src/item/Skull.php
+++ b/src/item/Skull.php
@@ -26,6 +26,8 @@ namespace pocketmine\item;
 use pocketmine\block\Block;
 use pocketmine\block\utils\SkullType;
 use pocketmine\block\VanillaBlocks;
+use pocketmine\inventory\ArmorInventory;
+use pocketmine\inventory\Inventory;
 
 class Skull extends Item{
 
@@ -45,5 +47,12 @@ class Skull extends Item{
 
 	public function getSkullType() : SkullType{
 		return $this->skullType;
+	}
+
+	public function isValidSlot(Inventory $inventory, int $slot) : bool{
+		if($inventory instanceof ArmorInventory){
+			return $slot === ArmorInventory::SLOT_HEAD;
+		}
+		return parent::isValidSlot($inventory, $slot);
 	}
 }


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This PR adds item validation to armor slots to prevent clients from putting incorrect items into them

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
- Added Item::isValidSlot() 

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
- Only skulls, pumpkins and helmets can be placed in the head armor slot anymore
- The other slots only accept armor items of the correct type

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
- No BC break
- Plugins can still put any item in there

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
- Add Elytra slot validation to #4462
- Add checks for offhand

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
- Put items into & out of the slots
- Tried putting an invalid item || chestplates in the slots using gophertunnel - transaction failed
- Put incorrect armor pieces using plugins - still works