### PR TITLE
Fixed incorrect doc for EncryptionContext

### DIFF
--- a/src/network/mcpe/encryption/EncryptionContext.php
+++ b/src/network/mcpe/encryption/EncryptionContext.php
@@ -61,7 +61,7 @@ class EncryptionContext{
 	}
 
 	/**
-	 * Returns an EncryptionContext suitable for decrypting Minecraft packets from 1.16.220.50(protocol 429) and up.
+	 * Returns an EncryptionContext suitable for decrypting Minecraft packets from 1.16.220.50 (protocol version 429) and up.
 	 *
 	 * MCPE uses GCM, but without the auth tag, which defeats the whole purpose of using GCM.
 	 * GCM is just a wrapper around CTR which adds the auth tag, so CTR can replace GCM for this case.

--- a/src/network/mcpe/encryption/EncryptionContext.php
+++ b/src/network/mcpe/encryption/EncryptionContext.php
@@ -61,7 +61,7 @@ class EncryptionContext{
 	}
 
 	/**
-	 * Returns an EncryptionContext suitable for decrypting Minecraft packets from 1.16.200 and up.
+	 * Returns an EncryptionContext suitable for decrypting Minecraft packets from 1.16.220.50(protocol 429) and up.
 	 *
 	 * MCPE uses GCM, but without the auth tag, which defeats the whole purpose of using GCM.
 	 * GCM is just a wrapper around CTR which adds the auth tag, so CTR can replace GCM for this case.


### PR DESCRIPTION
## Introduction
https://modscraft.net/mcpe/6375-download-minecraft-1-16-220-50-beta-for-android.html

### Relevant issues
## Changes
### API changes

### Behavioural changes

## Backwards compatibility
## Follow-up
## Tests

I tested the changes on my server, when i sent GCM encryption for versions 1.16.200(protocol 420) and 1.16.210(protocol 428) the server crashed
![the server crashed](https://user-images.githubusercontent.com/17208982/152147727-643b1ab7-b8af-4f1e-a93a-edef4d2f240f.png)