### PR TITLE
Improve performance of `InventoryManager::syncCreative()`

### DIFF
--- a/src/inventory/CreativeInventory.php
+++ b/src/inventory/CreativeInventory.php
@@ -30,6 +30,7 @@ use pocketmine\network\mcpe\protocol\CreativeContentPacket;
 use pocketmine\network\mcpe\protocol\types\inventory\CreativeContentEntry;
 use pocketmine\utils\SingletonTrait;
 use Webmozart\PathUtil\Path;
+use function array_map;
 use function file_get_contents;
 use function json_decode;
 

--- a/src/network/mcpe/InventoryManager.php
+++ b/src/network/mcpe/InventoryManager.php
@@ -50,7 +50,6 @@ use pocketmine\network\mcpe\protocol\InventorySlotPacket;
 use pocketmine\network\mcpe\protocol\MobEquipmentPacket;
 use pocketmine\network\mcpe\protocol\types\BlockPosition;
 use pocketmine\network\mcpe\protocol\types\inventory\ContainerIds;
-use pocketmine\network\mcpe\protocol\types\inventory\CreativeContentEntry;
 use pocketmine\network\mcpe\protocol\types\inventory\ItemStackWrapper;
 use pocketmine\network\mcpe\protocol\types\inventory\NetworkInventoryAction;
 use pocketmine\network\mcpe\protocol\types\inventory\WindowTypes;

--- a/src/network/mcpe/InventoryManager.php
+++ b/src/network/mcpe/InventoryManager.php
@@ -379,11 +379,6 @@ class InventoryManager{
 	}
 
 	public function syncCreative() : void{
-		$typeConverter = TypeConverter::getInstance();
-
-		$nextEntryId = 1;
-		$this->session->sendDataPacket(CreativeContentPacket::create(array_map(function(Item $item) use($typeConverter, &$nextEntryId) : CreativeContentEntry{
-			return new CreativeContentEntry($nextEntryId++, $typeConverter->coreItemStackToNet($item));
-		}, $this->player->isSpectator() ? [] : CreativeInventory::getInstance()->getAll())));
+		$this->session->sendDataPacket($this->player->isSpectator() ? CreativeContentPacket::create([]) : CreativeInventory::getInstance()->getContentPacket());
 	}
 }


### PR DESCRIPTION
## Introduction
I found that it is taking a long time to change the game mode of the player.
This is due to the time taken to generate the CreativeContentPacket.
This PR improves the performance of `InventoryManager::syncCreative()` by caching the packet.

### Relevant issues
N/A

## Changes
### API changes
N/A

## Backwards compatibility
N/A

## Tests
Reduced from about 100 milliseconds to 0.7 milliseconds.
```php
$startTime = microtime(true);
for($i = 0; $i < 10; ++$i){
	$_player->setGamemode(GameMode::SURVIVAL());
	$_player->setGamemode(GameMode::CREATIVE());
}
$time = microtime(true) - $startTime;
$_player->sendMessage(round($time * 10 ** 3, 1) . "ms");
```