### PR TITLE
Added gold(§g) color support

### DIFF
--- a/src/utils/Terminal.php
+++ b/src/utils/Terminal.php
@@ -132,7 +132,7 @@ abstract class Terminal{
 			self::$COLOR_DARK_AQUA = $colors >= 256 ? $setaf(37) : $setaf(6);
 			self::$COLOR_DARK_RED = $colors >= 256 ? $setaf(124) : $setaf(1);
 			self::$COLOR_PURPLE = $colors >= 256 ? $setaf(127) : $setaf(5);
-			self::$COLOR_ORANGE = $colors >= 256 ? $setaf(214) : $setaf(3);
+			self::$COLOR_GOLD = $colors >= 256 ? $setaf(214) : $setaf(3);
 			self::$COLOR_GRAY = $colors >= 256 ? $setaf(145) : $setaf(7);
 			self::$COLOR_DARK_GRAY = $colors >= 256 ? $setaf(59) : $setaf(8);
 			self::$COLOR_BLUE = $colors >= 256 ? $setaf(63) : $setaf(12);

--- a/src/utils/Terminal.php
+++ b/src/utils/Terminal.php
@@ -48,7 +48,7 @@ abstract class Terminal{
 	public static string $COLOR_DARK_AQUA = "";
 	public static string $COLOR_DARK_RED = "";
 	public static string $COLOR_PURPLE = "";
-	public static string $COLOR_ORANGE = "";
+	public static string $COLOR_GOLD = "";
 	public static string $COLOR_GRAY = "";
 	public static string $COLOR_DARK_GRAY = "";
 	public static string $COLOR_BLUE = "";
@@ -100,7 +100,7 @@ abstract class Terminal{
 		self::$COLOR_DARK_AQUA = $color(37);
 		self::$COLOR_DARK_RED = $color(124);
 		self::$COLOR_PURPLE = $color(127);
-		self::$COLOR_ORANGE = $color(214);
+		self::$COLOR_GOLD = $color(214);
 		self::$COLOR_GRAY = $color(145);
 		self::$COLOR_DARK_GRAY = $color(59);
 		self::$COLOR_BLUE = $color(63);
@@ -200,7 +200,7 @@ abstract class Terminal{
 				TextFormat::DARK_AQUA => Terminal::$COLOR_DARK_AQUA,
 				TextFormat::DARK_RED => Terminal::$COLOR_DARK_RED,
 				TextFormat::DARK_PURPLE => Terminal::$COLOR_PURPLE,
-				TextFormat::ORANGE => Terminal::$COLOR_ORANGE,
+				TextFormat::GOLD => Terminal::$COLOR_ORANGE,
 				TextFormat::GRAY => Terminal::$COLOR_GRAY,
 				TextFormat::DARK_GRAY => Terminal::$COLOR_DARK_GRAY,
 				TextFormat::BLUE => Terminal::$COLOR_BLUE,
@@ -210,7 +210,7 @@ abstract class Terminal{
 				TextFormat::LIGHT_PURPLE => Terminal::$COLOR_LIGHT_PURPLE,
 				TextFormat::YELLOW => Terminal::$COLOR_YELLOW,
 				TextFormat::WHITE => Terminal::$COLOR_WHITE,
-				TextFormat::GOLD => Terminal::$COLOR_YELLOW,
+				TextFormat::MINECOIN_GOLD => Terminal::$COLOR_YELLOW,
 				default => $token,
 			};
 		}

--- a/src/utils/Terminal.php
+++ b/src/utils/Terminal.php
@@ -213,7 +213,7 @@ abstract class Terminal{
 				TextFormat::LIGHT_PURPLE => Terminal::$COLOR_LIGHT_PURPLE,
 				TextFormat::YELLOW => Terminal::$COLOR_YELLOW,
 				TextFormat::WHITE => Terminal::$COLOR_WHITE,
-				TextFormat::MINECOIN_GOLD => Terminal::$COLOR_YELLOW,
+				TextFormat::MINECOIN_GOLD => Terminal::$COLOR_MINECOIN_GOLD,
 				default => $token,
 			};
 		}

--- a/src/utils/Terminal.php
+++ b/src/utils/Terminal.php
@@ -146,7 +146,7 @@ abstract class Terminal{
 			self::$COLOR_BLACK = self::$COLOR_DARK_GRAY = $setaf(0);
 			self::$COLOR_RED = self::$COLOR_DARK_RED = $setaf(1);
 			self::$COLOR_GREEN = self::$COLOR_DARK_GREEN = $setaf(2);
-			self::$COLOR_YELLOW = self::$COLOR_ORANGE = $setaf(3);
+			self::$COLOR_YELLOW = self::$COLOR_GOLD = $setaf(3);
 			self::$COLOR_BLUE = self::$COLOR_DARK_BLUE = $setaf(4);
 			self::$COLOR_LIGHT_PURPLE = self::$COLOR_PURPLE = $setaf(5);
 			self::$COLOR_AQUA = self::$COLOR_DARK_AQUA = $setaf(6);
@@ -200,7 +200,7 @@ abstract class Terminal{
 				TextFormat::DARK_AQUA => Terminal::$COLOR_DARK_AQUA,
 				TextFormat::DARK_RED => Terminal::$COLOR_DARK_RED,
 				TextFormat::DARK_PURPLE => Terminal::$COLOR_PURPLE,
-				TextFormat::GOLD => Terminal::$COLOR_ORANGE,
+				TextFormat::GOLD => Terminal::$COLOR_GOLD,
 				TextFormat::GRAY => Terminal::$COLOR_GRAY,
 				TextFormat::DARK_GRAY => Terminal::$COLOR_DARK_GRAY,
 				TextFormat::BLUE => Terminal::$COLOR_BLUE,

--- a/src/utils/Terminal.php
+++ b/src/utils/Terminal.php
@@ -58,6 +58,7 @@ abstract class Terminal{
 	public static string $COLOR_LIGHT_PURPLE = "";
 	public static string $COLOR_YELLOW = "";
 	public static string $COLOR_WHITE = "";
+	public static string $COLOR_MINECOIN_GOLD = "";
 
 	/** @var bool|null */
 	private static $formattingCodes = null;
@@ -110,6 +111,7 @@ abstract class Terminal{
 		self::$COLOR_LIGHT_PURPLE = $color(207);
 		self::$COLOR_YELLOW = $color(227);
 		self::$COLOR_WHITE = $color(231);
+		self::$COLOR_MINECOIN_GOLD = $color(226);
 	}
 
 	protected static function getEscapeCodes() : void{
@@ -142,11 +144,12 @@ abstract class Terminal{
 			self::$COLOR_LIGHT_PURPLE = $colors >= 256 ? $setaf(207) : $setaf(13);
 			self::$COLOR_YELLOW = $colors >= 256 ? $setaf(227) : $setaf(11);
 			self::$COLOR_WHITE = $colors >= 256 ? $setaf(231) : $setaf(15);
+			self::$COLOR_MINECOIN_GOLD = $colors >= 256 ? $setaf(226) : $setaf(11);
 		}else{
 			self::$COLOR_BLACK = self::$COLOR_DARK_GRAY = $setaf(0);
 			self::$COLOR_RED = self::$COLOR_DARK_RED = $setaf(1);
 			self::$COLOR_GREEN = self::$COLOR_DARK_GREEN = $setaf(2);
-			self::$COLOR_YELLOW = self::$COLOR_GOLD = $setaf(3);
+			self::$COLOR_YELLOW = self::$COLOR_GOLD = self::$COLOR_MINECOIN_GOLD = $setaf(3);
 			self::$COLOR_BLUE = self::$COLOR_DARK_BLUE = $setaf(4);
 			self::$COLOR_LIGHT_PURPLE = self::$COLOR_PURPLE = $setaf(5);
 			self::$COLOR_AQUA = self::$COLOR_DARK_AQUA = $setaf(6);

--- a/src/utils/Terminal.php
+++ b/src/utils/Terminal.php
@@ -48,7 +48,7 @@ abstract class Terminal{
 	public static string $COLOR_DARK_AQUA = "";
 	public static string $COLOR_DARK_RED = "";
 	public static string $COLOR_PURPLE = "";
-	public static string $COLOR_GOLD = "";
+	public static string $COLOR_ORANGE = "";
 	public static string $COLOR_GRAY = "";
 	public static string $COLOR_DARK_GRAY = "";
 	public static string $COLOR_BLUE = "";
@@ -100,7 +100,7 @@ abstract class Terminal{
 		self::$COLOR_DARK_AQUA = $color(37);
 		self::$COLOR_DARK_RED = $color(124);
 		self::$COLOR_PURPLE = $color(127);
-		self::$COLOR_GOLD = $color(214);
+		self::$COLOR_ORANGE = $color(214);
 		self::$COLOR_GRAY = $color(145);
 		self::$COLOR_DARK_GRAY = $color(59);
 		self::$COLOR_BLUE = $color(63);
@@ -132,7 +132,7 @@ abstract class Terminal{
 			self::$COLOR_DARK_AQUA = $colors >= 256 ? $setaf(37) : $setaf(6);
 			self::$COLOR_DARK_RED = $colors >= 256 ? $setaf(124) : $setaf(1);
 			self::$COLOR_PURPLE = $colors >= 256 ? $setaf(127) : $setaf(5);
-			self::$COLOR_GOLD = $colors >= 256 ? $setaf(214) : $setaf(3);
+			self::$COLOR_ORANGE = $colors >= 256 ? $setaf(214) : $setaf(3);
 			self::$COLOR_GRAY = $colors >= 256 ? $setaf(145) : $setaf(7);
 			self::$COLOR_DARK_GRAY = $colors >= 256 ? $setaf(59) : $setaf(8);
 			self::$COLOR_BLUE = $colors >= 256 ? $setaf(63) : $setaf(12);
@@ -146,7 +146,7 @@ abstract class Terminal{
 			self::$COLOR_BLACK = self::$COLOR_DARK_GRAY = $setaf(0);
 			self::$COLOR_RED = self::$COLOR_DARK_RED = $setaf(1);
 			self::$COLOR_GREEN = self::$COLOR_DARK_GREEN = $setaf(2);
-			self::$COLOR_YELLOW = self::$COLOR_GOLD = $setaf(3);
+			self::$COLOR_YELLOW = self::$COLOR_ORANGE = $setaf(3);
 			self::$COLOR_BLUE = self::$COLOR_DARK_BLUE = $setaf(4);
 			self::$COLOR_LIGHT_PURPLE = self::$COLOR_PURPLE = $setaf(5);
 			self::$COLOR_AQUA = self::$COLOR_DARK_AQUA = $setaf(6);
@@ -200,7 +200,7 @@ abstract class Terminal{
 				TextFormat::DARK_AQUA => Terminal::$COLOR_DARK_AQUA,
 				TextFormat::DARK_RED => Terminal::$COLOR_DARK_RED,
 				TextFormat::DARK_PURPLE => Terminal::$COLOR_PURPLE,
-				TextFormat::GOLD => Terminal::$COLOR_GOLD,
+				TextFormat::ORANGE => Terminal::$COLOR_ORANGE,
 				TextFormat::GRAY => Terminal::$COLOR_GRAY,
 				TextFormat::DARK_GRAY => Terminal::$COLOR_DARK_GRAY,
 				TextFormat::BLUE => Terminal::$COLOR_BLUE,
@@ -210,6 +210,7 @@ abstract class Terminal{
 				TextFormat::LIGHT_PURPLE => Terminal::$COLOR_LIGHT_PURPLE,
 				TextFormat::YELLOW => Terminal::$COLOR_YELLOW,
 				TextFormat::WHITE => Terminal::$COLOR_WHITE,
+				TextFormat::GOLD => Terminal::$COLOR_YELLOW,
 				default => $token,
 			};
 		}

--- a/src/utils/Terminal.php
+++ b/src/utils/Terminal.php
@@ -111,7 +111,7 @@ abstract class Terminal{
 		self::$COLOR_LIGHT_PURPLE = $color(207);
 		self::$COLOR_YELLOW = $color(227);
 		self::$COLOR_WHITE = $color(231);
-		self::$COLOR_MINECOIN_GOLD = $color(226);
+		self::$COLOR_MINECOIN_GOLD = $color(184);
 	}
 
 	protected static function getEscapeCodes() : void{

--- a/src/utils/Terminal.php
+++ b/src/utils/Terminal.php
@@ -144,7 +144,7 @@ abstract class Terminal{
 			self::$COLOR_LIGHT_PURPLE = $colors >= 256 ? $setaf(207) : $setaf(13);
 			self::$COLOR_YELLOW = $colors >= 256 ? $setaf(227) : $setaf(11);
 			self::$COLOR_WHITE = $colors >= 256 ? $setaf(231) : $setaf(15);
-			self::$COLOR_MINECOIN_GOLD = $colors >= 256 ? $setaf(226) : $setaf(11);
+			self::$COLOR_MINECOIN_GOLD = $colors >= 256 ? $setaf(184) : $setaf(11);
 		}else{
 			self::$COLOR_BLACK = self::$COLOR_DARK_GRAY = $setaf(0);
 			self::$COLOR_RED = self::$COLOR_DARK_RED = $setaf(1);

--- a/src/utils/TextFormat.php
+++ b/src/utils/TextFormat.php
@@ -52,7 +52,7 @@ abstract class TextFormat{
 	public const DARK_AQUA = TextFormat::ESCAPE . "3";
 	public const DARK_RED = TextFormat::ESCAPE . "4";
 	public const DARK_PURPLE = TextFormat::ESCAPE . "5";
-	public const ORANGE = TextFormat::ESCAPE . "6";
+	public const GOLD = TextFormat::ESCAPE . "6";
 	public const GRAY = TextFormat::ESCAPE . "7";
 	public const DARK_GRAY = TextFormat::ESCAPE . "8";
 	public const BLUE = TextFormat::ESCAPE . "9";
@@ -62,7 +62,7 @@ abstract class TextFormat{
 	public const LIGHT_PURPLE = TextFormat::ESCAPE . "d";
 	public const YELLOW = TextFormat::ESCAPE . "e";
 	public const WHITE = TextFormat::ESCAPE . "f";
-	public const GOLD = TextFormat::ESCAPE . "g";
+	public const MINECOIN_GOLD = TextFormat::ESCAPE . "g";
 
 	public const COLORS = [
 		self::BLACK => self::BLACK,
@@ -71,7 +71,7 @@ abstract class TextFormat{
 		self::DARK_AQUA => self::DARK_AQUA,
 		self::DARK_RED => self::DARK_RED,
 		self::DARK_PURPLE => self::DARK_PURPLE,
-		self::ORANGE => self::ORANGE,
+		self::GOLD => self::GOLD,
 		self::GRAY => self::GRAY,
 		self::DARK_GRAY => self::DARK_GRAY,
 		self::BLUE => self::BLUE,
@@ -81,7 +81,7 @@ abstract class TextFormat{
 		self::LIGHT_PURPLE => self::LIGHT_PURPLE,
 		self::YELLOW => self::YELLOW,
 		self::WHITE => self::WHITE,
-		self::GOLD => self::GOLD,
+		self::MINECOIN_GOLD => self::MINECOIN_GOLD,
 	];
 
 	public const OBFUSCATED = TextFormat::ESCAPE . "k";
@@ -216,7 +216,7 @@ abstract class TextFormat{
 					$newString .= "<span style=color:#A0A>";
 					++$tokens;
 					break;
-				case TextFormat::ORANGE:
+				case TextFormat::GOLD:
 					$newString .= "<span style=color:#FA0>";
 					++$tokens;
 					break;
@@ -256,7 +256,7 @@ abstract class TextFormat{
 					$newString .= "<span style=color:#FFF>";
 					++$tokens;
 					break;
-				case TextFormat::GOLD:
+				case TextFormat::MINECOIN_GOLD:
 					$newString .= "<span style=color:#dd0>";
 					++$tokens;
 					break;

--- a/src/utils/TextFormat.php
+++ b/src/utils/TextFormat.php
@@ -52,7 +52,7 @@ abstract class TextFormat{
 	public const DARK_AQUA = TextFormat::ESCAPE . "3";
 	public const DARK_RED = TextFormat::ESCAPE . "4";
 	public const DARK_PURPLE = TextFormat::ESCAPE . "5";
-	public const GOLD = TextFormat::ESCAPE . "6";
+	public const ORANGE = TextFormat::ESCAPE . "6";
 	public const GRAY = TextFormat::ESCAPE . "7";
 	public const DARK_GRAY = TextFormat::ESCAPE . "8";
 	public const BLUE = TextFormat::ESCAPE . "9";
@@ -62,6 +62,7 @@ abstract class TextFormat{
 	public const LIGHT_PURPLE = TextFormat::ESCAPE . "d";
 	public const YELLOW = TextFormat::ESCAPE . "e";
 	public const WHITE = TextFormat::ESCAPE . "f";
+	public const GOLD = TextFormat::ESCAPE . "g";
 
 	public const COLORS = [
 		self::BLACK => self::BLACK,
@@ -70,7 +71,7 @@ abstract class TextFormat{
 		self::DARK_AQUA => self::DARK_AQUA,
 		self::DARK_RED => self::DARK_RED,
 		self::DARK_PURPLE => self::DARK_PURPLE,
-		self::GOLD => self::GOLD,
+		self::ORANGE => self::ORANGE,
 		self::GRAY => self::GRAY,
 		self::DARK_GRAY => self::DARK_GRAY,
 		self::BLUE => self::BLUE,
@@ -80,6 +81,7 @@ abstract class TextFormat{
 		self::LIGHT_PURPLE => self::LIGHT_PURPLE,
 		self::YELLOW => self::YELLOW,
 		self::WHITE => self::WHITE,
+		self::GOLD => self::GOLD,
 	];
 
 	public const OBFUSCATED = TextFormat::ESCAPE . "k";
@@ -153,7 +155,7 @@ abstract class TextFormat{
 	 * @param string $placeholder default "&"
 	 */
 	public static function colorize(string $string, string $placeholder = "&") : string{
-		return self::preg_replace('/' . preg_quote($placeholder, "/") . '([0-9a-fk-or])/u', TextFormat::ESCAPE . '$1', $string);
+		return self::preg_replace('/' . preg_quote($placeholder, "/") . '([0-9a-gk-or])/u', TextFormat::ESCAPE . '$1', $string);
 	}
 
 	/**
@@ -214,7 +216,7 @@ abstract class TextFormat{
 					$newString .= "<span style=color:#A0A>";
 					++$tokens;
 					break;
-				case TextFormat::GOLD:
+				case TextFormat::ORANGE:
 					$newString .= "<span style=color:#FA0>";
 					++$tokens;
 					break;
@@ -252,6 +254,10 @@ abstract class TextFormat{
 					break;
 				case TextFormat::WHITE:
 					$newString .= "<span style=color:#FFF>";
+					++$tokens;
+					break;
+				case TextFormat::GOLD:
+					$newString .= "<span style=color:#dd0>";
 					++$tokens;
 					break;
 				default:

--- a/src/utils/TextFormat.php
+++ b/src/utils/TextFormat.php
@@ -144,7 +144,7 @@ abstract class TextFormat{
 		$string = mb_scrub($string, 'UTF-8');
 		$string = self::preg_replace("/[\x{E000}-\x{F8FF}]/u", "", $string); //remove unicode private-use-area characters (they might break the console)
 		if($removeFormat){
-			$string = str_replace(TextFormat::ESCAPE, "", self::preg_replace("/" . TextFormat::ESCAPE . "[0-9a-fg-or]/u", "", $string));
+			$string = str_replace(TextFormat::ESCAPE, "", self::preg_replace("/" . TextFormat::ESCAPE . "[0-9a-gk-or]/u", "", $string));
 		}
 		return str_replace("\x1b", "", self::preg_replace("/\x1b[\\(\\][[0-9;\\[\\(]+[Bm]/u", "", $string));
 	}

--- a/src/utils/TextFormat.php
+++ b/src/utils/TextFormat.php
@@ -130,7 +130,7 @@ abstract class TextFormat{
 	 * @return string[]
 	 */
 	public static function tokenize(string $string) : array{
-		$result = preg_split("/(" . TextFormat::ESCAPE . "[0-9a-fg-or])/u", $string, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
+		$result = preg_split("/(" . TextFormat::ESCAPE . "[0-9a-gk-or])/u", $string, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
 		if($result === false) throw self::makePcreError();
 		return $result;
 	}

--- a/src/utils/TextFormat.php
+++ b/src/utils/TextFormat.php
@@ -130,7 +130,7 @@ abstract class TextFormat{
 	 * @return string[]
 	 */
 	public static function tokenize(string $string) : array{
-		$result = preg_split("/(" . TextFormat::ESCAPE . "[0-9a-fk-or])/u", $string, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
+		$result = preg_split("/(" . TextFormat::ESCAPE . "[0-9a-fg-or])/u", $string, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
 		if($result === false) throw self::makePcreError();
 		return $result;
 	}
@@ -144,7 +144,7 @@ abstract class TextFormat{
 		$string = mb_scrub($string, 'UTF-8');
 		$string = self::preg_replace("/[\x{E000}-\x{F8FF}]/u", "", $string); //remove unicode private-use-area characters (they might break the console)
 		if($removeFormat){
-			$string = str_replace(TextFormat::ESCAPE, "", self::preg_replace("/" . TextFormat::ESCAPE . "[0-9a-fk-or]/u", "", $string));
+			$string = str_replace(TextFormat::ESCAPE, "", self::preg_replace("/" . TextFormat::ESCAPE . "[0-9a-fg-or]/u", "", $string));
 		}
 		return str_replace("\x1b", "", self::preg_replace("/\x1b[\\(\\][[0-9;\\[\\(]+[Bm]/u", "", $string));
 	}


### PR DESCRIPTION
## Introduction
Adds support for `§g` for console

## Changes
### API changes
```diff
+ TextFormat::MINECOIN_GOLD
+ Terminal::$COLOR_MINECOIN_GOLD
```