### PR TITLE
Fix behavior of the redstone wire when placing it or breaking the block underneath.

### DIFF
--- a/src/block/RedstoneWire.php
+++ b/src/block/RedstoneWire.php
@@ -23,11 +23,30 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\item\Item;
+use pocketmine\math\Facing;
+use pocketmine\math\Vector3;
 use pocketmine\block\utils\AnalogRedstoneSignalEmitterTrait;
 use pocketmine\block\utils\BlockDataSerializer;
+use pocketmine\world\BlockTransaction;
 
 class RedstoneWire extends Flowable{
 	use AnalogRedstoneSignalEmitterTrait;
+
+	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
+		$down = $this->getSide(Facing::DOWN);
+		if($down->isSolid()){
+			return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
+		}
+
+		return false;
+	}
+
+	public function onNearbyBlockChange() : void{
+		if($this->getSide(Facing::DOWN)->isTransparent()){
+			$this->position->getWorld()->useBreakOn($this->position);
+		}
+	}
 
 	public function readStateFromData(int $id, int $stateMeta) : void{
 		$this->signalStrength = BlockDataSerializer::readBoundedInt("signalStrength", $stateMeta, 0, 15);

--- a/src/block/RedstoneWire.php
+++ b/src/block/RedstoneWire.php
@@ -23,19 +23,44 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\block\utils\SlabType;
 use pocketmine\item\Item;
 use pocketmine\math\Facing;
 use pocketmine\math\Vector3;
 use pocketmine\block\utils\AnalogRedstoneSignalEmitterTrait;
 use pocketmine\block\utils\BlockDataSerializer;
+use pocketmine\player\Player;
 use pocketmine\world\BlockTransaction;
 
 class RedstoneWire extends Flowable{
 	use AnalogRedstoneSignalEmitterTrait;
 
+	private function canBeSupportedBy(Block $block) : bool{
+		if($block instanceof Slab) {
+			if ($block->getSlabType()->equals(SlabType::BOTTOM())) {
+				return false;
+			}
+			return true;
+		}
+		if($block instanceof Beacon ||
+			$block instanceof Glass ||
+			$block instanceof Farmland ||
+			$block instanceof Glowstone ||
+			$block instanceof GrassPath ||
+			$block instanceof HardenedGlass ||
+			$block instanceof Hopper ||
+			$block instanceof Ice ||
+			$block instanceof Melon ||
+			$block instanceof SeaLantern ||
+			$block instanceof Slime
+		) {
+			return true;
+		}
+		return !$block->isTransparent();
+	}
+
 	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		$down = $this->getSide(Facing::DOWN);
-		if($down->isSolid()){
+		if($this->canBeSupportedBy($this->getSide(Facing::DOWN))){
 			return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
 		}
 
@@ -43,7 +68,7 @@ class RedstoneWire extends Flowable{
 	}
 
 	public function onNearbyBlockChange() : void{
-		if($this->getSide(Facing::DOWN)->isTransparent()){
+		if(!$this->canBeSupportedBy($this->getSide(Facing::DOWN))){
 			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}

--- a/src/block/RedstoneWire.php
+++ b/src/block/RedstoneWire.php
@@ -36,8 +36,8 @@ class RedstoneWire extends Flowable{
 	use AnalogRedstoneSignalEmitterTrait;
 
 	private function canBeSupportedBy(Block $block) : bool{
-		if($block instanceof Slab) {
-			if ($block->getSlabType()->equals(SlabType::BOTTOM())) {
+		if($block instanceof Slab){
+			if($block->getSlabType()->equals(SlabType::BOTTOM())){
 				return false;
 			}
 			return true;
@@ -53,7 +53,7 @@ class RedstoneWire extends Flowable{
 			$block instanceof Melon ||
 			$block instanceof SeaLantern ||
 			$block instanceof Slime
-		) {
+		){
 			return true;
 		}
 		return !$block->isTransparent();


### PR DESCRIPTION
## Introduction
This pull request limits the places where the redstone wire block can be placed and now when the block is broken under the redstone wire, it breaks, also dropping the respective item.

## Changes

### API changes
N/A

### Behavioural changes
- The redstone wire block can now only be placed on non-transparent blocks, with the exceptions: Beacon, Glass, Farmland, Glowstone, GrassPath, HardenedGlass, Hopper, Ice, Melon, SeaLantern and Slime.
- As the block underneath the redstone wire breaks, it will break as well.

## Backwards compatibility
N/A

## Tests
Tested it on Android:
- It was tested in vanilla that transparent blocks are capable of supporting redstone wire and it was ensured that these had the same behavior in pocketmine.
- Breaking the block below also breaks the redstone wire.
- It was ensured that redstone wire can be placed in the slabs if it is type Double or Top.
- The behavior was compared with vanilla and the result was identical.
