### PR TITLE
Fix position of setworldspawn command

### DIFF
--- a/src/command/defaults/SetWorldSpawnCommand.php
+++ b/src/command/defaults/SetWorldSpawnCommand.php
@@ -32,7 +32,6 @@ use pocketmine\permission\DefaultPermissionNames;
 use pocketmine\player\Player;
 use pocketmine\utils\TextFormat;
 use function count;
-use function round;
 
 class SetWorldSpawnCommand extends VanillaCommand{
 
@@ -69,7 +68,7 @@ class SetWorldSpawnCommand extends VanillaCommand{
 
 		$world->setSpawnLocation($pos);
 
-		Command::broadcastCommandMessage($sender, KnownTranslationFactory::commands_setworldspawn_success((string) round($pos->x, 2), (string) round($pos->y, 2), (string) round($pos->z, 2)));
+		Command::broadcastCommandMessage($sender, KnownTranslationFactory::commands_setworldspawn_success((string) $pos->x, (string) $pos->y, (string) $pos->z));
 
 		return true;
 	}

--- a/src/command/defaults/SetWorldSpawnCommand.php
+++ b/src/command/defaults/SetWorldSpawnCommand.php
@@ -54,7 +54,7 @@ class SetWorldSpawnCommand extends VanillaCommand{
 			if($sender instanceof Player){
 				$location = $sender->getPosition();
 				$world = $location->getWorld();
-				$pos = $location->asVector3()->round();
+				$pos = $location->asVector3()->floor();
 			}else{
 				$sender->sendMessage(TextFormat::RED . "You can only perform this command as a player");
 


### PR DESCRIPTION
## Introduction
~~`setworldspawn` command is now consistent with vanilla behavior.~~
Now, the world's spawn position is set to the floored value instead of the rounded value.

## Changes
### Behavioural changes
World spawn position is no longer using rounded values.