### PR TITLE
Update PlayerPreLoginEvent documentation

### DIFF
--- a/src/event/player/PlayerPreLoginEvent.php
+++ b/src/event/player/PlayerPreLoginEvent.php
@@ -31,7 +31,7 @@ use function count;
 
 /**
  * Called when a player connects to the server, prior to authentication taking place.
- * Cancelling this event will cause the player to be disconnected with the kick message set.
+ * Set a kick reason to cancel the event and disconnect the player with the kick message set.
  *
  * This event should be used to decide if the player may continue to login to the server. Do things like checking
  * bans, whitelisting, server-full etc here.


### PR DESCRIPTION
Removed outdated documentation that was very misleading. Replaced with better documentation that accurately describes how to cancel the event.describes how to cancel the event.

## Introduction
The old and outdated documentation for ``PlayerPreLoginEvent`` was very misleading on how to properly cancel the event. The new documentation accurately describes how to cancel the event.describes how to cancel the event.

### Relevant issues
n/a

## Changes
### API changes
n/a

### Behavioural changes
n/a

## Backwards compatibility
n/a

## Follow-up
n/a

## Tests
n/a
