### PR TITLE
Set the correct max stack size for spyglass

### DIFF
--- a/src/item/ItemFactory.php
+++ b/src/item/ItemFactory.php
@@ -98,7 +98,6 @@ class ItemFactory{
 		$this->register(new GoldenApple(new IID(Ids::GOLDEN_APPLE), "Golden Apple"));
 		$this->register(new GoldenAppleEnchanted(new IID(Ids::ENCHANTED_GOLDEN_APPLE), "Enchanted Golden Apple"));
 		$this->register(new GoldenCarrot(new IID(Ids::GOLDEN_CARROT), "Golden Carrot"));
-		$this->register(new Spyglass(new IID(Ids::SPYGLASS), "Spyglass"));
 		$this->register(new Item(new IID(Ids::AMETHYST_SHARD), "Amethyst Shard"));
 		$this->register(new Item(new IID(Ids::BLAZE_POWDER), "Blaze Powder"));
 		$this->register(new Item(new IID(Ids::BLEACH), "Bleach")); //EDU
@@ -235,6 +234,7 @@ class ItemFactory{
 		$this->register(new ItemBlockWallOrFloor(new IID(Ids::WARPED_SIGN), Blocks::WARPED_SIGN(), Blocks::WARPED_WALL_SIGN()));
 		$this->register(new Snowball(new IID(Ids::SNOWBALL), "Snowball"));
 		$this->register(new SpiderEye(new IID(Ids::SPIDER_EYE), "Spider Eye"));
+		$this->register(new Spyglass(new IID(Ids::SPYGLASS), "Spyglass"));
 		$this->register(new Steak(new IID(Ids::STEAK), "Steak"));
 		$this->register(new Stick(new IID(Ids::STICK), "Stick"));
 		$this->register(new StringItem(new IID(Ids::STRING), "String"));

--- a/src/item/ItemFactory.php
+++ b/src/item/ItemFactory.php
@@ -98,6 +98,7 @@ class ItemFactory{
 		$this->register(new GoldenApple(new IID(Ids::GOLDEN_APPLE), "Golden Apple"));
 		$this->register(new GoldenAppleEnchanted(new IID(Ids::ENCHANTED_GOLDEN_APPLE), "Enchanted Golden Apple"));
 		$this->register(new GoldenCarrot(new IID(Ids::GOLDEN_CARROT), "Golden Carrot"));
+		$this->register(new Spyglass(new IID(Ids::SPYGLASS), "Spyglass"));
 		$this->register(new Item(new IID(Ids::AMETHYST_SHARD), "Amethyst Shard"));
 		$this->register(new Item(new IID(Ids::BLAZE_POWDER), "Blaze Powder"));
 		$this->register(new Item(new IID(Ids::BLEACH), "Bleach")); //EDU
@@ -185,7 +186,6 @@ class ItemFactory{
 		$this->register(new Item(new IID(Ids::RAW_IRON), "Raw Iron"));
 		$this->register(new Item(new IID(Ids::RAW_GOLD), "Raw Gold"));
 		$this->register(new Item(new IID(Ids::PHANTOM_MEMBRANE), "Phantom Membrane"));
-		$this->register(new Item(new IID(Ids::SPYGLASS), "Spyglass"));
 
 		//the meta values for buckets are intentionally hardcoded because block IDs will change in the future
 		$this->register(new LiquidBucket(new IID(Ids::WATER_BUCKET), "Water Bucket", Blocks::WATER()));

--- a/src/item/Spyglass.php
+++ b/src/item/Spyglass.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\item;
+
+class Spyglass extends Item{
+
+	public function getMaxStackSize() : int{
+		return 1;
+	}
+}

--- a/src/item/VanillaItems.php
+++ b/src/item/VanillaItems.php
@@ -249,7 +249,7 @@ use pocketmine\utils\CloningRegistryTrait;
  * @method static SplashPotion SPLASH_POTION()
  * @method static Boat SPRUCE_BOAT()
  * @method static ItemBlockWallOrFloor SPRUCE_SIGN()
- * @method static Item SPYGLASS()
+ * @method static Spyglass SPYGLASS()
  * @method static SpawnEgg SQUID_SPAWN_EGG()
  * @method static Steak STEAK()
  * @method static Stick STICK()


### PR DESCRIPTION
## Introduction
Fixes the maximum stack size of spyglass

## Changes
### API changes
Spyglass now has a separate class

### Behavioural changes
Now a player cannot have more than 1 spyglass in the slot

## Tests
```
/give PlayerName spyglass
```
before:
```
[PlayerName: Given Spyglass (spyglass) * 64 to PlayerName]
```
after:
```
[PlayerName: Given Spyglass (spyglass) * 1 to PlayerName]
```