### PR TITLE
Limit valid supporting blocks of dead bush

### DIFF
--- a/src/block/DeadBush.php
+++ b/src/block/DeadBush.php
@@ -66,10 +66,12 @@ class DeadBush extends Flowable{
 	}
 
 	private function isValidSupport(Block $block) : bool{
-		return $block->isSameType(VanillaBlocks::SAND())
-			|| $block->isSameType(VanillaBlocks::PODZOL())
-			|| $block->isSameType(VanillaBlocks::MYCELIUM())
-			|| $block->isSameType(VanillaBlocks::DIRT())
-			|| $block->isSameType(VanillaBlocks::HARDENED_CLAY());
+		$blockId = $block->getId();
+		return $blockId === BlockLegacyIds::SAND
+			|| $blockId === BlockLegacyIds::PODZOL
+			|| $blockId === BlockLegacyIds::MYCELIUM
+			|| $blockId === BlockLegacyIds::DIRT
+			|| $blockId === BlockLegacyIds::HARDENED_CLAY
+			|| $blockId === BlockLegacyIds::STAINED_HARDENED_CLAY;
 	}
 }

--- a/src/block/DeadBush.php
+++ b/src/block/DeadBush.php
@@ -66,12 +66,10 @@ class DeadBush extends Flowable{
 	}
 
 	private function isValidSupport(Block $block) : bool{
-		$id = $block->getId();
-		return $id === BlockLegacyIds::SAND
-			|| $id === BlockLegacyIds::PODZOL
-			|| $id === BlockLegacyIds::MYCELIUM
-			|| $id === BlockLegacyIds::DIRT
-			|| $id === BlockLegacyIds::HARDENED_CLAY
-			|| $id === BlockLegacyIds::TERRACOTTA;
+		return $block instanceof Sand
+			|| $block instanceof Podzol
+			|| $block instanceof Mycelium
+			|| $block instanceof Dirt
+			|| $block instanceof HardenedClay;
 	}
 }

--- a/src/block/DeadBush.php
+++ b/src/block/DeadBush.php
@@ -34,7 +34,7 @@ use function mt_rand;
 class DeadBush extends Flowable{
 
 	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		if($this->isValidSupport($this->getSide(Facing::DOWN))){
+		if($this->canBeSupportedBy($this->getSide(Facing::DOWN))){
 			return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
 		}
 
@@ -42,7 +42,7 @@ class DeadBush extends Flowable{
 	}
 
 	public function onNearbyBlockChange() : void{
-		if(!$this->isValidSupport($this->getSide(Facing::DOWN))){
+		if(!$this->canBeSupportedBy($this->getSide(Facing::DOWN))){
 			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
@@ -65,7 +65,7 @@ class DeadBush extends Flowable{
 		return 100;
 	}
 
-	private function isValidSupport(Block $block) : bool{
+	private function canBeSupportedBy(Block $block) : bool{
 		$blockId = $block->getId();
 		return $blockId === BlockLegacyIds::SAND
 			|| $blockId === BlockLegacyIds::PODZOL

--- a/src/block/DeadBush.php
+++ b/src/block/DeadBush.php
@@ -34,7 +34,7 @@ use function mt_rand;
 class DeadBush extends Flowable{
 
 	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		if(!$this->getSide(Facing::DOWN)->isTransparent()){
+		if($this->isValidSupport($this->getSide(Facing::DOWN))){
 			return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
 		}
 
@@ -42,7 +42,7 @@ class DeadBush extends Flowable{
 	}
 
 	public function onNearbyBlockChange() : void{
-		if($this->getSide(Facing::DOWN)->isTransparent()){
+		if(!$this->isValidSupport($this->getSide(Facing::DOWN))){
 			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
@@ -63,5 +63,15 @@ class DeadBush extends Flowable{
 
 	public function getFlammability() : int{
 		return 100;
+	}
+
+	private function isValidSupport(Block $block): bool{
+		$id = $block->getId();
+		return $id === BlockLegacyIds::SAND
+			|| $id === BlockLegacyIds::PODZOL
+			|| $id === BlockLegacyIds::MYCELIUM
+			|| $id === BlockLegacyIds::DIRT
+			|| $id === BlockLegacyIds::HARDENED_CLAY
+			|| $id === BlockLegacyIds::TERRACOTTA;
 	}
 }

--- a/src/block/DeadBush.php
+++ b/src/block/DeadBush.php
@@ -66,10 +66,10 @@ class DeadBush extends Flowable{
 	}
 
 	private function isValidSupport(Block $block) : bool{
-		return $block instanceof Sand
-			|| $block instanceof Podzol
-			|| $block instanceof Mycelium
-			|| $block instanceof Dirt
-			|| $block instanceof HardenedClay;
+		return $block->isSameType(VanillaBlocks::SAND())
+			|| $block->isSameType(VanillaBlocks::PODZOL())
+			|| $block->isSameType(VanillaBlocks::MYCELIUM())
+			|| $block->isSameType(VanillaBlocks::DIRT())
+			|| $block->isSameType(VanillaBlocks::HARDENED_CLAY());
 	}
 }

--- a/src/block/DeadBush.php
+++ b/src/block/DeadBush.php
@@ -65,7 +65,7 @@ class DeadBush extends Flowable{
 		return 100;
 	}
 
-	private function isValidSupport(Block $block): bool{
+	private function isValidSupport(Block $block) : bool{
 		$id = $block->getId();
 		return $id === BlockLegacyIds::SAND
 			|| $id === BlockLegacyIds::PODZOL


### PR DESCRIPTION
## Introduction
I noticed that while working on the placement of the blocks and this is a part that has been moved from the original, which fix the logic for the placement of DeadBush, and add specific support.
As we can see in the wiki:
> They can be placed on any kind of [sand](https://minecraft.fandom.com/wiki/Sand), [terracotta](https://minecraft.fandom.com/wiki/Terracotta), [dirt](https://minecraft.fandom.com/wiki/Dirt), [podzol](https://minecraft.fandom.com/wiki/Podzol)

Moreover, after tests, it turns out that mycelium is also added to the list of block support for dead bush

## Changes

DeadBush can now be placed on all kind of Sand, Dirt, Podzol, Mycelium, terracotta (Hardened clay for one block)

## Tests

https://user-images.githubusercontent.com/66992287/169579723-b4c08d42-569c-454b-8764-ce1d5549c250.mp4


