### PR TITLE
Performance improvement in Item::nbtSerialize()

### DIFF
--- a/src/item/Item.php
+++ b/src/item/Item.php
@@ -659,8 +659,9 @@ class Item implements \JsonSerializable{
 			->setByte("Count", Binary::signByte($this->count))
 			->setShort("Damage", $this->getMeta());
 
-		if($this->hasNamedTag()){
-			$result->setTag("tag", $this->getNamedTag());
+		$tag = $this->getNamedTag();
+		if($tag->count() > 0){
+			$result->setTag("tag", $tag);
 		}
 
 		if($slot !== -1){


### PR DESCRIPTION
## Introduction
`Item::nbtSerialize()` (indirectly) calls `Item::getNamedTag()` twice when setting the tag `"tag"` (if `Item::hasNamedTag()`):
```php
if($this->hasNamedTag()){ // equivalent of $this->getNamedTag()->count() > 0
	$result->setTag("tag", $this->getNamedTag()); // second $this->getNamedTag() call
}
```
This causes the `Item::serializeCompoundTag()` method be called twice in the case an item has namedtag. Holding `Item::getNamedTag()` in a variable and testing the held value for emptiness before setting it to the resulting tag reduces this second call.

### Relevant issues
None

## Changes
### API changes
None

### Behavioural changes
With this change, `Item::nbtSerialize()` performs about 70% faster than prior (for items that have a non-empty namedtag). Below is an execution time output from serialization of 27 items (the size of a normal chest) done 10k times.
```
Item::nbtSerialize: 1352.05ms		// prior to this change
self::fastNbtSerialize: 799.386ms	// after this change
```

## Backwards compatibility
None

## Follow-up
None

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
1. https://gist.github.com/Muqsit/9186f42c2bf7238bbb77c071fe242244
On executing the command `ist`, the script plugin performs serialization of 27 items, 10,000 times, and outputs execution time of existing and the changed item nbt serializer in milliseconds.