### PR TITLE
Implement Head Yaw.

### DIFF
--- a/src/entity/Location.php
+++ b/src/entity/Location.php
@@ -32,30 +32,43 @@ class Location extends Position{
 	/** @var float */
 	public $yaw;
 	/** @var float */
+	public float $headYaw;
+	/** @var float */
 	public $pitch;
 
-	public function __construct(float $x, float $y, float $z, ?World $world, float $yaw, float $pitch){
+	public function __construct(float $x, float $y, float $z, ?World $world, float $yaw, float $pitch, float $headYaw = -1){
 		$this->yaw = $yaw;
 		$this->pitch = $pitch;
+
+		if ($headYaw < 0) {
+			$headYaw = $yaw;
+		}
+
+		$this->headYaw = $headYaw;
 		parent::__construct($x, $y, $z, $world);
 	}
 
 	/**
 	 * @return Location
 	 */
-	public static function fromObject(Vector3 $pos, ?World $world, float $yaw = 0.0, float $pitch = 0.0){
-		return new Location($pos->x, $pos->y, $pos->z, $world ?? (($pos instanceof Position) ? $pos->world : null), $yaw, $pitch);
+	public static function fromObject(Vector3 $pos, ?World $world, float $yaw = 0.0, float $pitch = 0.0, float $headYaw = 0.0){
+		return new Location($pos->x, $pos->y, $pos->z, $world ?? (($pos instanceof Position) ? $pos->world : null), $yaw, $pitch, $headYaw);
 	}
 
 	/**
 	 * Return a Location instance
 	 */
 	public function asLocation() : Location{
-		return new Location($this->x, $this->y, $this->z, $this->world, $this->yaw, $this->pitch);
+		return new Location($this->x, $this->y, $this->z, $this->world, $this->yaw, $this->pitch, $this->headYaw);
 	}
 
 	public function getYaw() : float{
 		return $this->yaw;
+	}
+
+	public function getHeadYaw(): float
+	{
+		return $this->headYaw;
 	}
 
 	public function getPitch() : float{
@@ -68,7 +81,7 @@ class Location extends Position{
 
 	public function equals(Vector3 $v) : bool{
 		if($v instanceof Location){
-			return parent::equals($v) && $v->yaw == $this->yaw && $v->pitch == $this->pitch;
+			return parent::equals($v) && $v->yaw == $this->yaw && $v->headYaw == $this->headYaw && $v->pitch == $this->pitch;
 		}
 		return parent::equals($v);
 	}

--- a/src/entity/Location.php
+++ b/src/entity/Location.php
@@ -32,7 +32,7 @@ class Location extends Position{
 	/** @var float */
 	public $yaw;
 	/** @var float */
-	public float $headYaw;
+	public $headYaw;
 	/** @var float */
 	public $pitch;
 
@@ -66,7 +66,7 @@ class Location extends Position{
 		return $this->yaw;
 	}
 
-	public function getHeadYaw(): float
+	public function getHeadYaw() : float
 	{
 		return $this->headYaw;
 	}

--- a/src/network/mcpe/NetworkSession.php
+++ b/src/network/mcpe/NetworkSession.php
@@ -727,18 +727,19 @@ class NetworkSession{
 		$this->setHandler(new InGamePacketHandler($this->player, $this, $this->invManager));
 	}
 
-	public function syncMovement(Vector3 $pos, ?float $yaw = null, ?float $pitch = null, int $mode = MovePlayerPacket::MODE_NORMAL) : void{
+	public function syncMovement(Vector3 $pos, ?float $yaw = null, ?float $pitch = null, int $mode = MovePlayerPacket::MODE_NORMAL, ?float $headYaw = null) : void{
 		if($this->player !== null){
 			$location = $this->player->getLocation();
 			$yaw = $yaw ?? $location->getYaw();
 			$pitch = $pitch ?? $location->getPitch();
+			$headYaw = $headYaw ?? $location->getHeadYaw();
 
 			$this->sendDataPacket(MovePlayerPacket::simple(
 				$this->player->getId(),
 				$this->player->getOffsetPosition($pos),
 				$pitch,
 				$yaw,
-				$yaw, //TODO: head yaw
+				$headYaw,
 				$mode,
 				$this->player->onGround,
 				0, //TODO: riding entity ID

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -194,12 +194,17 @@ class InGamePacketHandler extends PacketHandler{
 		}
 
 		$yaw = fmod($packet->getYaw(), 360);
+		$headYaw = fmod($packet->getHeadYaw(), 360);
 		$pitch = fmod($packet->getPitch(), 360);
+
+		if ($headYaw < 0) {
+			$headYaw += 360;
+		}
 		if($yaw < 0){
 			$yaw += 360;
 		}
 
-		$this->player->setRotation($yaw, $pitch);
+		$this->player->setRotation($yaw, $pitch, $headYaw);
 
 		$curPos = $this->player->getLocation();
 		$newPos = $rawPos->round(4)->subtract(0, 1.62, 0);

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -2341,7 +2341,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 	/**
 	 * TODO: remove this
 	 */
-	protected function sendPosition(Vector3 $pos, ?float $yaw = null, ?float $pitch = null, int $mode = MovePlayerPacket::MODE_NORMAL) : void{
+	protected function sendPosition(Vector3 $pos, ?float $yaw = null, ?float $pitch = null, int $mode = MovePlayerPacket::MODE_NORMAL, ?float $headYaw = null) : void{
 		$this->getNetworkSession()->syncMovement($pos, $yaw, $pitch, $mode);
 
 		$this->ySize = 0;
@@ -2350,7 +2350,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 	/**
 	 * {@inheritdoc}
 	 */
-	public function teleport(Vector3 $pos, ?float $yaw = null, ?float $pitch = null) : bool{
+	public function teleport(Vector3 $pos, ?float $yaw = null, ?float $pitch = null, ?float $headYaw = null) : bool{
 		if(parent::teleport($pos, $yaw, $pitch)){
 
 			$this->removeCurrentWindow();


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Currently, PM doesn't really consider head-yaw to be a property. This can be tedious/nearly impossible when you want to change head-yaw without messing directly with the protocol. 

### Relevant issues
<!-- List relevant issues here -->

- There isn't really an issue for this.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Location now supports a property `headYaw`. The property is strictly of type `float`. The constructor accepts this as an optional argument. All methods used to change the rotation of an entity also use the `headYaw` property if set. Furthermore, all methods mentioned above accept this as an optional argument. 

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
The server should continue to behave the same way. If no `headYaw` is provided, then by default, the player's `yaw` is substituted in.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
To preserve BC, the argument has been added in as optional to all methods. Meaning plugins or internal functions not supplying a `headYaw` argument to either the constructor or changed methods will continue to work the same way with no behavior change. If they provide the optional field, they'll be able to use it. 

A possible issue is the methods extending the `Location` class. They might need to update the relevant signature for their constructor. A possible fix for this issue is by removing it from a constructor and adding it as a function-based setter.

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->

This adds a property that doesn't break any internal BC. Henceforth, it doesn't necessarily need to be tested as it behaves the same way. 
