### PR TITLE
Fix sharpness damage

### DIFF
--- a/src/item/enchantment/SharpnessEnchantment.php
+++ b/src/item/enchantment/SharpnessEnchantment.php
@@ -32,6 +32,6 @@ class SharpnessEnchantment extends MeleeWeaponEnchantment{
 	}
 
 	public function getDamageBonus(int $enchantmentLevel) : float{
-		return 0.5 * ($enchantmentLevel + 1);
+		return 1.25 * $enchantmentLevel;
 	}
 }


### PR DESCRIPTION
## Introduction
In Bedrock Edition the sharpness damage is calculated by: ``1.25 * level``.
Link to wiki [here](https://minecraft.fandom.com/wiki/Sharpness).

## Tests

https://user-images.githubusercontent.com/62452028/176953557-5327e113-199e-4ceb-8ba3-bd723fc96494.mp4

https://user-images.githubusercontent.com/62452028/176953621-4ca46e73-61fa-4342-b96b-ed803728c794.mp4


I used this script to send the final damage:
```php
public function onDamage(EntityDamageByEntityEvent $event): void
{
    $damager = $event->getDamager();
    if ($damager instanceof Player) {
        $damager->sendMessage("Final Damage: " . $event->getFinalDamage());
    }
}
```
**OBS:** The final damage is +1 which was expected because the base damage of a diamond sword is 8 instead of 7 as in the wiki.
