### PR TITLE
Add sendToast method, API to send toast with ToastRequestPacket

### DIFF
--- a/src/network/mcpe/NetworkSession.php
+++ b/src/network/mcpe/NetworkSession.php
@@ -1043,7 +1043,7 @@ class NetworkSession{
 		$this->sendDataPacket(EmotePacket::create($from->getId(), $emoteId, EmotePacket::FLAG_SERVER));
 	}
 
-	public function onToast(string $title, string $body){
+	public function onToast(string $title, string $body) : void{
 		$this->sendDataPacket(ToastRequestPacket::create($title, $body));
 	}
 

--- a/src/network/mcpe/NetworkSession.php
+++ b/src/network/mcpe/NetworkSession.php
@@ -1043,7 +1043,7 @@ class NetworkSession{
 		$this->sendDataPacket(EmotePacket::create($from->getId(), $emoteId, EmotePacket::FLAG_SERVER));
 	}
 
-	public function onToast(string $title, string $body) : void{
+	public function onToastNotification(string $title, string $body) : void{
 		$this->sendDataPacket(ToastRequestPacket::create($title, $body));
 	}
 

--- a/src/network/mcpe/NetworkSession.php
+++ b/src/network/mcpe/NetworkSession.php
@@ -88,6 +88,7 @@ use pocketmine\network\mcpe\protocol\SetTimePacket;
 use pocketmine\network\mcpe\protocol\SetTitlePacket;
 use pocketmine\network\mcpe\protocol\TakeItemActorPacket;
 use pocketmine\network\mcpe\protocol\TextPacket;
+use pocketmine\network\mcpe\protocol\ToastRequestPacket;
 use pocketmine\network\mcpe\protocol\TransferPacket;
 use pocketmine\network\mcpe\protocol\types\BlockPosition;
 use pocketmine\network\mcpe\protocol\types\command\CommandData;
@@ -1040,6 +1041,10 @@ class NetworkSession{
 
 	public function onEmote(Human $from, string $emoteId) : void{
 		$this->sendDataPacket(EmotePacket::create($from->getId(), $emoteId, EmotePacket::FLAG_SERVER));
+	}
+
+	public function onToast(string $title, string $body){
+		$this->sendDataPacket(ToastRequestPacket::create($title, $body));
 	}
 
 	public function tick() : void{

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1986,6 +1986,10 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		$this->getNetworkSession()->onTip($message);
 	}
 
+	public function sendToast(string $title, string $body) : void{
+		$this->getNetworkSession()->onToast($title, $body);
+	}
+
 	/**
 	 * Sends a Form to the player, or queue to send it if a form is already open.
 	 *

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1986,8 +1986,11 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		$this->getNetworkSession()->onTip($message);
 	}
 
-	public function sendToast(string $title, string $body) : void{
-		$this->getNetworkSession()->onToast($title, $body);
+	/**
+	 * Sends a toast message to the player, or queue to send it if a toast message is already shown.
+	 */
+	public function sendToastNotification(string $title, string $body) : void{
+		$this->getNetworkSession()->onToastNotification($title, $body);
 	}
 
 	/**


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Since Bedrock 1.19.0, there is a ToastRequestPacket but there is no API to send toast.
### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
No

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
add `Player::sendToast(string $title, string $body): void`

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
No

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
There is no BC break.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
```php
$player->sendToast("title", "body");
```
![image](https://user-images.githubusercontent.com/17157879/172493504-c809f047-83d8-4307-88ac-b40321039f24.png)
