### PR TITLE
Add ExperienceOrb attracts lock feature

### DIFF
--- a/src/entity/ExperienceManager.php
+++ b/src/entity/ExperienceManager.php
@@ -52,7 +52,7 @@ class ExperienceManager{
 	private $totalXp = 0;
 
 	/** @var bool */
-	private $attractsLocked = true;
+	private $attractsLocked = false;
 
 	/** @var int */
 	private $xpCooldown = 0;

--- a/src/entity/ExperienceManager.php
+++ b/src/entity/ExperienceManager.php
@@ -52,7 +52,7 @@ class ExperienceManager{
 	private $totalXp = 0;
 
 	/** @var bool */
-	private $attractsLocked = false;
+	private $canAttractXpOrbs = true;
 
 	/** @var int */
 	private $xpCooldown = 0;
@@ -303,11 +303,11 @@ class ExperienceManager{
 		}
 	}
 
-	public function isAttractsLocked(): bool{
+	public function canAttractXpOrbs(): bool{
 		return $this->attractsLocked;
 	}
 
-	public function setAttractsLocked(bool $v = true): void{
+	public function setCanAttractXpOrbs(bool $v = true): void{
 		$this->attractsLocked = $v;
 	}
 }

--- a/src/entity/ExperienceManager.php
+++ b/src/entity/ExperienceManager.php
@@ -51,6 +51,9 @@ class ExperienceManager{
 	/** @var int */
 	private $totalXp = 0;
 
+	/** @var bool */
+	private $attractsLocked = true;
+
 	/** @var int */
 	private $xpCooldown = 0;
 
@@ -298,5 +301,13 @@ class ExperienceManager{
 		if($this->xpCooldown > 0){
 			$this->xpCooldown = max(0, $this->xpCooldown - $tickDiff);
 		}
+	}
+
+	public function isAttractsLocked(): bool{
+		return $this->attractsLocked;
+	}
+
+	public function setAttractsLocked(bool $v = true): void{
+		$this->attractsLocked = $v;
 	}
 }

--- a/src/entity/ExperienceManager.php
+++ b/src/entity/ExperienceManager.php
@@ -304,10 +304,10 @@ class ExperienceManager{
 	}
 
 	public function canAttractXpOrbs(): bool{
-		return $this->attractsLocked;
+		return $this->canAttractXpOrbs;
 	}
 
 	public function setCanAttractXpOrbs(bool $v = true): void{
-		$this->attractsLocked = $v;
+		$this->canAttractXpOrbs = $v;
 	}
 }

--- a/src/entity/ExperienceManager.php
+++ b/src/entity/ExperienceManager.php
@@ -298,11 +298,11 @@ class ExperienceManager{
 		}
 	}
 
