### PR TITLE
Update changed method in 4.0 changelog

### DIFF
--- a/changelogs/4.0.md
+++ b/changelogs/4.0.md
@@ -496,7 +496,7 @@ However, if we add `src-namespace-prefix: pmmp\TesterPlugin` to the `plugin.yml`
   - `Human->onPickupXp()` -> `ExperienceManager->onPickupXp()`
   - `Human->resetXpCooldown()` -> `ExperienceManager->resetXpCooldown()`
 - The following API methods have been removed:
-  - `Human->getRawUniqueId()`: use `Human->getUniqueId()->toBinary()` instead
+  - `Human->getRawUniqueId()`: use `Human->getUniqueId()->getBytes()` instead
 - The following classes have been removed:
   - `Creature`
   - `Damageable`


### PR DESCRIPTION
## Introduction
`UUID::toBinary()` no longer exists and was superseded by `Ramsey\Uuid\UuidInterface::getBytes()`
This PR is just to clear up confusion as the 4.0 changelog still shows the aforementioned method.

## Changes

Changed `Human->getUniqueId()->toBinary()` to `Human->getUniqueId()->getBytes()` in 4.0 changelog
