### PR TITLE
Player: fixed fall damage when sprinting down stairs

### DIFF
--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1081,6 +1081,10 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 			$bb->minY = $this->location->y - 0.2;
 			$bb->maxY = $this->location->y + 0.2;
 
+			//we're already at the new position at this point; check if there are blocks we might have landed on between
+			//the old and new positions (running down stairs necessitates this)
+			$bb = $bb->addCoord(-$dx, -$dy, -$dz);
+
 			$this->onGround = $this->isCollided = count($this->getWorld()->getCollisionBlocks($bb, true)) > 0;
 		}
 	}


### PR DESCRIPTION
Due to the way positions are updated over the network, we only see the end result of a movement and not its preceding actions. In addition, we don't know for sure whether the MCPE collision checks work the same exact way as PM.

TL;DR: It's possible for the client to capture and send a movement frame after they collided with a step and then already moved forward from it some distance, resulting in a weird arc pattern.

This PR checks the range between the old and new positions for collision boxes to ensure that all possible areas are checked for detecting fall damage.

This has been tested and successfully resolves various issues involving running down stairs:
- missing sounds
- random fall damage

### Relevant issues
- Fixes #3166 

## Changes
### Behavioural changes
Described above.

## Backwards compatibility

## Tests
This has been extensively tested in game, however I am unsure if there are any side effects that I have not considered.