### PR TITLE
Add a way to explicitly blame a plugin for crashing the server

### DIFF
--- a/src/crash/BlamePluginCallProxy.php
+++ b/src/crash/BlamePluginCallProxy.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\crash;
+
+/**
+ * @internal
+ */
+final class BlamePluginCallProxy{
+	public const FILE = __FILE__;
+
+	private function __construct(){
+		//NOOP
+	}
+
+	public static ?string $blamedPlugin = null;
+
+	/**
+	 * Wrapper to explicitly blame a plugin for any fatal error or exception that gets thrown by the given Closure.
+	 * This is needed because sometimes crash frames will appear in PocketMine-MP code files even if they were caused by
+	 * plugins.
+	 *
+	 * For example, when constructing a plugin's main class, if the class declares a nonexisting constant as a default
+	 * value of a property or constant, the error will appear in PluginManager.php, even though the error was actually
+	 * caused by the borked main class.
+	 *
+	 * WARNING: If you catch any exception thrown by this function, be sure to clear the blamedPlugin, otherwise further
+	 * errors could be incorrectly blamed on the plugin.
+	 *
+	 * @phpstan-template TReturn
+	 * @phpstan-param \Closure() : TReturn $closure
+	 * @phpstan-return TReturn
+	 */
+	public static function call(string $pluginName, \Closure $closure) : mixed{
+		self::$blamedPlugin = $pluginName;
+		$result = $closure();
+		self::$blamedPlugin = null;
+		return $result;
+	}
+}

--- a/src/crash/CrashDumpRenderer.php
+++ b/src/crash/CrashDumpRenderer.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\crash;
 
+use pocketmine\utils\AssumptionFailedError;
 use pocketmine\utils\Utils;
 use pocketmine\utils\VersionString;
 use function count;
@@ -52,9 +53,9 @@ final class CrashDumpRenderer{
 		if($this->data->plugin_involvement !== CrashDump::PLUGIN_INVOLVEMENT_NONE){
 			$this->addLine();
 			$this->addLine(match($this->data->plugin_involvement){
-				CrashDump::PLUGIN_INVOLVEMENT_DIRECT => "THIS CRASH WAS CAUSED BY A PLUGIN",
+				CrashDump::PLUGIN_INVOLVEMENT_BLAME, CrashDump::PLUGIN_INVOLVEMENT_DIRECT => "THIS CRASH WAS CAUSED BY A PLUGIN",
 				CrashDump::PLUGIN_INVOLVEMENT_INDIRECT => "A PLUGIN WAS INVOLVED IN THIS CRASH",
-				default => "Unknown plugin involvement!"
+				default => throw new AssumptionFailedError()
 			});
 		}
 		if($this->data->plugin !== ""){

--- a/src/plugin/PluginManager.php
+++ b/src/plugin/PluginManager.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\plugin;
 
+use pocketmine\crash\BlamePluginCallProxy;
 use pocketmine\event\Cancellable;
 use pocketmine\event\Event;
 use pocketmine\event\EventPriority;
@@ -207,11 +208,14 @@ class PluginManager{
 			}
 		}
 
-		/**
-		 * @var Plugin $plugin
-		 * @see Plugin::__construct()
-		 */
-		$plugin = new $mainClass($loader, $this->server, $description, $dataFolder, $prefixed, new DiskResourceProvider($prefixed . "/resources/"));
+		$plugin = BlamePluginCallProxy::call($description->getName(), function() use ($mainClass, $loader, $description, $dataFolder, $prefixed) : Plugin{
+			/**
+			 * @var Plugin $plugin
+			 * @see Plugin::__construct()
+			 */
+			$plugin = new $mainClass($loader, $this->server, $description, $dataFolder, $prefixed, new DiskResourceProvider($prefixed . "/resources/"));
+			return $plugin;
+		});
 		$this->plugins[$plugin->getDescription()->getName()] = $plugin;
 
 		return $plugin;


### PR DESCRIPTION


## Introduction
We often see cryptic crashes like these: https://crash.pmmp.io/view/5617460

These are actually caused by bogus plugin code, but due to a PHP bug, they are reported in PluginManager instead of at their actual location.
This is not likely to be addressed in the near future (it's been a bug for a very long time), and in the meantime it's adding pollution to the crash archive.

A new crashdump plugin_involvement 'blame' status is added, which the crash archive will need to support. I think for now it's important to distinguish between these at the CA level, so that any bugs in the call proxy can be identified correctly.

## Changes
### API changes
No changes to public API.

A new class `BlamePluginCallProxy` is added for internals use.

### Behavioural changes
Errors that occur while constructing a plugin's main class will now be correctly blamed on the plugin.

## Follow-up
We may also want to extend this to the following areas:

- plugin.yml parsing (debatable; we should be validating it properly anyway)
- command permission setting (this is the source of a lot of PM4 "core" crashes right now)

## Tests
```php
class Main extends PluginBase{
	public const TEST = \pocketmine\item\Item::IRON_INGOT;
}
```

Before the patch: 
[Mon_Dec_13-19.52.31-GMT_2021.log](https://github.com/pmmp/PocketMine-MP/files/7706672/Mon_Dec_13-19.52.31-GMT_2021.log)

After the patch:
[Mon_Dec_13-19.53.06-GMT_2021.log](https://github.com/pmmp/PocketMine-MP/files/7706675/Mon_Dec_13-19.53.06-GMT_2021.log)