### PR TITLE
Implement PlayerViewDistanceChangeEvent

### DIFF
--- a/src/event/player/PlayerViewDistanceChangeEvent.php
+++ b/src/event/player/PlayerViewDistanceChangeEvent.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\event\player;
+
+use pocketmine\event\Cancellable;
+use pocketmine\event\CancellableTrait;
+use pocketmine\player\Player;
+
+/**
+ * Called when a player requests a different viewing distance than the current one.
+ */
+class PlayerViewDistanceChangeEvent extends PlayerEvent implements Cancellable{
+	use CancellableTrait;
+
+	protected int $radius;
+
+	public function __construct(Player $player, int $radius){
+		$this->player = $player;
+		$this->radius = $radius;
+	}
+
+	public function setRadius(int $radius) : void{
+		$this->radius = $radius;
+	}
+
+	public function getRadius() : int{
+		return $this->radius;
+	}
+}

--- a/src/event/player/PlayerViewDistanceChangeEvent.php
+++ b/src/event/player/PlayerViewDistanceChangeEvent.php
@@ -29,17 +29,17 @@ use pocketmine\player\Player;
  * Called when a player requests a different viewing distance than the current one.
  */
 class PlayerViewDistanceChangeEvent extends PlayerEvent{
-	protected int $radius;
+	protected int $newRadius;
 	protected int $oldRadius;
 
-	public function __construct(Player $player, int $radius, int $oldRadius){
+	public function __construct(Player $player, int $newRadius, int $oldRadius){
 		$this->player = $player;
-		$this->radius = $radius;
+		$this->newRadius = $newRadius;
 		$this->oldRadius = $oldRadius;
 	}
 
-	public function getRadius() : int{
-		return $this->radius;
+	public function getNewRadius() : int{
+		return $this->newRadius;
 	}
 
 	public function getOldRadius() : int{

--- a/src/event/player/PlayerViewDistanceChangeEvent.php
+++ b/src/event/player/PlayerViewDistanceChangeEvent.php
@@ -32,10 +32,10 @@ class PlayerViewDistanceChangeEvent extends PlayerEvent{
 	protected int $newRadius;
 	protected int $oldRadius;
 
-	public function __construct(Player $player, int $newRadius, int $oldRadius){
+	public function __construct(Player $player, int $oldRadius, int $newRadius){
 		$this->player = $player;
-		$this->newRadius = $newRadius;
 		$this->oldRadius = $oldRadius;
+		$this->newRadius = $newRadius;
 	}
 
 	public function getNewRadius() : int{

--- a/src/event/player/PlayerViewDistanceChangeEvent.php
+++ b/src/event/player/PlayerViewDistanceChangeEvent.php
@@ -39,15 +39,15 @@ class PlayerViewDistanceChangeEvent extends PlayerEvent{
 	}
 
 	/**
-	 * Returns an int corresponding to the number of chunks forming the new view distance
+	 * Returns the new view radius, measured in chunks.
 	 */
 	public function getNewDistance() : int{
 		return $this->newDistance;
 	}
 
 	/**
-	 * Returns an int corresponding to the number of chunks forming the previous view distance, before change
-	 * If the player connects to the server, it will return -1
+	 * Returns the old view radius, measured in chunks.
+	 * A value of -1 means that the player has just connected and did not have a view distance before this event.
 	 */
 	public function getOldDistance() : int{
 		return $this->oldDistance;

--- a/src/event/player/PlayerViewDistanceChangeEvent.php
+++ b/src/event/player/PlayerViewDistanceChangeEvent.php
@@ -23,28 +23,26 @@ declare(strict_types=1);
 
 namespace pocketmine\event\player;
 
-use pocketmine\event\Cancellable;
-use pocketmine\event\CancellableTrait;
 use pocketmine\player\Player;
 
 /**
  * Called when a player requests a different viewing distance than the current one.
  */
-class PlayerViewDistanceChangeEvent extends PlayerEvent implements Cancellable{
-	use CancellableTrait;
-
+class PlayerViewDistanceChangeEvent extends PlayerEvent{
 	protected int $radius;
+	protected int $oldRadius;
 
-	public function __construct(Player $player, int $radius){
+	public function __construct(Player $player, int $radius, int $oldRadius){
 		$this->player = $player;
 		$this->radius = $radius;
-	}
-
-	public function setRadius(int $radius) : void{
-		$this->radius = $radius;
+		$this->oldRadius = $oldRadius;
 	}
 
 	public function getRadius() : int{
 		return $this->radius;
+	}
+
+	public function getOldRadius() : int{
+		return $this->oldRadius;
 	}
 }

--- a/src/event/player/PlayerViewDistanceChangeEvent.php
+++ b/src/event/player/PlayerViewDistanceChangeEvent.php
@@ -38,10 +38,17 @@ class PlayerViewDistanceChangeEvent extends PlayerEvent{
 		$this->newDistance = $newDistance;
 	}
 
+	/**
+	 * Returns an int corresponding to the number of chunks forming the new view distance
+	 */
 	public function getNewDistance() : int{
 		return $this->newDistance;
 	}
 
+	/**
+	 * Returns an int corresponding to the number of chunks forming the previous view distance, before change
+	 * If the player connects to the server, it will return -1
+	 */
 	public function getOldDistance() : int{
 		return $this->oldDistance;
 	}

--- a/src/event/player/PlayerViewDistanceChangeEvent.php
+++ b/src/event/player/PlayerViewDistanceChangeEvent.php
@@ -29,20 +29,20 @@ use pocketmine\player\Player;
  * Called when a player requests a different viewing distance than the current one.
  */
 class PlayerViewDistanceChangeEvent extends PlayerEvent{
-	protected int $newRadius;
-	protected int $oldRadius;
+	protected int $newDistance;
+	protected int $oldDistance;
 
-	public function __construct(Player $player, int $oldRadius, int $newRadius){
+	public function __construct(Player $player, int $oldDistance, int $newDistance){
 		$this->player = $player;
-		$this->oldRadius = $oldRadius;
-		$this->newRadius = $newRadius;
+		$this->oldDistance = $oldDistance;
+		$this->newDistance = $newDistance;
 	}
 
-	public function getNewRadius() : int{
-		return $this->newRadius;
+	public function getNewDistance() : int{
+		return $this->newDistance;
 	}
 
-	public function getOldRadius() : int{
-		return $this->oldRadius;
+	public function getOldDistance() : int{
+		return $this->oldDistance;
 	}
 }

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -30,7 +30,6 @@ use pocketmine\entity\animation\ConsumingItemAnimation;
 use pocketmine\entity\Attribute;
 use pocketmine\entity\InvalidSkinException;
 use pocketmine\event\player\PlayerEditBookEvent;
-use pocketmine\event\player\PlayerViewDistanceChangeEvent;
 use pocketmine\inventory\transaction\action\InventoryAction;
 use pocketmine\inventory\transaction\CraftingTransaction;
 use pocketmine\inventory\transaction\InventoryTransaction;
@@ -686,13 +685,6 @@ class InGamePacketHandler extends PacketHandler{
 	}
 
 	public function handleRequestChunkRadius(RequestChunkRadiusPacket $packet) : bool{
-		if($this->player->getViewDistance() !== $packet->radius){
-			$ev = new PlayerViewDistanceChangeEvent($this->player, $packet->radius);
-			$ev->call();
-			if($ev->isCancelled()){
-				return true;
-			}
-		}
 		$this->player->setViewDistance($packet->radius);
 
 		return true;

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -30,6 +30,7 @@ use pocketmine\entity\animation\ConsumingItemAnimation;
 use pocketmine\entity\Attribute;
 use pocketmine\entity\InvalidSkinException;
 use pocketmine\event\player\PlayerEditBookEvent;
+use pocketmine\event\player\PlayerViewDistanceChangeEvent;
 use pocketmine\inventory\transaction\action\InventoryAction;
 use pocketmine\inventory\transaction\CraftingTransaction;
 use pocketmine\inventory\transaction\InventoryTransaction;
@@ -685,6 +686,13 @@ class InGamePacketHandler extends PacketHandler{
 	}
 
 	public function handleRequestChunkRadius(RequestChunkRadiusPacket $packet) : bool{
+		if($this->player->getViewDistance() !== $packet->radius){
+			$ev = new PlayerViewDistanceChangeEvent($this->player, $packet->radius);
+			$ev->call();
+			if($ev->isCancelled()){
+				return true;
+			}
+		}
 		$this->player->setViewDistance($packet->radius);
 
 		return true;

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -71,6 +71,7 @@ use pocketmine\event\player\PlayerToggleFlightEvent;
 use pocketmine\event\player\PlayerToggleSneakEvent;
 use pocketmine\event\player\PlayerToggleSprintEvent;
 use pocketmine\event\player\PlayerTransferEvent;
+use pocketmine\event\player\PlayerViewDistanceChangeEvent;
 use pocketmine\form\Form;
 use pocketmine\form\FormValidationException;
 use pocketmine\inventory\CallbackInventoryListener;
@@ -477,6 +478,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 	}
 
 	public function setViewDistance(int $distance) : void{
+		$oldViewDistance = $this->viewDistance;
 		$this->viewDistance = $this->server->getAllowedViewDistance($distance);
 
 		$this->spawnThreshold = (int) (min($this->viewDistance, $this->server->getConfigGroup()->getPropertyInt("chunk-sending.spawn-radius", 4)) ** 2 * M_PI);
@@ -484,6 +486,11 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		$this->nextChunkOrderRun = 0;
 
 		$this->getNetworkSession()->syncViewAreaRadius($this->viewDistance);
+
+		if($this->viewDistance !== $oldViewDistance){
+			$ev = new PlayerViewDistanceChangeEvent($this, $this->viewDistance, $oldViewDistance);
+			$ev->call();
+		}
 
 		$this->logger->debug("Setting view distance to " . $this->viewDistance . " (requested " . $distance . ")");
 	}

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -488,7 +488,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		$this->getNetworkSession()->syncViewAreaRadius($this->viewDistance);
 
 		if($this->viewDistance !== $oldViewDistance){
-			$ev = new PlayerViewDistanceChangeEvent($this, $this->viewDistance, $oldViewDistance);
+			$ev = new PlayerViewDistanceChangeEvent($this, $oldViewDistance, $this->viewDistance);
 			$ev->call();
 		}
 

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -493,7 +493,6 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 
 		$this->getNetworkSession()->syncViewAreaRadius($this->viewDistance);
 
-
 		$this->logger->debug("Setting view distance to " . $this->viewDistance . " (requested " . $distance . ")");
 	}
 

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -478,8 +478,14 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 	}
 
 	public function setViewDistance(int $distance) : void{
-		$oldViewDistance = $this->viewDistance;
-		$this->viewDistance = $this->server->getAllowedViewDistance($distance);
+		$newViewDistance = $this->server->getAllowedViewDistance($distance);
+
+		if($newViewDistance !== $this->viewDistance){
+			$ev = new PlayerViewDistanceChangeEvent($this, $this->viewDistance, $newViewDistance);
+			$ev->call();
+		}
+
+		$this->viewDistance = $newViewDistance;
 
 		$this->spawnThreshold = (int) (min($this->viewDistance, $this->server->getConfigGroup()->getPropertyInt("chunk-sending.spawn-radius", 4)) ** 2 * M_PI);
 
@@ -487,10 +493,6 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 
 		$this->getNetworkSession()->syncViewAreaRadius($this->viewDistance);
 
-		if($this->viewDistance !== $oldViewDistance){
-			$ev = new PlayerViewDistanceChangeEvent($this, $oldViewDistance, $this->viewDistance);
-			$ev->call();
-		}
 
 		$this->logger->debug("Setting view distance to " . $this->viewDistance . " (requested " . $distance . ")");
 	}


### PR DESCRIPTION
## Introduction
There is currently no simple way to recover a player's view distance change

### Relevant issues
* Fixes #4550 

## Changes
### API changes
* Add PlayerViewDistanceChangeEvent

### Behavioural changes
When a player requests a new distance, if it is different from the player's current distance, the event will be called.
The event will not be called when the player connecting because no view distance is established

## Tests
Make a simple plugin of this type: 
```php
class Main extends PluginBase implements Listener{

	public function onEnable() : void{
		$this->getServer()->getPluginManager()->registerEvents($this, $this);
	}

	public function onViewDistance(PlayerViewDistanceChangeEvent $event){
		$this->getServer()->broadcastMessage($event->getPlayer()->getName() . " request a different radius, " . $event->getNewDistance() . " instead of " . $event->getOldDistance());
	}
}
```
Go to your settings and change your rendering distance
