### PR TITLE
TimeCommand: changed behavior to affect a single world

### DIFF
--- a/src/command/defaults/TimeCommand.php
+++ b/src/command/defaults/TimeCommand.php
@@ -29,6 +29,7 @@ use pocketmine\command\utils\InvalidCommandSyntaxException;
 use pocketmine\lang\KnownTranslationFactory;
 use pocketmine\permission\DefaultPermissionNames;
 use pocketmine\player\Player;
+use pocketmine\utils\AssumptionFailedError;
 use pocketmine\world\World;
 use function count;
 use function implode;
@@ -59,6 +60,9 @@ class TimeCommand extends VanillaCommand{
 		}
 
 		$world = $sender instanceof Player ? $sender->getWorld() : $sender->getServer()->getWorldManager()->getDefaultWorld();
+		if($world === null){
+			throw new AssumptionFailedError("Default world should always be loaded");
+		}
 
 		if($args[0] === "start"){
 			if(!$this->testPermission($sender, DefaultPermissionNames::COMMAND_TIME_START)){

--- a/src/command/defaults/TimeCommand.php
+++ b/src/command/defaults/TimeCommand.php
@@ -58,32 +58,25 @@ class TimeCommand extends VanillaCommand{
 			throw new InvalidCommandSyntaxException();
 		}
 
+		$world = $sender instanceof Player ? $sender->getWorld() : $sender->getServer()->getWorldManager()->getDefaultWorld();
+
 		if($args[0] === "start"){
 			if(!$this->testPermission($sender, DefaultPermissionNames::COMMAND_TIME_START)){
 				return true;
 			}
-			foreach($sender->getServer()->getWorldManager()->getWorlds() as $world){
-				$world->startTime();
-			}
+			$world->startTime();
 			Command::broadcastCommandMessage($sender, "Restarted the time");
 			return true;
 		}elseif($args[0] === "stop"){
 			if(!$this->testPermission($sender, DefaultPermissionNames::COMMAND_TIME_STOP)){
 				return true;
 			}
-			foreach($sender->getServer()->getWorldManager()->getWorlds() as $world){
-				$world->stopTime();
-			}
+			$world->stopTime();
 			Command::broadcastCommandMessage($sender, "Stopped the time");
 			return true;
 		}elseif($args[0] === "query"){
 			if(!$this->testPermission($sender, DefaultPermissionNames::COMMAND_TIME_QUERY)){
 				return true;
-			}
-			if($sender instanceof Player){
-				$world = $sender->getWorld();
-			}else{
-				$world = $sender->getServer()->getWorldManager()->getDefaultWorld();
 			}
 			$sender->sendMessage($sender->getLanguage()->translate(KnownTranslationFactory::commands_time_query((string) $world->getTime())));
 			return true;
@@ -98,33 +91,17 @@ class TimeCommand extends VanillaCommand{
 				return true;
 			}
 
-			switch($args[1]){
-				case "day":
-					$value = World::TIME_DAY;
-					break;
-				case "noon":
-					$value = World::TIME_NOON;
-					break;
-				case "sunset":
-					$value = World::TIME_SUNSET;
-					break;
-				case "night":
-					$value = World::TIME_NIGHT;
-					break;
-				case "midnight":
-					$value = World::TIME_MIDNIGHT;
-					break;
-				case "sunrise":
-					$value = World::TIME_SUNRISE;
-					break;
-				default:
-					$value = $this->getInteger($sender, $args[1], 0);
-					break;
-			}
+			$value = match ($args[1]) {
+				"day" => World::TIME_DAY,
+				"noon" => World::TIME_NOON,
+				"sunset" => World::TIME_SUNSET,
+				"night" => World::TIME_NIGHT,
+				"midnight" => World::TIME_MIDNIGHT,
+				"sunrise" => World::TIME_SUNRISE,
+				default => $this->getInteger($sender, $args[1], 0),
+			};
 
-			foreach($sender->getServer()->getWorldManager()->getWorlds() as $world){
-				$world->setTime($value);
-			}
+			$world->setTime($value);
 			Command::broadcastCommandMessage($sender, KnownTranslationFactory::commands_time_set((string) $value));
 		}elseif($args[0] === "add"){
 			if(!$this->testPermission($sender, DefaultPermissionNames::COMMAND_TIME_ADD)){
@@ -132,9 +109,7 @@ class TimeCommand extends VanillaCommand{
 			}
 
 			$value = $this->getInteger($sender, $args[1], 0);
-			foreach($sender->getServer()->getWorldManager()->getWorlds() as $world){
-				$world->setTime($world->getTime() + $value);
-			}
+			$world->setTime($world->getTime() + $value);
 			Command::broadcastCommandMessage($sender, KnownTranslationFactory::commands_time_added((string) $value));
 		}else{
 			throw new InvalidCommandSyntaxException();

--- a/src/command/defaults/TimeCommand.php
+++ b/src/command/defaults/TimeCommand.php
@@ -91,7 +91,7 @@ class TimeCommand extends VanillaCommand{
 				return true;
 			}
 
-			$value = match ($args[1]) {
+			$value = match($args[1]){
 				"day" => World::TIME_DAY,
 				"noon" => World::TIME_NOON,
 				"sunset" => World::TIME_SUNSET,

--- a/src/command/defaults/TimeCommand.php
+++ b/src/command/defaults/TimeCommand.php
@@ -95,15 +95,29 @@ class TimeCommand extends VanillaCommand{
 				return true;
 			}
 
-			$value = match($args[1]){
-				"day" => World::TIME_DAY,
-				"noon" => World::TIME_NOON,
-				"sunset" => World::TIME_SUNSET,
-				"night" => World::TIME_NIGHT,
-				"midnight" => World::TIME_MIDNIGHT,
-				"sunrise" => World::TIME_SUNRISE,
-				default => $this->getInteger($sender, $args[1], 0),
-			};
+			switch($args[1]){
+				case "day":
+					$value = World::TIME_DAY;
+					break;
+				case "noon":
+					$value = World::TIME_NOON;
+					break;
+				case "sunset":
+					$value = World::TIME_SUNSET;
+					break;
+				case "night":
+					$value = World::TIME_NIGHT;
+					break;
+				case "midnight":
+					$value = World::TIME_MIDNIGHT;
+					break;
+				case "sunrise":
+					$value = World::TIME_SUNRISE;
+					break;
+				default:
+					$value = $this->getInteger($sender, $args[1], 0);
+					break;
+			}
 
 			$world->setTime($value);
 			Command::broadcastCommandMessage($sender, KnownTranslationFactory::commands_time_set((string) $value));


### PR DESCRIPTION
## Introduction
Currently, the time command affects all loaded worlds.
This PR restricts the affect of the time command to a single world.

## Changes
### Behavioural changes
- The time command no longer affects the time of all worlds.
  - The player executes the command, the time of the world the player is in will be changed.
  - The console executed the command, the default world time will be changed.
