### PR TITLE
Add correct drop for Podzol

### DIFF
--- a/src/block/Podzol.php
+++ b/src/block/Podzol.php
@@ -23,6 +23,13 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\item\Item;
+
 class Podzol extends Opaque{
 
+	public function getDropsForCompatibleTool(Item $item) : array{
+		return [
+			VanillaBlocks::DIRT()->asItem()
+		];
+	}
 }


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Previously, mining podzol will drop the podzol itself. This Pull Request aims to fix that and change the podzol drop to dirt.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
N/A
## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
N/A
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
N/A
## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
N/A
## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
N/A
## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
N/A