### PR TITLE
Allow picking up part of dropped items

### DIFF
--- a/src/event/entity/EntityItemPickupEvent.php
+++ b/src/event/entity/EntityItemPickupEvent.php
@@ -57,13 +57,6 @@ class EntityItemPickupEvent extends EntityEvent implements Cancellable{
 	}
 
 	/**
-	 * Change the items to receive.
-	 */
-	public function setItem(Item $item) : void{
-		$this->item = clone $item;
-	}
-
-	/**
 	 * Inventory to which received items will be added.
 	 */
 	public function getInventory() : ?Inventory{


### PR DESCRIPTION
## Introduction
Because of the method `Inventory->canAddItem()` not checking whether *part* of an item can be added to an inventory, players could never pickup part of an item stack. The method `Inventory->getAddableItemQuantity()` which was added not too long ago returns the amount of the item stack that can be added.

`ItemEntity->onCollideWithPlayer()` now uses  `Inventory->getAddableItemQuantity()` to check if an item can be added, and adds that amount, leaving the rest of the items in the item stack. One thing to note: there is a client-sided bug where the item stack texture does not update on the ground to show the new item count. [Example](https://youtu.be/35QzsbO9GWY) of this bug.

### Relevant issues
Fixes #4499

## Changes
### API changes
none

### Behavioural changes
none

## Backwards compatibility
n/a

## Follow-up
n/a

Requires translations:

n/a

## Tests

Spent some time dropping different amounts of items, and picking them up. Dropped more items than what could be picked up by the player to ensure only part of the item stack was picked up.

Test Video: https://youtu.be/p1ZyEQTgps8