### PR TITLE
Allow input of relative coordinates to setworldspawn command

### DIFF
--- a/src/command/defaults/SetWorldSpawnCommand.php
+++ b/src/command/defaults/SetWorldSpawnCommand.php
@@ -31,6 +31,7 @@ use pocketmine\math\Vector3;
 use pocketmine\permission\DefaultPermissionNames;
 use pocketmine\player\Player;
 use pocketmine\utils\TextFormat;
+use pocketmine\world\World;
 use function count;
 
 class SetWorldSpawnCommand extends VanillaCommand{
@@ -69,7 +70,7 @@ class SetWorldSpawnCommand extends VanillaCommand{
 			}
 			$pos = (new Vector3(
 				$this->getRelativeDouble($base->x, $sender, $args[0]),
-				$this->getRelativeDouble($base->y, $sender, $args[1], 0, 256),
+				$this->getRelativeDouble($base->y, $sender, $args[1], World::Y_MIN, World::Y_MAX),
 				$this->getRelativeDouble($base->z, $sender, $args[2]),
 			))->floor();
 		}else{

--- a/src/command/defaults/SetWorldSpawnCommand.php
+++ b/src/command/defaults/SetWorldSpawnCommand.php
@@ -60,8 +60,18 @@ class SetWorldSpawnCommand extends VanillaCommand{
 				return true;
 			}
 		}elseif(count($args) === 3){
-			$world = $sender->getServer()->getWorldManager()->getDefaultWorld();
-			$pos = new Vector3($this->getInteger($sender, $args[0]), $this->getInteger($sender, $args[1]), $this->getInteger($sender, $args[2]));
+			if($sender instanceof Player){
+				$base = $sender->getPosition();
+				$world = $base->getWorld();
+			}else{
+				$base = new Vector3(0.0, 0.0, 0.0);
+				$world = $sender->getServer()->getWorldManager()->getDefaultWorld();
+			}
+			$pos = (new Vector3(
+				$this->getRelativeDouble($base->x, $sender, $args[0]),
+				$this->getRelativeDouble($base->y, $sender, $args[1], 0, 256),
+				$this->getRelativeDouble($base->z, $sender, $args[2]),
+			))->floor();
 		}else{
 			throw new InvalidCommandSyntaxException();
 		}


### PR DESCRIPTION
## Introduction
This is actually a continuation of #4574.
The input value is now converted to a floor value, and implemented the input of relative coordinates.

## Changes
### Behavioural changes
- Relative coordinates can now be used.
- Target world is now always the world of the player who executed the command.
- If the command is executed from the console, the default world will be targeted.
  - If relative coordinates are entered, the coordinates (0,0,0) will be set as the base point. (This behavior is based on BDS.)