### PR TITLE
Fixed world spawn point not updating to players

### DIFF
--- a/src/world/World.php
+++ b/src/world/World.php
@@ -2259,8 +2259,9 @@ class World implements ChunkManager{
 		$this->provider->getWorldData()->setSpawn($pos);
 		(new SpawnChangeEvent($this, $previousSpawn))->call();
 
+		$location = Position::fromObject($pos, $this);
 		foreach($this->players as $player){
-			$player->getNetworkSession()->syncWorldSpawnPoint($pos);
+			$player->getNetworkSession()->syncWorldSpawnPoint($location);
 		}
 	}
 

--- a/src/world/World.php
+++ b/src/world/World.php
@@ -2258,6 +2258,10 @@ class World implements ChunkManager{
 		$previousSpawn = $this->getSpawnLocation();
 		$this->provider->getWorldData()->setSpawn($pos);
 		(new SpawnChangeEvent($this, $previousSpawn))->call();
+
+		foreach($this->players as $player){
+			$player->getNetworkSession()->syncWorldSpawnPoint($pos);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Currently when you update the world spawn point using /setworldspawn it doesn’t get updated to all players in that world. This pull request aims to fix that.
### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
* Fixes #4383 
## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
None
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
World spawn point now gets updated to all players in that world.
## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
None
## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
None
## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->

https://user-images.githubusercontent.com/58715544/148113896-114f332e-f4bf-4093-b823-7b38e4dbce39.mp4