### PR TITLE
Allow handling PlayerChatEvent asynchronously

### DIFF
--- a/src/event/player/PlayerChatEvent.php
+++ b/src/event/player/PlayerChatEvent.php
@@ -28,6 +28,7 @@ use pocketmine\event\Cancellable;
 use pocketmine\event\CancellableTrait;
 use pocketmine\player\Player;
 use pocketmine\utils\Utils;
+use pocketmine\utils\WaitGroup;
 
 /**
  * Called when a player chats something
@@ -44,6 +45,8 @@ class PlayerChatEvent extends PlayerEvent implements Cancellable{
 	/** @var CommandSender[] */
 	protected $recipients = [];
 
+	private WaitGroup $waitGroup;
+
 	/**
 	 * @param CommandSender[] $recipients
 	 */
@@ -54,6 +57,8 @@ class PlayerChatEvent extends PlayerEvent implements Cancellable{
 		$this->format = $format;
 
 		$this->recipients = $recipients;
+
+		$this->waitGroup = new WaitGroup;
 	}
 
 	public function getMessage() : string{
@@ -92,5 +97,9 @@ class PlayerChatEvent extends PlayerEvent implements Cancellable{
 	public function setRecipients(array $recipients) : void{
 		Utils::validateArrayValueType($recipients, function(CommandSender $_) : void{});
 		$this->recipients = $recipients;
+	}
+
+	public function getWaitGroup() : WaitGroup{
+		return $this->waitGroup;
 	}
 }

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1404,9 +1404,11 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 				}else{
 					$ev = new PlayerChatEvent($this, $ev->getMessage(), $this->server->getBroadcastChannelSubscribers(Server::BROADCAST_CHANNEL_USERS));
 					$ev->call();
-					if(!$ev->isCancelled()){
-						$this->server->broadcastMessage($this->getServer()->getLanguage()->translateString($ev->getFormat(), [$ev->getPlayer()->getDisplayName(), $ev->getMessage()]), $ev->getRecipients());
-					}
+					$ev->getWaitGroup()->wait(function() use($ev) : void{
+						if(!$ev->isCancelled()){
+							$this->server->broadcastMessage($this->getServer()->getLanguage()->translateString($ev->getFormat(), [$ev->getPlayer()->getDisplayName(), $ev->getMessage()]), $ev->getRecipients());
+						}
+					});
 				}
 			}
 		}

--- a/src/utils/WaitGroup.php
+++ b/src/utils/WaitGroup.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+*/
+
+declare(strict_types=1);
+
+namespace pocketmine\utils;
+
+use Closure;
+use InvalidArgumentException;
+use RuntimeException;
+
+/**
+ * Represents a group of tasks that can be asynchronously completed.
+ *
+ * Unlike `sync.WaitGroup` in Go, each WaitGroup can only be used once.
+ * New tasks cannot be added after `wait()` has been called.
+ *
+ * A WaitGroup can be one of three states:
+ *
+ * - Collecting: `locked` is false, `execute` is null. This is the initial state.
+ *   `add()` and `done()` can be called as long as number of tasks added is not less than number of tasks done.
+ *   Transitions to Waiting state when `wait()` is called.
+ * - Waiting: `locked` is true, `execute` is a closure.
+ *   `add()` can no longer be called. The `execute` function is called after all pending tasks are done.
+ *   Transitions to Complete state and calls the `execute` function is called after all pending tasks are done.
+ * - Complete: `locked` is true, `execute` is null.
+ *   The number of pending tasks is exactly zero, so `add()` and `done()` cannot be called.
+ *   The WaitGroup should no longer be used at this state.
+ */
+final class WaitGroup{
+
+	/** @var bool Whether the WaitGroup has been locked */
+	private bool $locked = false;
+	/** @phpstan-var null|Closure(): void The function to execute after lock */
+	private ?Closure $execute = null;
+	/** @var int Number of pending tasks */
+	private int $counter = 0;
+
+	/**
+	 * Executes a function when all pending tasks have completed.
+	 * Prevents further tasks to be added.
+	 *
+	 * @phpstan-param Closure(): void $execute The function to be executed after completion.
+	 */
+	public function wait(Closure $execute) : void{
+		if($this->locked){
+			throw new RuntimeException("Cannot wait the same WaitGroup multiple times");
+		}
+
+		$this->locked = true;
+
+		if($this->counter === 0){
+			$execute();
+		} else {
+			$this->execute = $execute;
+		}
+	}
+
+	/**
+	 * Adds $count pending tasks to the wait group.
+	 *
+	 * New tasks cannot be added after `wait()` has been called.
+	 */
+	public function add(int $count = 1) : void{
+		if($count === 0){
+			return; // so that we don't perform subsequent sanity checks
+		}
+
+		if($count < 0){
+			throw new InvalidArgumentException("\$count must be non-negative");
+		}
+
+		if($this->locked){
+			throw new RuntimeException("Cannot add to WaitGroup after locked");
+		}
+
+		$this->counter += $count;
+	}
+
+	/**
+	 * Marks $count pending tasks as complete.
+	 * The tasks must be `add()`ed to the wait group in prior.
+	 *
+	 * This method triggers the wait-execute function if `wait()` has been called.
+	 */
+	public function done(int $count = 1) : void{
+		if($count === 0){
+			return; // so that we don't perform subsequent sanity checks
+		}
+
+		if($count < 0){
+			throw new InvalidArgumentException("\$count must be non-negative");
+		}
+
+		if($this->counter - $count < 0){
+			throw new RuntimeException("More done() called than add()");
+		}
+
+		$this->counter -= $count;
+
+		if($this->locked){
+			if($this->execute === null){
+				throw new AssumptionFailedError("WaitGroup has completed but counter is nonzero");
+			}
+
+			if($this->counter === 0){
+				($this->execute)();
+				$this->execute = null; // to avoid calling multiple times
+			}
+		}
+	}
+}


