### PR TITLE
EnumTrait: Name can be set to one character

### DIFF
--- a/src/utils/EnumTrait.php
+++ b/src/utils/EnumTrait.php
@@ -70,7 +70,7 @@ trait EnumTrait{
 	 * @throws \InvalidArgumentException
 	 */
 	private function __construct(string $enumName){
-		if(preg_match('/^\D[A-Za-z\d_]+$/u', $enumName, $matches) === 0){
+		if(preg_match('/^(?!\d)[A-Za-z\d_]+$/u', $enumName, $matches) === 0){
 			throw new \InvalidArgumentException("Invalid enum member name \"$enumName\", should only contain letters, numbers and underscores, and must not start with a number");
 		}
 		$this->enumName = $enumName;


### PR DESCRIPTION
The cause of this problem is that `\D` is interpreted as a single character.

## Introduction
This fixes an issue where the Enum name could not be set to a single character.

### Relevant issues
No

## Changes
### API changes
It's not an API change, but it's a bug fix.

### Behavioural changes
The enum name can be one character!

## Backwards compatibility
No break, this is bug fix.
Code that sets the enum name to one character and expects an exception to break is broken, but this is rare.

## Follow-up
None

## Tests
This is a simple regular expression change

![7ca0ed39482dc3760d7a15fae020bd3a](https://user-images.githubusercontent.com/38120936/158636372-0c5f1d44-14bb-41f8-805a-7aefd1318c93.png)
![69d9ace1e5645b56d9dee68744e5197d](https://user-images.githubusercontent.com/38120936/158636383-e576e0b2-df83-402f-9c88-718a32a6e4c6.png)

