### PR TITLE
Fixed spectator players being able to drop items

### DIFF
--- a/src/inventory/transaction/action/DropItemAction.php
+++ b/src/inventory/transaction/action/DropItemAction.php
@@ -46,6 +46,9 @@ class DropItemAction extends InventoryAction{
 
 	public function onPreExecute(Player $source) : bool{
 		$ev = new PlayerDropItemEvent($source, $this->targetItem);
+		if($source->isSpectator()){
+			$ev->cancel();
+		}
 		$ev->call();
 		if($ev->isCancelled()){
 			return false;


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Currently you can drop an item while being in spectator mode.
### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
* Fixes #4765 
## Changes
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
`PlayerDropItemEvent` is now cancelled if the player is in spectator mode.
## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->

https://user-images.githubusercontent.com/58715544/151222308-ed132a3b-72cb-44cc-a6de-ab5262b79eaa.mov

