### PR TITLE
Fix button dropping when supporting block is broken

### DIFF
--- a/src/block/Button.php
+++ b/src/block/Button.php
@@ -86,4 +86,10 @@ abstract class Button extends Flowable{
 			$this->position->getWorld()->addSound($this->position->add(0.5, 0.5, 0.5), new RedstonePowerOffSound());
 		}
 	}
+
+	public function onNearbyBlockChange() : void{
+		if($this->getSide(Facing::opposite($this->facing))->getId() === BlockLegacyIds::AIR){
+			$this->position->getWorld()->useBreakOn($this->position);
+		}
+	}
 }


### PR DESCRIPTION
## Introduction
Currently buttons do not drop when the supporting block is broken, this PR is to fix that.

## Tests
Before: https://streamable.com/odyp8i

After: https://streamable.com/va7k0n