### PR TITLE
Stop throwing exceptions on extra properties.

### DIFF
--- a/src/resourcepacks/ZippedResourcePack.php
+++ b/src/resourcepacks/ZippedResourcePack.php
@@ -105,7 +105,6 @@ class ZippedResourcePack implements ResourcePack{
 		}
 
 		$mapper = new \JsonMapper();
-		// $mapper->bExceptionOnUndefinedProperty = true;
 		$mapper->bExceptionOnMissingData = true;
 
 		try{

--- a/src/resourcepacks/ZippedResourcePack.php
+++ b/src/resourcepacks/ZippedResourcePack.php
@@ -105,7 +105,7 @@ class ZippedResourcePack implements ResourcePack{
 		}
 
 		$mapper = new \JsonMapper();
-		$mapper->bExceptionOnUndefinedProperty = true;
+		// $mapper->bExceptionOnUndefinedProperty = true;
 		$mapper->bExceptionOnMissingData = true;
 
 		try{


### PR DESCRIPTION
## Introduction
This code currently throws errors when properties other than the base required ones are added. This can be from resource packs created by "bridge.", where the IDE adds a "generated_with" property to the manifest. Ultimately, this leads to PM flagging it as an undefined property. Should this be set true again, it is recommended that extra work be put into ensuring that the Undefined Property flag doesn't detect extra defined properties.

### Relevant issues
- Won't load packs made via Bridge. - https://bridge-core.app/ (No issue made for this).

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
There are no API changes with this PR.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
The server will behave the exact same way. The PR just removes whether the server checks for typos in extra manifest properties as mentioned by @dktapps .

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
There should be no backwards compatibility changes other than resource packs not loading (even when they're safe) before, being able to load now because they're safe to be loaded.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
No actions need to be done.

## Tests
This PR just changes a boolean value for exceptions. No behavior/API changes, it can be safely merged after respective reviews.
