### PR TITLE
PlayerExhaustEvent: popularize to EntityExhaustEvent

### DIFF
--- a/src/entity/Human.php
+++ b/src/entity/Human.php
@@ -29,7 +29,7 @@ use pocketmine\entity\effect\EffectInstance;
 use pocketmine\entity\effect\VanillaEffects;
 use pocketmine\entity\projectile\ProjectileSource;
 use pocketmine\event\entity\EntityDamageEvent;
-use pocketmine\event\player\PlayerExhaustEvent;
+use pocketmine\event\entity\EntityExhaustEvent;
 use pocketmine\inventory\CallbackInventoryListener;
 use pocketmine\inventory\Inventory;
 use pocketmine\inventory\InventoryHolder;
@@ -146,9 +146,9 @@ class Human extends Living implements ProjectileSource, InventoryHolder{
 	public function jump() : void{
 		parent::jump();
 		if($this->isSprinting()){
-			$this->hungerManager->exhaust(0.2, PlayerExhaustEvent::CAUSE_SPRINT_JUMPING);
+			$this->hungerManager->exhaust(0.2, EntityExhaustEvent::CAUSE_SPRINT_JUMPING);
 		}else{
-			$this->hungerManager->exhaust(0.05, PlayerExhaustEvent::CAUSE_JUMPING);
+			$this->hungerManager->exhaust(0.05, EntityExhaustEvent::CAUSE_JUMPING);
 		}
 	}
 

--- a/src/entity/HungerManager.php
+++ b/src/entity/HungerManager.php
@@ -24,8 +24,8 @@ declare(strict_types=1);
 namespace pocketmine\entity;
 
 use pocketmine\event\entity\EntityDamageEvent;
+use pocketmine\event\entity\EntityExhaustEvent;
 use pocketmine\event\entity\EntityRegainHealthEvent;
-use pocketmine\event\player\PlayerExhaustEvent;
 use pocketmine\world\World;
 use function max;
 use function min;
@@ -129,11 +129,11 @@ class HungerManager{
 	 *
 	 * @return float the amount of exhaustion level increased
 	 */
-	public function exhaust(float $amount, int $cause = PlayerExhaustEvent::CAUSE_CUSTOM) : float{
+	public function exhaust(float $amount, int $cause = EntityExhaustEvent::CAUSE_CUSTOM) : float{
 		if(!$this->enabled){
 			return 0;
 		}
-		$ev = new PlayerExhaustEvent($this->entity, $amount, $cause);
+		$ev = new EntityExhaustEvent($this->entity, $amount, $cause);
 		$ev->call();
 		if($ev->isCancelled()){
 			return 0.0;
@@ -200,7 +200,7 @@ class HungerManager{
 			if($food >= 18){
 				if($health < $this->entity->getMaxHealth()){
 					$this->entity->heal(new EntityRegainHealthEvent($this->entity, 1, EntityRegainHealthEvent::CAUSE_SATURATION));
-					$this->exhaust(6.0, PlayerExhaustEvent::CAUSE_HEALTH_REGEN);
+					$this->exhaust(6.0, EntityExhaustEvent::CAUSE_HEALTH_REGEN);
 				}
 			}elseif($food <= 0){
 				if(($difficulty === World::DIFFICULTY_EASY && $health > 10) || ($difficulty === World::DIFFICULTY_NORMAL && $health > 1) || $difficulty === World::DIFFICULTY_HARD){

--- a/src/entity/effect/HungerEffect.php
+++ b/src/entity/effect/HungerEffect.php
@@ -26,7 +26,7 @@ namespace pocketmine\entity\effect;
 use pocketmine\entity\Entity;
 use pocketmine\entity\Human;
 use pocketmine\entity\Living;
-use pocketmine\event\player\PlayerExhaustEvent;
+use pocketmine\event\entity\EntityExhaustEvent;
 
 class HungerEffect extends Effect{
 
@@ -36,7 +36,7 @@ class HungerEffect extends Effect{
 
 	public function applyEffect(Living $entity, EffectInstance $instance, float $potency = 1.0, ?Entity $source = null) : void{
 		if($entity instanceof Human){
-			$entity->getHungerManager()->exhaust(0.1 * $instance->getEffectLevel(), PlayerExhaustEvent::CAUSE_POTION);
+			$entity->getHungerManager()->exhaust(0.1 * $instance->getEffectLevel(), EntityExhaustEvent::CAUSE_POTION);
 		}
 	}
 }

--- a/src/event/entity/EntityExhaustEvent.php
+++ b/src/event/entity/EntityExhaustEvent.php
@@ -21,17 +21,16 @@
 
 declare(strict_types=1);
 
-namespace pocketmine\event\player;
+namespace pocketmine\event\entity;
 
 use pocketmine\entity\Human;
 use pocketmine\event\Cancellable;
 use pocketmine\event\CancellableTrait;
-use pocketmine\event\entity\EntityEvent;
 
 /**
  * @phpstan-extends EntityEvent<Human>
  */
-class PlayerExhaustEvent extends EntityEvent implements Cancellable{
+class EntityExhaustEvent extends EntityEvent implements Cancellable{
 	use CancellableTrait;
 
 	public const CAUSE_ATTACK = 1;
@@ -46,23 +45,12 @@ class PlayerExhaustEvent extends EntityEvent implements Cancellable{
 	public const CAUSE_SPRINT_JUMPING = 10;
 	public const CAUSE_CUSTOM = 11;
 
-	/** @var Human */
-	protected $player;
-
 	public function __construct(
-		Human $human,
+		protected Human $human,
 		private float $amount,
 		private int $cause
 	){
 		$this->entity = $human;
-		$this->player = $human;
-	}
-
-	/**
-	 * @return Human
-	 */
-	public function getPlayer(){
-		return $this->player;
 	}
 
 	public function getAmount() : float{

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -44,6 +44,7 @@ use pocketmine\entity\projectile\Arrow;
 use pocketmine\entity\Skin;
 use pocketmine\event\entity\EntityDamageByEntityEvent;
 use pocketmine\event\entity\EntityDamageEvent;
+use pocketmine\event\entity\EntityExhaustEvent;
 use pocketmine\event\inventory\InventoryCloseEvent;
 use pocketmine\event\inventory\InventoryOpenEvent;
 use pocketmine\event\player\PlayerBedEnterEvent;
@@ -56,7 +57,6 @@ use pocketmine\event\player\PlayerDeathEvent;
 use pocketmine\event\player\PlayerDisplayNameChangeEvent;
 use pocketmine\event\player\PlayerEmoteEvent;
 use pocketmine\event\player\PlayerEntityInteractEvent;
-use pocketmine\event\player\PlayerExhaustEvent;
 use pocketmine\event\player\PlayerGameModeChangeEvent;
 use pocketmine\event\player\PlayerInteractEvent;
 use pocketmine\event\player\PlayerItemConsumeEvent;
@@ -1256,9 +1256,9 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 			if($horizontalDistanceTravelled > 0){
 				//TODO: check for swimming
 				if($this->isSprinting()){
-					$this->hungerManager->exhaust(0.01 * $horizontalDistanceTravelled, PlayerExhaustEvent::CAUSE_SPRINTING);
+					$this->hungerManager->exhaust(0.01 * $horizontalDistanceTravelled, EntityExhaustEvent::CAUSE_SPRINTING);
 				}else{
-					$this->hungerManager->exhaust(0.0, PlayerExhaustEvent::CAUSE_WALKING);
+					$this->hungerManager->exhaust(0.0, EntityExhaustEvent::CAUSE_WALKING);
 				}
 
 				if($this->nextChunkOrderRun > 20){
@@ -1658,7 +1658,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 					}
 					$this->inventory->setItemInHand($item);
 				}
-				$this->hungerManager->exhaust(0.005, PlayerExhaustEvent::CAUSE_MINING);
+				$this->hungerManager->exhaust(0.005, EntityExhaustEvent::CAUSE_MINING);
 				return true;
 			}
 		}else{
@@ -1768,7 +1768,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 				$this->inventory->setItemInHand($heldItem);
 			}
 
-			$this->hungerManager->exhaust(0.1, PlayerExhaustEvent::CAUSE_ATTACK);
+			$this->hungerManager->exhaust(0.1, EntityExhaustEvent::CAUSE_ATTACK);
 		}
 
 		return true;
@@ -2310,7 +2310,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 	protected function applyPostDamageEffects(EntityDamageEvent $source) : void{
 		parent::applyPostDamageEffects($source);
 
-		$this->hungerManager->exhaust(0.1, PlayerExhaustEvent::CAUSE_DAMAGE);
+		$this->hungerManager->exhaust(0.1, EntityExhaustEvent::CAUSE_DAMAGE);
 	}
 
 	public function attack(EntityDamageEvent $source) : void{


### PR DESCRIPTION
## Introduction

PlayerExhaustEvent is located in \pocketmine\event\player but it not only called by player but also called in custom human entity, it isn't a suitable name.

This commit popularize PlayerExhaustEvent.

### Relevant issues

* Fixes #5086 

## Changes
### API changes

- PlayerExhaustEvent -> EntityExhaustEvent

- PlayerExhastEvent::getPlayer():Human => EntityExhaustEvent::getEntity()

- PlayerExhaustEvent->player(private property) removed.

### Behavioural changes

server call EntityExhaustEvent instead of PlayerExhaustEvent now.


## Backwards compatibility

There is backwards incompatible changes.

Solution:
- Replace PlayerExhaustEvent to EntityExhaustEvent
- Call EntityExhaustEvent::getEntity() instead of PlayerExhaustEvent::getPlayer()
- Any reflection call of PlayerExhaustEvent::player should replace to EntityExhaustEvent::entity

## Tests

I write a plugin to test the event, just like

```php
public function o(EntityExhaustEvent $e) : void {
     var_dump("T");
}
```
