### PR TITLE
Fix torch placement

### DIFF
--- a/src/block/Torch.php
+++ b/src/block/Torch.php
@@ -99,35 +99,40 @@ class Torch extends Flowable{
 
 	private function isValidSupport(Block $block, int $face) : bool{
 		//TODO: side of composter
-		if($block instanceof Stair){
-			if($face === Facing::UP && $block->isUpsideDown()){
+		if($block instanceof Stair && (
+			$face === Facing::UP && $block->isUpsideDown() ||
+			$face === $block->getFacing()
+		)){
 				return true;
-			}elseif($face === $block->getFacing()){
-				return true;
-			}
-		}elseif($block instanceof Slab){
-			if($face === Facing::UP && (
-				$block->getSlabType()->equals(SlabType::TOP()) ||
-				$block->getSlabType()->equals(SlabType::DOUBLE())
-			)){
-				return true;
-			}elseif(in_array($face, Facing::HORIZONTAL, true) && $block->getSlabType()->equals(SlabType::DOUBLE())){
-				return true;
-			}
-		}elseif($block instanceof Trapdoor){
-			if($face === Facing::UP && $block->isTop() && !$block->isOpen()){
-				return true;
-			}
-		}elseif($face === Facing::UP && (
-			$block instanceof Fence ||
-			$block instanceof Wall
+		}elseif($block instanceof Slab && (
+			$face === Facing::UP && (
+					$block->getSlabType()->equals(SlabType::TOP()) ||
+					$block->getSlabType()->equals(SlabType::DOUBLE())
+				) ||
+			in_array($face, Facing::HORIZONTAL, true) && $block->getSlabType()->equals(SlabType::DOUBLE())
 		)){
 			return true;
+		}elseif($block instanceof Trapdoor &&
+			$face === Facing::UP &&
+			$block->isTop() &&
+			!$block->isOpen()
+		){
+			return true;
+		}elseif($face === Facing::UP &&
+			(
+				$block instanceof Fence ||
+				$block instanceof Wall
+			)
+		){
+			return true;
 		}elseif($block->isSolid() ||
-				($block instanceof Farmland ||
+			(
+				$block instanceof Farmland ||
 				$block instanceof GrassPath ||
 				$block instanceof Ice ||
-				$block->getId() === BlockLegacyIds::BARRIER)){
+				$block->getId() === BlockLegacyIds::BARRIER
+			)
+		){
 			return true;
 		}
 		return false;

--- a/src/block/Torch.php
+++ b/src/block/Torch.php
@@ -99,40 +99,35 @@ class Torch extends Flowable{
 
 	private function isValidSupport(Block $block, int $face) : bool{
 		//TODO: side of composter
-		if($block instanceof Stair && (
-			$face === Facing::UP && $block->isUpsideDown() ||
-			$face === $block->getFacing()
-		)){
+		if($block instanceof Stair){
+			if($face === Facing::UP && $block->isUpsideDown()){
 				return true;
-		}elseif($block instanceof Slab && (
-			$face === Facing::UP && (
-					$block->getSlabType()->equals(SlabType::TOP()) ||
-					$block->getSlabType()->equals(SlabType::DOUBLE())
-				) ||
-			in_array($face, Facing::HORIZONTAL, true) && $block->getSlabType()->equals(SlabType::DOUBLE())
+			}elseif($face === $block->getFacing()){
+				return true;
+			}
+		}elseif($block instanceof Slab){
+			if($face === Facing::UP && (
+				$block->getSlabType()->equals(SlabType::TOP()) ||
+				$block->getSlabType()->equals(SlabType::DOUBLE())
+			)){
+				return true;
+			}elseif(in_array($face, Facing::HORIZONTAL, true) && $block->getSlabType()->equals(SlabType::DOUBLE())){
+				return true;
+			}
+		}elseif($block instanceof Trapdoor){
+			if($face === Facing::UP && $block->isTop() && !$block->isOpen()){
+				return true;
+			}
+		}elseif($face === Facing::UP && (
+			$block instanceof Fence ||
+			$block instanceof Wall
 		)){
-			return true;
-		}elseif($block instanceof Trapdoor &&
-			$face === Facing::UP &&
-			$block->isTop() &&
-			!$block->isOpen()
-		){
-			return true;
-		}elseif($face === Facing::UP &&
-			(
-				$block instanceof Fence ||
-				$block instanceof Wall
-			)
-		){
 			return true;
 		}elseif($block->isSolid() ||
-			(
-				$block instanceof Farmland ||
+				($block instanceof Farmland ||
 				$block instanceof GrassPath ||
 				$block instanceof Ice ||
-				$block->getId() === BlockLegacyIds::BARRIER
-			)
-		){
+				$block->getId() === BlockLegacyIds::BARRIER)){
 			return true;
 		}
 		return false;

--- a/src/block/Torch.php
+++ b/src/block/Torch.php
@@ -64,10 +64,9 @@ class Torch extends Flowable{
 	}
 
 	public function onNearbyBlockChange() : void{
-		$below = $this->getSide(Facing::DOWN);
-		$face = Facing::opposite($this->facing);
+		$support = $this->getSide(Facing::opposite($this->facing));
 
-		if(!$this->isValidSupport($below, $face)){
+		if(!$this->isValidSupport($support, $this->facing)){
 			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
@@ -102,19 +101,29 @@ class Torch extends Flowable{
 		//TODO: side composter
 		//TODO: trapdoor top closed
 		//TODO: slabs top, slabs double
-		//TODO: stairs
 		//TODO: ice
+		if($block instanceof Stair){
+			if($face === Facing::UP && $block->isUpsideDown()){
+				return true;
+			}elseif($face === $block->getFacing()){
+				return true;
+			}else{
+				return false;
+			}
+		}
 		if($face === Facing::UP && (
 			$block instanceof Fence ||
 			$block instanceof Wall ||
 			($block instanceof Slab && (
 				$block->getSlabType()->equals(SlabType::TOP()) ||
-				$block->getSlabType()->equals(SlabType::DOUBLE()))) ||
-			($block instanceof Stair && $block->isUpsideDown())
+				$block->getSlabType()->equals(SlabType::DOUBLE())))
 		)){
 			return true;
 		}
-		if($block->isSolid()){
+		if($block->isSolid() || (
+			$block instanceof Farmland ||
+			$block instanceof GrassPath
+		)){
 			return true;
 		}
 		return false;

--- a/src/block/Torch.php
+++ b/src/block/Torch.php
@@ -67,7 +67,7 @@ class Torch extends Flowable{
 		$below = $this->getSide(Facing::DOWN);
 		$face = Facing::opposite($this->facing);
 
-		if($this->getSide($face)->isTransparent() && !($face === Facing::DOWN && ($below->getId() === BlockLegacyIds::FENCE || $below->getId() === BlockLegacyIds::COBBLESTONE_WALL))){
+		if(!$this->isValidSupport($below, $face)){
 			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}

--- a/src/block/Torch.php
+++ b/src/block/Torch.php
@@ -118,11 +118,10 @@ class Torch extends Flowable{
 			if($face === Facing::UP && $block->isTop() && !$block->isOpen()){
 				return true;
 			}
-		}elseif($face === Facing::UP && (
-			$block instanceof Fence ||
-			$block instanceof Wall
-		)){
-			return true;
+		}elseif($block instanceof Fence || $block instanceof Wall){
+			if($face === Facing::UP){
+				return true;
+			}
 		}elseif($block->isSolid() ||
 				($block instanceof Farmland ||
 				$block instanceof GrassPath ||

--- a/src/block/Torch.php
+++ b/src/block/Torch.php
@@ -30,6 +30,7 @@ use pocketmine\math\Facing;
 use pocketmine\math\Vector3;
 use pocketmine\player\Player;
 use pocketmine\world\BlockTransaction;
+use function in_array;
 
 class Torch extends Flowable{
 
@@ -100,7 +101,6 @@ class Torch extends Flowable{
 		//TODO: dirt path/land
 		//TODO: side composter
 		//TODO: trapdoor top closed
-		//TODO: slabs top, slabs double
 		//TODO: ice
 		if($block instanceof Stair){
 			if($face === Facing::UP && $block->isUpsideDown()){
@@ -110,13 +110,21 @@ class Torch extends Flowable{
 			}else{
 				return false;
 			}
+		}elseif($block instanceof Slab){
+			if($face === Facing::UP && (
+				$block->getSlabType()->equals(SlabType::TOP()) ||
+				$block->getSlabType()->equals(SlabType::DOUBLE())
+			)){
+				return true;
+			}elseif(in_array($face, Facing::HORIZONTAL, true) && $block->getSlabType()->equals(SlabType::DOUBLE())){
+				return true;
+			}else{
+				return false;
+			}
 		}
 		if($face === Facing::UP && (
 			$block instanceof Fence ||
-			$block instanceof Wall ||
-			($block instanceof Slab && (
-				$block->getSlabType()->equals(SlabType::TOP()) ||
-				$block->getSlabType()->equals(SlabType::DOUBLE())))
+			$block instanceof Wall
 		)){
 			return true;
 		}

--- a/src/block/Torch.php
+++ b/src/block/Torch.php
@@ -115,9 +115,7 @@ class Torch extends Flowable{
 				return true;
 			}
 		}elseif($block instanceof Trapdoor){
-			if($face === Facing::UP && $block->isTop() && !$block->isOpen()){
-				return true;
-			}
+			return false;
 		}elseif($block instanceof Fence || $block instanceof Wall){
 			if($face === Facing::UP){
 				return true;

--- a/src/block/Torch.php
+++ b/src/block/Torch.php
@@ -98,16 +98,12 @@ class Torch extends Flowable{
 	}
 
 	private function isValidSupport(Block $block, int $face) : bool{
-		//TODO: dirt path/land
-		//TODO: side composter
-		//TODO: ice
+		//TODO: side of composter
 		if($block instanceof Stair){
 			if($face === Facing::UP && $block->isUpsideDown()){
 				return true;
 			}elseif($face === $block->getFacing()){
 				return true;
-			}else{
-				return false;
 			}
 		}elseif($block instanceof Slab){
 			if($face === Facing::UP && (
@@ -117,25 +113,21 @@ class Torch extends Flowable{
 				return true;
 			}elseif(in_array($face, Facing::HORIZONTAL, true) && $block->getSlabType()->equals(SlabType::DOUBLE())){
 				return true;
-			}else{
-				return false;
 			}
 		}elseif($block instanceof Trapdoor){
 			if($face === Facing::UP && $block->isTop() && !$block->isOpen()){
 				return true;
 			}
-			return false;
-		}
-		if($face === Facing::UP && (
+		}elseif($face === Facing::UP && (
 			$block instanceof Fence ||
 			$block instanceof Wall
 		)){
 			return true;
-		}
-		if($block->isSolid() || (
-			$block instanceof Farmland ||
-			$block instanceof GrassPath
-		)){
+		}elseif($block->isSolid() ||
+				($block instanceof Farmland ||
+				$block instanceof GrassPath ||
+				$block instanceof Ice ||
+				$block->getId() === BlockLegacyIds::BARRIER)){
 			return true;
 		}
 		return false;

--- a/src/block/Torch.php
+++ b/src/block/Torch.php
@@ -100,7 +100,6 @@ class Torch extends Flowable{
 	private function isValidSupport(Block $block, int $face) : bool{
 		//TODO: dirt path/land
 		//TODO: side composter
-		//TODO: trapdoor top closed
 		//TODO: ice
 		if($block instanceof Stair){
 			if($face === Facing::UP && $block->isUpsideDown()){
@@ -121,6 +120,11 @@ class Torch extends Flowable{
 			}else{
 				return false;
 			}
+		}elseif($block instanceof Trapdoor){
+			if($face === Facing::UP && $block->isTop() && !$block->isOpen()){
+				return true;
+			}
+			return false;
 		}
 		if($face === Facing::UP && (
 			$block instanceof Fence ||


### PR DESCRIPTION
## Introduction
The current version of PocketMine-MP does not allow to place the torches like Vanilla, limiting the placement only on solid blocks or barriers / walls. However, minecraft vanilla allows placement on slabs in high position / stair on top position, etc etc

### Relevant issues
* Linked #458 

## Changes
### Behavioural changes
A more complete check is made on the torch support

## Follow-up
Keep up to date with the implementation of new blocks such as the composter or other unimplemented vanilla blocks

## Tests
https://user-images.githubusercontent.com/66992287/150692172-736af462-cff5-451e-b991-4bb7cb820030.mp4
