### PR TITLE
Incorrect BlockBreakInfo

### DIFF
--- a/src/block/BlockFactory.php
+++ b/src/block/BlockFactory.php
@@ -458,11 +458,10 @@ class BlockFactory{
 		$planksBreakInfo = new BlockBreakInfo(2.0, BlockToolType::AXE, 0, 15.0);
 		$leavesBreakInfo = new class(0.2, BlockToolType::HOE) extends BlockBreakInfo{
 				public function getBreakTime(Item $item) : float{
-					return match($item->getBlockToolType()){
-						BlockToolType::SWORD => 0.2,
-						BlockToolType::SHEARS => 0.0,
-						default => parent::getBreakTime($item),
-					};
+					if($item->getBlockToolType() === BlockToolType::SHEARS){
+						return 0.0;
+					}
+					return parent::getBreakTime($item);
 				}
 			};
 		$signBreakInfo = new BlockBreakInfo(1.0, BlockToolType::AXE);

--- a/src/block/BlockFactory.php
+++ b/src/block/BlockFactory.php
@@ -115,14 +115,7 @@ class BlockFactory{
 		$this->registerAllMeta(new ActivatorRail(new BID(Ids::ACTIVATOR_RAIL, 0), "Activator Rail", $railBreakInfo));
 		$this->registerAllMeta(new Air(new BID(Ids::AIR, 0), "Air", BlockBreakInfo::indestructible(-1.0)));
 		$this->registerAllMeta(new Anvil(new BID(Ids::ANVIL, 0), "Anvil", new BlockBreakInfo(5.0, BlockToolType::PICKAXE, ToolTier::WOOD()->getHarvestLevel(), 6000.0)));
-		$this->registerAllMeta(new Bamboo(new BID(Ids::BAMBOO, 0), "Bamboo", new class(2.0 /* 1.0 in PC */, BlockToolType::AXE) extends BlockBreakInfo{
-			public function getBreakTime(Item $item) : float{
-				if($item->getBlockToolType()){
-					return 0.0;
-				}
-				return parent::getBreakTime($item);
-			}
-		}));
+		$this->registerAllMeta(new Bamboo(new BID(Ids::BAMBOO, 0), "Bamboo", new BlockBreakInfo(2.0 /* 1.0 in PC */, BlockToolType::AXE)));
 		$this->registerAllMeta(new BambooSapling(new BID(Ids::BAMBOO_SAPLING, 0), "Bamboo Sapling", BlockBreakInfo::instant()));
 
 		$bannerBreakInfo = new BlockBreakInfo(1.0, BlockToolType::AXE);
@@ -265,7 +258,7 @@ class BlockFactory{
 		$this->registerAllMeta(new Magma(new BID(Ids::MAGMA, 0), "Magma Block", new BlockBreakInfo(0.5, BlockToolType::PICKAXE, ToolTier::WOOD()->getHarvestLevel())));
 		$this->registerAllMeta(new Melon(new BID(Ids::MELON_BLOCK, 0), "Melon Block", new BlockBreakInfo(1.0, BlockToolType::AXE)));
 		$this->registerAllMeta(new MelonStem(new BID(Ids::MELON_STEM, 0, ItemIds::MELON_SEEDS), "Melon Stem", BlockBreakInfo::instant()));
-		$this->registerAllMeta(new MonsterSpawner(new BID(Ids::MOB_SPAWNER, 0, null, TileMonsterSpawner::class), "Monster Spawner", new BlockBreakInfo(0.75, BlockToolType::PICKAXE)));
+		$this->registerAllMeta(new MonsterSpawner(new BID(Ids::MOB_SPAWNER, 0, null, TileMonsterSpawner::class), "Monster Spawner", new BlockBreakInfo(5.0, BlockToolType::PICKAXE, ToolTier::WOOD()->getHarvestLevel())));
 		$this->registerAllMeta(new Mycelium(new BID(Ids::MYCELIUM, 0), "Mycelium", new BlockBreakInfo(0.6, BlockToolType::SHOVEL)));
 
 		$netherBrickBreakInfo = new BlockBreakInfo(2.0, BlockToolType::PICKAXE, ToolTier::WOOD()->getHarvestLevel(), 30.0);
@@ -456,15 +449,7 @@ class BlockFactory{
 		$this->registerAllMeta(new Wheat(new BID(Ids::WHEAT_BLOCK, 0), "Wheat Block", BlockBreakInfo::instant()));
 
 		$planksBreakInfo = new BlockBreakInfo(2.0, BlockToolType::AXE, 0, 15.0);
-		$leavesBreakInfo = new class(0.2, BlockToolType::HOE) extends BlockBreakInfo{
-				public function getBreakTime(Item $item) : float{
-					return match($item->getBlockToolType()){
-						BlockToolType::SWORD => 0.2,
-						BlockToolType::SHEARS => 0.0,
-						default => parent::getBreakTime($item),
-					};
-				}
-			};
+		$leavesBreakInfo = new BlockBreakInfo(0.2, BlockToolType::SHEARS);
 		$signBreakInfo = new BlockBreakInfo(1.0, BlockToolType::AXE);
 		$logBreakInfo = new BlockBreakInfo(2.0, BlockToolType::AXE);
 		$woodenDoorBreakInfo = new BlockBreakInfo(3.0, BlockToolType::AXE, 0, 15.0);

--- a/src/block/BlockFactory.php
+++ b/src/block/BlockFactory.php
@@ -265,7 +265,7 @@ class BlockFactory{
 		$this->registerAllMeta(new Magma(new BID(Ids::MAGMA, 0), "Magma Block", new BlockBreakInfo(0.5, BlockToolType::PICKAXE, ToolTier::WOOD()->getHarvestLevel())));
 		$this->registerAllMeta(new Melon(new BID(Ids::MELON_BLOCK, 0), "Melon Block", new BlockBreakInfo(1.0, BlockToolType::AXE)));
 		$this->registerAllMeta(new MelonStem(new BID(Ids::MELON_STEM, 0, ItemIds::MELON_SEEDS), "Melon Stem", BlockBreakInfo::instant()));
-		$this->registerAllMeta(new MonsterSpawner(new BID(Ids::MOB_SPAWNER, 0, null, TileMonsterSpawner::class), "Monster Spawner", new BlockBreakInfo(0.75, BlockToolType::PICKAXE)));
+		$this->registerAllMeta(new MonsterSpawner(new BID(Ids::MOB_SPAWNER, 0, null, TileMonsterSpawner::class), "Monster Spawner", new BlockBreakInfo(5.0, BlockToolType::PICKAXE, ToolTier::WOOD()->getHarvestLevel())));
 		$this->registerAllMeta(new Mycelium(new BID(Ids::MYCELIUM, 0), "Mycelium", new BlockBreakInfo(0.6, BlockToolType::SHOVEL)));
 
 		$netherBrickBreakInfo = new BlockBreakInfo(2.0, BlockToolType::PICKAXE, ToolTier::WOOD()->getHarvestLevel(), 30.0);
@@ -372,7 +372,7 @@ class BlockFactory{
 			$crackedStoneBrick = new Opaque(new BID(Ids::STONEBRICK, Meta::STONE_BRICK_CRACKED), "Cracked Stone Bricks", $stoneBreakInfo),
 			$chiseledStoneBrick = new Opaque(new BID(Ids::STONEBRICK, Meta::STONE_BRICK_CHISELED), "Chiseled Stone Bricks", $stoneBreakInfo)
 		);
-		$infestedStoneBreakInfo = new BlockBreakInfo(0.75);
+		$infestedStoneBreakInfo = new BlockBreakInfo(0.75, BlockToolType::PICKAXE);
 		$this->registerAllMeta(
 			new InfestedStone(new BID(Ids::MONSTER_EGG, Meta::INFESTED_STONE), "Infested Stone", $infestedStoneBreakInfo, $stone),
 			new InfestedStone(new BID(Ids::MONSTER_EGG, Meta::INFESTED_STONE_BRICK), "Infested Stone Brick", $infestedStoneBreakInfo, $stoneBrick),

--- a/src/block/BlockFactory.php
+++ b/src/block/BlockFactory.php
@@ -117,7 +117,7 @@ class BlockFactory{
 		$this->registerAllMeta(new Anvil(new BID(Ids::ANVIL, 0), "Anvil", new BlockBreakInfo(5.0, BlockToolType::PICKAXE, ToolTier::WOOD()->getHarvestLevel(), 6000.0)));
 		$this->registerAllMeta(new Bamboo(new BID(Ids::BAMBOO, 0), "Bamboo", new class(2.0 /* 1.0 in PC */, BlockToolType::AXE) extends BlockBreakInfo{
 			public function getBreakTime(Item $item) : float{
-				if($item->getBlockToolType()){
+				if($item->getBlockToolType() === BlockToolType::SWORD){
 					return 0.0;
 				}
 				return parent::getBreakTime($item);

--- a/src/block/BlockFactory.php
+++ b/src/block/BlockFactory.php
@@ -457,13 +457,13 @@ class BlockFactory{
 
 		$planksBreakInfo = new BlockBreakInfo(2.0, BlockToolType::AXE, 0, 15.0);
 		$leavesBreakInfo = new class(0.2, BlockToolType::HOE) extends BlockBreakInfo{
-				public function getBreakTime(Item $item) : float{
-					if($item->getBlockToolType() === BlockToolType::SHEARS){
-						return 0.0;
-					}
-					return parent::getBreakTime($item);
+			public function getBreakTime(Item $item) : float{
+				if($item->getBlockToolType() === BlockToolType::SHEARS){
+					return 0.0;
 				}
-			};
+				return parent::getBreakTime($item);
+			}
+		};
 		$signBreakInfo = new BlockBreakInfo(1.0, BlockToolType::AXE);
 		$logBreakInfo = new BlockBreakInfo(2.0, BlockToolType::AXE);
 		$woodenDoorBreakInfo = new BlockBreakInfo(3.0, BlockToolType::AXE, 0, 15.0);

--- a/src/block/BlockFactory.php
+++ b/src/block/BlockFactory.php
@@ -115,7 +115,14 @@ class BlockFactory{
 		$this->registerAllMeta(new ActivatorRail(new BID(Ids::ACTIVATOR_RAIL, 0), "Activator Rail", $railBreakInfo));
 		$this->registerAllMeta(new Air(new BID(Ids::AIR, 0), "Air", BlockBreakInfo::indestructible(-1.0)));
 		$this->registerAllMeta(new Anvil(new BID(Ids::ANVIL, 0), "Anvil", new BlockBreakInfo(5.0, BlockToolType::PICKAXE, ToolTier::WOOD()->getHarvestLevel(), 6000.0)));
-		$this->registerAllMeta(new Bamboo(new BID(Ids::BAMBOO, 0), "Bamboo", new BlockBreakInfo(2.0 /* 1.0 in PC */, BlockToolType::AXE)));
+		$this->registerAllMeta(new Bamboo(new BID(Ids::BAMBOO, 0), "Bamboo", new class(2.0 /* 1.0 in PC */, BlockToolType::AXE) extends BlockBreakInfo{
+			public function getBreakTime(Item $item) : float{
+				if($item->getBlockToolType()){
+					return 0.0;
+				}
+				return parent::getBreakTime($item);
+			}
+		}));
 		$this->registerAllMeta(new BambooSapling(new BID(Ids::BAMBOO_SAPLING, 0), "Bamboo Sapling", BlockBreakInfo::instant()));
 
 		$bannerBreakInfo = new BlockBreakInfo(1.0, BlockToolType::AXE);
@@ -258,7 +265,7 @@ class BlockFactory{
 		$this->registerAllMeta(new Magma(new BID(Ids::MAGMA, 0), "Magma Block", new BlockBreakInfo(0.5, BlockToolType::PICKAXE, ToolTier::WOOD()->getHarvestLevel())));
 		$this->registerAllMeta(new Melon(new BID(Ids::MELON_BLOCK, 0), "Melon Block", new BlockBreakInfo(1.0, BlockToolType::AXE)));
 		$this->registerAllMeta(new MelonStem(new BID(Ids::MELON_STEM, 0, ItemIds::MELON_SEEDS), "Melon Stem", BlockBreakInfo::instant()));
-		$this->registerAllMeta(new MonsterSpawner(new BID(Ids::MOB_SPAWNER, 0, null, TileMonsterSpawner::class), "Monster Spawner", new BlockBreakInfo(5.0, BlockToolType::PICKAXE, ToolTier::WOOD()->getHarvestLevel())));
+		$this->registerAllMeta(new MonsterSpawner(new BID(Ids::MOB_SPAWNER, 0, null, TileMonsterSpawner::class), "Monster Spawner", new BlockBreakInfo(0.75, BlockToolType::PICKAXE)));
 		$this->registerAllMeta(new Mycelium(new BID(Ids::MYCELIUM, 0), "Mycelium", new BlockBreakInfo(0.6, BlockToolType::SHOVEL)));
 
 		$netherBrickBreakInfo = new BlockBreakInfo(2.0, BlockToolType::PICKAXE, ToolTier::WOOD()->getHarvestLevel(), 30.0);
@@ -449,7 +456,15 @@ class BlockFactory{
 		$this->registerAllMeta(new Wheat(new BID(Ids::WHEAT_BLOCK, 0), "Wheat Block", BlockBreakInfo::instant()));
 
 		$planksBreakInfo = new BlockBreakInfo(2.0, BlockToolType::AXE, 0, 15.0);
-		$leavesBreakInfo = new BlockBreakInfo(0.2, BlockToolType::SHEARS);
+		$leavesBreakInfo = new class(0.2, BlockToolType::HOE) extends BlockBreakInfo{
+				public function getBreakTime(Item $item) : float{
+					return match($item->getBlockToolType()){
+						BlockToolType::SWORD => 0.2,
+						BlockToolType::SHEARS => 0.0,
+						default => parent::getBreakTime($item),
+					};
+				}
+			};
 		$signBreakInfo = new BlockBreakInfo(1.0, BlockToolType::AXE);
 		$logBreakInfo = new BlockBreakInfo(2.0, BlockToolType::AXE);
 		$woodenDoorBreakInfo = new BlockBreakInfo(3.0, BlockToolType::AXE, 0, 15.0);

--- a/src/block/BlockFactory.php
+++ b/src/block/BlockFactory.php
@@ -277,7 +277,7 @@ class BlockFactory{
 		$this->registerAllMeta(new NetherPortal(new BID(Ids::PORTAL, 0), "Nether Portal", BlockBreakInfo::indestructible(0.0)));
 		$this->registerAllMeta(new NetherQuartzOre(new BID(Ids::NETHER_QUARTZ_ORE, 0), "Nether Quartz Ore", new BlockBreakInfo(3.0, BlockToolType::PICKAXE, ToolTier::WOOD()->getHarvestLevel())));
 		$this->registerAllMeta(new NetherReactor(new BID(Ids::NETHERREACTOR, 0), "Nether Reactor Core", new BlockBreakInfo(3.0, BlockToolType::PICKAXE, ToolTier::WOOD()->getHarvestLevel())));
-		$this->registerAllMeta(new Opaque(new BID(Ids::NETHER_WART_BLOCK, 0), "Nether Wart Block", new BlockBreakInfo(1.0)));
+		$this->registerAllMeta(new Opaque(new BID(Ids::NETHER_WART_BLOCK, 0), "Nether Wart Block", new BlockBreakInfo(1.0, BlockToolType::HOE)));
 		$this->registerAllMeta(new NetherWartPlant(new BID(Ids::NETHER_WART_PLANT, 0, ItemIds::NETHER_WART), "Nether Wart", BlockBreakInfo::instant()));
 		$this->registerAllMeta(new Netherrack(new BID(Ids::NETHERRACK, 0), "Netherrack", new BlockBreakInfo(0.4, BlockToolType::PICKAXE, ToolTier::WOOD()->getHarvestLevel())));
 		$this->registerAllMeta(new Note(new BID(Ids::NOTEBLOCK, 0, null, TileNote::class), "Note Block", new BlockBreakInfo(0.8, BlockToolType::AXE)));
@@ -448,7 +448,7 @@ class BlockFactory{
 		$this->registerAllMeta(new UnderwaterTorch(new BID(Ids::UNDERWATER_TORCH, 0), "Underwater Torch", BlockBreakInfo::instant()));
 		$this->registerAllMeta(new Vine(new BID(Ids::VINE, 0), "Vines", new BlockBreakInfo(0.2, BlockToolType::AXE)));
 		$this->registerAllMeta(new Water(new BIDFlattened(Ids::FLOWING_WATER, [Ids::STILL_WATER], 0), "Water", BlockBreakInfo::indestructible(500.0)));
-		$this->registerAllMeta(new WaterLily(new BID(Ids::LILY_PAD, 0), "Lily Pad", new BlockBreakInfo(0.6)));
+		$this->registerAllMeta(new WaterLily(new BID(Ids::LILY_PAD, 0), "Lily Pad", BlockBreakInfo::instant()));
 
 		$weightedPressurePlateBreakInfo = new BlockBreakInfo(0.5, BlockToolType::PICKAXE, ToolTier::WOOD()->getHarvestLevel());
 		$this->registerAllMeta(new WeightedPressurePlateHeavy(new BID(Ids::HEAVY_WEIGHTED_PRESSURE_PLATE, 0), "Weighted Pressure Plate Heavy", $weightedPressurePlateBreakInfo));


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
test with plugin
```
	var $t = 0;
	
	function onEnable () : void {
		$this->getServer()->getPluginManager()->registerEvents($this,$this);
	}
	
	function tap ( PlayerInteractEvent $e ) {
		if ( $e->getAction() === PlayerInteractEvent::LEFT_CLICK_BLOCK ) {
			$this->t = hrtime(true);
		}
	}
	
	function bb ( BlockBreakEvent $e ) {
		$e->getPlayer()->sendMessage('T = ' . round((hrtime(true) - $this->t) / 1_000_000_000, 2) . 's');
		$this->t = 0;
	}
```
Result (PE, Android):

Bamboo: https://minecraft.fandom.com/wiki/Bamboo
- wooden sword: 0, 0, 0.21, 0.2, 0.21, 0.2 => 0
- wooden sword: 0, 0, 0, 0, 0, 0.2, 0, 0, 0, 0 => 0
- sometimes this will be 0.05 or 0.2.  i think this should be considered instant break because it seems the unexplained delay occurs

Nether wart blocks: https://minecraft.fandom.com/wiki/Nether_Wart_Block
- no tool: 1.46, 1.51, 1.5, 1.51 => 1.5
- wooden hoe: 0.71, 0.75, 0.76 => 0.75
- diamond hoe: 0.15, 0.2, 0.2 => 0.2

Infested Stone: https://minecraft.fandom.com/wiki/Infested_Block
- no tool: 1.1, 1.15, 1.16, 1.15 => 1.15 (97:0 - 97:5 have the same result)
- diamond pickaxe: 0.1, 0.16, 0.15, 0.15 => 0.15 (97:0 - 97:5 have the same result)

Lily Pad: https://minecraft.fandom.com/wiki/Lily_Pad
- no tool: 0

Leaves: https://minecraft.fandom.com/wiki/Leaves
- no tool: 0.25, 0.31, 0.3, 0.3 => 0.3
- wooden sword: 0.15, 0.2, 0.2, 0.21 => 0.2
- stone hoe: 0.05, 0.1, 0.1, 0.1 => 0.1
- iron hoe: 0.0, 0.05, 0.05, 0.05 => 0 (instant break)
- shears: 0.0, 0.05, 0.05, 0.05 => 0 (instant break)

I have not tested the return of BlockBreakInfo->getBreakTime() and BlockBreakInfo->isToolCompatible(), pls tell me if it is necessary