### PR TITLE
Add stick drop chance for leaves

### DIFF
--- a/src/block/Leaves.php
+++ b/src/block/Leaves.php
@@ -148,6 +148,9 @@ class Leaves extends Transparent{
 		if(($this->treeType->equals(TreeType::OAK()) || $this->treeType->equals(TreeType::DARK_OAK())) && mt_rand(1, 200) === 1){ //Apples
 			$drops[] = VanillaItems::APPLE();
 		}
+		if(mt_rand(1, 50) === 1){ //Sticks
+			$drops = VanillaItems::STICK()->setCount(mt_rand(1, 2));
+		}
 
 		return $drops;
 	}

--- a/src/block/Leaves.php
+++ b/src/block/Leaves.php
@@ -149,7 +149,7 @@ class Leaves extends Transparent{
 			$drops[] = VanillaItems::APPLE();
 		}
 		if(mt_rand(1, 50) === 1){ //Sticks
-			$drops = VanillaItems::STICK()->setCount(mt_rand(1, 2));
+			$drops[] = VanillaItems::STICK()->setCount(mt_rand(1, 2));
 		}
 
 		return $drops;

--- a/src/block/Leaves.php
+++ b/src/block/Leaves.php
@@ -148,7 +148,7 @@ class Leaves extends Transparent{
 		if(($this->treeType->equals(TreeType::OAK()) || $this->treeType->equals(TreeType::DARK_OAK())) && mt_rand(1, 200) === 1){ //Apples
 			$drops[] = VanillaItems::APPLE();
 		}
-		if(mt_rand(1, 50) === 1){ //Sticks
+		if(mt_rand(1, 50) === 1){
 			$drops[] = VanillaItems::STICK()->setCount(mt_rand(1, 2));
 		}
 


### PR DESCRIPTION
## Introduction
This PR adds a stick drop chance for leaves which occurs in vanilla Minecraft but not PocketMine currently.

### Relevant issues
* Fixes #4988 

## Tests
https://streamable.com/7zd2k6
