### PR TITLE
Prevent ServerCrash when given ItemId is out of Range

### DIFF
--- a/src/command/defaults/GiveCommand.php
+++ b/src/command/defaults/GiveCommand.php
@@ -67,7 +67,7 @@ class GiveCommand extends VanillaCommand{
 
 		try{
 			$item = StringToItemParser::getInstance()->parse($args[1]) ?? LegacyStringToItemParser::getInstance()->parse($args[1]);
-		}catch(LegacyStringToItemParserException $e){
+		}catch(LegacyStringToItemParserException | \InvalidArgumentException $e){
 			$sender->sendMessage(KnownTranslationFactory::commands_give_item_notFound($args[1])->prefix(TextFormat::RED));
 			return true;
 		}


### PR DESCRIPTION
Catch InvalidArgumentException too

## Introduction
It leads to a server crash due to an InvalidArgumentException (thrown by Itemfactory::getListOffset() on Line 498) if an ItemID outside the permitted range is entered with the GiveCommand.

### Relevant issues
No issue existing for this

## Changes
### API changes
No

### Behavioural changes
No

## Backwards compatibility
No

## Follow-up
/

## Tests
Before Changes:
Triggering the crash by executing command "/give <playername> 999999999 <amount>
After Changes:
"Item not Found"-Message will be send to CommandSender
