### PR TITLE
PlayerExhaustEvent: popularize to EntityExhaustEvent

### DIFF
--- a/src/VersionInfo.php
+++ b/src/VersionInfo.php
@@ -31,9 +31,9 @@ use function str_repeat;
 
 final class VersionInfo{
 	public const NAME = "PocketMine-MP";
-	public const BASE_VERSION = "4.4.1";
+	public const BASE_VERSION = "4.6.0";
 	public const IS_DEVELOPMENT_BUILD = true;
-	public const BUILD_CHANNEL = "stable";
+	public const BUILD_CHANNEL = "beta";
 
 	private function __construct(){
 		//NOOP

--- a/src/VersionInfo.php
+++ b/src/VersionInfo.php
@@ -31,9 +31,9 @@ use function str_repeat;
 
 final class VersionInfo{
 	public const NAME = "PocketMine-MP";
-	public const BASE_VERSION = "4.6.0";
+	public const BASE_VERSION = "5.0.0";
 	public const IS_DEVELOPMENT_BUILD = true;
-	public const BUILD_CHANNEL = "beta";
+	public const BUILD_CHANNEL = "alpha";
 
 	private function __construct(){
 		//NOOP

--- a/src/entity/Entity.php
+++ b/src/entity/Entity.php
@@ -141,9 +141,6 @@ abstract class Entity{
 	/** @var int */
 	protected $fireTicks = 0;
 
-	/** @var bool */
-	protected $isStatic = false;
-
 	private bool $savedWithChunk = true;
 
 	/** @var bool */
@@ -999,9 +996,7 @@ abstract class Entity{
 
 		$this->timings->stopTiming();
 
-		//if($this->isStatic())
 		return ($hasUpdate || $this->hasMovementUpdate());
-		//return !($this instanceof Player);
 	}
 
 	final public function scheduleUpdate() : void{

--- a/src/entity/Entity.php
+++ b/src/entity/Entity.php
@@ -140,8 +140,6 @@ abstract class Entity{
 	public $lastUpdate;
 	/** @var int */
 	protected $fireTicks = 0;
-	/** @var bool */
-	public $canCollide = true;
 
 	/** @var bool */
 	protected $isStatic = false;

--- a/src/entity/Entity.php
+++ b/src/entity/Entity.php
@@ -90,120 +90,79 @@ abstract class Entity{
 	}
 
 	/** @var Player[] */
-	protected $hasSpawned = [];
+	protected array $hasSpawned = [];
 
-	/** @var int */
-	protected $id;
+	protected int $id;
 
 	private EntityMetadataCollection $networkProperties;
 
-	/** @var EntityDamageEvent|null */
-	protected $lastDamageCause = null;
+	protected ?EntityDamageEvent $lastDamageCause = null;
 
 	/** @var Block[]|null */
-	protected $blocksAround;
+	protected ?array $blocksAround = null;
 
-	/** @var Location */
-	protected $location;
-	/** @var Location */
-	protected $lastLocation;
-	/** @var Vector3 */
-	protected $motion;
-	/** @var Vector3 */
-	protected $lastMotion;
-	/** @var bool */
-	protected $forceMovementUpdate = false;
+	protected Location $location;
+	protected Location $lastLocation;
+	protected Vector3 $motion;
+	protected Vector3 $lastMotion;
+	protected bool $forceMovementUpdate = false;
 
-	/** @var AxisAlignedBB */
-	public $boundingBox;
-	/** @var bool */
-	public $onGround = false;
+	public AxisAlignedBB $boundingBox;
+	public bool $onGround = false;
 
-	/** @var EntitySizeInfo */
-	public $size;
+	public EntitySizeInfo $size;
 
 	private float $health = 20.0;
 	private int $maxHealth = 20;
 
-	/** @var float */
-	protected $ySize = 0.0;
-	/** @var float */
-	protected $stepHeight = 0.0;
-	/** @var bool */
-	public $keepMovement = false;
+	protected float $ySize = 0.0;
+	protected float $stepHeight = 0.0;
+	public bool $keepMovement = false;
 
-	/** @var float */
-	public $fallDistance = 0.0;
-	/** @var int */
-	public $ticksLived = 0;
-	/** @var int */
-	public $lastUpdate;
-	/** @var int */
-	protected $fireTicks = 0;
+	public float $fallDistance = 0.0;
+	public int $ticksLived = 0;
+	public int $lastUpdate;
+	protected int $fireTicks = 0;
 
 	private bool $savedWithChunk = true;
 
-	/** @var bool */
-	public $isCollided = false;
-	/** @var bool */
-	public $isCollidedHorizontally = false;
-	/** @var bool */
-	public $isCollidedVertically = false;
+	public bool $isCollided = false;
+	public bool $isCollidedHorizontally = false;
+	public bool $isCollidedVertically = false;
 
-	/** @var int */
-	public $noDamageTicks = 0;
-	/** @var bool */
-	protected $justCreated = true;
+	public int $noDamageTicks = 0;
+	protected bool $justCreated = true;
 
-	/** @var AttributeMap */
-	protected $attributeMap;
+	protected AttributeMap $attributeMap;
 
-	/** @var float */
-	protected $gravity;
-	/** @var float */
-	protected $drag;
-	/** @var bool */
-	protected $gravityEnabled = true;
+	protected float $gravity;
+	protected float $drag;
+	protected bool $gravityEnabled = true;
 
-	/** @var Server */
-	protected $server;
+	protected Server $server;
 
-	/** @var bool */
-	protected $closed = false;
+	protected bool $closed = false;
 	private bool $closeInFlight = false;
 	private bool $needsDespawn = false;
 
-	/** @var TimingsHandler */
-	protected $timings;
+	protected TimingsHandler $timings;
 
 	protected bool $networkPropertiesDirty = false;
 
-	/** @var string */
-	protected $nameTag = "";
-	/** @var bool */
-	protected $nameTagVisible = true;
-	/** @var bool */
-	protected $alwaysShowNameTag = false;
-	/** @var string */
-	protected $scoreTag = "";
-	/** @var float */
-	protected $scale = 1.0;
+	protected string $nameTag = "";
+	protected bool $nameTagVisible = true;
+	protected bool $alwaysShowNameTag = false;
+	protected string $scoreTag = "";
+	protected float $scale = 1.0;
 
-	/** @var bool */
-	protected $canClimb = false;
-	/** @var bool */
-	protected $canClimbWalls = false;
-	/** @var bool */
-	protected $immobile = false;
-	/** @var bool */
-	protected $invisible = false;
-	/** @var bool */
-	protected $silent = false;
+	protected bool $canClimb = false;
+	protected bool $canClimbWalls = false;
+	protected bool $immobile = false;
+	protected bool $invisible = false;
+	protected bool $silent = false;
 
-	/** @var int|null */
-	protected $ownerId = null;
-	/** @var int|null */
-	protected $targetId = null;
+	protected ?int $ownerId = null;
+	protected ?int $targetId = null;
 
 	private bool $constructorCalled = false;
 

--- a/src/entity/Entity.php
+++ b/src/entity/Entity.php
@@ -222,6 +222,8 @@ abstract class Entity{
 		$this->timings = Timings::getEntityTimings($this);
 
 		$this->size = $this->getInitialSizeInfo();
+		$this->drag = $this->getInitialDragMultiplier();
+		$this->gravity = $this->getInitialGravity();
 
 		$this->id = self::nextRuntimeId();
 		$this->server = $location->getWorld()->getServer();
@@ -256,6 +258,21 @@ abstract class Entity{
 	}
 
 	abstract protected function getInitialSizeInfo() : EntitySizeInfo;
+
+	/**
+	 * Returns the percentage by which the entity's velocity is reduced per tick when moving through air.
+	 * The entity's velocity is multiplied by 1 minus this value.
+	 *
+	 * @return float 0-1
+	 */
+	abstract protected function getInitialDragMultiplier() : float;
+
+	/**
+	 * Returns the downwards acceleration of the entity when falling, in blocks/tick².
+	 *
+	 * @return float minimum 0
+	 */
+	abstract protected function getInitialGravity() : float;
 
 	public function getNameTag() : string{
 		return $this->nameTag;

--- a/src/entity/Human.php
+++ b/src/entity/Human.php
@@ -74,28 +74,18 @@ class Human extends Living implements ProjectileSource, InventoryHolder{
 
 	public static function getNetworkTypeId() : string{ return EntityIds::PLAYER; }
 
-	/** @var PlayerInventory */
-	protected $inventory;
+	protected PlayerInventory $inventory;
+	protected PlayerOffHandInventory $offHandInventory;
+	protected PlayerEnderInventory $enderInventory;
 
-	/** @var PlayerOffHandInventory */
-	protected $offHandInventory;
+	protected UuidInterface $uuid;
 
-	/** @var PlayerEnderInventory */
-	protected $enderInventory;
+	protected Skin $skin;
 
-	/** @var UuidInterface */
-	protected $uuid;
+	protected HungerManager $hungerManager;
+	protected ExperienceManager $xpManager;
 
-	/** @var Skin */
-	protected $skin;
-
-	/** @var HungerManager */
-	protected $hungerManager;
-	/** @var ExperienceManager */
-	protected $xpManager;
-
-	/** @var int */
-	protected $xpSeed;
+	protected int $xpSeed;
 
 	public function __construct(Location $location, Skin $skin, ?CompoundTag $nbt = null){
 		$this->skin = $skin;
@@ -383,9 +373,9 @@ class Human extends Living implements ProjectileSource, InventoryHolder{
 
 	public function getDrops() : array{
 		return array_filter(array_merge(
-			$this->inventory !== null ? array_values($this->inventory->getContents()) : [],
-			$this->armorInventory !== null ? array_values($this->armorInventory->getContents()) : [],
-			$this->offHandInventory !== null ? array_values($this->offHandInventory->getContents()) : [],
+			array_values($this->inventory->getContents()),
+			array_values($this->armorInventory->getContents()),
+			array_values($this->offHandInventory->getContents()),
 		), function(Item $item) : bool{ return !$item->hasEnchantment(VanillaEnchantments::VANISHING()); });
 	}
 
@@ -404,55 +394,51 @@ class Human extends Living implements ProjectileSource, InventoryHolder{
 
 		$inventoryTag = new ListTag([], NBT::TAG_Compound);
 		$nbt->setTag("Inventory", $inventoryTag);
-		if($this->inventory !== null){
-			//Normal inventory
-			$slotCount = $this->inventory->getSize() + $this->inventory->getHotbarSize();
-			for($slot = $this->inventory->getHotbarSize(); $slot < $slotCount; ++$slot){
-				$item = $this->inventory->getItem($slot - 9);
-				if(!$item->isNull()){
-					$inventoryTag->push($item->nbtSerialize($slot));
-				}
-			}
 
-			//Armor
-			for($slot = 100; $slot < 104; ++$slot){
-				$item = $this->armorInventory->getItem($slot - 100);
-				if(!$item->isNull()){
-					$inventoryTag->push($item->nbtSerialize($slot));
-				}
+		//Normal inventory
+		$slotCount = $this->inventory->getSize() + $this->inventory->getHotbarSize();
+		for($slot = $this->inventory->getHotbarSize(); $slot < $slotCount; ++$slot){
+			$item = $this->inventory->getItem($slot - 9);
+			if(!$item->isNull()){
+				$inventoryTag->push($item->nbtSerialize($slot));
 			}
-
-			$nbt->setInt("SelectedInventorySlot", $this->inventory->getHeldItemIndex());
 		}
+
+		//Armor
+		for($slot = 100; $slot < 104; ++$slot){
+			$item = $this->armorInventory->getItem($slot - 100);
+			if(!$item->isNull()){
+				$inventoryTag->push($item->nbtSerialize($slot));
+			}
+		}
+
+		$nbt->setInt("SelectedInventorySlot", $this->inventory->getHeldItemIndex());
+
 		$offHandItem = $this->offHandInventory->getItem(0);
 		if(!$offHandItem->isNull()){
 			$nbt->setTag("OffHandItem", $offHandItem->nbtSerialize());
 		}
 
-		if($this->enderInventory !== null){
-			/** @var CompoundTag[] $items */
-			$items = [];
+		/** @var CompoundTag[] $items */
+		$items = [];
 
-			$slotCount = $this->enderInventory->getSize();
-			for($slot = 0; $slot < $slotCount; ++$slot){
-				$item = $this->enderInventory->getItem($slot);
-				if(!$item->isNull()){
-					$items[] = $item->nbtSerialize($slot);
-				}
+		$slotCount = $this->enderInventory->getSize();
+		for($slot = 0; $slot < $slotCount; ++$slot){
+			$item = $this->enderInventory->getItem($slot);
+			if(!$item->isNull()){
+				$items[] = $item->nbtSerialize($slot);
 			}
-
-			$nbt->setTag("EnderChestInventory", new ListTag($items, NBT::TAG_Compound));
 		}
 
-		if($this->skin !== null){
-			$nbt->setTag("Skin", CompoundTag::create()
-				->setString("Name", $this->skin->getSkinId())
-				->setByteArray("Data", $this->skin->getSkinData())
-				->setByteArray("CapeData", $this->skin->getCapeData())
-				->setString("GeometryName", $this->skin->getGeometryName())
-				->setByteArray("GeometryData", $this->skin->getGeometryData())
-			);
-		}
+		$nbt->setTag("EnderChestInventory", new ListTag($items, NBT::TAG_Compound));
+
+		$nbt->setTag("Skin", CompoundTag::create()
+			->setString("Name", $this->skin->getSkinId())
+			->setByteArray("Data", $this->skin->getSkinData())
+			->setByteArray("CapeData", $this->skin->getCapeData())
+			->setString("GeometryName", $this->skin->getGeometryName())
+			->setByteArray("GeometryData", $this->skin->getGeometryData())
+		);
 
 		return $nbt;
 	}
@@ -512,11 +498,13 @@ class Human extends Living implements ProjectileSource, InventoryHolder{
 	}
 
 	protected function destroyCycles() : void{
-		$this->inventory = null;
-		$this->offHandInventory = null;
-		$this->enderInventory = null;
-		$this->hungerManager = null;
-		$this->xpManager = null;
+		unset(
+			$this->inventory,
+			$this->offHandInventory,
+			$this->enderInventory,
+			$this->hungerManager,
+			$this->xpManager
+		);
 		parent::destroyCycles();
 	}
 }

--- a/src/entity/Human.php
+++ b/src/entity/Human.php
@@ -29,7 +29,7 @@ use pocketmine\entity\effect\EffectInstance;
 use pocketmine\entity\effect\VanillaEffects;
 use pocketmine\entity\projectile\ProjectileSource;
 use pocketmine\event\entity\EntityDamageEvent;
-use pocketmine\event\player\PlayerExhaustEvent;
+use pocketmine\event\entity\EntityExhaustEvent;
 use pocketmine\inventory\CallbackInventoryListener;
 use pocketmine\inventory\Inventory;
 use pocketmine\inventory\InventoryHolder;
@@ -146,9 +146,9 @@ class Human extends Living implements ProjectileSource, InventoryHolder{
 	public function jump() : void{
 		parent::jump();
 		if($this->isSprinting()){
-			$this->hungerManager->exhaust(0.2, PlayerExhaustEvent::CAUSE_SPRINT_JUMPING);
+			$this->hungerManager->exhaust(0.2, EntityExhaustEvent::CAUSE_SPRINT_JUMPING);
 		}else{
-			$this->hungerManager->exhaust(0.05, PlayerExhaustEvent::CAUSE_JUMPING);
+			$this->hungerManager->exhaust(0.05, EntityExhaustEvent::CAUSE_JUMPING);
 		}
 	}
 

--- a/src/entity/HungerManager.php
+++ b/src/entity/HungerManager.php
@@ -24,8 +24,8 @@ declare(strict_types=1);
 namespace pocketmine\entity;
 
 use pocketmine\event\entity\EntityDamageEvent;
+use pocketmine\event\entity\EntityExhaustEvent;
 use pocketmine\event\entity\EntityRegainHealthEvent;
-use pocketmine\event\player\PlayerExhaustEvent;
 use pocketmine\world\World;
 use function max;
 use function min;
@@ -129,11 +129,11 @@ class HungerManager{
 	 *
 	 * @return float the amount of exhaustion level increased
 	 */
-	public function exhaust(float $amount, int $cause = PlayerExhaustEvent::CAUSE_CUSTOM) : float{
+	public function exhaust(float $amount, int $cause = EntityExhaustEvent::CAUSE_CUSTOM) : float{
 		if(!$this->enabled){
 			return 0;
 		}
-		$ev = new PlayerExhaustEvent($this->entity, $amount, $cause);
+		$ev = new EntityExhaustEvent($this->entity, $amount, $cause);
 		$ev->call();
 		if($ev->isCancelled()){
 			return 0.0;
@@ -200,7 +200,7 @@ class HungerManager{
 			if($food >= 18){
 				if($health < $this->entity->getMaxHealth()){
 					$this->entity->heal(new EntityRegainHealthEvent($this->entity, 1, EntityRegainHealthEvent::CAUSE_SATURATION));
-					$this->exhaust(6.0, PlayerExhaustEvent::CAUSE_HEALTH_REGEN);
+					$this->exhaust(6.0, EntityExhaustEvent::CAUSE_HEALTH_REGEN);
 				}
 			}elseif($food <= 0){
 				if(($difficulty === World::DIFFICULTY_EASY && $health > 10) || ($difficulty === World::DIFFICULTY_NORMAL && $health > 1) || $difficulty === World::DIFFICULTY_HARD){

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -76,9 +76,6 @@ use const M_PI;
 abstract class Living extends Entity{
 	protected const DEFAULT_BREATH_TICKS = 300;
 
-	protected $gravity = 0.08;
-	protected $drag = 0.02;
-
 	/** @var int */
 	protected $attackTime = 0;
 
@@ -120,6 +117,10 @@ abstract class Living extends Entity{
 	protected $gliding = false;
 	/** @var bool */
 	protected $swimming = false;
+
+	protected function getInitialDragMultiplier() : float{ return 0.02; }
+
+	protected function getInitialGravity() : float{ return 0.08; }
 
 	abstract public function getName() : string;
 

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -76,47 +76,30 @@ use const M_PI;
 abstract class Living extends Entity{
 	protected const DEFAULT_BREATH_TICKS = 300;
 
-	/** @var int */
-	protected $attackTime = 0;
+	protected int $attackTime = 0;
 
-	/** @var int */
-	public $deadTicks = 0;
-	/** @var int */
-	protected $maxDeadTicks = 25;
+	public int $deadTicks = 0;
+	protected int $maxDeadTicks = 25;
 
-	/** @var float */
-	protected $jumpVelocity = 0.42;
+	protected float $jumpVelocity = 0.42;
 
-	/** @var EffectManager */
-	protected $effectManager;
+	protected EffectManager $effectManager;
 
-	/** @var ArmorInventory */
-	protected $armorInventory;
+	protected ArmorInventory $armorInventory;
 
-	/** @var bool */
-	protected $breathing = true;
-	/** @var int */
-	protected $breathTicks = self::DEFAULT_BREATH_TICKS;
-	/** @var int */
-	protected $maxBreathTicks = self::DEFAULT_BREATH_TICKS;
+	protected bool $breathing = true;
+	protected int $breathTicks = self::DEFAULT_BREATH_TICKS;
+	protected int $maxBreathTicks = self::DEFAULT_BREATH_TICKS;
 
-	/** @var Attribute */
-	protected $healthAttr;
-	/** @var Attribute */
-	protected $absorptionAttr;
-	/** @var Attribute */
-	protected $knockbackResistanceAttr;
-	/** @var Attribute */
-	protected $moveSpeedAttr;
+	protected Attribute $healthAttr;
+	protected Attribute $absorptionAttr;
+	protected Attribute $knockbackResistanceAttr;
+	protected Attribute $moveSpeedAttr;
 
-	/** @var bool */
-	protected $sprinting = false;
-	/** @var bool */
-	protected $sneaking = false;
-	/** @var bool */
-	protected $gliding = false;
-	/** @var bool */
-	protected $swimming = false;
+	protected bool $sprinting = false;
+	protected bool $sneaking = false;
+	protected bool $gliding = false;
+	protected bool $swimming = false;
 
 	protected function getInitialDragMultiplier() : float{ return 0.02; }
 
@@ -851,8 +834,10 @@ abstract class Living extends Entity{
 	}
 
 	protected function destroyCycles() : void{
-		$this->armorInventory = null;
-		$this->effectManager = null;
+		unset(
+			$this->armorInventory,
+			$this->effectManager
+		);
 		parent::destroyCycles();
 	}
 }

--- a/src/entity/Location.php
+++ b/src/entity/Location.php
@@ -29,10 +29,8 @@ use pocketmine\world\World;
 
 class Location extends Position{
 
-	/** @var float */
-	public $yaw;
-	/** @var float */
-	public $pitch;
+	public float $yaw;
+	public float $pitch;
 
 	public function __construct(float $x, float $y, float $z, ?World $world, float $yaw, float $pitch){
 		$this->yaw = $yaw;

--- a/src/entity/Squid.php
+++ b/src/entity/Squid.php
@@ -39,10 +39,8 @@ class Squid extends WaterAnimal{
 
 	public static function getNetworkTypeId() : string{ return EntityIds::SQUID; }
 
-	/** @var Vector3|null */
-	public $swimDirection = null;
-	/** @var float */
-	public $swimSpeed = 0.1;
+	public ?Vector3 $swimDirection = null;
+	public float $swimSpeed = 0.1;
 
 	private int $switchDirectionTicker = 0;
 

--- a/src/entity/WaterAnimal.php
+++ b/src/entity/WaterAnimal.php
@@ -28,8 +28,7 @@ use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataCollection;
 use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataFlags;
 
 abstract class WaterAnimal extends Living implements Ageable{
-	/** @var bool */
-	protected $baby = false;
+	protected bool $baby = false;
 
 	public function isBaby() : bool{
 		return $this->baby;

--- a/src/entity/effect/EffectManager.php
+++ b/src/entity/effect/EffectManager.php
@@ -33,25 +33,22 @@ use function count;
 use function spl_object_id;
 
 class EffectManager{
-
 	/** @var EffectInstance[] */
-	protected $effects = [];
+	protected array $effects = [];
 
-	/** @var Color */
-	protected $bubbleColor;
-	/** @var bool */
-	protected $onlyAmbientEffects = false;
+	protected Color $bubbleColor;
+	protected bool $onlyAmbientEffects = false;
 
 	/**
 	 * @var \Closure[]|ObjectSet
 	 * @phpstan-var ObjectSet<\Closure(EffectInstance, bool $replacesOldEffect) : void>
 	 */
-	protected $effectAddHooks;
+	protected ObjectSet $effectAddHooks;
 	/**
 	 * @var \Closure[]|ObjectSet
 	 * @phpstan-var ObjectSet<\Closure(EffectInstance) : void>
 	 */
-	protected $effectRemoveHooks;
+	protected ObjectSet $effectRemoveHooks;
 
 	public function __construct(
 		private Living $entity

--- a/src/entity/effect/HungerEffect.php
+++ b/src/entity/effect/HungerEffect.php
@@ -26,7 +26,7 @@ namespace pocketmine\entity\effect;
 use pocketmine\entity\Entity;
 use pocketmine\entity\Human;
 use pocketmine\entity\Living;
-use pocketmine\event\player\PlayerExhaustEvent;
+use pocketmine\event\entity\EntityExhaustEvent;
 
 class HungerEffect extends Effect{
 
@@ -36,7 +36,7 @@ class HungerEffect extends Effect{
 
 	public function applyEffect(Living $entity, EffectInstance $instance, float $potency = 1.0, ?Entity $source = null) : void{
 		if($entity instanceof Human){
-			$entity->getHungerManager()->exhaust(0.1 * $instance->getEffectLevel(), PlayerExhaustEvent::CAUSE_POTION);
+			$entity->getHungerManager()->exhaust(0.1 * $instance->getEffectLevel(), EntityExhaustEvent::CAUSE_POTION);
 		}
 	}
 }

--- a/src/entity/object/ExperienceOrb.php
+++ b/src/entity/object/ExperienceOrb.php
@@ -78,9 +78,6 @@ class ExperienceOrb extends Entity{
 		return $result;
 	}
 
-	public $gravity = 0.04;
-	public $drag = 0.02;
-
 	/** @var int */
 	protected $age = 0;
 
@@ -105,6 +102,10 @@ class ExperienceOrb extends Entity{
 	}
 
 	protected function getInitialSizeInfo() : EntitySizeInfo{ return new EntitySizeInfo(0.25, 0.25); }
+
+	protected function getInitialDragMultiplier() : float{ return 0.02; }
+
+	protected function getInitialGravity() : float{ return 0.04; }
 
 	protected function initEntity(CompoundTag $nbt) : void{
 		parent::initEntity($nbt);

--- a/src/entity/object/ExperienceOrb.php
+++ b/src/entity/object/ExperienceOrb.php
@@ -78,23 +78,15 @@ class ExperienceOrb extends Entity{
 		return $result;
 	}
 
-	/** @var int */
-	protected $age = 0;
+	protected int $age = 0;
 
-	/**
-	 * @var int
-	 * Ticker used for determining interval in which to look for new target players.
-	 */
-	protected $lookForTargetTime = 0;
+	/** Ticker used for determining interval in which to look for new target players. */
+	protected int $lookForTargetTime = 0;
 
-	/**
-	 * @var int|null
-	 * Runtime entity ID of the player this XP orb is targeting.
-	 */
-	protected $targetPlayerRuntimeId = null;
+	/** Runtime entity ID of the player this XP orb is targeting. */
+	protected ?int $targetPlayerRuntimeId = null;
 
-	/** @var int */
-	protected $xpValue;
+	protected int $xpValue;
 
 	public function __construct(Location $location, int $xpValue, ?CompoundTag $nbt = null){
 		$this->xpValue = $xpValue;

--- a/src/entity/object/FallingBlock.php
+++ b/src/entity/object/FallingBlock.php
@@ -46,9 +46,6 @@ class FallingBlock extends Entity{
 
 	public static function getNetworkTypeId() : string{ return EntityIds::FALLING_BLOCK; }
 
-	protected $gravity = 0.04;
-	protected $drag = 0.02;
-
 	/** @var Block */
 	protected $block;
 
@@ -60,6 +57,10 @@ class FallingBlock extends Entity{
 	}
 
 	protected function getInitialSizeInfo() : EntitySizeInfo{ return new EntitySizeInfo(0.98, 0.98); }
+
+	protected function getInitialDragMultiplier() : float{ return 0.02; }
+
+	protected function getInitialGravity() : float{ return 0.04; }
 
 	public static function parseBlockNBT(BlockFactory $factory, CompoundTag $nbt) : Block{
 		$blockId = 0;

--- a/src/entity/object/FallingBlock.php
+++ b/src/entity/object/FallingBlock.php
@@ -49,8 +49,6 @@ class FallingBlock extends Entity{
 	/** @var Block */
 	protected $block;
 
-	public $canCollide = false;
-
 	public function __construct(Location $location, Block $block, ?CompoundTag $nbt = null){
 		$this->block = $block;
 		parent::__construct($location, $nbt);

--- a/src/entity/object/FallingBlock.php
+++ b/src/entity/object/FallingBlock.php
@@ -46,8 +46,7 @@ class FallingBlock extends Entity{
 
 	public static function getNetworkTypeId() : string{ return EntityIds::FALLING_BLOCK; }
 
-	/** @var Block */
-	protected $block;
+	protected Block $block;
 
 	public function __construct(Location $location, Block $block, ?CompoundTag $nbt = null){
 		$this->block = $block;

--- a/src/entity/object/ItemEntity.php
+++ b/src/entity/object/ItemEntity.php
@@ -59,9 +59,6 @@ class ItemEntity extends Entity{
 	/** @var Item */
 	protected $item;
 
-	protected $gravity = 0.04;
-	protected $drag = 0.02;
-
 	public $canCollide = false;
 
 	/** @var int */
@@ -76,6 +73,10 @@ class ItemEntity extends Entity{
 	}
 
 	protected function getInitialSizeInfo() : EntitySizeInfo{ return new EntitySizeInfo(0.25, 0.25); }
+
+	protected function getInitialDragMultiplier() : float{ return 0.02; }
+
+	protected function getInitialGravity() : float{ return 0.04; }
 
 	protected function initEntity(CompoundTag $nbt) : void{
 		parent::initEntity($nbt);

--- a/src/entity/object/ItemEntity.php
+++ b/src/entity/object/ItemEntity.php
@@ -50,17 +50,11 @@ class ItemEntity extends Entity{
 	public const NEVER_DESPAWN = -1;
 	public const MAX_DESPAWN_DELAY = 32767 + self::DEFAULT_DESPAWN_DELAY; //max value storable by mojang NBT :(
 
-	/** @var string */
-	protected $owner = "";
-	/** @var string */
-	protected $thrower = "";
-	/** @var int */
-	protected $pickupDelay = 0;
-	/** @var Item */
-	protected $item;
-
-	/** @var int */
-	protected $despawnDelay = self::DEFAULT_DESPAWN_DELAY;
+	protected string $owner = "";
+	protected string $thrower = "";
+	protected int $pickupDelay = 0;
+	protected int $despawnDelay = self::DEFAULT_DESPAWN_DELAY;
+	protected Item $item;
 
 	public function __construct(Location $location, Item $item, ?CompoundTag $nbt = null){
 		if($item->isNull()){
@@ -196,12 +190,8 @@ class ItemEntity extends Entity{
 		}
 		$nbt->setShort("Age", $age);
 		$nbt->setShort("PickupDelay", $this->pickupDelay);
-		if($this->owner !== null){
-			$nbt->setString("Owner", $this->owner);
-		}
-		if($this->thrower !== null){
-			$nbt->setString("Thrower", $this->thrower);
-		}
+		$nbt->setString("Owner", $this->owner);
+		$nbt->setString("Thrower", $this->thrower);
 
 		return $nbt;
 	}

--- a/src/entity/object/ItemEntity.php
+++ b/src/entity/object/ItemEntity.php
@@ -59,8 +59,6 @@ class ItemEntity extends Entity{
 	/** @var Item */
 	protected $item;
 
-	public $canCollide = false;
-
 	/** @var int */
 	protected $despawnDelay = self::DEFAULT_DESPAWN_DELAY;
 

--- a/src/entity/object/Painting.php
+++ b/src/entity/object/Painting.php
@@ -56,12 +56,9 @@ class Painting extends Entity{
 		Facing::EAST => 3
 	];
 
-	/** @var Vector3 */
-	protected $blockIn;
-	/** @var int */
-	protected $facing = Facing::NORTH;
-	/** @var PaintingMotive */
-	protected $motive;
+	protected Vector3 $blockIn;
+	protected int $facing;
+	protected PaintingMotive $motive;
 
 	public function __construct(Location $location, Vector3 $blockIn, int $facing, PaintingMotive $motive, ?CompoundTag $nbt = null){
 		$this->motive = $motive;

--- a/src/entity/object/Painting.php
+++ b/src/entity/object/Painting.php
@@ -56,11 +56,6 @@ class Painting extends Entity{
 		Facing::EAST => 3
 	];
 
-	/** @var float */
-	protected $gravity = 0.0;
-	/** @var float */
-	protected $drag = 1.0;
-
 	/** @var Vector3 */
 	protected $blockIn;
 	/** @var int */
@@ -79,6 +74,10 @@ class Painting extends Entity{
 		//these aren't accurate, but it doesn't matter since they aren't used (vanilla PC does something similar)
 		return new EntitySizeInfo(0.5, 0.5);
 	}
+
+	protected function getInitialDragMultiplier() : float{ return 1.0; }
+
+	protected function getInitialGravity() : float{ return 0.0; }
 
 	protected function initEntity(CompoundTag $nbt) : void{
 		$this->setMaxHealth(1);

--- a/src/entity/object/PaintingMotive.php
+++ b/src/entity/object/PaintingMotive.php
@@ -84,18 +84,11 @@ class PaintingMotive{
 		return self::$motives;
 	}
 
-	/** @var string */
-	protected $name;
-	/** @var int */
-	protected $width;
-	/** @var int */
-	protected $height;
-
-	public function __construct(int $width, int $height, string $name){
-		$this->name = $name;
-		$this->width = $width;
-		$this->height = $height;
-	}
+	public function __construct(
+		protected int $width,
+		protected int $height,
+		protected string $name
+	){}
 
 	public function getName() : string{
 		return $this->name;

--- a/src/entity/object/PrimedTNT.php
+++ b/src/entity/object/PrimedTNT.php
@@ -46,8 +46,6 @@ class PrimedTNT extends Entity implements Explosive{
 
 	protected bool $worksUnderwater = false;
 
-	public $canCollide = false;
-
 	protected function getInitialSizeInfo() : EntitySizeInfo{ return new EntitySizeInfo(0.98, 0.98); }
 
 	protected function getInitialDragMultiplier() : float{ return 0.02; }

--- a/src/entity/object/PrimedTNT.php
+++ b/src/entity/object/PrimedTNT.php
@@ -41,9 +41,6 @@ class PrimedTNT extends Entity implements Explosive{
 
 	public static function getNetworkTypeId() : string{ return EntityIds::TNT; }
 
-	protected $gravity = 0.04;
-	protected $drag = 0.02;
-
 	/** @var int */
 	protected $fuse;
 
@@ -52,6 +49,10 @@ class PrimedTNT extends Entity implements Explosive{
 	public $canCollide = false;
 
 	protected function getInitialSizeInfo() : EntitySizeInfo{ return new EntitySizeInfo(0.98, 0.98); }
+
+	protected function getInitialDragMultiplier() : float{ return 0.02; }
+
+	protected function getInitialGravity() : float{ return 0.04; }
 
 	public function getFuse() : int{
 		return $this->fuse;

--- a/src/entity/object/PrimedTNT.php
+++ b/src/entity/object/PrimedTNT.php
@@ -41,9 +41,7 @@ class PrimedTNT extends Entity implements Explosive{
 
 	public static function getNetworkTypeId() : string{ return EntityIds::TNT; }
 
-	/** @var int */
-	protected $fuse;
-
+	protected int $fuse;
 	protected bool $worksUnderwater = false;
 
 	protected function getInitialSizeInfo() : EntitySizeInfo{ return new EntitySizeInfo(0.98, 0.98); }

--- a/src/entity/projectile/Arrow.php
+++ b/src/entity/projectile/Arrow.php
@@ -52,9 +52,6 @@ class Arrow extends Projectile{
 	private const TAG_PICKUP = "pickup"; //TAG_Byte
 	public const TAG_CRIT = "crit"; //TAG_Byte
 
-	protected $gravity = 0.05;
-	protected $drag = 0.01;
-
 	/** @var float */
 	protected $damage = 2.0;
 
@@ -76,6 +73,10 @@ class Arrow extends Projectile{
 	}
 
 	protected function getInitialSizeInfo() : EntitySizeInfo{ return new EntitySizeInfo(0.25, 0.25); }
+
+	protected function getInitialDragMultiplier() : float{ return 0.01; }
+
+	protected function getInitialGravity() : float{ return 0.05; }
 
 	protected function initEntity(CompoundTag $nbt) : void{
 		parent::initEntity($nbt);

--- a/src/entity/projectile/Arrow.php
+++ b/src/entity/projectile/Arrow.php
@@ -52,20 +52,11 @@ class Arrow extends Projectile{
 	private const TAG_PICKUP = "pickup"; //TAG_Byte
 	public const TAG_CRIT = "crit"; //TAG_Byte
 
-	/** @var float */
-	protected $damage = 2.0;
-
-	/** @var int */
-	protected $pickupMode = self::PICKUP_ANY;
-
-	/** @var float */
-	protected $punchKnockback = 0.0;
-
-	/** @var int */
-	protected $collideTicks = 0;
-
-	/** @var bool */
-	protected $critical = false;
+	protected float $damage = 2.0;
+	protected int $pickupMode = self::PICKUP_ANY;
+	protected float $punchKnockback = 0.0;
+	protected int $collideTicks = 0;
+	protected bool $critical = false;
 
 	public function __construct(Location $location, ?Entity $shootingEntity, bool $critical, ?CompoundTag $nbt = null){
 		parent::__construct($location, $shootingEntity, $nbt);

--- a/src/entity/projectile/ExperienceBottle.php
+++ b/src/entity/projectile/ExperienceBottle.php
@@ -32,7 +32,7 @@ use function mt_rand;
 class ExperienceBottle extends Throwable{
 	public static function getNetworkTypeId() : string{ return EntityIds::XP_BOTTLE; }
 
-	protected $gravity = 0.07;
+	protected function getInitialGravity() : float{ return 0.07; }
 
 	public function getResultDamage() : int{
 		return -1;

--- a/src/entity/projectile/Projectile.php
+++ b/src/entity/projectile/Projectile.php
@@ -51,11 +51,8 @@ use const PHP_INT_MAX;
 
 abstract class Projectile extends Entity{
 
-	/** @var float */
-	protected $damage = 0.0;
-
-	/** @var Block|null */
-	protected $blockHit;
+	protected float $damage = 0.0;
+	protected ?Block $blockHit = null;
 
 	public function __construct(Location $location, ?Entity $shootingEntity, ?CompoundTag $nbt = null){
 		parent::__construct($location, $nbt);

--- a/src/entity/projectile/SplashPotion.php
+++ b/src/entity/projectile/SplashPotion.php
@@ -52,8 +52,7 @@ class SplashPotion extends Throwable{
 
 	public static function getNetworkTypeId() : string{ return EntityIds::SPLASH_POTION; }
 
-	/** @var bool */
-	protected $linger = false;
+	protected bool $linger = false;
 	protected PotionType $potionType;
 
 	public function __construct(Location $location, ?Entity $shootingEntity, PotionType $potionType, ?CompoundTag $nbt = null){

--- a/src/entity/projectile/SplashPotion.php
+++ b/src/entity/projectile/SplashPotion.php
@@ -52,9 +52,6 @@ class SplashPotion extends Throwable{
 
 	public static function getNetworkTypeId() : string{ return EntityIds::SPLASH_POTION; }
 
-	protected $gravity = 0.05;
-	protected $drag = 0.01;
-
 	/** @var bool */
 	protected $linger = false;
 	protected PotionType $potionType;
@@ -63,6 +60,8 @@ class SplashPotion extends Throwable{
 		$this->potionType = $potionType;
 		parent::__construct($location, $shootingEntity, $nbt);
 	}
+
+	protected function getInitialGravity() : float{ return 0.05; }
 
 	public function saveNBT() : CompoundTag{
 		$nbt = parent::saveNBT();

--- a/src/entity/projectile/Throwable.php
+++ b/src/entity/projectile/Throwable.php
@@ -29,10 +29,11 @@ use pocketmine\math\RayTraceResult;
 
 abstract class Throwable extends Projectile{
 
-	protected $gravity = 0.03;
-	protected $drag = 0.01;
-
 	protected function getInitialSizeInfo() : EntitySizeInfo{ return new EntitySizeInfo(0.25, 0.25); }
+
+	protected function getInitialDragMultiplier() : float{ return 0.01; }
+
+	protected function getInitialGravity() : float{ return 0.03; }
 
 	protected function onHitBlock(Block $blockHit, RayTraceResult $hitResult) : void{
 		parent::onHitBlock($blockHit, $hitResult);

--- a/src/event/entity/EntityExhaustEvent.php
+++ b/src/event/entity/EntityExhaustEvent.php
@@ -21,7 +21,7 @@
 
 declare(strict_types=1);
 
-namespace pocketmine\event\player;
+namespace pocketmine\event\entity;
 
 use pocketmine\entity\Human;
 use pocketmine\event\Cancellable;
@@ -31,7 +31,7 @@ use pocketmine\event\entity\EntityEvent;
 /**
  * @phpstan-extends EntityEvent<Human>
  */
-class PlayerExhaustEvent extends EntityEvent implements Cancellable{
+class EntityExhaustEvent extends EntityEvent implements Cancellable{
 	use CancellableTrait;
 
 	public const CAUSE_ATTACK = 1;
@@ -46,23 +46,12 @@ class PlayerExhaustEvent extends EntityEvent implements Cancellable{
 	public const CAUSE_SPRINT_JUMPING = 10;
 	public const CAUSE_CUSTOM = 11;
 
-	/** @var Human */
-	protected $player;
-
 	public function __construct(
-		Human $human,
+		protected Human $human,
 		private float $amount,
 		private int $cause
 	){
 		$this->entity = $human;
-		$this->player = $human;
-	}
-
-	/**
-	 * @return Human
-	 */
-	public function getPlayer(){
-		return $this->player;
 	}
 
 	public function getAmount() : float{

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -241,8 +241,8 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 	protected ?float $lastMovementProcess = null;
 
 	protected int $inAirTicks = 0;
-	/** @var float */
-	protected $stepHeight = 0.6;
+
+	protected float $stepHeight = 0.6;
 
 	protected ?Vector3 $sleeping = null;
 	private ?Position $spawnPosition = null;
@@ -2217,16 +2217,10 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 				$this->getWorld()->dropItem($this->location, $item);
 			}
 
-			if($this->inventory !== null){
-				$this->inventory->setHeldItemIndex(0);
-				$this->inventory->clearAll();
-			}
-			if($this->armorInventory !== null){
-				$this->armorInventory->clearAll();
-			}
-			if($this->offHandInventory !== null){
-				$this->offHandInventory->clearAll();
-			}
+			$this->inventory->setHeldItemIndex(0);
+			$this->inventory->clearAll();
+			$this->armorInventory->clearAll();
+			$this->offHandInventory->clearAll();
 		}
 
 		if(!$ev->getKeepXp()){

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -44,6 +44,7 @@ use pocketmine\entity\projectile\Arrow;
 use pocketmine\entity\Skin;
 use pocketmine\event\entity\EntityDamageByEntityEvent;
 use pocketmine\event\entity\EntityDamageEvent;
+use pocketmine\event\entity\EntityExhaustEvent;
 use pocketmine\event\inventory\InventoryCloseEvent;
 use pocketmine\event\inventory\InventoryOpenEvent;
 use pocketmine\event\player\PlayerBedEnterEvent;
@@ -56,7 +57,6 @@ use pocketmine\event\player\PlayerDeathEvent;
 use pocketmine\event\player\PlayerDisplayNameChangeEvent;
 use pocketmine\event\player\PlayerEmoteEvent;
 use pocketmine\event\player\PlayerEntityInteractEvent;
-use pocketmine\event\player\PlayerExhaustEvent;
 use pocketmine\event\player\PlayerGameModeChangeEvent;
 use pocketmine\event\player\PlayerInteractEvent;
 use pocketmine\event\player\PlayerItemConsumeEvent;
@@ -1256,9 +1256,9 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 			if($horizontalDistanceTravelled > 0){
 				//TODO: check for swimming
 				if($this->isSprinting()){
-					$this->hungerManager->exhaust(0.01 * $horizontalDistanceTravelled, PlayerExhaustEvent::CAUSE_SPRINTING);
+					$this->hungerManager->exhaust(0.01 * $horizontalDistanceTravelled, EntityExhaustEvent::CAUSE_SPRINTING);
 				}else{
-					$this->hungerManager->exhaust(0.0, PlayerExhaustEvent::CAUSE_WALKING);
+					$this->hungerManager->exhaust(0.0, EntityExhaustEvent::CAUSE_WALKING);
 				}
 
 				if($this->nextChunkOrderRun > 20){
@@ -1658,7 +1658,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 					}
 					$this->inventory->setItemInHand($item);
 				}
-				$this->hungerManager->exhaust(0.005, PlayerExhaustEvent::CAUSE_MINING);
+				$this->hungerManager->exhaust(0.005, EntityExhaustEvent::CAUSE_MINING);
 				return true;
 			}
 		}else{
@@ -1768,7 +1768,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 				$this->inventory->setItemInHand($heldItem);
 			}
 
-			$this->hungerManager->exhaust(0.1, PlayerExhaustEvent::CAUSE_ATTACK);
+			$this->hungerManager->exhaust(0.1, EntityExhaustEvent::CAUSE_ATTACK);
 		}
 
 		return true;
@@ -2310,7 +2310,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 	protected function applyPostDamageEffects(EntityDamageEvent $source) : void{
 		parent::applyPostDamageEffects($source);
 
-		$this->hungerManager->exhaust(0.1, PlayerExhaustEvent::CAUSE_DAMAGE);
+		$this->hungerManager->exhaust(0.1, EntityExhaustEvent::CAUSE_DAMAGE);
 	}
 
 	public function attack(EntityDamageEvent $source) : void{

--- a/src/world/Position.php
+++ b/src/world/Position.php
@@ -28,16 +28,9 @@ use pocketmine\utils\AssumptionFailedError;
 use function assert;
 
 class Position extends Vector3{
+	public ?World $world = null;
 
-	/** @var World|null */
-	public $world = null;
-
-	/**
-	 * @param float|int $x
-	 * @param float|int $y
-	 * @param float|int $z
-	 */
-	public function __construct($x, $y, $z, ?World $world){
+	public function __construct(float|int $x, float|int $y, float|int $z, ?World $world){
 		parent::__construct($x, $y, $z);
 		if($world !== null && !$world->isLoaded()){
 			throw new \InvalidArgumentException("Specified world has been unloaded and cannot be used");

--- a/src/world/World.php
+++ b/src/world/World.php
@@ -1904,11 +1904,9 @@ class World implements ChunkManager{
 	public function getCollidingEntities(AxisAlignedBB $bb, ?Entity $entity = null) : array{
 		$nearby = [];
 
-		if($entity === null || $entity->canCollide){
-			foreach($this->getNearbyEntities($bb, $entity) as $ent){
-				if($ent->canBeCollidedWith() && ($entity === null || $entity->canCollideWith($ent))){
-					$nearby[] = $ent;
-				}
+		foreach($this->getNearbyEntities($bb, $entity) as $ent){
+			if($ent->canBeCollidedWith() && ($entity === null || $entity->canCollideWith($ent))){
+				$nearby[] = $ent;
 			}
 		}
 

--- a/tests/plugins/TesterPlugin/plugin.yml
+++ b/tests/plugins/TesterPlugin/plugin.yml
@@ -2,7 +2,7 @@ name: TesterPlugin
 main: pmmp\TesterPlugin\Main
 src-namespace-prefix: pmmp\TesterPlugin
 version: 0.1.0
-api: [3.2.0, 4.0.0]
+api: [5.0.0]
 load: POSTWORLD
 author: pmmp
 description: Plugin used to run tests on PocketMine-MP


### PR DESCRIPTION
## Introduction

PlayerExhaustEvent is located in \pocketmine\event\player but it not only called by player but also called in custom human entity, it isn't a suitable name.

This commit popularize PlayerExhaustEvent.

### Relevant issues

* Fixes #5086 

## Changes
### API changes

- PlayerExhaustEvent -> EntityExhaustEvent

- PlayerExhastEvent::getPlayer():Human => EntityExhaustEvent::getEntity()

- PlayerExhaustEvent->player(private property) removed.

### Behavioural changes

server call EntityExhaustEvent instead of PlayerExhaustEvent now.


## Backwards compatibility

There is backwards incompatible changes.

Solution:
- Replace PlayerExhaustEvent to EntityExhaustEvent
- Call EntityExhaustEvent::getEntity() instead of PlayerExhaustEvent::getPlayer()
- Any reflection call of PlayerExhaustEvent::player should replace to EntityExhaustEvent::entity

## Tests

I write a plugin to test the event, just like

```php
public function o(EntityExhaustEvent $e) : void {
     var_dump("T");
}
```
