### PR TITLE
Implemented IPv6 support

### DIFF
--- a/src/PocketMine.php
+++ b/src/PocketMine.php
@@ -34,6 +34,7 @@ namespace pocketmine {
 	use pocketmine\utils\Timezone;
 	use pocketmine\wizard\SetupWizard;
 	use Webmozart\PathUtil\Path;
+	use function defined;
 	use function extension_loaded;
 	use function phpversion;
 	use function preg_match;
@@ -143,6 +144,10 @@ namespace pocketmine {
 
 		if(extension_loaded("pocketmine")){
 			$messages[] = "The native PocketMine extension is no longer supported.";
+		}
+
+		if(!defined('AF_INET6')){
+			$messages[] = "IPv6 support is required, but your PHP binary was built without IPv6 support.";
 		}
 
 		return $messages;

--- a/src/Server.php
+++ b/src/Server.php
@@ -320,6 +320,10 @@ class Server{
 		return $this->configGroup->getConfigInt("server-port", 19132);
 	}
 
+	public function getPortV6() : int{
+		return $this->configGroup->getConfigInt("server-portv6", 19133);
+	}
+
 	public function getViewDistance() : int{
 		return max(2, $this->configGroup->getConfigInt("view-distance", 8));
 	}
@@ -334,6 +338,11 @@ class Server{
 	public function getIp() : string{
 		$str = $this->configGroup->getConfigString("server-ip");
 		return $str !== "" ? $str : "0.0.0.0";
+	}
+
+	public function getIpV6() : string{
+		$str = $this->configGroup->getConfigString("server-ipv6");
+		return $str !== "" ? $str : "::";
 	}
 
 	public function getServerUniqueId() : UuidInterface{
@@ -783,6 +792,8 @@ class Server{
 				new Config(Path::join($this->dataPath, "server.properties"), Config::PROPERTIES, [
 					"motd" => VersionInfo::NAME . " Server",
 					"server-port" => 19132,
+					"server-portv6" => 19133,
+					"enable-ipv6" => true,
 					"white-list" => false,
 					"max-players" => 20,
 					"gamemode" => 0,
@@ -1113,25 +1124,42 @@ class Server{
 		return true;
 	}
 
-	private function startupPrepareNetworkInterfaces() : bool{
-		$useQuery = $this->configGroup->getConfigBool("enable-query", true);
-
+	private function startupPrepareConnectableNetworkInterfaces(string $ip, int $port, bool $ipV6, bool $useQuery) : bool{
+		$prettyIp = $ipV6 ? "[$ip]" : $ip;
 		try{
-			$rakLibRegistered = $this->network->registerInterface(new RakLibInterface($this));
+			$rakLibRegistered = $this->network->registerInterface(new RakLibInterface($this, $ip, $port, $ipV6));
 		}catch(NetworkInterfaceStartException $e){
 			$this->logger->emergency($this->language->translate(KnownTranslationFactory::pocketmine_server_networkStartFailed(
-				$this->getIp(),
-				(string) $this->getPort(),
+				$ip,
+				(string) $port,
 				$e->getMessage()
 			)));
 			return false;
 		}
-		if(!$rakLibRegistered && $useQuery){
-			//RakLib would normally handle the transport for Query packets
-			//if it's not registered we need to make sure Query still works
-			$this->network->registerInterface(new DedicatedQueryNetworkInterface($this->getIp(), $this->getPort(), new \PrefixedLogger($this->logger, "Dedicated Query Interface")));
+		$this->logger->info($this->getLanguage()->translate(KnownTranslationFactory::pocketmine_server_networkStart($prettyIp, (string) $port)));
+		if($useQuery){
+			if(!$rakLibRegistered){
+				//RakLib would normally handle the transport for Query packets
+				//if it's not registered we need to make sure Query still works
+				$this->network->registerInterface(new DedicatedQueryNetworkInterface($ip, $port, $ipV6, new \PrefixedLogger($this->logger, "Dedicated Query Interface")));
+			}
+			$this->logger->info($this->getLanguage()->translate(KnownTranslationFactory::pocketmine_server_query_running($prettyIp, (string) $port)));
 		}
-		$this->logger->info($this->getLanguage()->translate(KnownTranslationFactory::pocketmine_server_networkStart($this->getIp(), (string) $this->getPort())));
+		return true;
+	}
+
+	private function startupPrepareNetworkInterfaces() : bool{
+		$useQuery = $this->configGroup->getConfigBool("enable-query", true);
+
+		if(
+			!$this->startupPrepareConnectableNetworkInterfaces($this->getIp(), $this->getPort(), false, $useQuery) ||
+			(
+				$this->configGroup->getConfigBool("enable-ipv6", true) &&
+				!$this->startupPrepareConnectableNetworkInterfaces($this->getIpV6(), $this->getPortV6(), true, $useQuery)
+			)
+		){
+			return false;
+		}
 
 		if($useQuery){
 			$this->network->registerRawPacketHandler(new QueryHandler($this));

--- a/src/command/defaults/BanIpCommand.php
+++ b/src/command/defaults/BanIpCommand.php
@@ -32,7 +32,7 @@ use pocketmine\player\Player;
 use function array_shift;
 use function count;
 use function implode;
-use function preg_match;
+use function inet_pton;
 
 class BanIpCommand extends VanillaCommand{
 
@@ -57,7 +57,7 @@ class BanIpCommand extends VanillaCommand{
 		$value = array_shift($args);
 		$reason = implode(" ", $args);
 
-		if(preg_match("/^([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])$/", $value)){
+		if(inet_pton($value) !== false){
 			$this->processIPBan($value, $sender, $reason);
 
 			Command::broadcastCommandMessage($sender, KnownTranslationFactory::commands_banip_success($value));

--- a/src/command/defaults/PardonIpCommand.php
+++ b/src/command/defaults/PardonIpCommand.php
@@ -29,7 +29,7 @@ use pocketmine\command\utils\InvalidCommandSyntaxException;
 use pocketmine\lang\KnownTranslationFactory;
 use pocketmine\permission\DefaultPermissionNames;
 use function count;
-use function preg_match;
+use function inet_pton;
 
 class PardonIpCommand extends VanillaCommand{
 
@@ -52,7 +52,7 @@ class PardonIpCommand extends VanillaCommand{
 			throw new InvalidCommandSyntaxException();
 		}
 
-		if(preg_match("/^([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])$/", $args[0])){
+		if(inet_pton($args[0]) !== false){
 			$sender->getServer()->getIPBans()->remove($args[0]);
 			$sender->getServer()->getNetwork()->unblockAddress($args[0]);
 			Command::broadcastCommandMessage($sender, KnownTranslationFactory::commands_unbanip_success($args[0]));

--- a/src/network/mcpe/raklib/RakLibInterface.php
+++ b/src/network/mcpe/raklib/RakLibInterface.php
@@ -88,7 +88,7 @@ class RakLibInterface implements ServerEventListener, AdvancedNetworkInterface{
 	/** @var PacketBroadcaster */
 	private $broadcaster;
 
-	public function __construct(Server $server){
+	public function __construct(Server $server, string $ip, int $port, bool $ipV6){
 		$this->server = $server;
 		$this->rakServerId = mt_rand(0, PHP_INT_MAX);
 
@@ -101,7 +101,7 @@ class RakLibInterface implements ServerEventListener, AdvancedNetworkInterface{
 			$this->server->getLogger(),
 			$mainToThreadBuffer,
 			$threadToMainBuffer,
-			new InternetAddress($this->server->getIp(), $this->server->getPort(), 4),
+			new InternetAddress($ip, $port, $ipV6 ? 6 : 4),
 			$this->rakServerId,
 			$this->server->getConfigGroup()->getPropertyInt("network.max-mtu-size", 1492),
 			self::MCPE_RAKNET_PROTOCOL_VERSION,

--- a/src/network/query/QueryHandler.php
+++ b/src/network/query/QueryHandler.php
@@ -27,7 +27,6 @@ declare(strict_types=1);
  */
 namespace pocketmine\network\query;
 
-use pocketmine\lang\KnownTranslationFactory;
 use pocketmine\network\AdvancedNetworkInterface;
 use pocketmine\network\RawPacketHandler;
 use pocketmine\Server;
@@ -57,8 +56,6 @@ class QueryHandler implements RawPacketHandler{
 	public function __construct(Server $server){
 		$this->server = $server;
 		$this->logger = new \PrefixedLogger($this->server->getLogger(), "Query Handler");
-		$addr = $this->server->getIp();
-		$port = $this->server->getPort();
 
 		/*
 		The Query protocol is built on top of the existing Minecraft PE UDP network stack.
@@ -71,7 +68,6 @@ class QueryHandler implements RawPacketHandler{
 
 		$this->regenerateToken();
 		$this->lastToken = $this->token;
-		$this->logger->info($this->server->getLanguage()->translate(KnownTranslationFactory::pocketmine_server_query_running($addr, (string) $port)));
 	}
 
 	public function getPattern() : string{


### PR DESCRIPTION
## Introduction
This PR implements comprehensive IPv6 support for PM4, including:

- Query working on IPv4/IPv6 (including when RakLib is disabled)
- Ability to disable IPv6
- Support for IPv6 in /ban-ip and /unban-ip

## Changes
### API changes
Some minor changes have been made to RakLibInterface and DedicatedQueryNetworkInterface to allow the IP, port and IP version to be specified.

- Added `Server::getIpV6()`
- Added `Server::getPortV6()`

### Behavioural changes
The server now supports connecting via IPv6.

## Tests
This is currently live on test6.pmmp.io:19133.