### PR TITLE
Fixed falling damage caused by changing the player's position during a PlayerToggleSneakEvent.

### DIFF
--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -228,7 +228,9 @@ class InGamePacketHandler extends PacketHandler{
 			$this->player->jump();
 		}
 
-		if(!$this->forceMoveSync){
+		/** @phpstan-var bool $forceMoveSync */
+		$forceMoveSync = $this->forceMoveSync;
+		if(!$forceMoveSync){
 			//TODO: this packet has WAYYYYY more useful information that we're not using
 			$this->player->handleMovement($newPos);
 		}

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -228,7 +228,7 @@ class InGamePacketHandler extends PacketHandler{
 			$this->player->jump();
 		}
 
-		if($curPos->equals($this->player->getPosition())){
+		if(!$this->forceMoveSync){
 			//TODO: HACK Allow plugins to update position with PlayerToggleSneakEvent etc.
 
 			//TODO: this packet has WAYYYYY more useful information that we're not using

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -228,9 +228,7 @@ class InGamePacketHandler extends PacketHandler{
 			$this->player->jump();
 		}
 
-		/** @phpstan-var bool $forceMoveSync */
-		$forceMoveSync = $this->forceMoveSync;
-		if(!$forceMoveSync){
+		if(!$this->forceMoveSync){
 			//TODO: this packet has WAYYYYY more useful information that we're not using
 			$this->player->handleMovement($newPos);
 		}

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -211,13 +211,6 @@ class InGamePacketHandler extends PacketHandler{
 		// Once we get a movement within a reasonable distance, treat it as a teleport ACK and remove position lock
 		$this->forceMoveSync = false;
 
-		if($packet->hasFlag(PlayerAuthInputFlags::START_JUMPING)){
-			$this->player->jump();
-		}
-
-		//TODO: this packet has WAYYYYY more useful information that we're not using
-		$this->player->handleMovement($newPos);
-
 		$sneaking = $this->resolveOnOffInputFlags($packet, PlayerAuthInputFlags::START_SNEAKING, PlayerAuthInputFlags::STOP_SNEAKING);
 		$sprinting = $this->resolveOnOffInputFlags($packet, PlayerAuthInputFlags::START_SPRINTING, PlayerAuthInputFlags::STOP_SPRINTING);
 		$swimming = $this->resolveOnOffInputFlags($packet, PlayerAuthInputFlags::START_SWIMMING, PlayerAuthInputFlags::STOP_SWIMMING);
@@ -229,6 +222,17 @@ class InGamePacketHandler extends PacketHandler{
 			($gliding !== null && !$this->player->toggleGlide($gliding));
 		if((bool) $mismatch){
 			$this->player->sendData([$this->player]);
+		}
+
+		if($packet->hasFlag(PlayerAuthInputFlags::START_JUMPING)){
+			$this->player->jump();
+		}
+
+		if($curPos->equals($this->player->getPosition())){
+			//TODO: HACK Allow plugins to update position with PlayerToggleSneakEvent etc.
+
+			//TODO: this packet has WAYYYYY more useful information that we're not using
+			$this->player->handleMovement($newPos);
 		}
 
 		$packetHandled = true;

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -211,6 +211,13 @@ class InGamePacketHandler extends PacketHandler{
 		// Once we get a movement within a reasonable distance, treat it as a teleport ACK and remove position lock
 		$this->forceMoveSync = false;
 
+		if($packet->hasFlag(PlayerAuthInputFlags::START_JUMPING)){
+			$this->player->jump();
+		}
+
+		//TODO: this packet has WAYYYYY more useful information that we're not using
+		$this->player->handleMovement($newPos);
+
 		$sneaking = $this->resolveOnOffInputFlags($packet, PlayerAuthInputFlags::START_SNEAKING, PlayerAuthInputFlags::STOP_SNEAKING);
 		$sprinting = $this->resolveOnOffInputFlags($packet, PlayerAuthInputFlags::START_SPRINTING, PlayerAuthInputFlags::STOP_SPRINTING);
 		$swimming = $this->resolveOnOffInputFlags($packet, PlayerAuthInputFlags::START_SWIMMING, PlayerAuthInputFlags::STOP_SWIMMING);
@@ -223,13 +230,6 @@ class InGamePacketHandler extends PacketHandler{
 		if((bool) $mismatch){
 			$this->player->sendData([$this->player]);
 		}
-
-		if($packet->hasFlag(PlayerAuthInputFlags::START_JUMPING)){
-			$this->player->jump();
-		}
-
-		//TODO: this packet has WAYYYYY more useful information that we're not using
-		$this->player->handleMovement($newPos);
 
 		$packetHandled = true;
 

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -229,8 +229,6 @@ class InGamePacketHandler extends PacketHandler{
 		}
 
 		if(!$this->forceMoveSync){
-			//TODO: HACK Allow plugins to update position with PlayerToggleSneakEvent etc.
-
 			//TODO: this packet has WAYYYYY more useful information that we're not using
 			$this->player->handleMovement($newPos);
 		}

--- a/tests/phpstan/configs/phpstan-bugs.neon
+++ b/tests/phpstan/configs/phpstan-bugs.neon
@@ -85,3 +85,8 @@ parameters:
 			count: 2
 			path: ../../../src/world/format/io/region/RegionLoader.php
 
+		-
+			message: "#^Negated boolean expression is always true\\.$#"
+			count: 1
+			path: ../../../src/network/mcpe/handler/InGamePacketHandler.php
+


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

https://user-images.githubusercontent.com/76860328/159113616-3370d5d9-ae7a-4039-8a2c-76f5430e8229.mp4

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->

https://user-images.githubusercontent.com/76860328/159114401-62e3f1cc-7cdb-49cb-b9b3-dab887bc1e1b.mp4

Code to reproduce the problem
```php
/** @var PluginBase $plugin */
$server = $plugin->getServer();
$server->getPluginManager()->registerEvent(PlayerToggleSneakEvent::class, static function(PlayerToggleSneakEvent $ev) : void{
	if(!$ev->isSneaking()){
		return;
	}
	$player = $ev->getPlayer();
	$position = $player->getPosition();
	$block = $position->getWorld()->getBlock($position->down());
	$newY = match(true){
		$block->isSameType(VanillaBlocks::IRON()) => 4,
		$block->isSameType(VanillaBlocks::GOLD()) => -4,
		default => null
	};
	if($newY === null){
		return;
	}
	$player->teleport($position->add(0, $newY, 0));
}, EventPriority::NORMAL, $plugin);
$plugin->getScheduler()->scheduleRepeatingTask(new ClosureTask(static function() use ($server) : void{
	foreach($server->getOnlinePlayers() as $player){
		$position = $player->getPosition();
		$position->getWorld()->addParticle($position, new RedstoneParticle());
	}
}), 1);
```
