### PR TITLE
Changed visibility of Projectile->move to Protected.

### DIFF
--- a/src/entity/projectile/Projectile.php
+++ b/src/entity/projectile/Projectile.php
@@ -166,7 +166,7 @@ abstract class Projectile extends Entity{
 		return $this->blockHit === null and parent::hasMovementUpdate();
 	}
 
-	public function move(float $dx, float $dy, float $dz) : void{
+	protected function move(float $dx, float $dy, float $dz) : void{
 		$this->blocksAround = null;
 
 		Timings::$entityMove->startTiming();


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
https://github.com/pmmp/PocketMine-MP/blob/master/changelogs/4.0.md#general-2
> `Entity->move()` is now `protected`.

but `Projectile->move` is still `public`
### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
