### PR TITLE
Advisory chunk locking for chunk population

### DIFF
--- a/src/world/ChunkLockId.php
+++ b/src/world/ChunkLockId.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\world;
+
+use pocketmine\utils\NotCloneable;
+use pocketmine\utils\NotSerializable;
+
+/**
+ * Represents a unique lock ID for use with World chunk locking.
+ *
+ * @see World::lockChunk()
+ * @see World::unlockChunk()
+ */
+final class ChunkLockId{
+	use NotCloneable;
+	use NotSerializable;
+}

--- a/src/world/World.php
+++ b/src/world/World.php
@@ -251,7 +251,7 @@ class World implements ChunkManager{
 
 	private int $nextChunkPopulationLockId = 0;
 	/** @var int[] */
-	private $chunkPopulationLock = [];
+	private $chunkLock = [];
 	/** @var int */
 	private $maxConcurrentChunkPopulationTasks = 2;
 	/**
@@ -2100,25 +2100,25 @@ class World implements ChunkManager{
 		return $result;
 	}
 
-	private function lockChunk(int $chunkX, int $chunkZ, int $populationTaskId) : void{
+	public function lockChunk(int $chunkX, int $chunkZ, int $lockId) : void{
 		$chunkHash = World::chunkHash($chunkX, $chunkZ);
-		if(isset($this->chunkPopulationLock[$chunkHash])){
+		if(isset($this->chunkLock[$chunkHash])){
 			throw new \InvalidArgumentException("Chunk $chunkX $chunkZ is already locked");
 		}
-		$this->chunkPopulationLock[$chunkHash] = $populationTaskId;
+		$this->chunkLock[$chunkHash] = $lockId;
 	}
 
-	private function unlockChunk(int $chunkX, int $chunkZ, ?int $populationTaskId) : bool{
+	public function unlockChunk(int $chunkX, int $chunkZ, ?int $lockId) : bool{
 		$chunkHash = World::chunkHash($chunkX, $chunkZ);
-		if(isset($this->chunkPopulationLock[$chunkHash]) && ($populationTaskId === null || $this->chunkPopulationLock[$chunkHash] === $populationTaskId)){
-			unset($this->chunkPopulationLock[$chunkHash]);
+		if(isset($this->chunkLock[$chunkHash]) && ($lockId === null || $this->chunkLock[$chunkHash] === $lockId)){
+			unset($this->chunkLock[$chunkHash]);
 			return true;
 		}
 		return false;
 	}
 
-	private function isChunkLocked(int $chunkX, int $chunkZ) : bool{
-		return isset($this->chunkPopulationLock[World::chunkHash($chunkX, $chunkZ)]);
+	public function isChunkLocked(int $chunkX, int $chunkZ) : bool{
+		return isset($this->chunkLock[World::chunkHash($chunkX, $chunkZ)]);
 	}
 
 	public function setChunk(int $chunkX, int $chunkZ, Chunk $chunk) : void{

--- a/src/world/World.php
+++ b/src/world/World.php
@@ -2884,9 +2884,6 @@ class World implements ChunkManager{
 						$listener->onChunkPopulated($x, $z, $chunk);
 					}
 				}
-				if(count($adjacentChunks) > 0){
-					$this->logger->debug("Population for chunk x=$x,z=$z resulted in modification of " . count($adjacentChunks) . " adjacent chunks");
-				}
 			}else{
 				$this->logger->debug("Discarding population result for chunk x=$x,z=$z - terrain was modified on the main thread before async population completed");
 			}

--- a/src/world/generator/PopulationTask.php
+++ b/src/world/generator/PopulationTask.php
@@ -64,7 +64,7 @@ class PopulationTask extends AsyncTask{
 	/** @var string|null */
 	public $chunk8;
 
-	public function __construct(World $world, int $chunkX, int $chunkZ, ?Chunk $chunk){
+	public function __construct(World $world, int $chunkX, int $chunkZ, ?Chunk $chunk, private int $populationTaskId){
 		$this->worldId = $world->getId();
 		$this->chunkX = $chunkX;
 		$this->chunkZ = $chunkZ;
@@ -144,7 +144,8 @@ class PopulationTask extends AsyncTask{
 		/** @var World $world */
 		$world = $this->fetchLocal(self::TLS_KEY_WORLD);
 		if($world->isLoaded()){
-			$chunk = $this->chunk !== null ? FastChunkSerializer::deserializeTerrain($this->chunk) : null;
+			$centerChunk = $this->chunk !== null ? FastChunkSerializer::deserializeTerrain($this->chunk) : throw new AssumptionFailedError("Center chunk should never be null");
+			$adjacentChunks = [];
 
 			for($i = 0; $i < 9; ++$i){
 				if($i === 4){
@@ -156,11 +157,11 @@ class PopulationTask extends AsyncTask{
 					$zz = -1 + intdiv($i, 3);
 
 					$c = FastChunkSerializer::deserializeTerrain($c);
-					$world->generateChunkCallback($this->chunkX + $xx, $this->chunkZ + $zz, $c);
+					$adjacentChunks[World::chunkHash($this->chunkX + $xx, $this->chunkZ + $zz)] = $c;
 				}
 			}
 
-			$world->generateChunkCallback($this->chunkX, $this->chunkZ, $chunk);
+			$world->generateChunkCallback($this->populationTaskId, $this->chunkX, $this->chunkZ, $centerChunk, $adjacentChunks);
 		}
 	}
 }

--- a/src/world/generator/PopulationTask.php
+++ b/src/world/generator/PopulationTask.php
@@ -27,6 +27,7 @@ use pocketmine\data\bedrock\BiomeIds;
 use pocketmine\scheduler\AsyncTask;
 use pocketmine\utils\AssumptionFailedError;
 use pocketmine\world\ChunkLoader;
+use pocketmine\world\ChunkLockId;
 use pocketmine\world\format\BiomeArray;
 use pocketmine\world\format\Chunk;
 use pocketmine\world\format\io\FastChunkSerializer;
@@ -40,6 +41,7 @@ use function intdiv;
 class PopulationTask extends AsyncTask{
 	private const TLS_KEY_WORLD = "world";
 	private const TLS_KEY_CHUNK_LOADER = "chunkLoader";
+	private const TLS_KEY_LOCK_ID = "chunkLockId";
 
 	/** @var int */
 	public $worldId;
@@ -53,7 +55,7 @@ class PopulationTask extends AsyncTask{
 
 	private string $adjacentChunks;
 
-	public function __construct(World $world, int $chunkX, int $chunkZ, ?Chunk $chunk, ChunkLoader $temporaryChunkLoader, private int $populationTaskId){
+	public function __construct(World $world, int $chunkX, int $chunkZ, ?Chunk $chunk, ChunkLoader $temporaryChunkLoader, ChunkLockId $chunkLockId){
 		$this->worldId = $world->getId();
 		$this->chunkX = $chunkX;
 		$this->chunkZ = $chunkZ;
@@ -66,6 +68,7 @@ class PopulationTask extends AsyncTask{
 
 		$this->storeLocal(self::TLS_KEY_WORLD, $world);
 		$this->storeLocal(self::TLS_KEY_CHUNK_LOADER, $temporaryChunkLoader);
+		$this->storeLocal(self::TLS_KEY_LOCK_ID, $chunkLockId);
 	}
 
 	public function onRun() : void{
@@ -131,6 +134,8 @@ class PopulationTask extends AsyncTask{
 		$world = $this->fetchLocal(self::TLS_KEY_WORLD);
 		/** @var ChunkLoader $temporaryChunkLoader */
 		$temporaryChunkLoader = $this->fetchLocal(self::TLS_KEY_CHUNK_LOADER);
+		/** @var ChunkLockId $lockId */
+		$lockId = $this->fetchLocal(self::TLS_KEY_LOCK_ID);
 		if($world->isLoaded()){
 			$chunk = $this->chunk !== null ?
 				FastChunkSerializer::deserializeTerrain($this->chunk) :
@@ -151,7 +156,7 @@ class PopulationTask extends AsyncTask{
 				}
 			}
 
-			$world->generateChunkCallback($this->populationTaskId, $this->chunkX, $this->chunkZ, $chunk, $adjacentChunks, $temporaryChunkLoader);
+			$world->generateChunkCallback($lockId, $this->chunkX, $this->chunkZ, $chunk, $adjacentChunks, $temporaryChunkLoader);
 		}
 	}
 }


### PR DESCRIPTION
## Introduction
PopulationTask must lock chunks to ensure that other PopulationTasks don't try to modify the same chunks at the same time, but this doesn't have to get in the way of general modifications.

Overall, the advent of PM4 has shown it's quite problematic to have chunks randomly become read-only just because some other chunk wanted to be generated.

Instead of a mandatory lock on the used chunks, this PR implements weak locking for chunk population instead. This has all the original benefits of the chunk locking system (as per PM3), with the added advantage that user changes to chunks currently in use by population tasks won't be overwritten.

If a change is made to a locked chunk, the chunk lock is removed. This serves two purposes:
- A new PopulationTask acting on the target chunk can be scheduled immediately.
- A completing PopulationTask whose results have been invalidated by the modification will know that its changes are obsolete (either the chunk lock is removed, or the chunk lock ID doesn't match (another task was already scheduled since the lock was removed)).

### Relevant issues
- Fixes #3990 - this is a major blocker for PM4 release
- Fixes various other unreported issues with block updates in locked terrain.

## Changes
### API changes
- Chunk locking API is no longer exposed to the public API. Since this functionality is quite sensitive, it was a mistake to expose this in the first place. It's not exposed on PM3, so this technically isn't a BC break (although it might affect existing PM4 dev and beta users).
- `World::chunkGenerationCallback()` has been specialized specifically for `PopulationTask`'s use. Alternative use cases (like MineReset's mine regenerator) should use `World::setChunk()` directly instead of this method.

## Follow-up
Explore how a cooperative locking system can be exposed to plugins, so that plugins can signal to the core not to try and modify some chunk while a plugin is working on it (e.g. a world edit operation, mine reset, etc).

Explore how to make this unlocking more efficient, so that other locked chunks don't have to wait for the population task to finish. Currently, only the modified chunk is unlocked, leaving up to 8 other chunks locked for a dead PopulationTask; the others are only unlocked once PopulationTask returns and finds out that its work has been invalidated. This prevents the PopulationTask's center chunk from being immediately scheduled for repopulation.

## Tests
This has been lightly tested, but more thorough tests are needed.