### PR TITLE
ClearCommand: Add OffHandInventory to $inventories

### DIFF
--- a/src/command/defaults/ClearCommand.php
+++ b/src/command/defaults/ClearCommand.php
@@ -100,7 +100,8 @@ class ClearCommand extends VanillaCommand{
 		$inventories = [
 			$target->getInventory(),
 			$target->getCursorInventory(),
-			$target->getArmorInventory()
+			$target->getArmorInventory(),
+			$target->getOffHandInventory()
 		];
 
 		// Checking player's inventory for all the items matching the criteria


### PR DESCRIPTION
## Introduction
Building off of #4619, this small change appends the player's off-hand inventory to the list of inventories in ClearCommand. This ensures that there are no disparities between the latest vanilla update and PocketMine-MP's version.

### Relevant issues
N/A

## Changes
### API changes
N/A

### Behavioural changes
N/A

## Backwards compatibility
N/A

## Follow-up
N/A
## Tests
Testing used a fairly simple suite. Using a similar testing script to #4619, I checked that the ordering of the inventories matched to that of the vanilla game's.