### PR TITLE
Player: creative players should not be damaged by the void

### DIFF
--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -2315,7 +2315,6 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 
 		if($this->isCreative()
 			&& $source->getCause() !== EntityDamageEvent::CAUSE_SUICIDE
-			&& $source->getCause() !== EntityDamageEvent::CAUSE_VOID
 		){
 			$source->cancel();
 		}elseif($this->allowFlight && $source->getCause() === EntityDamageEvent::CAUSE_FALL){


### PR DESCRIPTION
## Introduction
In vanilla, the creative player does not take void damage.

### Relevant issues
* Fixes #4403 

## Changes
### Behavioural changes
Creative players are no longer damaged by the void.