### PR TITLE
Allows to add arbitrary BlockInventory callbacks to ContainerOpenCallbacks in InventoryManager

### DIFF
--- a/src/network/mcpe/InventoryManager.php
+++ b/src/network/mcpe/InventoryManager.php
@@ -187,8 +187,11 @@ class InventoryManager{
 				$inv instanceof AnvilInventory => WindowTypes::ANVIL,
 				$inv instanceof HopperInventory => WindowTypes::HOPPER,
 				$inv instanceof CraftingTableInventory => WindowTypes::WORKBENCH,
-				default => WindowTypes::CONTAINER
+				default => null
 			};
+			if($windowType === null){
+				return null;
+			}
 			return [ContainerOpenPacket::blockInv($id, $windowType, $blockPosition)];
 		}
 		return null;

--- a/src/network/mcpe/InventoryManager.php
+++ b/src/network/mcpe/InventoryManager.php
@@ -26,6 +26,7 @@ namespace pocketmine\network\mcpe;
 use pocketmine\block\inventory\AnvilInventory;
 use pocketmine\block\inventory\BlockInventory;
 use pocketmine\block\inventory\BrewingStandInventory;
+use pocketmine\block\inventory\ChestInventory;
 use pocketmine\block\inventory\CraftingTableInventory;
 use pocketmine\block\inventory\EnchantInventory;
 use pocketmine\block\inventory\FurnaceInventory;
@@ -187,6 +188,7 @@ class InventoryManager{
 				$inv instanceof AnvilInventory => WindowTypes::ANVIL,
 				$inv instanceof HopperInventory => WindowTypes::HOPPER,
 				$inv instanceof CraftingTableInventory => WindowTypes::WORKBENCH,
+				$inv instanceof ChestInventory => WindowTypes::CONTAINER,
 				default => null
 			};
 			if($windowType === null){


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Currently, if you create a custom inventory that extends `BlockInventory`, a ContainerOpenPacket with WindowType of　` WindowTypes::CONTAINER` will be generated unconditionally and the added callback will not be called.
The workaround is to add a custom callback at the beginning of the ObjectSet.
https://github.com/pmmp/PocketMine-MP/blob/38e34093cf63f2a70f8a76a2c6ad6f3cd13d9b53/src/network/mcpe/InventoryManager.php#L190

I'm not quite sure how this default value is used, so I may need to make further changes.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

InventoryManager: Unknown BlockInventory returns null

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

[Unknown BlockInventory returns null](https://github.com/pmmp/PocketMine-MP/commit/36a434892af657abc76c69aa7300f53b73a36a28)

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

Maybe it doesn't break compatibility, but you can get and call callbacks with `InventoryManager::getContainerOpenCallbacks()`.
However, since this is a network change, it does not affect API compatibility in the first place.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->

This change is minor and I don't know how to test it.
