### PR TITLE
Player: allow controlling client-sided block collisions irrespective of Spectator Mode

### DIFF
--- a/src/network/mcpe/NetworkSession.php
+++ b/src/network/mcpe/NetworkSession.php
@@ -793,8 +793,8 @@ class NetworkSession{
 			$for->getId()
 		);
 
-		$pk->setFlag(AdventureSettingsPacket::WORLD_IMMUTABLE, $for->isWorldImmutable());
-		$pk->setFlag(AdventureSettingsPacket::NO_PVP, $for->getNoPvP());
+		$pk->setFlag(AdventureSettingsPacket::WORLD_IMMUTABLE, $for->isSpectator());
+		$pk->setFlag(AdventureSettingsPacket::NO_PVP, $for->isSpectator());
 		$pk->setFlag(AdventureSettingsPacket::AUTO_JUMP, $for->hasAutoJump());
 		$pk->setFlag(AdventureSettingsPacket::ALLOW_FLIGHT, $for->getAllowFlight());
 		$pk->setFlag(AdventureSettingsPacket::NO_CLIP, $for->canNoClip());

--- a/src/network/mcpe/NetworkSession.php
+++ b/src/network/mcpe/NetworkSession.php
@@ -797,7 +797,7 @@ class NetworkSession{
 		$pk->setFlag(AdventureSettingsPacket::NO_PVP, $for->isSpectator());
 		$pk->setFlag(AdventureSettingsPacket::AUTO_JUMP, $for->hasAutoJump());
 		$pk->setFlag(AdventureSettingsPacket::ALLOW_FLIGHT, $for->getAllowFlight());
-		$pk->setFlag(AdventureSettingsPacket::NO_CLIP, $for->canNoClip());
+		$pk->setFlag(AdventureSettingsPacket::NO_CLIP, $for->hasBlockCollision());
 		$pk->setFlag(AdventureSettingsPacket::FLYING, $for->isFlying());
 
 		//TODO: permission flags

--- a/src/network/mcpe/NetworkSession.php
+++ b/src/network/mcpe/NetworkSession.php
@@ -793,11 +793,11 @@ class NetworkSession{
 			$for->getId()
 		);
 
-		$pk->setFlag(AdventureSettingsPacket::WORLD_IMMUTABLE, $for->isSpectator());
-		$pk->setFlag(AdventureSettingsPacket::NO_PVP, $for->isSpectator());
+		$pk->setFlag(AdventureSettingsPacket::WORLD_IMMUTABLE, $for->isWorldImmutable());
+		$pk->setFlag(AdventureSettingsPacket::NO_PVP, $for->getNoPvP());
 		$pk->setFlag(AdventureSettingsPacket::AUTO_JUMP, $for->hasAutoJump());
 		$pk->setFlag(AdventureSettingsPacket::ALLOW_FLIGHT, $for->getAllowFlight());
-		$pk->setFlag(AdventureSettingsPacket::NO_CLIP, $for->isSpectator());
+		$pk->setFlag(AdventureSettingsPacket::NO_CLIP, $for->canNoClip());
 		$pk->setFlag(AdventureSettingsPacket::FLYING, $for->isFlying());
 
 		//TODO: permission flags

--- a/src/network/mcpe/NetworkSession.php
+++ b/src/network/mcpe/NetworkSession.php
@@ -797,7 +797,7 @@ class NetworkSession{
 		$pk->setFlag(AdventureSettingsPacket::NO_PVP, $for->isSpectator());
 		$pk->setFlag(AdventureSettingsPacket::AUTO_JUMP, $for->hasAutoJump());
 		$pk->setFlag(AdventureSettingsPacket::ALLOW_FLIGHT, $for->getAllowFlight());
-		$pk->setFlag(AdventureSettingsPacket::NO_CLIP, $for->hasBlockCollision());
+		$pk->setFlag(AdventureSettingsPacket::NO_CLIP, !$for->hasBlockCollision());
 		$pk->setFlag(AdventureSettingsPacket::FLYING, $for->isFlying());
 
 		//TODO: permission flags

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -979,8 +979,8 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		$this->hungerManager->setEnabled($this->isSurvival());
 
 		if($this->isSpectator()){
-			$this->setHasBlockCollision(false);
 			$this->setFlying(true);
+			$this->setHasBlockCollision(false);
 			$this->setSilent();
 			$this->onGround = false;
 

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -232,8 +232,11 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 	private bool $respawnLocked = false;
 
 	//TODO: Abilities
+	protected bool $worldImmutable = false;
+	protected bool $noPvP = false;
 	protected bool $autoJump = true;
 	protected bool $allowFlight = false;
+	protected bool $noClip = false;
 	protected bool $flying = false;
 
 	protected ?int $lineHeight = null;
@@ -385,6 +388,24 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		return $this->lastPlayed - $this->firstPlayed > 1; // microtime(true) - microtime(true) may have less than one millisecond difference
 	}
 
+	public function setWorldImmutable(bool $value) : void{
+		$this->worldImmutable = $value;
+		$this->getNetworkSession()->syncAdventureSettings($this);
+	}
+
+	public function isWorldImmutable() : bool{
+		return $this->worldImmutable;
+	}
+
+	public function setNoPvP(bool $value) : void{
+		$this->noPvP = $value;
+		$this->getNetworkSession()->syncAdventureSettings($this);
+	}
+
+	public function getNoPvP() : bool{
+		return $this->noPvP;
+	}
+
 	public function setAllowFlight(bool $value) : void{
 		$this->allowFlight = $value;
 		$this->getNetworkSession()->syncAdventureSettings($this);
@@ -392,6 +413,15 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 
 	public function getAllowFlight() : bool{
 		return $this->allowFlight;
+	}
+
+	public function setNoClip(bool $value) : void{
+		$this->noClip = $value;
+		$this->getNetworkSession()->syncAdventureSettings($this);
+	}
+
+	public function canNoClip() : bool{
+		return $this->noClip;
 	}
 
 	public function setFlying(bool $value) : void{
@@ -969,6 +999,9 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		$this->hungerManager->setEnabled($this->isSurvival());
 
 		if($this->isSpectator()){
+			$this->setWorldImmutable(true);
+			$this->setNoPvP(true);
+			$this->setNoClip(true);
 			$this->setFlying(true);
 			$this->setSilent();
 			$this->onGround = false;

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -232,8 +232,6 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 	private bool $respawnLocked = false;
 
 	//TODO: Abilities
-	protected bool $worldImmutable = false;
-	protected bool $noPvP = false;
 	protected bool $autoJump = true;
 	protected bool $allowFlight = false;
 	protected bool $noClip = false;
@@ -386,24 +384,6 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 
 	public function hasPlayedBefore() : bool{
 		return $this->lastPlayed - $this->firstPlayed > 1; // microtime(true) - microtime(true) may have less than one millisecond difference
-	}
-
-	public function setWorldImmutable(bool $value) : void{
-		$this->worldImmutable = $value;
-		$this->getNetworkSession()->syncAdventureSettings($this);
-	}
-
-	public function isWorldImmutable() : bool{
-		return $this->worldImmutable;
-	}
-
-	public function setNoPvP(bool $value) : void{
-		$this->noPvP = $value;
-		$this->getNetworkSession()->syncAdventureSettings($this);
-	}
-
-	public function getNoPvP() : bool{
-		return $this->noPvP;
 	}
 
 	public function setAllowFlight(bool $value) : void{
@@ -999,8 +979,6 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		$this->hungerManager->setEnabled($this->isSurvival());
 
 		if($this->isSpectator()){
-			$this->setWorldImmutable(true);
-			$this->setNoPvP(true);
 			$this->setNoClip(true);
 			$this->setFlying(true);
 			$this->setSilent();

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -234,7 +234,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 	//TODO: Abilities
 	protected bool $autoJump = true;
 	protected bool $allowFlight = false;
-	protected bool $noClip = false;
+	protected bool $blockCollision = false;
 	protected bool $flying = false;
 
 	protected ?int $lineHeight = null;
@@ -395,13 +395,13 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		return $this->allowFlight;
 	}
 
-	public function setNoClip(bool $value) : void{
-		$this->noClip = $value;
+	public function setHasBlockCollision(bool $value) : void{
+		$this->blockCollision = $value;
 		$this->getNetworkSession()->syncAdventureSettings($this);
 	}
 
-	public function canNoClip() : bool{
-		return $this->noClip;
+	public function hasBlockCollision() : bool{
+		return $this->blockCollision;
 	}
 
 	public function setFlying(bool $value) : void{
@@ -979,7 +979,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		$this->hungerManager->setEnabled($this->isSurvival());
 
 		if($this->isSpectator()){
-			$this->setNoClip(true);
+			$this->setHasBlockCollision(true);
 			$this->setFlying(true);
 			$this->setSilent();
 			$this->onGround = false;

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -991,6 +991,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 			if($this->isSurvival()){
 				$this->setFlying(false);
 			}
+			$this->setHasBlockCollision(true);
 			$this->setSilent(false);
 			$this->checkGroundState(0, 0, 0, 0, 0, 0);
 		}

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -234,7 +234,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 	//TODO: Abilities
 	protected bool $autoJump = true;
 	protected bool $allowFlight = false;
-	protected bool $blockCollision = false;
+	protected bool $blockCollision = true;
 	protected bool $flying = false;
 
 	protected ?int $lineHeight = null;
@@ -979,7 +979,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		$this->hungerManager->setEnabled($this->isSurvival());
 
 		if($this->isSpectator()){
-			$this->setHasBlockCollision(true);
+			$this->setHasBlockCollision(false);
 			$this->setFlying(true);
 			$this->setSilent();
 			$this->onGround = false;


### PR DESCRIPTION
## Introduction
Presently, PocketMine does not provide a simple way to set if players have the ability to ignore block collision or not

## Changes
To maintain compatibility with spectators, in internalSetGameMode, the block collision flag is toggled

### API changes
The following variables have been implemented:
- protected Player->blockCollision

The following methods have been implemented:
- Player->setHasBlockCollision(bool) : void
- Player->hasBlockCollision() : bool