### PR TITLE
Changed "Level" string to "World" in Position::__toString() method.

### DIFF
--- a/src/world/Position.php
+++ b/src/world/Position.php
@@ -98,7 +98,7 @@ class Position extends Vector3{
 	}
 
 	public function __toString(){
-		return "Position(World=" . ($this->isValid() ? $this->getWorld()->getDisplayName() : "null") . ",x=" . $this->x . ",y=" . $this->y . ",z=" . $this->z . ")";
+		return "Position(world=" . ($this->isValid() ? $this->getWorld()->getDisplayName() : "null") . ",x=" . $this->x . ",y=" . $this->y . ",z=" . $this->z . ")";
 	}
 
 	public function equals(Vector3 $v) : bool{

--- a/src/world/Position.php
+++ b/src/world/Position.php
@@ -98,7 +98,7 @@ class Position extends Vector3{
 	}
 
 	public function __toString(){
-		return "Position(level=" . ($this->isValid() ? $this->getWorld()->getDisplayName() : "null") . ",x=" . $this->x . ",y=" . $this->y . ",z=" . $this->z . ")";
+		return "Position(World=" . ($this->isValid() ? $this->getWorld()->getDisplayName() : "null") . ",x=" . $this->x . ",y=" . $this->y . ",z=" . $this->z . ")";
 	}
 
 	public function equals(Vector3 $v) : bool{


### PR DESCRIPTION
## Introduction
All references from Level got renamed to World in the master branch.
Since this one in the Position class didn't get changed I decided to fix this.

## Tests
![image](https://user-images.githubusercontent.com/34657342/140660376-4846cd3c-57b6-49ad-873f-f9cb53cb5554.png)

