### PR TITLE
[Fix] ItemEntity bounces on Slime Block

### DIFF
--- a/src/entity/object/ItemEntity.php
+++ b/src/entity/object/ItemEntity.php
@@ -186,6 +186,16 @@ class ItemEntity extends Entity{
 		return true;
 	}
 
+	protected function onHitGround() : ?float{
+		$fallBlockPos = $this->location->floor();
+		$fallBlock = $this->getWorld()->getBlock($fallBlockPos);
+		if(count($fallBlock->getCollisionBoxes()) === 0){
+			$fallBlockPos = $fallBlockPos->down();
+			$fallBlock = $this->getWorld()->getBlock($fallBlockPos);
+		}
+		return $fallBlock->onEntityLand($this);
+	}
+
 	public function canSaveWithChunk() : bool{
 		return !$this->item->isNull() && parent::canSaveWithChunk();
 	}

--- a/src/entity/object/ItemEntity.php
+++ b/src/entity/object/ItemEntity.php
@@ -39,6 +39,7 @@ use pocketmine\network\mcpe\protocol\AddItemActorPacket;
 use pocketmine\network\mcpe\protocol\types\entity\EntityIds;
 use pocketmine\network\mcpe\protocol\types\inventory\ItemStackWrapper;
 use pocketmine\player\Player;
+use function count;
 use function max;
 
 class ItemEntity extends Entity{


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This PR fixes items previously not bouncing on slime blocks.

### Relevant issues

* Fixes #4830

## Changes
Items now bounce on slime blocks.
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
No significant API changes, as `onHitGround()` was only overriden. It may break plugins that depend on ItemEntity's previous behavior of landing without calling `$fallBlock->onEntityLand()`.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
Items now bounce on slime blocks.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
This is a backwards compatible change.
## Follow-up
Perhaps moving generic physics code and applying that to ItemEntity, armor_stand, etc.
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
I haven't added any tests.
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
