### PR TITLE
Flower pot

### DIFF
--- a/src/block/FlowerPot.php
+++ b/src/block/FlowerPot.php
@@ -114,6 +114,10 @@ class FlowerPot extends Flowable{
 		}elseif(!$this->canAddPlant($plant)){
 			return false;
 		}else{
+			if($plant instanceof BambooSapling){
+				//Hack to convert bamboosapling to bamboo block (different id)
+				$plant = VanillaBlocks::BAMBOO();
+			}
 			$this->setPlant($plant);
 			$item->pop();
 		}
@@ -168,7 +172,8 @@ class FlowerPot extends Flowable{
 			case $block instanceof RedMushroom:
 			case $block instanceof BrownMushroom:
 			case $block instanceof Sapling:
-			//TODO: bamboo, roots, azaleas, 
+			case $block instanceof BambooSapling:
+			//TODO: roots, azaleas 
 				return true;
 				break;
 			case $block instanceof TallGrass:

--- a/src/block/FlowerPot.php
+++ b/src/block/FlowerPot.php
@@ -139,14 +139,16 @@ class FlowerPot extends Flowable{
 		return $this->plant !== null ? $this->plant->asItem() : parent::getPickedItem($addUserData);
 	}
 
+	/**
+	 * Checks the viability of the support to place the flower pot
+	 */
 	protected function isValidSupport(Block $down): bool{
 		if($down instanceof Slab && ($down->getSlabType()->equals(SlabType::TOP()) || $down->getSlabType()->equals(SlabType::DOUBLE()))){
 			return true;
 		}elseif($down instanceof Stair && $down->isUpsideDown()){
 			return true;
 		}
-		//TODO: piston, dropper
-		switch ($down->getId()) {
+		switch($down->getId()){
 			case BlockLegacyIds::BEACON:
 			case BlockLegacyIds::GLASS:
 			case BlockLegacyIds::FARMLAND:
@@ -158,14 +160,18 @@ class FlowerPot extends Flowable{
 			case BlockLegacyIds::STONE_WALL:
 			case BlockLegacyIds::STONE_WALL:
 			case BlockLegacyIds::SEA_LANTERN:
+				//TODO: piston, dropper
 				return true;
 				break;
 		}
 		return !$down->isTransparent();
 	}
 
+	/**
+	 * Checks the viability of the item to be put in the flower pot
+	 */
 	protected function canBePlacedInFlowerPot(Block $block): bool{
-		switch (true) {
+		switch(true){
 			case $block instanceof Cactus:
 			case $block instanceof DeadBush:
 			case $block instanceof Flower:
@@ -173,7 +179,7 @@ class FlowerPot extends Flowable{
 			case $block instanceof BrownMushroom:
 			case $block instanceof Sapling:
 			case $block instanceof BambooSapling:
-			//TODO: roots, azaleas 
+			//TODO: roots, azaleas, fungus
 				return true;
 				break;
 			case $block instanceof TallGrass:

--- a/src/block/FlowerPot.php
+++ b/src/block/FlowerPot.php
@@ -162,7 +162,6 @@ class FlowerPot extends Flowable{
 			case BlockLegacyIds::SEA_LANTERN:
 				//TODO: piston, dropper
 				return true;
-				break;
 		}
 		return !$down->isTransparent();
 	}
@@ -181,10 +180,8 @@ class FlowerPot extends Flowable{
 			case $block instanceof BambooSapling:
 			//TODO: roots, azaleas, fungus
 				return true;
-				break;
 			case $block instanceof TallGrass:
 				return $block->getIdInfo()->getVariant() === BlockLegacyMetadata::TALLGRASS_FERN;
-				break;
 		}
 		return false;
 	}


### PR DESCRIPTION
## Introduction
The current problem is that the flowerpots have been implemented but at their functional limit. For example, we cannot currently put them on anything that is stairs in a high position / slab etc. But also, some plants weren't allowed to go there even though the vanilla version of minecraft allowed them.

### Relevant issues
This pull request is slightly related to #458 due to the fact that it patches this part for flower pots

## Changes
### API changes
Several functions have been added to the FlowerPot class to check the contents of the flowerpot and the support underneath it.

### Behavioural changes
Apart from the fact that the flower pots can be placed on a larger number of blocks, no

## Follow-up
This pull request is entirely related to the flowerpot but many other blocks are in the same case like the torches.
It can be converted into a whole change and a fix of all these blocks to fix this problem that has been present for quite some time.

## Tests
The tests are quite simple, use the flowerpots as if you were using them in vanilla minecraft, on the slabs, stairs, and other transparent blocks that support it