### PR TITLE
Fixed saplings cannot be placed on farmland

### DIFF
--- a/src/block/Sapling.php
+++ b/src/block/Sapling.php
@@ -71,7 +71,8 @@ class Sapling extends Flowable{
 			$block instanceof Dirt ||
 			$block instanceof Grass ||
 			$block instanceof Podzol ||
-			$block instanceof Farmland;
+			$block instanceof Farmland ||
+			$block instanceof Mycelium;
 	}
 
 	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{

--- a/src/block/Sapling.php
+++ b/src/block/Sapling.php
@@ -66,9 +66,16 @@ class Sapling extends Flowable{
 		return $this;
 	}
 
+	private function canBeSupportedBy(Block $block) : bool{
+		return
+			$block instanceof Dirt ||
+			$block instanceof Grass ||
+			$block instanceof Podzol ||
+			$block instanceof Farmland;
+	}
+
 	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		$down = $this->getSide(Facing::DOWN);
-		if($down->getId() === BlockLegacyIds::GRASS or $down->getId() === BlockLegacyIds::DIRT or $down->getId() === BlockLegacyIds::FARMLAND){
+		if($this->canBeSupportedBy($this->getSide(Facing::DOWN))){
 			return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
 		}
 
@@ -86,8 +93,7 @@ class Sapling extends Flowable{
 	}
 
 	public function onNearbyBlockChange() : void{
-		$down = $this->getSide(Facing::DOWN);
-		if($down->getId() !== BlockLegacyIds::GRASS and $down->getId() !== BlockLegacyIds::DIRT and $down->getId() !== BlockLegacyIds::FARMLAND){
+		if(!$this->canBeSupportedBy($this->getSide(Facing::DOWN))){
 			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}

--- a/src/block/Sapling.php
+++ b/src/block/Sapling.php
@@ -86,7 +86,8 @@ class Sapling extends Flowable{
 	}
 
 	public function onNearbyBlockChange() : void{
-		if($this->getSide(Facing::DOWN)->isTransparent()){
+		$down = $this->getSide(Facing::DOWN);
+		if($down->getId() !== BlockLegacyIds::GRASS and $down->getId() !== BlockLegacyIds::DIRT and $down->getId() !== BlockLegacyIds::FARMLAND){
 			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}


### PR DESCRIPTION
## Introduction
Fixed an issue that caused saplings to be destroyed only when they were placed on farmland.

### Relevant issues
* Fixes #4528

## Changes
### Behavioural changes
- Saplings can now be placed correctly on farmland and podzol.