### PR TITLE
Fixed incorrect drops for ender chest

### DIFF
--- a/src/block/EnderChest.php
+++ b/src/block/EnderChest.php
@@ -66,4 +66,8 @@ class EnderChest extends Transparent{
 			VanillaBlocks::OBSIDIAN()->asItem()->setCount(8)
 		];
 	}
+
+	public function isAffectedBySilkTouch() : bool{
+		return true;
+	}
 }


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

Ender chest drops itself when the pickaxe has Silk Touch

https://minecraft.fandom.com/wiki/Ender_Chest
> Breaking
> Ender chests require a pickaxe to be mined. Otherwise, they drop nothing. Unless the pickaxe is enchanted with Silk Touch, the ender chest drops only 8 obsidian with no Eyes of Ender. Any pickaxe allows the ender chest to drop either itself or 8 obsidian, despite obsidian itself only being obtainable with a diamond or netherite pickaxe.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
