### PR TITLE
The player can send a message with a length of 512 characters

### DIFF
--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1292,7 +1292,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 
 		$message = TextFormat::clean($message, false);
 		foreach(explode("\n", $message) as $messagePart){
-			if(trim($messagePart) !== "" and strlen($messagePart) <= 255 and $this->messageCounter-- > 0){
+			if(trim($messagePart) !== "" and strlen($messagePart) <= 512 and $this->messageCounter-- > 0){
 				if(strpos($messagePart, './') === 0){
 					$messagePart = substr($messagePart, 1);
 				}


### PR DESCRIPTION
## Introduction
PMMP discards messages longer than 255 characters, but the client can send up to 512 characters. I'm sure the limit should be increased to 512.

## Changes

### Behavioural changes
Message character limit raised to 512

