### PR TITLE
Whitelist command now kicks non-whitelisted online players

### DIFF
--- a/src/command/defaults/WhitelistCommand.php
+++ b/src/command/defaults/WhitelistCommand.php
@@ -140,7 +140,7 @@ class WhitelistCommand extends VanillaCommand{
 
 	private function kickNonWhitelistedPlayers(Server $server) : void{
 		foreach($server->getOnlinePlayers() as $player){
-			if(!$server->isWhitelisted($player)){
+			if(!$server->isWhitelisted($player->getName())){
 				$player->kick("Server whitelisted.");
 			}
 		}

--- a/src/command/defaults/WhitelistCommand.php
+++ b/src/command/defaults/WhitelistCommand.php
@@ -125,7 +125,7 @@ class WhitelistCommand extends VanillaCommand{
 					if($this->testPermission($sender, DefaultPermissionNames::COMMAND_WHITELIST_REMOVE)){
 						$server = $sender->getServer();
 						$server->removeWhitelist($args[1]);
-						if($server->hasWhitelist()){
+						if(!$server->isWhitelisted($args[1])){
 							$server->getPlayerExact($args[1])?->kick("Server whitelisted.");
 						}
 						Command::broadcastCommandMessage($sender, KnownTranslationFactory::commands_whitelist_remove_success($args[1]));

--- a/src/command/defaults/WhitelistCommand.php
+++ b/src/command/defaults/WhitelistCommand.php
@@ -29,6 +29,7 @@ use pocketmine\command\utils\InvalidCommandSyntaxException;
 use pocketmine\lang\KnownTranslationFactory;
 use pocketmine\permission\DefaultPermissionNames;
 use pocketmine\player\Player;
+use pocketmine\Server;
 use function count;
 use function implode;
 use function sort;


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Currently when you remove someone from whitelist or enable whitelist it doesn’t kick all the non-whitelisted online players.
### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
* Fixes #3868 
## Changes
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
The server now kicks non-whitelisted online players once whitelist has been enabled.
## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->

https://user-images.githubusercontent.com/58715544/151087681-dfd922c9-613b-4fea-9c37-d1a9c34a09f4.mov



