### PR TITLE
plants no longer remove fertilizers if respective growth event was cancelled

### DIFF
--- a/src/block/Crops.php
+++ b/src/block/Crops.php
@@ -80,9 +80,8 @@ abstract class Crops extends Flowable{
 			$ev->call();
 			if(!$ev->isCancelled()){
 				$this->position->getWorld()->setBlock($this->position, $ev->getNewState());
+				$item->pop();
 			}
-
-			$item->pop();
 
 			return true;
 		}

--- a/src/block/Sapling.php
+++ b/src/block/Sapling.php
@@ -76,9 +76,7 @@ class Sapling extends Flowable{
 	}
 
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		if($item instanceof Fertilizer){
-			$this->grow($player);
-
+		if($item instanceof Fertilizer && $this->grow($player)){
 			$item->pop();
 
 			return true;
@@ -108,19 +106,20 @@ class Sapling extends Flowable{
 		}
 	}
 
-	private function grow(?Player $player) : void{
+	private function grow(?Player $player) : bool{
 		$random = new Random(mt_rand());
 		$tree = TreeFactory::get($random, $this->treeType);
 		$transaction = $tree?->getBlockTransaction($this->position->getWorld(), $this->position->getFloorX(), $this->position->getFloorY(), $this->position->getFloorZ(), $random);
 		if($transaction === null){
-			return;
+			return false;
 		}
 
 		$ev = new StructureGrowEvent($this, $transaction, $player);
 		$ev->call();
 		if(!$ev->isCancelled()){
-			$transaction->apply();
+			return $transaction->apply();
 		}
+		return false;
 	}
 
 	public function getFuelTime() : int{

--- a/src/block/Sugarcane.php
+++ b/src/block/Sugarcane.php
@@ -48,7 +48,8 @@ class Sugarcane extends Flowable{
 		return 0b1111;
 	}
 
-	private function grow() : void{
+	private function grow() : bool{
+		$grew = false;
 		for($y = 1; $y < 3; ++$y){
 			if(!$this->position->getWorld()->isInWorld($this->position->x, $this->position->y + $y, $this->position->z)){
 				break;
@@ -61,12 +62,14 @@ class Sugarcane extends Flowable{
 					break;
 				}
 				$this->position->getWorld()->setBlock($b->position, $ev->getNewState());
+				$grew = true;
 			}else{
 				break;
 			}
 		}
 		$this->age = 0;
 		$this->position->getWorld()->setBlock($this->position, $this);
+		return $grew;
 	}
 
 	public function getAge() : int{ return $this->age; }
@@ -82,11 +85,9 @@ class Sugarcane extends Flowable{
 
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
 		if($item instanceof Fertilizer){
-			if(!$this->getSide(Facing::DOWN)->isSameType($this)){
-				$this->grow();
+			if(!$this->getSide(Facing::DOWN)->isSameType($this) && $this->grow()){
+				$item->pop();
 			}
-
-			$item->pop();
 
 			return true;
 		}

--- a/src/block/SweetBerryBush.php
+++ b/src/block/SweetBerryBush.php
@@ -99,9 +99,9 @@ class SweetBerryBush extends Flowable{
 
 			if(!$ev->isCancelled()){
 				$this->position->getWorld()->setBlock($this->position, $ev->getNewState());
+				$item->pop();
 			}
 
-			$item->pop();
 		}elseif(($dropAmount = $this->getBerryDropAmount()) > 0){
 			$this->position->getWorld()->setBlock($this->position, $this->setAge(self::STAGE_BUSH_NO_BERRIES));
 			$this->position->getWorld()->dropItem($this->position, $this->asItem()->setCount($dropAmount));


### PR DESCRIPTION
## Introduction
As explained in the issue, right now it's not consistent whether fertilizers are removed if a plant's respective growth event was cancelled.
This PR restores this consistency so that fertilizers are no longer removed from a players inventory if the BlockGrowthEvent / StructureGrowthEvent was cancelled.

### Relevant issues
* Fixes https://github.com/pmmp/PocketMine-MP/issues/4545

## Changes
### API changes
- `Sapling::grow()`'s return type was changed from `void` to `bool`
- `Sugarcane::grow()`'s return type was changed from `void` to `bool`

## Tests
Fertilizers are no longer removed from the players inventory:
```php
use pocketmine\event\block\BlockGrowEvent;
use pocketmine\event\block\StructureGrowEvent;
use pocketmine\event\Listener;
use pocketmine\plugin\PluginBase;

class TestPlugin extends PluginBase implements Listener {

	public function onEnable() : void {
		$this->getServer()->getPluginManager()->registerEvents($this, $this);
	}

	public function onBlockGrow(BlockGrowEvent $event) : void {
		$event->cancel();
	}

	public function onStructureGrow(StructureGrowEvent $event) : void {
		$event->cancel();
	}
}
```