### PR TITLE
Make OfflinePlayer->getName() more consistent with Player->getName()

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -470,7 +470,6 @@ class Server{
 	 * @return OfflinePlayer|Player
 	 */
 	public function getOfflinePlayer(string $name){
-		$name = strtolower($name);
 		$result = $this->getPlayerExact($name);
 
 		if($result === null){


### PR DESCRIPTION
## Introduction
`strtolower` is already being called on [`Server->getPlayerExact()`](https://github.com/pmmp/PocketMine-MP/blob/67a0ae02469c3d116d30f872a6333dda40d9e00c/src/Server.php#L639) and [`Server->getOfflinePlayerData()`](https://github.com/pmmp/PocketMine-MP/blob/67a0ae02469c3d116d30f872a6333dda40d9e00c/src/Server.php#L502), there is no need to change the letter casing on `Server->getOfflinePlayer()` as it only makes `OfflinePlayer->getName()` inconsistent with `Player->getName()`

### Relevant issues
None

## Changes
### API changes
`OfflinePlayer->getName()` will now be more consistent with `Player->getName()`

### Behavioural changes
None

## Backwards compatibility
In an extremely rare case where a plugin depended on this inconsistency, one may just use `strtolower` directly

## Follow-up
None

## Tests
```php
Server::getInstance()->getOfflinePlayer("NonexistentPlayer")->getName() // nonexistentplayer
```
