### PR TITLE
Skull: improve calculation of collision boxes

### DIFF
--- a/src/block/Skull.php
+++ b/src/block/Skull.php
@@ -124,8 +124,13 @@ class Skull extends Flowable{
 	 * @return AxisAlignedBB[]
 	 */
 	protected function recalculateCollisionBoxes() : array{
-		//TODO: different bounds depending on attached face
-		return [AxisAlignedBB::one()->contract(0.25, 0, 0.25)->trim(Facing::UP, 0.5)];
+		return match ($this->facing) {
+			Facing::NORTH => [AxisAlignedBB::one()->contract(0.25, 0.25, 0.0)->trim(Facing::NORTH, 0.5)],
+			Facing::SOUTH => [AxisAlignedBB::one()->contract(0.25, 0.25, 0.0)->trim(Facing::SOUTH, 0.5)],
+			Facing::WEST => [AxisAlignedBB::one()->contract(0.0, 0.25, 0.25)->trim(Facing::WEST, 0.5)],
+			Facing::EAST => [AxisAlignedBB::one()->contract(0.0, 0.25, 0.25)->trim(Facing::EAST, 0.5)],
+			default => [AxisAlignedBB::one()->contract(0.25, 0, 0.25)->trim(Facing::UP, 0.5)]
+		};
 	}
 
 	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{

--- a/src/block/Skull.php
+++ b/src/block/Skull.php
@@ -124,12 +124,13 @@ class Skull extends Flowable{
 	 * @return AxisAlignedBB[]
 	 */
 	protected function recalculateCollisionBoxes() : array{
+		$collisionBox = AxisAlignedBB::one()->contract(0.25, 0, 0.25)->trim(Facing::UP, 0.5);
 		return match ($this->facing) {
-			Facing::NORTH => [AxisAlignedBB::one()->contract(0.25, 0.25, 0.0)->trim(Facing::NORTH, 0.5)],
-			Facing::SOUTH => [AxisAlignedBB::one()->contract(0.25, 0.25, 0.0)->trim(Facing::SOUTH, 0.5)],
-			Facing::WEST => [AxisAlignedBB::one()->contract(0.0, 0.25, 0.25)->trim(Facing::WEST, 0.5)],
-			Facing::EAST => [AxisAlignedBB::one()->contract(0.0, 0.25, 0.25)->trim(Facing::EAST, 0.5)],
-			default => [AxisAlignedBB::one()->contract(0.25, 0, 0.25)->trim(Facing::UP, 0.5)]
+			Facing::NORTH => [$collisionBox->offset(0, 0.25, 0.25)],
+			Facing::SOUTH => [$collisionBox->offset(0, 0.25, -0.25)],
+			Facing::WEST => [$collisionBox->offset(0.25, 0.25, 0)],
+			Facing::EAST => [$collisionBox->offset(-0.25, 0.25, 0)],
+			default => [$collisionBox]
 		};
 	}
 

--- a/src/block/Skull.php
+++ b/src/block/Skull.php
@@ -125,7 +125,7 @@ class Skull extends Flowable{
 	 */
 	protected function recalculateCollisionBoxes() : array{
 		$collisionBox = AxisAlignedBB::one()->contract(0.25, 0, 0.25)->trim(Facing::UP, 0.5);
-		return match ($this->facing) {
+		return match($this->facing){
 			Facing::NORTH => [$collisionBox->offset(0, 0.25, 0.25)],
 			Facing::SOUTH => [$collisionBox->offset(0, 0.25, -0.25)],
 			Facing::WEST => [$collisionBox->offset(0.25, 0.25, 0)],


### PR DESCRIPTION
## Introduction
As it is explained in a comment inside the `Skull::recalculateCollisionBoxes()` method, the returned collision box is only correct if the block's facing equals `Facing::UP`.
https://github.com/pmmp/PocketMine-MP/blob/7fd712c1ff5e33c2df8e888f8b3986947f3f4eb4/src/block/Skull.php#L127
This PR aims to change this by implementing the correct calculation of the skulls collision box based on the direction it is facing.

## Tests and proof
![x_z_axis](https://user-images.githubusercontent.com/54852588/143144582-f89c1411-7d34-4bcf-89c8-f27cf29ff730.png)
![y_axis](https://user-images.githubusercontent.com/54852588/143144599-83a7608d-7b89-4ffd-ab14-4ef51b693468.png)