### PR DESCRIPTION
Two simple code snippets for TLDR:

```php
function handle(PlayerChatEvent $event) : void{
    $event->getWaitGroup()->add();
    callTranslateApi($event->getMessage(), function(string $message) {
        $event->setMessage($message);
        $event->getWaitGroup()->done();
    }, function(Exception $error){
        $this->getLogger()->error($error->getMessage();
        $event->getWaitGroup()->done();
    });
}
```

await-generator users:

```php
function handle(PlayerChatEvent $event) : void{
    Await::f2c(function() use($event) : void{
        try{
           $event->getWaitGroup()->add();
           $message = yield from callTranslateApi($event->getMessage();
           $event->setMessage($message);
       }finally{
           $event->getWaitGroup()->done();
       }
    });
}
```

## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
PlayerChatEvent is a simple event that can be handled asynchronously. As an early prototype, this PR implements a minimal, non-intrusive, backwards-compatible approach to enable asynchronous capabilities without introducing any changes to the event API in general (and does not even impact existing handlers of PlayerChatEvent, unless they have some unfortunate logic that expects the message to be sent immediately, in the same tick).

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

There are multiple prior attempts to implement asynchronous events, most of which have failed due to excessive complexity.

The initial attempt was proposed in #1881 and implemented in #2096. It adopted a more sophisticated approach that adds a generic `pause` function to all events and requires `callAsyncEvent` instead of `callEvent` to be used. It stops the whole handler chain to wait for a single function.

The more recent attempt was #4120, which enforced concurrency isolation at each priority.

In contrast to the previous attempts, this PR lacks the following features:
- If a WaitGroup is never marked as `done()`, user will never be able to figure out what's wrong. This can be improved in the future when we have better async framework in PocketMine that allows easily scheduling a task to check that a called WaitGroup event is not complete after an expected duration and generate warnings.
- There is no concurrency control between multiple event handlers. This means all handlers get called together, and asynchronous modifications in one handler does not immediately notify another handler. Considering lower latency is more important, and that there is little mutual dependency between multiple event callers anyway (usually async is only used for calling translation/profanity checking APIs), this is currently not a concern.
- Handlers cannot observe the final state of a PlayerChatEvent. This can be a future enhancement to add another set of hooks called after event completion. Note that unlike Go `sync.WaitGroup`, my `WaitGroup::wait()` does not allow calling multiple times in favor of more explicit state control.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Adds a `WaitGroup` class, and initializes it as a field in `PlayerChatEvent`. Users can defer execution of the event with the following code:

```php
function handle(PlayerChatEvent $event) : void{
    $event->getWaitGroup()->add();
    callTranslateApi($event->getMessage(), function(string $message) {
        $event->setMessage($message);
        $event->getWaitGroup()->done();
    }, function(Exception $error){
        $this->getLogger()->error($error->getMessage();
        $event->getWaitGroup()->done();
    });
}
```

It is tempting to call `done` before setting the message in the example above. Calling an event setter after event completion, just as it currently is to modify a normal synchronous event in an async callback, is a bug, and should lead to an error, which should be addressed in a separate issue.

Since there is no async runtime involved, forgetting to call `done()` on a WaitGroup will lead to the event getting silently dropped. Although this is not desired (because no handler got notified of the cancellation and is most likely a bug anyway), this does not lead to memory leak because the WaitGroup and the executor are only referenced from the context that holds the WaitGroup. The most common case of forgetting to call `done()` is the error case, in which I would recommend using await-generator instead:

```php
function handle(PlayerChatEvent $event) : void{
    Await::f2c(function() use($event) : void{
        try{
           $event->getWaitGroup()->add();
           $message = yield from callTranslateApi($event->getMessage();
           $event->setMessage($message);
       }finally{
           $event->getWaitGroup()->done();
       }
    });
}
```

Another advantage of using await-generator is that the developer would not accidentally call `done` before using `setMessage` in the case above.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
If no plugins handle the event asynchronously, there are no behavioral changes.

For plugins that handle the event asynchronously but resolve correctly, the only change is slightly delayed message broadcast, which is expected and is barely noticeable for users.

For plugins that do not resolve correctly, see the analysis above.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

PlayerChatEvent cannot be invoked multiple times. Plugins have never been expected to leak the PlayerchatEvent and call the same instance anyway, as there is practically no advantage to this.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
I would add tests after the API design has been reviewed.