### PR TITLE
Fixed desynchronization of hunger

### DIFF
--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -27,6 +27,7 @@ use pocketmine\block\BaseSign;
 use pocketmine\block\ItemFrame;
 use pocketmine\block\utils\SignText;
 use pocketmine\entity\animation\ConsumingItemAnimation;
+use pocketmine\entity\Attribute;
 use pocketmine\entity\InvalidSkinException;
 use pocketmine\event\player\PlayerEditBookEvent;
 use pocketmine\inventory\transaction\action\InventoryAction;
@@ -371,6 +372,8 @@ class InGamePacketHandler extends PacketHandler{
 			case UseItemTransactionData::ACTION_CLICK_AIR:
 				if($this->player->isUsingItem()){
 					if(!$this->player->consumeHeldItem()){
+						$hungerAttr = $this->player->getAttributeMap()->get(Attribute::HUNGER) ?? throw new AssumptionFailedError();
+						$this->session->syncAttributes($this->player, [$hungerAttr]);
 						$this->inventoryManager->syncSlot($this->player->getInventory(), $this->player->getInventory()->getHeldItemIndex());
 					}
 					return true;

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -373,7 +373,7 @@ class InGamePacketHandler extends PacketHandler{
 				if($this->player->isUsingItem()){
 					if(!$this->player->consumeHeldItem()){
 						$hungerAttr = $this->player->getAttributeMap()->get(Attribute::HUNGER) ?? throw new AssumptionFailedError();
-						$this->session->syncAttributes($this->player, [$hungerAttr]);
+						$hungerAttr->markSynchronized(false);
 						$this->inventoryManager->syncSlot($this->player->getInventory(), $this->player->getInventory()->getHeldItemIndex());
 					}
 					return true;


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Currently when you cancel `PlayerItemConsumeEvent` it doesn’t synchronize the hunger bars to the player. This pull request aims to fix that.
### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
* Fixes #2728
## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
None
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
The server now synchronizes the hunger bars to the player when `PlayerItemConsumeEvent` gets cancelled or `Living->consumeObject()` returns false.
## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
None
## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
None
## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
```php
<?php

declare(strict_types = 1);

namespace JavierLeon9966\HungerTest;

use pocketmine\event\EventPriority;
use pocketmine\event\player\PlayerItemConsumeEvent;
use pocketmine\plugin\PluginBase;

class Main extends PluginBase{
    public function onEnable(): void{
        $this->getServer()->getPluginManager()->registerEvent(PlayerItemConsumeEvent::class, static fn(PlayerItemConsumeEvent $event) => $event->cancel(), EventPriority::HIGHEST, $this);
    }
}
```
https://user-images.githubusercontent.com/58715544/147900890-d66258a1-08ad-4c24-ab1a-b27897048f6b.mp4