### PR TITLE
Implement BlockMeltEvent

### DIFF
--- a/src/block/Ice.php
+++ b/src/block/Ice.php
@@ -55,7 +55,7 @@ class Ice extends Transparent{
 			$ev = new BlockMeltEvent($this, VanillaBlocks::WATER());
 			$ev->call();
 			if(!$ev->isCancelled()){
-				$this->position->getWorld()->setBlock($this->position, $ev->getNewState(), false);
+				$this->position->getWorld()->setBlock($this->position, $ev->getNewState());
 			}
 		}
 	}

--- a/src/block/Ice.php
+++ b/src/block/Ice.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
-use pocketmine\event\block\IceMeltEvent;
+use pocketmine\event\block\BlockMeltEvent;
 use pocketmine\item\enchantment\VanillaEnchantments;
 use pocketmine\item\Item;
 use pocketmine\player\Player;
@@ -52,10 +52,10 @@ class Ice extends Transparent{
 
 	public function onRandomTick() : void{
 		if($this->position->getWorld()->getHighestAdjacentBlockLight($this->position->x, $this->position->y, $this->position->z) >= 12){
-			$ev = new IceMeltEvent($this);
+			$ev = new BlockMeltEvent($this, VanillaBlocks::WATER());
 			$ev->call();
 			if(!$ev->isCancelled()){
-				$this->position->getWorld()->useBreakOn($this->position);
+				$this->position->getWorld()->setBlock($this->position, $ev->getNewState(), false);
 			}
 		}
 	}

--- a/src/block/Ice.php
+++ b/src/block/Ice.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\event\block\IceMeltEvent;
 use pocketmine\item\enchantment\VanillaEnchantments;
 use pocketmine\item\Item;
 use pocketmine\player\Player;
@@ -51,7 +52,11 @@ class Ice extends Transparent{
 
 	public function onRandomTick() : void{
 		if($this->position->getWorld()->getHighestAdjacentBlockLight($this->position->x, $this->position->y, $this->position->z) >= 12){
-			$this->position->getWorld()->useBreakOn($this->position);
+			$ev = new IceMeltEvent($this);
+			$ev->call();
+			if(!$ev->isCancelled()){
+				$this->position->getWorld()->useBreakOn($this->position);
+			}
 		}
 	}
 

--- a/src/block/SnowLayer.php
+++ b/src/block/SnowLayer.php
@@ -104,7 +104,7 @@ class SnowLayer extends Flowable implements Fallable{
 			$ev = new BlockMeltEvent($this, VanillaBlocks::AIR());
 			$ev->call();
 			if(!$ev->isCancelled()){
-				$this->position->getWorld()->setBlock($this->position, $ev->getNewState(), false);
+				$this->position->getWorld()->setBlock($this->position, $ev->getNewState());
 			}
 		}
 	}

--- a/src/block/SnowLayer.php
+++ b/src/block/SnowLayer.php
@@ -26,6 +26,7 @@ namespace pocketmine\block;
 use pocketmine\block\utils\BlockDataSerializer;
 use pocketmine\block\utils\Fallable;
 use pocketmine\block\utils\FallableTrait;
+use pocketmine\event\block\BlockMeltEvent;
 use pocketmine\item\Item;
 use pocketmine\item\VanillaItems;
 use pocketmine\math\AxisAlignedBB;
@@ -100,7 +101,11 @@ class SnowLayer extends Flowable implements Fallable{
 
 	public function onRandomTick() : void{
 		if($this->position->getWorld()->getBlockLightAt($this->position->x, $this->position->y, $this->position->z) >= 12){
-			$this->position->getWorld()->setBlock($this->position, VanillaBlocks::AIR(), false);
+			$ev = new BlockMeltEvent($this, VanillaBlocks::AIR());
+			$ev->call();
+			if(!$ev->isCancelled()){
+				$this->position->getWorld()->setBlock($this->position, $ev->getNewState(), false);
+			}
 		}
 	}
 

--- a/src/event/block/BlockMeltEvent.php
+++ b/src/event/block/BlockMeltEvent.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace pocketmine\event\block;
 
 /**
- * Called when a block melts due to the light level being too high
+ * Called when a block melts, e.g. if the light level is too high
  */
 class BlockMeltEvent extends BaseBlockChangeEvent{
 

--- a/src/event/block/BlockMeltEvent.php
+++ b/src/event/block/BlockMeltEvent.php
@@ -23,9 +23,6 @@ declare(strict_types=1);
 
 namespace pocketmine\event\block;
 
-use pocketmine\event\Cancellable;
-use pocketmine\event\CancellableTrait;
-
 /**
  * Called when a block melts due to the light level being too high
  */

--- a/src/event/block/BlockMeltEvent.php
+++ b/src/event/block/BlockMeltEvent.php
@@ -27,8 +27,8 @@ use pocketmine\event\Cancellable;
 use pocketmine\event\CancellableTrait;
 
 /**
- * Called when ice melts due to the light level being too high
+ * Called when a block melts due to the light level being too high
  */
-class IceMeltEvent extends BlockEvent implements Cancellable{
-	use CancellableTrait;
+class BlockMeltEvent extends BaseBlockChangeEvent{
+
 }

--- a/src/event/block/IceMeltEvent.php
+++ b/src/event/block/IceMeltEvent.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\event\block;
+
+use pocketmine\event\Cancellable;
+use pocketmine\event\CancellableTrait;
+
+/**
+ * Called when ice melts due to the light level being too high
+ */
+class IceMeltEvent extends BlockEvent implements Cancellable{
+	use CancellableTrait;
+}


### PR DESCRIPTION
## Introduction
Currently, there's no way to stop Ice from melting using events since the BlockBreakEvent isn't called due to it not being Player related.

## Changes
### API changes
Add `BlockMeltEvent` extending `BaseBlockChangeEvent`