### PR TITLE
Change setPageText of WritableBook

### DIFF
--- a/src/item/WritableBookBase.php
+++ b/src/item/WritableBookBase.php
@@ -69,29 +69,18 @@ abstract class WritableBookBase extends Item{
 	 *
 	 * @return $this
 	 */
-	public function setPageText(int $pageId, string $pageText) : self{
+	public function setPageText(int $pageId, string $pageText = "") : self{
 		if(!$this->pageExists($pageId)){
-			$this->addPage($pageId);
+			if($pageId < 0){
+				throw new \InvalidArgumentException("Page number \"$pageId\" is out of range");
+			}
+
+			for($current = count($this->pages); $current < $pageId; $current++){
+				$this->pages[] = new WritableBookPage("");
+			}
 		}
 
 		$this->pages[$pageId] = new WritableBookPage($pageText);
-		return $this;
-	}
-
-	/**
-	 * Adds a new page with the given page ID.
-	 * Creates a new page for every page between the given ID and existing pages that doesn't yet exist.
-	 *
-	 * @return $this
-	 */
-	public function addPage(int $pageId) : self{
-		if($pageId < 0){
-			throw new \InvalidArgumentException("Page number \"$pageId\" is out of range");
-		}
-
-		for($current = count($this->pages); $current <= $pageId; $current++){
-			$this->pages[] = new WritableBookPage("");
-		}
 		return $this;
 	}
 

--- a/src/item/WritableBookBase.php
+++ b/src/item/WritableBookBase.php
@@ -69,7 +69,7 @@ abstract class WritableBookBase extends Item{
 	 *
 	 * @return $this
 	 */
-	public function setPageText(int $pageId, string $pageText = "") : self{
+	public function setPageText(int $pageId, string $pageText) : self{
 		if(!$this->pageExists($pageId)){
 			if($pageId < 0){
 				throw new \InvalidArgumentException("Page number \"$pageId\" is out of range");

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -118,7 +118,6 @@ use function is_infinite;
 use function is_nan;
 use function json_decode;
 use function json_encode;
-use function max;
 use function mb_strlen;
 use function microtime;
 use function preg_match;
@@ -823,10 +822,6 @@ class InGamePacketHandler extends PacketHandler{
 				$modifiedPages[] = $packet->pageNumber;
 				break;
 			case BookEditPacket::TYPE_SWAP_PAGES:
-				if(!$newBook->pageExists($packet->pageNumber) || !$newBook->pageExists($packet->secondaryPageNumber)){
-					//the client will create pages on its own without telling us until it tries to switch them
-					$newBook->setPageText(max($packet->pageNumber, $packet->secondaryPageNumber));
-				}
 				$newBook->swapPages($packet->pageNumber, $packet->secondaryPageNumber);
 				$modifiedPages = [$packet->pageNumber, $packet->secondaryPageNumber];
 				break;

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -825,7 +825,7 @@ class InGamePacketHandler extends PacketHandler{
 			case BookEditPacket::TYPE_SWAP_PAGES:
 				if(!$newBook->pageExists($packet->pageNumber) || !$newBook->pageExists($packet->secondaryPageNumber)){
 					//the client will create pages on its own without telling us until it tries to switch them
-					$newBook->addPage(max($packet->pageNumber, $packet->secondaryPageNumber));
+					$newBook->setPageText(max($packet->pageNumber, $packet->secondaryPageNumber));
 				}
 				$newBook->swapPages($packet->pageNumber, $packet->secondaryPageNumber);
 				$modifiedPages = [$packet->pageNumber, $packet->secondaryPageNumber];


### PR DESCRIPTION
## Introduction
As stated in the issue that is linked to this PR, the ``addPage`` function is identical to ``setPageText``, both will add empty pages.

One of the given proposals is more suitable. Deleting the ``setPageText`` function was not the right way to go about it, as it would remove the ability for the plugin to directly modify the content of a page. 
The second one was to remove ``addPage``, which was content with simply adding empty pages if necessary. This mechanism not being used elsewhere could be moved to ``setPageText`` to keep this part of control to the plugin.

At the moment, there is no other solution that seems to me to be better than the second one.

### Relevant issues
* Fixes #4694 

## Changes
### API changes
* Remove ``addPage(pageID)`` from ``WritableBookBase``

### Behavioural changes
N/A

## Backwards compatibility
N/A

## Tests
* Get a Book & Quill
* Create any pages of you want
