### PR TITLE
Stop the server if any plugin failed to load

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -1006,12 +1006,12 @@ class Server{
 			$loadErrorCount = 0;
 			$this->pluginManager->loadPlugins($this->pluginPath, $loadErrorCount);
 			if($loadErrorCount > 0){
-				$this->logger->emergency("Some plugins failed to load");
+				$this->logger->emergency($this->language->translate(KnownTranslationFactory::pocketmine_plugin_someLoadErrors()));
 				$this->forceShutdown();
 				return;
 			}
 			if(!$this->enablePlugins(PluginEnableOrder::STARTUP())){
-				$this->logger->emergency("Some plugins failed to enable");
+				$this->logger->emergency($this->language->translate(KnownTranslationFactory::pocketmine_plugin_someEnableErrors()));
 				$this->forceShutdown();
 				return;
 			}
@@ -1022,7 +1022,7 @@ class Server{
 			}
 
 			if(!$this->enablePlugins(PluginEnableOrder::POSTWORLD())){
-				$this->logger->emergency("Some plugins failed to enable");
+				$this->logger->emergency($this->language->translate(KnownTranslationFactory::pocketmine_plugin_someEnableErrors()));
 				$this->forceShutdown();
 				return;
 			}

--- a/src/Server.php
+++ b/src/Server.php
@@ -1002,7 +1002,13 @@ class Server{
 
 			register_shutdown_function([$this, "crashDump"]);
 
-			$this->pluginManager->loadPlugins($this->pluginPath);
+			$loadErrorCount = 0;
+			$this->pluginManager->loadPlugins($this->pluginPath, $loadErrorCount);
+			if($loadErrorCount > 0){
+				$this->logger->emergency("Some plugins failed to load");
+				$this->forceShutdown();
+				return;
+			}
 			$this->enablePlugins(PluginEnableOrder::STARTUP());
 
 			if(!$this->startupPrepareWorlds()){

--- a/src/plugin/PluginManager.php
+++ b/src/plugin/PluginManager.php
@@ -138,7 +138,7 @@ class PluginManager{
 
 		$dataFolder = $this->getDataDirectory($path, $description->getName());
 		if(file_exists($dataFolder) && !is_dir($dataFolder)){
-			$this->server->getLogger()->error($language->translate(KnownTranslationFactory::pocketmine_plugin_loadError(
+			$this->server->getLogger()->critical($language->translate(KnownTranslationFactory::pocketmine_plugin_loadError(
 				$description->getName(),
 				KnownTranslationFactory::pocketmine_plugin_badDataFolder($dataFolder)
 			)));
@@ -153,14 +153,14 @@ class PluginManager{
 
 		$mainClass = $description->getMain();
 		if(!class_exists($mainClass, true)){
-			$this->server->getLogger()->error($language->translate(KnownTranslationFactory::pocketmine_plugin_loadError(
+			$this->server->getLogger()->critical($language->translate(KnownTranslationFactory::pocketmine_plugin_loadError(
 				$description->getName(),
 				KnownTranslationFactory::pocketmine_plugin_mainClassNotFound()
 			)));
 			return null;
 		}
 		if(!is_a($mainClass, Plugin::class, true)){
-			$this->server->getLogger()->error($language->translate(KnownTranslationFactory::pocketmine_plugin_loadError(
+			$this->server->getLogger()->critical($language->translate(KnownTranslationFactory::pocketmine_plugin_loadError(
 				$description->getName(),
 				KnownTranslationFactory::pocketmine_plugin_mainClassWrongType(Plugin::class)
 			)));
@@ -168,7 +168,7 @@ class PluginManager{
 		}
 		$reflect = new \ReflectionClass($mainClass); //this shouldn't throw; we already checked that it exists
 		if(!$reflect->isInstantiable()){
-			$this->server->getLogger()->error($language->translate(KnownTranslationFactory::pocketmine_plugin_loadError(
+			$this->server->getLogger()->critical($language->translate(KnownTranslationFactory::pocketmine_plugin_loadError(
 				$description->getName(),
 				KnownTranslationFactory::pocketmine_plugin_mainClassAbstract()
 			)));
@@ -179,7 +179,7 @@ class PluginManager{
 		foreach($description->getPermissions() as $permsGroup){
 			foreach($permsGroup as $perm){
 				if($permManager->getPermission($perm->getName()) !== null){
-					$this->server->getLogger()->error($language->translate(KnownTranslationFactory::pocketmine_plugin_loadError(
+					$this->server->getLogger()->critical($language->translate(KnownTranslationFactory::pocketmine_plugin_loadError(
 						$description->getName(),
 						KnownTranslationFactory::pocketmine_plugin_duplicatePermissionError($perm->getName())
 					)));
@@ -261,14 +261,14 @@ class PluginManager{
 				try{
 					$description = $loader->getPluginDescription($file);
 				}catch(PluginDescriptionParseException $e){
-					$this->server->getLogger()->error($this->server->getLanguage()->translate(KnownTranslationFactory::pocketmine_plugin_loadError(
+					$this->server->getLogger()->critical($this->server->getLanguage()->translate(KnownTranslationFactory::pocketmine_plugin_loadError(
 						$file,
 						KnownTranslationFactory::pocketmine_plugin_invalidManifest($e->getMessage())
 					)));
 					$loadErrorCount++;
 					continue;
 				}catch(\RuntimeException $e){ //TODO: more specific exception handling
-					$this->server->getLogger()->error($this->server->getLanguage()->translate(KnownTranslationFactory::pocketmine_plugin_loadError($file, $e->getMessage())));
+					$this->server->getLogger()->critical($this->server->getLanguage()->translate(KnownTranslationFactory::pocketmine_plugin_loadError($file, $e->getMessage())));
 					$this->server->getLogger()->logException($e);
 					$loadErrorCount++;
 					continue;
@@ -280,13 +280,13 @@ class PluginManager{
 				$name = $description->getName();
 
 				if(($loadabilityError = $loadabilityChecker->check($description)) !== null){
-					$this->server->getLogger()->error($this->server->getLanguage()->translate(KnownTranslationFactory::pocketmine_plugin_loadError($name, $loadabilityError)));
+					$this->server->getLogger()->critical($this->server->getLanguage()->translate(KnownTranslationFactory::pocketmine_plugin_loadError($name, $loadabilityError)));
 					$loadErrorCount++;
 					continue;
 				}
 
 				if(isset($triage->plugins[$name]) || $this->getPlugin($name) instanceof Plugin){
-					$this->server->getLogger()->error($this->server->getLanguage()->translate(KnownTranslationFactory::pocketmine_plugin_duplicateError($name)));
+					$this->server->getLogger()->critical($this->server->getLanguage()->translate(KnownTranslationFactory::pocketmine_plugin_duplicateError($name)));
 					$loadErrorCount++;
 					continue;
 				}

--- a/src/plugin/PluginManager.php
+++ b/src/plugin/PluginManager.php
@@ -221,7 +221,7 @@ class PluginManager{
 	 * @param string[]|null $newLoaders
 	 * @phpstan-param list<class-string<PluginLoader>> $newLoaders
 	 */
-	private function triagePlugins(string $path, PluginLoadTriage $triage, ?array $newLoaders = null) : void{
+	private function triagePlugins(string $path, PluginLoadTriage $triage, int &$loadErrorCount, ?array $newLoaders = null) : void{
 		if(is_array($newLoaders)){
 			$loaders = [];
 			foreach($newLoaders as $key){
@@ -257,10 +257,12 @@ class PluginManager{
 						$file,
 						KnownTranslationFactory::pocketmine_plugin_invalidManifest($e->getMessage())
 					)));
+					$loadErrorCount++;
 					continue;
 				}catch(\RuntimeException $e){ //TODO: more specific exception handling
 					$this->server->getLogger()->error($this->server->getLanguage()->translate(KnownTranslationFactory::pocketmine_plugin_loadError($file, $e->getMessage())));
 					$this->server->getLogger()->logException($e);
+					$loadErrorCount++;
 					continue;
 				}
 				if($description === null){
@@ -271,11 +273,13 @@ class PluginManager{
 
 				if(($loadabilityError = $loadabilityChecker->check($description)) !== null){
 					$this->server->getLogger()->error($this->server->getLanguage()->translate(KnownTranslationFactory::pocketmine_plugin_loadError($name, $loadabilityError)));
+					$loadErrorCount++;
 					continue;
 				}
 
 				if(isset($triage->plugins[$name]) || $this->getPlugin($name) instanceof Plugin){
 					$this->server->getLogger()->error($this->server->getLanguage()->translate(KnownTranslationFactory::pocketmine_plugin_duplicateError($name)));
+					$loadErrorCount++;
 					continue;
 				}
 
@@ -288,6 +292,9 @@ class PluginManager{
 						$name,
 						$this->graylist->isWhitelist() ? KnownTranslationFactory::pocketmine_plugin_disallowedByWhitelist() : KnownTranslationFactory::pocketmine_plugin_disallowedByBlacklist()
 					)));
+					//this does NOT increment loadErrorCount, because using the graylist to prevent a plugin from
+					//loading is not considered accidental; this is the same as if the plugin were manually removed
+					//this means that the server will continue to boot even if some plugins were blocked by graylist
 					continue;
 				}
 
@@ -331,14 +338,14 @@ class PluginManager{
 	/**
 	 * @return Plugin[]
 	 */
-	public function loadPlugins(string $path) : array{
+	public function loadPlugins(string $path, int &$loadErrorCount = 0) : array{
 		if($this->loadPluginsGuard){
 			throw new \LogicException(__METHOD__ . "() cannot be called from within itself");
 		}
 		$this->loadPluginsGuard = true;
 
 		$triage = new PluginLoadTriage();
-		$this->triagePlugins($path, $triage);
+		$this->triagePlugins($path, $triage, $loadErrorCount);
 
 		$loadedPlugins = [];
 
@@ -364,10 +371,12 @@ class PluginManager{
 						if(count($diffLoaders) !== 0){
 							$this->server->getLogger()->debug("Plugin $name registered a new plugin loader during load, scanning for new plugins");
 							$plugins = $triage->plugins;
-							$this->triagePlugins($path, $triage, $diffLoaders);
+							$this->triagePlugins($path, $triage, $loadErrorCount, $diffLoaders);
 							$diffPlugins = array_diff_key($triage->plugins, $plugins);
 							$this->server->getLogger()->debug("Re-triage found plugins: " . implode(", ", array_keys($diffPlugins)));
 						}
+					}else{
+						$loadErrorCount++;
 					}
 				}
 			}
@@ -410,12 +419,14 @@ class PluginManager{
 								KnownTranslationFactory::pocketmine_plugin_unknownDependency(implode(", ", $unknownDependencies))
 							)));
 							unset($triage->plugins[$name]);
+							$loadErrorCount++;
 						}
 					}
 				}
 
 				foreach(Utils::stringifyKeys($triage->plugins) as $name => $file){
 					$this->server->getLogger()->critical($this->server->getLanguage()->translate(KnownTranslationFactory::pocketmine_plugin_loadError($name, KnownTranslationFactory::pocketmine_plugin_circularDependency())));
+					$loadErrorCount++;
 				}
 				break;
 			}

--- a/src/plugin/PluginManager.php
+++ b/src/plugin/PluginManager.php
@@ -448,7 +448,7 @@ class PluginManager{
 		return isset($this->plugins[$plugin->getDescription()->getName()]) && $plugin->isEnabled();
 	}
 
-	public function enablePlugin(Plugin $plugin) : void{
+	public function enablePlugin(Plugin $plugin) : bool{
 		if(!$plugin->isEnabled()){
 			$this->server->getLogger()->info($this->server->getLanguage()->translate(KnownTranslationFactory::pocketmine_plugin_enable($plugin->getDescription()->getFullName())));
 
@@ -458,6 +458,8 @@ class PluginManager{
 				$this->enabledPlugins[$plugin->getDescription()->getName()] = $plugin;
 
 				(new PluginEnableEvent($plugin))->call();
+
+				return true;
 			}else{
 				$this->server->getLogger()->critical($this->server->getLanguage()->translate(
 					KnownTranslationFactory::pocketmine_plugin_enableError(
@@ -465,8 +467,12 @@ class PluginManager{
 						KnownTranslationFactory::pocketmine_plugin_suicide()
 					)
 				));
+
+				return false;
 			}
 		}
+
+		return true; //TODO: maybe this should be an error?
 	}
 
 	public function disablePlugins() : void{


### PR DESCRIPTION
## Introduction

If plugins fail to load for some reason, it's highly likely that some critical functionality of the server is compromised. For example:
- if an NPC plugin fails to load, all custom entities will be deleted from worlds
- if a world protection plugin fails, players will be able to grief your otherwise immutable lobby map
- if a worldgen plugin fails, worlds using custom generators won't load
- if a permission plugin fails, players might have access to commands and features they aren't supposed to have
- the list goes on...

This change makes the server commit graceful suicide if any plugin fails to load for error-related reasons, including (but not limited to):
- Incompatible API version
- Missing dependencies
- Invalid plugin.yml
- Invalid main class

Plugins prevented from loading by `plugin_list.yml` are not considered errors and **are not** included in this change. If a plugin is disallowed from loading due to the `plugin_list`, the server will continue to run as if the plugin was not present.

### Relevant issues
closes #3080

## Changes
### API changes
- `PluginManager->loadPlugins()` now accepts an additional `loadErrorsCount` reference parameter.

### Behavioural changes
The server will now shut down if any plugin fails to load during startup.

Note that plugins loaded manually by other plugins are **not** affected by this change.

## Backwards compatibility
No issues known.

## Follow-up
Extend this to cover plugin enabling as well as loading, since runtime errors which cause plugins to disable themselves are likely critical too (e.g. malformed config, failure to connect to a database).

## Tests
This has been briefly tested locally with `plugin_list.yml` and a folder plugin with a malformed `plugin.yml`. It's possible that I may have missed some scenarios, so please let me know if you find any that aren't covered.