### PR TITLE
definition of the default meta 0 in BlockFactory

### DIFF
--- a/src/block/BlockFactory.php
+++ b/src/block/BlockFactory.php
@@ -1042,7 +1042,7 @@ class BlockFactory{
 	 *
 	 * Deserializes a block from the provided legacy ID and legacy meta.
 	 */
-	public function get(int $id, int $meta) : Block{
+	public function get(int $id, int $meta = 0) : Block{
 		if($meta < 0 || $meta >= (1 << Block::INTERNAL_METADATA_BITS)){
 			throw new \InvalidArgumentException("Block meta value $meta is out of bounds");
 		}


### PR DESCRIPTION
In order to allow the definition of a block without putting the meta

## Introduction
Ihis allows you to put 0 without having to put it every time

no api change

