### PR TITLE
ClearCommand: Cleanup logic & fix vanilla disparities

### DIFF
--- a/changelogs/4.0.md
+++ b/changelogs/4.0.md
@@ -836,7 +836,7 @@ However, if we add `src-namespace-prefix: pmmp\TesterPlugin` to the `plugin.yml`
   - `Item::clearCreativeItems()` -> `CreativeInventory::clear()`
   - `Item::getCreativeItemIndex()` -> `CreativeInventory::getItemIndex()`
   - `Item::getCreativeItems()` -> `CreativeInventory::getAll()`
-  - `Item::initCreativeItems()` -> `CreativeInventory::init()`
+  - `Item::initCreativeItems()` -> `CreativeInventory::reset()`
   - `Item::isCreativeItem()` -> `CreativeInventory::contains()`
   - `Item::removeCreativeItem()` -> `CreativeInventory::remove()`
 - The following classes have been added:

--- a/src/command/defaults/ClearCommand.php
+++ b/src/command/defaults/ClearCommand.php
@@ -137,10 +137,6 @@ class ClearCommand extends VanillaCommand{
 						break;
 					}
 
-					if(count($inventory->getContents()) === 0){
-						continue;
-					}
-
 					foreach($inventory->all($targetItem) as $index => $item){
 						// The count to reduce from the item and max count
 						$reductionCount = min($item->getCount(), $maxCount);

--- a/src/command/defaults/ClearCommand.php
+++ b/src/command/defaults/ClearCommand.php
@@ -26,7 +26,7 @@ namespace pocketmine\command\defaults;
 use pocketmine\command\Command;
 use pocketmine\command\CommandSender;
 use pocketmine\command\utils\InvalidCommandSyntaxException;
-use pocketmine\inventory\SimpleInventory;
+use pocketmine\inventory\Inventory;
 use pocketmine\item\Item;
 use pocketmine\item\LegacyStringToItemParser;
 use pocketmine\item\LegacyStringToItemParserException;

--- a/src/command/defaults/ClearCommand.php
+++ b/src/command/defaults/ClearCommand.php
@@ -106,7 +106,7 @@ class ClearCommand extends VanillaCommand{
 
 		// Checking player's inventory for all the items matching the criteria
 		if($targetItem !== null and $maxCount === 0){
-			$count = array_reduce($inventories, fn(int $carry, Inventory $inventory) => $carry + $this->countItems($inventory, $targetItem), 0);
+			$count =  $this->countItems($inventories, $targetItem);
 			if($count > 0){
 				$sender->sendMessage(KnownTranslationFactory::commands_clear_testing($target->getName(), (string) $count));
 			}else{
@@ -120,14 +120,14 @@ class ClearCommand extends VanillaCommand{
 		if($targetItem === null){
 			// Clear all items from the inventories
 			foreach($inventories as $inventory) {
-				$clearedCount += $this->countItems($inventory, null);
+				$clearedCount += $this->countItems([$inventory], null);
 				$inventory->clearAll();
 			}
 		}else{
 			// Clear the item from target's inventory irrelevant of the count
 			if($maxCount === -1){
 				foreach($inventories as $inventory) {
-					$clearedCount += $this->countItems($inventory, $targetItem);
+					$clearedCount += $this->countItems([$inventory], $targetItem);
 					$inventory->remove($targetItem);
 				}
 			}else{
@@ -167,11 +167,19 @@ class ClearCommand extends VanillaCommand{
 		return true;
 	}
 
-	protected function countItems(Inventory $inventory, ?Item $target) : int{
+	/**
+	 * @param Inventory[] $inventories
+	 * @param Item|null $target
+	 *
+	 * @return int
+	 */
+	protected function countItems(array $inventories, ?Item $target) : int{
 		$count = 0;
-		$contents = $target instanceof Item ? $inventory->all($target) : $inventory->getContents();
-		foreach($contents as $item) {
-			$count += $item->getCount();
+		foreach($inventories as $inventory) {
+			$contents = $target instanceof Item ? $inventory->all($target) : $inventory->getContents();
+			foreach($contents as $item) {
+				$count += $item->getCount();
+			}
 		}
 		return $count;
 	}

--- a/src/command/defaults/ClearCommand.php
+++ b/src/command/defaults/ClearCommand.php
@@ -168,9 +168,6 @@ class ClearCommand extends VanillaCommand{
 
 	/**
 	 * @param Inventory[] $inventories
-	 * @param Item|null $target
-	 *
-	 * @return int
 	 */
 	protected function countItems(array $inventories, ?Item $target) : int{
 		$count = 0;

--- a/src/command/defaults/ClearCommand.php
+++ b/src/command/defaults/ClearCommand.php
@@ -104,7 +104,7 @@ class ClearCommand extends VanillaCommand{
 
 		// Checking player's inventory for all the items matching the criteria
 		if($targetItem !== null and $maxCount === 0){
-			$count = array_reduce($inventories, static fn(int $carry, SimpleInventory $inventory) => $carry + $this->countItems($inventory, $targetItem), 0);
+			$count = array_reduce($inventories, fn(int $carry, SimpleInventory $inventory) => $carry + $this->countItems($inventory, $targetItem), 0);
 
 			if($count > 0){
 				$sender->sendMessage(KnownTranslationFactory::commands_clear_testing($target->getName(), (string) $count));
@@ -164,7 +164,7 @@ class ClearCommand extends VanillaCommand{
 		return true;
 	}
 
-	protected function countItems(SimpleInventory $inventory, ?Item $target): int {
+	protected static function countItems(SimpleInventory $inventory, ?Item $target): int {
 		return array_reduce(
 			$target instanceof Item ? $inventory->all($target) : $inventory->getContents(),
 			static fn(int $carry, Item $item): int => $carry + $item->getCount(),

--- a/src/command/defaults/ClearCommand.php
+++ b/src/command/defaults/ClearCommand.php
@@ -166,7 +166,7 @@ class ClearCommand extends VanillaCommand{
 		return true;
 	}
 
-	protected static function countItems(SimpleInventory $inventory, ?Item $target): int {
+	protected function countItems(SimpleInventory $inventory, ?Item $target): int {
 		return array_reduce(
 			$target instanceof Item ? $inventory->all($target) : $inventory->getContents(),
 			static fn(int $carry, Item $item): int => $carry + $item->getCount(),

--- a/src/command/defaults/ClearCommand.php
+++ b/src/command/defaults/ClearCommand.php
@@ -35,7 +35,6 @@ use pocketmine\lang\KnownTranslationFactory;
 use pocketmine\permission\DefaultPermissionNames;
 use pocketmine\player\Player;
 use pocketmine\utils\TextFormat;
-use function array_reduce;
 use function count;
 use function implode;
 use function min;

--- a/src/command/defaults/ClearCommand.php
+++ b/src/command/defaults/ClearCommand.php
@@ -132,11 +132,6 @@ class ClearCommand extends VanillaCommand{
 			}else{
 				// Clear the item from target's inventory up to maxCount
 				foreach($inventories as $inventory){
-					// Break if we've cleared enough items
-					if($maxCount === 0){
-						break;
-					}
-
 					foreach($inventory->all($targetItem) as $index => $item){
 						// The count to reduce from the item and max count
 						$reductionCount = min($item->getCount(), $maxCount);

--- a/src/command/defaults/ClearCommand.php
+++ b/src/command/defaults/ClearCommand.php
@@ -171,4 +171,12 @@ class ClearCommand extends VanillaCommand{
 
 		return true;
 	}
+
+	protected function countItems(SimpleInventory $inventory, ?Item $target): int {
+		return array_reduce(
+			$target instanceof Item ? $inventory->all($target) : $inventory->getContents(),
+			static fn(int $carry, Item $item): int => $carry + $item->getCount(),
+			0
+		);
+	}
 }

--- a/src/command/defaults/ClearCommand.php
+++ b/src/command/defaults/ClearCommand.php
@@ -118,17 +118,17 @@ class ClearCommand extends VanillaCommand{
 		$clearedCount = 0;
 		if($targetItem === null){
 			// Clear all items from the inventories
+			$clearedCount += $this->countItems($inventories, null);
 			foreach($inventories as $inventory) {
 				$inventory->clearAll();
 			}
-			$clearedCount += $this->countItems($inventories, null);
 		}else{
 			// Clear the item from target's inventory irrelevant of the count
 			if($maxCount === -1){
+				$clearedCount += $this->countItems($inventories, $targetItem);
 				foreach($inventories as $inventory) {
 					$inventory->remove($targetItem);
 				}
-				$clearedCount += $this->countItems($inventories, $targetItem);
 			}else{
 				// Clear the item from target's inventory up to maxCount
 				foreach($inventories as $inventory) {

--- a/src/command/defaults/ClearCommand.php
+++ b/src/command/defaults/ClearCommand.php
@@ -172,7 +172,7 @@ class ClearCommand extends VanillaCommand{
 	protected function countItems(array $inventories, ?Item $target) : int{
 		$count = 0;
 		foreach($inventories as $inventory){
-			$contents = $target instanceof Item ? $inventory->all($target) : $inventory->getContents();
+			$contents = $target !== null ? $inventory->all($target) : $inventory->getContents();
 			foreach($contents as $item){
 				$count += $item->getCount();
 			}

--- a/src/command/defaults/ClearCommand.php
+++ b/src/command/defaults/ClearCommand.php
@@ -35,8 +35,10 @@ use pocketmine\lang\KnownTranslationFactory;
 use pocketmine\permission\DefaultPermissionNames;
 use pocketmine\player\Player;
 use pocketmine\utils\TextFormat;
+use function array_reduce;
 use function count;
 use function implode;
+use function min;
 
 class ClearCommand extends VanillaCommand{
 

--- a/src/command/defaults/ClearCommand.php
+++ b/src/command/defaults/ClearCommand.php
@@ -166,11 +166,12 @@ class ClearCommand extends VanillaCommand{
 		return true;
 	}
 
-	protected function countItems(SimpleInventory $inventory, ?Item $target): int {
-		return array_reduce(
-			$target instanceof Item ? $inventory->all($target) : $inventory->getContents(),
-			static fn(int $carry, Item $item): int => $carry + $item->getCount(),
-			0
-		);
+	protected function countItems(Inventory $inventory, ?Item $target) : int{
+		$count = 0;
+		$contents = $target instanceof Item ? $inventory->all($target) : $inventory->getContents();
+		foreach($contents as $item) {
+			$count += $item->getCount();
+		}
+		return $count;
 	}
 }

--- a/src/command/defaults/ClearCommand.php
+++ b/src/command/defaults/ClearCommand.php
@@ -120,16 +120,16 @@ class ClearCommand extends VanillaCommand{
 		if($targetItem === null){
 			// Clear all items from the inventories
 			foreach($inventories as $inventory) {
-				$clearedCount += $this->countItems([$inventory], null);
 				$inventory->clearAll();
 			}
+			$clearedCount += $this->countItems($inventories, null);
 		}else{
 			// Clear the item from target's inventory irrelevant of the count
 			if($maxCount === -1){
 				foreach($inventories as $inventory) {
-					$clearedCount += $this->countItems([$inventory], $targetItem);
 					$inventory->remove($targetItem);
 				}
+				$clearedCount += $this->countItems($inventories, $targetItem);
 			}else{
 				// Clear the item from target's inventory up to maxCount
 				foreach($inventories as $inventory) {

--- a/src/command/defaults/ClearCommand.php
+++ b/src/command/defaults/ClearCommand.php
@@ -105,7 +105,7 @@ class ClearCommand extends VanillaCommand{
 
 		// Checking player's inventory for all the items matching the criteria
 		if($targetItem !== null and $maxCount === 0){
-			$count =  $this->countItems($inventories, $targetItem);
+			$count = $this->countItems($inventories, $targetItem);
 			if($count > 0){
 				$sender->sendMessage(KnownTranslationFactory::commands_clear_testing($target->getName(), (string) $count));
 			}else{
@@ -119,29 +119,29 @@ class ClearCommand extends VanillaCommand{
 		if($targetItem === null){
 			// Clear all items from the inventories
 			$clearedCount += $this->countItems($inventories, null);
-			foreach($inventories as $inventory) {
+			foreach($inventories as $inventory){
 				$inventory->clearAll();
 			}
 		}else{
 			// Clear the item from target's inventory irrelevant of the count
 			if($maxCount === -1){
 				$clearedCount += $this->countItems($inventories, $targetItem);
-				foreach($inventories as $inventory) {
+				foreach($inventories as $inventory){
 					$inventory->remove($targetItem);
 				}
 			}else{
 				// Clear the item from target's inventory up to maxCount
-				foreach($inventories as $inventory) {
+				foreach($inventories as $inventory){
 					// Break if we've cleared enough items
 					if($maxCount === 0){
 						break;
 					}
 
-					if(count($inventory->getContents()) === 0) {
+					if(count($inventory->getContents()) === 0){
 						continue;
 					}
 
-					foreach($inventory->all($targetItem) as $index => $item) {
+					foreach($inventory->all($targetItem) as $index => $item){
 						// The count to reduce from the item and max count
 						$reductionCount = min($item->getCount(), $maxCount);
 						$item->pop($reductionCount);
@@ -171,9 +171,9 @@ class ClearCommand extends VanillaCommand{
 	 */
 	protected function countItems(array $inventories, ?Item $target) : int{
 		$count = 0;
-		foreach($inventories as $inventory) {
+		foreach($inventories as $inventory){
 			$contents = $target instanceof Item ? $inventory->all($target) : $inventory->getContents();
-			foreach($contents as $item) {
+			foreach($contents as $item){
 				$count += $item->getCount();
 			}
 		}


### PR DESCRIPTION
## Introduction
At the moment, ClearCommand is redundant in logic, has unclear naming with variables and has discrepancies with the vanilla game. This pull request aims to tackle these issues by:

A) Removing any redundant logic that exists and replacing it with more generalized logic that can be used with all of the player's attached inventories.
B) Renaming the variables to be more concise in nature.
C) Correcting the order in which the inventories are cleared in (as to follow vanilla mechanics).

### Relevant issues
N/A

## Changes
### API changes
N/A

### Behavioural changes
After extensive testing, I have found the performance difference between the current stable commit and the pull request to be negligible.

## Backwards compatibility
Given the small scope of this pull request, there are no issues as to backwards compatibility.

## Follow-up
One big follow-up is to implement the off-hand inventory. However, given the new logic, it'll only require one more line for it to be implemented into the command. Modifying the $inventories variable by adding `$target->getOffHandInventory()` will complete support. The end product will look like:
```php
$inventories = [
    $target->getInventory(),
    $target->getCursorInventory(),
    $target->getArmorInventory(),
    $target->getOffHandInventory()
];
```

## Tests
To ensure no disparities between PMMP's and the vanilla games, I tested the ordering of the inventories using command blocks.

Vanilla Behavior:
https://user-images.githubusercontent.com/13668008/144777839-671d18f5-9f75-493a-9df8-fb14daadccfd.mp4

PocketMine-MP Behavior (w/ patch):
https://user-images.githubusercontent.com/13668008/144779411-1af5902e-c45c-4ff7-95fd-35a27d78dbec.mp4

Here is the function used to emulate the command blocks:
```php
public function handlePlayerJoin(PlayerJoinEvent $event): void {
    $player = $event->getPlayer();

    $arrows = VanillaItems::ARROW()->setCount(5);

    // Clear inventory & set items w/ indexes
    $player->getInventory()->clearAll();
    $player->getInventory()->setItem(0, $arrows);
    $player->getInventory()->setItem(1, $arrows);

    // Set item to head slot
    $player->getArmorInventory()->clearAll();
    $player->getArmorInventory()->setItem(ArmorInventory::SLOT_HEAD, VanillaItems::ARROW()->setCount(5));

    // Run command /clear {name} arrow 1 every second after 10 seconds of day
    $this->getPlugin()->getScheduler()->scheduleDelayedRepeatingTask(
        new ClosureTask(function () use($player): void {
            $this->getPlugin()->getServer()->dispatchCommand($player, "clear {$player->getName()} arrow 1");
            if(count($player->getArmorInventory()->getContents()) <= 0) {
                $this->getPlugin()->getScheduler()->cancelAllTasks();
            }
        }),
        20 * 10, 20
    );
}
```