### PR TITLE
Changelog: Player::getLowerCaseName() Removed

### DIFF
--- a/changelogs/4.0.md
+++ b/changelogs/4.0.md
@@ -1063,6 +1063,7 @@ However, if we add `src-namespace-prefix: pmmp\TesterPlugin` to the `plugin.yml`
   - `Player->setCraftingGrid()`: crafting tables now work the same way as other containers; use `Player->setCurrentWindow()`
   - `Player->updateNextPosition()`: use `Player->handleMovement()` instead
   - `Player->updatePing()`: moved to `NetworkSession`
+  - `Player->getLowerCaseName()`: removed, use `strtolower(Player->getName())` instead
 
 ### Plugin
 - API version checks are now more strict. It is no longer legal to declare multiple minimum versions on the same major version. Doing so will now cause the plugin to fail to load with the message `Multiple minimum API versions found for some major versions`.


### PR DESCRIPTION
## Introduction
This just informs that ``Player::getLowerCaseName()`` has removed on changelog.md