### PR TITLE
Sugarcane: fix block placement

### DIFF
--- a/src/block/Sugarcane.php
+++ b/src/block/Sugarcane.php
@@ -98,7 +98,7 @@ class Sugarcane extends Flowable{
 
 	public function onNearbyBlockChange() : void{
 		$down = $this->getSide(Facing::DOWN);
-		if($down->isTransparent() && !$down->isSameType($this)){
+		if(!$this->isValidSupport($down)){
 			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
@@ -122,14 +122,25 @@ class Sugarcane extends Flowable{
 		$down = $this->getSide(Facing::DOWN);
 		if($down->isSameType($this)){
 			return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
-		}elseif($down->getId() === BlockLegacyIds::GRASS || $down->getId() === BlockLegacyIds::DIRT || $down->getId() === BlockLegacyIds::SAND || $down->getId() === BlockLegacyIds::PODZOL){
+		}elseif($this->isValidSupport($down)){
 			foreach(Facing::HORIZONTAL as $side){
-				if($down->getSide($side) instanceof Water){
+				if($down->getSide($side) instanceof Water || $down->getSide($side) instanceof FrostedIce){
 					return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
 				}
 			}
 		}
 
 		return false;
+	}
+
+	private function isValidSupport(Block $block) : bool{
+		$id = $block->getId();
+		//TODO: rooted dirt, moss block
+		return $id === BlockLegacyIds::SUGARCANE_BLOCK
+			|| $id === BlockLegacyIds::GRASS
+			|| $id === BlockLegacyIds::DIRT
+			|| $id === BlockLegacyIds::PODZOL
+			|| $id === BlockLegacyIds::MYCELIUM
+			|| $id === BlockLegacyIds::SAND;
 	}
 }

--- a/src/block/Sugarcane.php
+++ b/src/block/Sugarcane.php
@@ -124,7 +124,8 @@ class Sugarcane extends Flowable{
 			return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
 		}elseif($this->isValidSupport($down)){
 			foreach(Facing::HORIZONTAL as $side){
-				if($down->getSide($side) instanceof Water || $down->getSide($side) instanceof FrostedIce){
+				$sideBlock = $down->getSide($side);
+				if($sideBlock instanceof Water || $sideBlock instanceof FrostedIce){
 					return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
 				}
 			}
@@ -136,7 +137,7 @@ class Sugarcane extends Flowable{
 	private function isValidSupport(Block $block) : bool{
 		$id = $block->getId();
 		//TODO: rooted dirt, moss block
-		return $id === BlockLegacyIds::SUGARCANE_BLOCK
+		return $block->isSameType($this)
 			|| $id === BlockLegacyIds::GRASS
 			|| $id === BlockLegacyIds::DIRT
 			|| $id === BlockLegacyIds::PODZOL


### PR DESCRIPTION
## Introduction
I noticed that while working on the placement of the blocks, that the sugar canes did not follow any real logic of placement at the moment (they can be placed almost anywhere)

As we can see in the wiki:
> Sugar cane must be planted on a [grass block](https://minecraft.fandom.com/wiki/Grass_block), [dirt](https://minecraft.fandom.com/wiki/Dirt), [coarse dirt](https://minecraft.fandom.com/wiki/Coarse_dirt), [rooted dirt](https://minecraft.fandom.com/wiki/Rooted_dirt), [podzol](https://minecraft.fandom.com/wiki/Podzol), [sand](https://minecraft.fandom.com/wiki/Sand), [moss block](https://minecraft.fandom.com/wiki/Moss_Block), [mycelium](https://minecraft.fandom.com/wiki/Mycelium), [red sand](https://minecraft.fandom.com/wiki/Red_sand) or [mud](https://minecraft.fandom.com/wiki/Mud) that is directly adjacent to [water](https://minecraft.fandom.com/wiki/Water), [waterlogged](https://minecraft.fandom.com/wiki/Waterlogged) block, or [frosted ice](https://minecraft.fandom.com/wiki/Frosted_ice)

## Changes

Sugarcane block can be now: 
- placed on: grass, dirt, coarse dirt, podzol, mycelium, sand, red sand (rooted dirt, moss block are in TODO because they are not yet implemented)
- placed next to Frosted ice and Water

## Tests

https://user-images.githubusercontent.com/66992287/169569652-23327f15-9937-48cb-ba84-d1cb374e1f4f.mp4