-	public function canAttractXpOrbs(): bool{
+	public function canAttractXpOrbs() : bool{
 		return $this->canAttractXpOrbs;
 	}
 
-	public function setCanAttractXpOrbs(bool $v = true): void{
+	public function setCanAttractXpOrbs(bool $v = true) : void{
 		$this->canAttractXpOrbs = $v;
 	}
 }

--- a/src/entity/object/ExperienceOrb.php
+++ b/src/entity/object/ExperienceOrb.php
@@ -145,7 +145,7 @@ class ExperienceOrb extends Entity{
 		}
 
 		$entity = $this->getWorld()->getEntity($this->targetPlayerRuntimeId);
-		if($entity instanceof Human && !$entity->getXpManager()->isAttractsLocked()){
+		if($entity instanceof Human){
 			return $entity;
 		}
 
@@ -153,11 +153,7 @@ class ExperienceOrb extends Entity{
 	}
 
 	public function setTargetPlayer(?Human $player) : void{
-		if(($player instanceof Human && !$player->getXpManager()->isAttractsLocked()) or $player === null){
-			$this->targetPlayerRuntimeId = $player !== null ? $player->getId() : null;
-		}else{
-			$this->targetPlayerRuntimeId = null;
-		}
+		$this->targetPlayerRuntimeId = $player !== null ? $player->getId() : null;
 	}
 
 	protected function entityBaseTick(int $tickDiff = 1) : bool{
@@ -170,7 +166,7 @@ class ExperienceOrb extends Entity{
 		}
 
 		$currentTarget = $this->getTargetPlayer();
-		if($currentTarget !== null and (!$currentTarget->isAlive() or $currentTarget->location->distanceSquared($this->location) > self::MAX_TARGET_DISTANCE ** 2)){
+		if($currentTarget !== null and (!$currentTarget->isAlive() or $currentTarget->getXpManager()->isAttractsLocked() or $currentTarget->location->distanceSquared($this->location) > self::MAX_TARGET_DISTANCE ** 2)){
 			$currentTarget = null;
 		}
 

--- a/src/entity/object/ExperienceOrb.php
+++ b/src/entity/object/ExperienceOrb.php
@@ -145,7 +145,7 @@ class ExperienceOrb extends Entity{
 		}
 
 		$entity = $this->getWorld()->getEntity($this->targetPlayerRuntimeId);
-		if($entity instanceof Human){
+		if($entity instanceof Human && !$entity->getXpManager()->isAttractsLocked()){
 			return $entity;
 		}
 
@@ -153,7 +153,11 @@ class ExperienceOrb extends Entity{
 	}
 
 	public function setTargetPlayer(?Human $player) : void{
-		$this->targetPlayerRuntimeId = $player !== null ? $player->getId() : null;
+		if(($player instanceof Human && !$player->getXpManager()->isAttractsLocked()) or $player === null){
+			$this->targetPlayerRuntimeId = $player !== null ? $player->getId() : null;
+		}else{
+			$this->targetPlayerRuntimeId = null;
+		}
 	}
 
 	protected function entityBaseTick(int $tickDiff = 1) : bool{
@@ -174,7 +178,7 @@ class ExperienceOrb extends Entity{
 			if($currentTarget === null){
 				$newTarget = $this->getWorld()->getNearestEntity($this->location, self::MAX_TARGET_DISTANCE, Human::class);
 
-				if($newTarget instanceof Human and !($newTarget instanceof Player and $newTarget->isSpectator())){
+				if($newTarget instanceof Human and !($newTarget instanceof Player and $newTarget->isSpectator()) and !$newTarget->getXpManager()->isAttractsLocked()){
 					$currentTarget = $newTarget;
 				}
 			}

--- a/src/entity/object/ExperienceOrb.php
+++ b/src/entity/object/ExperienceOrb.php
@@ -166,7 +166,7 @@ class ExperienceOrb extends Entity{
 		}
 
 		$currentTarget = $this->getTargetPlayer();
-		if($currentTarget !== null and (!$currentTarget->isAlive() or $currentTarget->getXpManager()->isAttractsLocked() or $currentTarget->location->distanceSquared($this->location) > self::MAX_TARGET_DISTANCE ** 2)){
+		if($currentTarget !== null and (!$currentTarget->isAlive() or !$currentTarget->getXpManager()->canAttractXpOrbs() or $currentTarget->location->distanceSquared($this->location) > self::MAX_TARGET_DISTANCE ** 2)){
 			$currentTarget = null;
 		}
 
@@ -174,7 +174,7 @@ class ExperienceOrb extends Entity{
 			if($currentTarget === null){
 				$newTarget = $this->getWorld()->getNearestEntity($this->location, self::MAX_TARGET_DISTANCE, Human::class);
 
-				if($newTarget instanceof Human and !($newTarget instanceof Player and $newTarget->isSpectator()) and !$newTarget->getXpManager()->isAttractsLocked()){
+				if($newTarget instanceof Human and !($newTarget instanceof Player and $newTarget->isSpectator()) and $newTarget->getXpManager()->canAttractXpOrbs()){
 					$currentTarget = $newTarget;
 				}
 			}


### PR DESCRIPTION
## Introduction
As explained in the issue #4589 , there is a need to allow developers to remove players from the attraction of xp orbs. 

### Relevant issues
* Fixes #4589

## Changes
### API changes
The following methods have been added to the ``ExperienceManager`` :
* ``isAttractsLocked`` : Returns true if the Human no longer accepts xp orbs attracts, false otherwise
* ``setAttractsLocked`` : The setter to change the acceptance status of xp orbs

### Behavioural changes
In ``ExperienceOrb``:
* The ``getTargetPlayer`` method will no longer return an instance of ``Human`` if ``isAttractsLocked`` return true for the instance
* The ``setTargetPlayer`` method will no longer choose a ``Human`` that returns true to ``isAttractsLocked``
* In ``entityBaseTick`` the orb will no longer choose a target that returns true to ``isAttractsLocked``

## Follow-up
No specific action is required

## Tests
* To test the normal system, mine a block of diamond ore in survival and the orb will indeed follow you.
* To test the locked system, create a plugin that disables orbs by default for any given player and it will look like this:
![image](https://user-images.githubusercontent.com/66992287/145113974-5a235712-380d-4049-b0cd-5dc0b248170a.png)

