### PR TITLE
Don't log if NetworkInterfaceRegisterEvent is cancelled

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -1143,7 +1143,9 @@ class Server{
 			)));
 			return false;
 		}
-		$this->logger->info($this->getLanguage()->translate(KnownTranslationFactory::pocketmine_server_networkStart($prettyIp, (string) $port)));
+		if($rakLibRegistered){
+			$this->logger->info($this->getLanguage()->translate(KnownTranslationFactory::pocketmine_server_networkStart($prettyIp, (string) $port)));
+		}
 		if($useQuery){
 			if(!$rakLibRegistered){
 				//RakLib would normally handle the transport for Query packets

--- a/src/Server.php
+++ b/src/Server.php
@@ -1150,10 +1150,8 @@ class Server{
 			if(!$rakLibRegistered){
 				//RakLib would normally handle the transport for Query packets
 				//if it's not registered we need to make sure Query still works
-				$queryRegistered = $this->network->registerInterface(new DedicatedQueryNetworkInterface($ip, $port, $ipV6, new \PrefixedLogger($this->logger, "Dedicated Query Interface")));
-				if($queryRegistered){
-					$this->logger->info($this->getLanguage()->translate(KnownTranslationFactory::pocketmine_server_query_running($prettyIp, (string) $port)));
-				}
+				$this->network->registerInterface(new DedicatedQueryNetworkInterface($ip, $port, $ipV6, new \PrefixedLogger($this->logger, "Dedicated Query Interface")));
+				$this->logger->info($this->getLanguage()->translate(KnownTranslationFactory::pocketmine_server_query_running($prettyIp, (string) $port)));
 			}
 		}
 		return true;

--- a/src/Server.php
+++ b/src/Server.php
@@ -1151,9 +1151,9 @@ class Server{
 				//RakLib would normally handle the transport for Query packets
 				//if it's not registered we need to make sure Query still works
 				$queryRegistered = $this->network->registerInterface(new DedicatedQueryNetworkInterface($ip, $port, $ipV6, new \PrefixedLogger($this->logger, "Dedicated Query Interface")));
-			}
-			if($queryRegistered){
-				$this->logger->info($this->getLanguage()->translate(KnownTranslationFactory::pocketmine_server_query_running($prettyIp, (string) $port)));
+				if($queryRegistered){
+					$this->logger->info($this->getLanguage()->translate(KnownTranslationFactory::pocketmine_server_query_running($prettyIp, (string) $port)));
+				}
 			}
 		}
 		return true;

--- a/src/Server.php
+++ b/src/Server.php
@@ -1151,8 +1151,8 @@ class Server{
 				//RakLib would normally handle the transport for Query packets
 				//if it's not registered we need to make sure Query still works
 				$this->network->registerInterface(new DedicatedQueryNetworkInterface($ip, $port, $ipV6, new \PrefixedLogger($this->logger, "Dedicated Query Interface")));
-				$this->logger->info($this->getLanguage()->translate(KnownTranslationFactory::pocketmine_server_query_running($prettyIp, (string) $port)));
 			}
+			$this->logger->info($this->getLanguage()->translate(KnownTranslationFactory::pocketmine_server_query_running($prettyIp, (string) $port)));
 		}
 		return true;
 	}

--- a/src/Server.php
+++ b/src/Server.php
@@ -1150,9 +1150,11 @@ class Server{
 			if(!$rakLibRegistered){
 				//RakLib would normally handle the transport for Query packets
 				//if it's not registered we need to make sure Query still works
-				$this->network->registerInterface(new DedicatedQueryNetworkInterface($ip, $port, $ipV6, new \PrefixedLogger($this->logger, "Dedicated Query Interface")));
+				$queryRegistered = $this->network->registerInterface(new DedicatedQueryNetworkInterface($ip, $port, $ipV6, new \PrefixedLogger($this->logger, "Dedicated Query Interface")));
 			}
-			$this->logger->info($this->getLanguage()->translate(KnownTranslationFactory::pocketmine_server_query_running($prettyIp, (string) $port)));
+			if($queryRegistered){
+				$this->logger->info($this->getLanguage()->translate(KnownTranslationFactory::pocketmine_server_query_running($prettyIp, (string) $port)));
+			}
 		}
 		return true;
 	}


### PR DESCRIPTION
## Introduction
This is purely an aesthetic change and to prevent confusion to end users, But even though `NetworkInterfaceRegisterEvent` got cancelled, PM4 still logs `pocketmine.server.networkStart` and `pocketmine.server.query.running` to console

## Changes

### Behavioural changes
 - `pocketmine.server.networkStart` is no longer logged to console if their respective `NetworkInterfaceRegisterEvent` gets cancelled