### PR TITLE
Initial `getPlugin` updates

### DIFF
--- a/src/plugin/PluginManager.php
+++ b/src/plugin/PluginManager.php
@@ -97,6 +97,11 @@ class PluginManager{
 		}
 	}
 
+	/**
+	 * @param string $class
+	 * @phpstan-param class-string<Plugin> $class
+	 * @return Plugin|null
+	 */
 	public function getPlugin(string $class) : ?Plugin{
 		if(!is_a($class, Plugin::class, true)) return null;
 		return $this->plugins[$class];

--- a/src/plugin/PluginManager.php
+++ b/src/plugin/PluginManager.php
@@ -97,12 +97,9 @@ class PluginManager{
 		}
 	}
 
-	public function getPlugin(string $name) : ?Plugin{
-		if(isset($this->plugins[$name])){
-			return $this->plugins[$name];
-		}
-
-		return null;
+	public function getPlugin(string $class) : ?Plugin{
+		if(!is_a($class, Plugin::class, true)) return null;
+		return $this->plugins[$class];
 	}
 
 	public function registerInterface(PluginLoader $loader) : void{
@@ -211,7 +208,7 @@ class PluginManager{
 		 * @see Plugin::__construct()
 		 */
 		$plugin = new $mainClass($loader, $this->server, $description, $dataFolder, $prefixed, new DiskResourceProvider($prefixed . "/resources/"));
-		$this->plugins[$plugin->getDescription()->getName()] = $plugin;
+		$this->plugins[$plugin->getDescription()->getMain()] = $plugin;
 
 		return $plugin;
 	}
@@ -287,7 +284,7 @@ class PluginManager{
 					continue;
 				}
 
-				if(isset($triage->plugins[$name]) || $this->getPlugin($name) instanceof Plugin){
+				if(isset($triage->plugins[$name]) || $this->getPlugin($description->getMain()) instanceof Plugin){
 					$this->server->getLogger()->critical($this->server->getLanguage()->translate(KnownTranslationFactory::pocketmine_plugin_duplicateError($name)));
 					$loadErrorCount++;
 					continue;
@@ -436,7 +433,7 @@ class PluginManager{
 	}
 
 	public function isPluginEnabled(Plugin $plugin) : bool{
-		return isset($this->plugins[$plugin->getDescription()->getName()]) && $plugin->isEnabled();
+		return isset($this->plugins[$plugin->getDescription()->getMain()]) && $plugin->isEnabled();
 	}
 
 	public function enablePlugin(Plugin $plugin) : bool{


### PR DESCRIPTION
## Introduction
This PR implements a suggestion made previously by SOF3 and further agreed by Dylan about `getPlugin` accepting class strings instead of plugin names as the parameter.

### Relevant issues
#2506

## Changes
### API changes
`getPlugin` now accepts a class string instead of plugin names

## Backwards compatibility
Any plugins that use `getPlugin` with hardcoded plugin names would have to change to use class strings instead.

## Tests
Created 2 test plugins:
1 with base plugin files (plugin.yml, Test1.php extending PluginBase but nothing inside `onEnable`)
The second has the same file structure however the following code was placed inside of `onEnable` :

```
protected function onEnable() : void {
		  $plugin = $this->getServer()->getPluginManager()->getPlugin(Test1::class);

		  $this->getLogger()->info($plugin->getDescription()->getDescription());
}
```

The result was the description of Test1 being displayed inside the console.