### PR TITLE
Account for given deltas in projective move

### DIFF
--- a/src/pocketmine/entity/projectile/Projectile.php
+++ b/src/pocketmine/entity/projectile/Projectile.php
@@ -180,7 +180,7 @@ abstract class Projectile extends Entity{
 		Timings::$entityMoveTimer->startTiming();
 
 		$start = $this->asVector3();
-		$end = $start->add($this->motion);
+		$end = $start->add($dx, $dy, $dz);
 
 		$blockHit = null;
 		$entityHit = null;


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Projectiles moving based on motion instead of passed in deltas is unexpected behavior.

This PR applies the fix mentioned in a previous discord conversation.
https://discord.com/channels/373199722573201408/373214753147060235/891732629731295252

### Relevant issues
<!-- List relevant issues here -->
- N/A

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
- N/A

### Behavioral changes
<!-- Any change in how the server behaves, or its performance? -->
Parameters for the `move` function will now be accounted for.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
- No issues

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
- N/A

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Pending Test Results
