### PR TITLE
Fix boats illegally stacking

### DIFF
--- a/src/item/Boat.php
+++ b/src/item/Boat.php
@@ -42,5 +42,9 @@ class Boat extends Item{
 		return 1200; //400 in PC
 	}
 
+	public function getMaxStackSize() : int{
+		return 1;
+	}
+
 	//TODO
 }


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Boats stack in player inventories when given with /give or dropped and picked back up due to the dropped item entity merging.
