### PR TITLE
ShulkerBoxes can now be opened correctly

### DIFF
--- a/src/block/ShulkerBox.php
+++ b/src/block/ShulkerBox.php
@@ -91,7 +91,7 @@ class ShulkerBox extends Opaque{
 			$shulker = $this->position->getWorld()->getTile($this->position);
 			if($shulker instanceof TileShulkerBox){
 				if(
-					$this->getSide($this->facing)->getId() !== BlockLegacyIds::AIR ||
+					$this->getSide($this->facing)->isSolid() ||
 					!$shulker->canOpenWith($item->getCustomName())
 				){
 					return true;


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
ShulkerBoxe can now be opened if it dont have a solid block blocking it. 
### Relevant issues
<!-- List relevant issues here -->

* Fixes #4884

## Backwards compatibility
BC Compatible

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Does not require
