### PR TITLE
Fix for #4680 - /kill not actually killing

### DIFF
--- a/src/command/defaults/KillCommand.php
+++ b/src/command/defaults/KillCommand.php
@@ -58,7 +58,7 @@ class KillCommand extends VanillaCommand{
 			return true;
 		}
 
-		$player->attack(new EntityDamageEvent($player, EntityDamageEvent::CAUSE_SUICIDE, 1000));
+		$player->attack(new EntityDamageEvent($player, EntityDamageEvent::CAUSE_SUICIDE, PHP_INT_MAX));
 		if($player === $sender){
 			$sender->sendMessage(KnownTranslationFactory::commands_kill_successful($sender->getName()));
 		}else{

--- a/src/command/defaults/KillCommand.php
+++ b/src/command/defaults/KillCommand.php
@@ -31,6 +31,7 @@ use pocketmine\lang\KnownTranslationFactory;
 use pocketmine\permission\DefaultPermissionNames;
 use function count;
 use function implode;
+use const PHP_INT_MAX;
 
 class KillCommand extends VanillaCommand{
 


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Fixes /kill not functioning when player had more than 1000 health

### Relevant issues
<!-- List relevant issues here -->
* Fixes #4680

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
N/A

### Behavioral changes
<!-- Any change in how the server behaves, or its performance? -->
/kill will now *always* kill the player

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
N/A

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
N/A

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
In-game testing with absorption 255 + regen 255 + health boost 255 + resistance 255 results in player death