### PR TITLE
Fixed typo (occured => occurred)

### DIFF
--- a/src/utils/Internet.php
+++ b/src/utils/Internet.php
@@ -160,7 +160,7 @@ class Internet{
 	 *
 	 * @param string[]|string $args
 	 * @param string[]        $extraHeaders
-	 * @param string|null     $err reference parameter, will be set to the output of curl_error(). Use this to retrieve errors that occured during the operation.
+	 * @param string|null     $err reference parameter, will be set to the output of curl_error(). Use this to retrieve errors that occurred during the operation.
 	 * @phpstan-param string|array<string, string> $args
 	 * @phpstan-param list<string>                 $extraHeaders
 	 */


### PR DESCRIPTION
## Introduction
Fixes a typo in the PHPDoc of `Internet::getURL()`.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
No any.

### Behavioural changes
No any.

## Backwards compatibility
No any.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
Not tested.
