### PR TITLE
Explosions can destroy unbreakable blocks like bedrock

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -18,7 +18,7 @@ jobs:
           submodules: true
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@2.19.0
+        uses: shivammathur/setup-php@2.19.1
         with:
           php-version: 8.0
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -195,7 +195,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup PHP and tools
-        uses: shivammathur/setup-php@2.19.0
+        uses: shivammathur/setup-php@2.19.1
         with:
           php-version: 8.0
           tools: php-cs-fixer:3.2

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
       "webmozart/path-util": "^2.3"
    },
    "require-dev": {
-      "phpstan/phpstan": "1.7.15",
+      "phpstan/phpstan": "1.8.0",
       "phpstan/phpstan-phpunit": "^1.1.0",
       "phpstan/phpstan-strict-rules": "^1.2.0",
       "phpunit/phpunit": "^9.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "54ae200719453a6bb90afa4c67a50e71",
+    "content-hash": "c9c0412cf5610ee7fa623b679b5471fb",
     "packages": [
         {
             "name": "adhocore/json-comment",
@@ -1737,16 +1737,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.7.15",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "cd0202ea1b1fc6d1bbe156c6e2e18a03e0ff160a"
+                "reference": "b7648d4ee9321665acaf112e49da9fd93df8fbd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/cd0202ea1b1fc6d1bbe156c6e2e18a03e0ff160a",
-                "reference": "cd0202ea1b1fc6d1bbe156c6e2e18a03e0ff160a",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b7648d4ee9321665acaf112e49da9fd93df8fbd5",
+                "reference": "b7648d4ee9321665acaf112e49da9fd93df8fbd5",
                 "shasum": ""
             },
             "require": {
@@ -1772,7 +1772,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.7.15"
+                "source": "https://github.com/phpstan/phpstan/tree/1.8.0"
             },
             "funding": [
                 {
@@ -1792,7 +1792,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-20T08:29:01+00:00"
+            "time": "2022-06-29T08:53:31+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",

--- a/src/entity/object/PrimedTNT.php
+++ b/src/entity/object/PrimedTNT.php
@@ -122,7 +122,7 @@ class PrimedTNT extends Entity implements Explosive{
 			//TODO: deal with underwater TNT (underwater TNT treats water as if it has a blast resistance of 0)
 			$explosion = new Explosion(Position::fromObject($this->location->add(0, $this->size->getHeight() / 2, 0), $this->getWorld()), $ev->getForce(), $this);
 			if($ev->isBlockBreaking()){
-				$explosion->explodeA($ev->canBreakUnbreakableBlocks());
+				$explosion->explodeA($ev->isForcedToBreakAll());
 			}
 			$explosion->explodeB();
 		}

--- a/src/entity/object/PrimedTNT.php
+++ b/src/entity/object/PrimedTNT.php
@@ -116,13 +116,13 @@ class PrimedTNT extends Entity implements Explosive{
 	}
 
 	public function explode() : void{
-		$ev = new ExplosionPrimeEvent($this, 4);
+		$ev = new ExplosionPrimeEvent($this, 4, false);
 		$ev->call();
 		if(!$ev->isCancelled()){
 			//TODO: deal with underwater TNT (underwater TNT treats water as if it has a blast resistance of 0)
 			$explosion = new Explosion(Position::fromObject($this->location->add(0, $this->size->getHeight() / 2, 0), $this->getWorld()), $ev->getForce(), $this);
 			if($ev->isBlockBreaking()){
-				$explosion->explodeA();
+				$explosion->explodeA($ev->canBreakUnbreakableBlocks());
 			}
 			$explosion->explodeB();
 		}

--- a/src/entity/object/PrimedTNT.php
+++ b/src/entity/object/PrimedTNT.php
@@ -122,7 +122,7 @@ class PrimedTNT extends Entity implements Explosive{
 			//TODO: deal with underwater TNT (underwater TNT treats water as if it has a blast resistance of 0)
 			$explosion = new Explosion(Position::fromObject($this->location->add(0, $this->size->getHeight() / 2, 0), $this->getWorld()), $ev->getForce(), $this);
 			if($ev->isBlockBreaking()){
-				$explosion->explodeA($ev->isForcedToBreakAll());
+				$explosion->explodeA($ev->canBreakAll());
 			}
 			$explosion->explodeB();
 		}

--- a/src/event/entity/ExplosionPrimeEvent.php
+++ b/src/event/entity/ExplosionPrimeEvent.php
@@ -40,15 +40,15 @@ class ExplosionPrimeEvent extends EntityEvent implements Cancellable{
 
 	protected float $force;
 	private bool $blockBreaking = true;
-	private bool $canBreakUnbreakableBlocks;
+	private bool $forceToBreakAll;
 
-	public function __construct(Entity $entity, float $force, bool $canBreakUnbreakableBlocks){
+	public function __construct(Entity $entity, float $force, bool $forceToBreakAll){
 		if($force <= 0){
 			throw new \InvalidArgumentException("Explosion radius must be positive");
 		}
 		$this->entity = $entity;
 		$this->force = $force;
-		$this->canBreakUnbreakableBlocks = $canBreakUnbreakableBlocks;
+		$this->forceToBreakAll = $forceToBreakAll;
 	}
 
 	public function getForce() : float{
@@ -69,12 +69,12 @@ class ExplosionPrimeEvent extends EntityEvent implements Cancellable{
 		$this->blockBreaking = $affectsBlocks;
 	}
 
-	public function canBreakUnbreakableBlocks() : bool{
-		return $this->canBreakUnbreakableBlocks;
+	public function isForcedToBreakAll() : bool{
+		return $this->forceToBreakAll;
 	}
 
-	public function setCanBreakUnbreakableBlocks(bool $value = true) : void{
-		$this->canBreakUnbreakableBlocks = $value;
+	public function setForceToBreakAll(bool $value = true) : void{
+		$this->forceToBreakAll = $value;
 	}
 
 }

--- a/src/event/entity/ExplosionPrimeEvent.php
+++ b/src/event/entity/ExplosionPrimeEvent.php
@@ -40,20 +40,31 @@ class ExplosionPrimeEvent extends EntityEvent implements Cancellable{
 
 	/** @var float */
 	protected $force;
+	/** @var bool */
 	private bool $blockBreaking = true;
+	/** @var bool */
+	private bool $canBreakUnbreakableBlocks;
 
-	public function __construct(Entity $entity, float $force){
+	public function __construct(Entity $entity, float $force, bool $canBreakUnbreakableBlocks){
 		if($force <= 0){
 			throw new \InvalidArgumentException("Explosion radius must be positive");
 		}
 		$this->entity = $entity;
 		$this->force = $force;
+		$this->canBreakUnbreakableBlocks = $canBreakUnbreakableBlocks;
 	}
 
+	/**
+	 * @return float
+	 */
 	public function getForce() : float{
 		return $this->force;
 	}
 
+	/**
+	 * @param float $force
+	 * @return void
+	 */
 	public function setForce(float $force) : void{
 		if($force <= 0){
 			throw new \InvalidArgumentException("Explosion radius must be positive");
@@ -61,11 +72,34 @@ class ExplosionPrimeEvent extends EntityEvent implements Cancellable{
 		$this->force = $force;
 	}
 
+	/**
+	 * @return bool
+	 */
 	public function isBlockBreaking() : bool{
 		return $this->blockBreaking;
 	}
 
+	/**
+	 * @param bool $affectsBlocks
+	 * @return void
+	 */
 	public function setBlockBreaking(bool $affectsBlocks) : void{
 		$this->blockBreaking = $affectsBlocks;
 	}
+
+	/**
+	 * @return bool
+	 */
+	public function canBreakUnbreakableBlocks() : bool{
+		return $this->canBreakUnbreakableBlocks;
+	}
+
+	/**
+	 * @param bool $value
+	 * @return void
+	 */
+	public function setCanBreakUnbreakableBlocks(bool $value = true) : void{
+		$this->canBreakUnbreakableBlocks = $value;
+	}
+
 }

--- a/src/event/entity/ExplosionPrimeEvent.php
+++ b/src/event/entity/ExplosionPrimeEvent.php
@@ -38,7 +38,8 @@ use pocketmine\event\CancellableTrait;
 class ExplosionPrimeEvent extends EntityEvent implements Cancellable{
 	use CancellableTrait;
 
-	protected float $force;
+	/** @var float */
+	protected $force;
 	private bool $blockBreaking = true;
 	private bool $canBreakAll;
 
@@ -61,6 +62,7 @@ class ExplosionPrimeEvent extends EntityEvent implements Cancellable{
 		}
 		$this->force = $force;
 	}
+
 	public function isBlockBreaking() : bool{
 		return $this->blockBreaking;
 	}

--- a/src/event/entity/ExplosionPrimeEvent.php
+++ b/src/event/entity/ExplosionPrimeEvent.php
@@ -54,50 +54,28 @@ class ExplosionPrimeEvent extends EntityEvent implements Cancellable{
 		$this->canBreakUnbreakableBlocks = $canBreakUnbreakableBlocks;
 	}
 
-	/**
-	 * @return float
-	 */
 	public function getForce() : float{
 		return $this->force;
 	}
 
-	/**
-	 * @param float $force
-	 * @return void
-	 */
 	public function setForce(float $force) : void{
 		if($force <= 0){
 			throw new \InvalidArgumentException("Explosion radius must be positive");
 		}
 		$this->force = $force;
 	}
-
-	/**
-	 * @return bool
-	 */
 	public function isBlockBreaking() : bool{
 		return $this->blockBreaking;
 	}
 
-	/**
-	 * @param bool $affectsBlocks
-	 * @return void
-	 */
 	public function setBlockBreaking(bool $affectsBlocks) : void{
 		$this->blockBreaking = $affectsBlocks;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function canBreakUnbreakableBlocks() : bool{
 		return $this->canBreakUnbreakableBlocks;
 	}
 
-	/**
-	 * @param bool $value
-	 * @return void
-	 */
 	public function setCanBreakUnbreakableBlocks(bool $value = true) : void{
 		$this->canBreakUnbreakableBlocks = $value;
 	}

--- a/src/event/entity/ExplosionPrimeEvent.php
+++ b/src/event/entity/ExplosionPrimeEvent.php
@@ -40,15 +40,15 @@ class ExplosionPrimeEvent extends EntityEvent implements Cancellable{
 
 	protected float $force;
 	private bool $blockBreaking = true;
-	private bool $forceToBreakAll;
+	private bool $canBreakAll;
 
-	public function __construct(Entity $entity, float $force, bool $forceToBreakAll){
+	public function __construct(Entity $entity, float $force, bool $canBreakAll){
 		if($force <= 0){
 			throw new \InvalidArgumentException("Explosion radius must be positive");
 		}
 		$this->entity = $entity;
 		$this->force = $force;
-		$this->forceToBreakAll = $forceToBreakAll;
+		$this->canBreakAll = $canBreakAll;
 	}
 
 	public function getForce() : float{
@@ -69,12 +69,15 @@ class ExplosionPrimeEvent extends EntityEvent implements Cancellable{
 		$this->blockBreaking = $affectsBlocks;
 	}
 
-	public function isForcedToBreakAll() : bool{
-		return $this->forceToBreakAll;
+	/**
+	 * Destroy the unbreakable blocks like bedrock
+	 */
+	public function canBreakAll() : bool{
+		return $this->canBreakAll;
 	}
 
-	public function setForceToBreakAll(bool $value = true) : void{
-		$this->forceToBreakAll = $value;
+	public function setCanBreakAll(bool $value = true) : void{
+		$this->canBreakAll = $value;
 	}
 
 }

--- a/src/event/entity/ExplosionPrimeEvent.php
+++ b/src/event/entity/ExplosionPrimeEvent.php
@@ -38,11 +38,8 @@ use pocketmine\event\CancellableTrait;
 class ExplosionPrimeEvent extends EntityEvent implements Cancellable{
 	use CancellableTrait;
 
-	/** @var float */
-	protected $force;
-	/** @var bool */
+	protected float $force;
 	private bool $blockBreaking = true;
-	/** @var bool */
 	private bool $canBreakUnbreakableBlocks;
 
 	public function __construct(Entity $entity, float $force, bool $canBreakUnbreakableBlocks){

--- a/src/world/Explosion.php
+++ b/src/world/Explosion.php
@@ -84,7 +84,7 @@ class Explosion{
 	 * Calculates which blocks will be destroyed by this explosion. If explodeB() is called without calling this, no blocks
 	 * will be destroyed.
 	 */
-	public function explodeA(bool $forceToBreakAll = false) : bool{
+	public function explodeA(bool $canBreakAll = false) : bool{
 		if($this->size < 0.1){
 			return false;
 		}
@@ -130,7 +130,7 @@ class Explosion{
 										$_block = $this->world->getBlockAt($vBlockX, $vBlockY, $vBlockZ, true, false);
 										foreach($_block->getAffectedBlocks() as $_affectedBlock){
 
-											if(!$forceToBreakAll && !$_affectedBlock->getBreakInfo()->isBreakable())
+											if(!$canBreakAll && !$_affectedBlock->getBreakInfo()->isBreakable())
 												continue;
 
 											$_affectedBlockPos = $_affectedBlock->getPosition();

--- a/src/world/Explosion.php
+++ b/src/world/Explosion.php
@@ -84,7 +84,7 @@ class Explosion{
 	 * Calculates which blocks will be destroyed by this explosion. If explodeB() is called without calling this, no blocks
 	 * will be destroyed.
 	 */
-	public function explodeA(bool $canBreakUnbreakableBlocks = false) : bool{
+	public function explodeA(bool $forceToBreakAll = false) : bool{
 		if($this->size < 0.1){
 			return false;
 		}
@@ -130,7 +130,7 @@ class Explosion{
 										$_block = $this->world->getBlockAt($vBlockX, $vBlockY, $vBlockZ, true, false);
 										foreach($_block->getAffectedBlocks() as $_affectedBlock){
 
-											if(!$canBreakUnbreakableBlocks && !$_affectedBlock->getBreakInfo()->isBreakable())
+											if(!$forceToBreakAll && !$_affectedBlock->getBreakInfo()->isBreakable())
 												continue;
 
 											$_affectedBlockPos = $_affectedBlock->getPosition();

--- a/src/world/Explosion.php
+++ b/src/world/Explosion.php
@@ -84,7 +84,7 @@ class Explosion{
 	 * Calculates which blocks will be destroyed by this explosion. If explodeB() is called without calling this, no blocks
 	 * will be destroyed.
 	 */
-	public function explodeA() : bool{
+	public function explodeA(bool $canBreakUnbreakableBlocks = false) : bool{
 		if($this->size < 0.1){
 			return false;
 		}
@@ -129,6 +129,10 @@ class Explosion{
 									if(!isset($this->affectedBlocks[World::blockHash($vBlockX, $vBlockY, $vBlockZ)])){
 										$_block = $this->world->getBlockAt($vBlockX, $vBlockY, $vBlockZ, true, false);
 										foreach($_block->getAffectedBlocks() as $_affectedBlock){
+
+											if(!$canBreakUnbreakableBlocks && !$_affectedBlock->getBreakInfo()->isBreakable())
+												continue;
+
 											$_affectedBlockPos = $_affectedBlock->getPosition();
 											$this->affectedBlocks[World::blockHash($_affectedBlockPos->x, $_affectedBlockPos->y, $_affectedBlockPos->z)] = $_affectedBlock;
 										}

--- a/src/world/Explosion.php
+++ b/src/world/Explosion.php
@@ -130,8 +130,9 @@ class Explosion{
 										$_block = $this->world->getBlockAt($vBlockX, $vBlockY, $vBlockZ, true, false);
 										foreach($_block->getAffectedBlocks() as $_affectedBlock){
 
-											if(!$canBreakAll && !$_affectedBlock->getBreakInfo()->isBreakable())
+											if(!$canBreakAll && !$_affectedBlock->getBreakInfo()->isBreakable()){
 												continue;
+											}
 
 											$_affectedBlockPos = $_affectedBlock->getPosition();
 											$this->affectedBlocks[World::blockHash($_affectedBlockPos->x, $_affectedBlockPos->y, $_affectedBlockPos->z)] = $_affectedBlock;


### PR DESCRIPTION
## Introduction
currently on pocketmine, explosions break unbreakable blocks like bedrock, this pull request allows to solve this problem or to force this breaking of blocks

## Changes
- patch of the bug which allows to break unbreakable blocks
- addition of a condition in the ExplosionPrimeEvent to be able to break the unbreakable blocks (allows to force the explosion)

## Tests
Before:
![before](https://user-images.githubusercontent.com/53645183/177538026-b89b373c-2d00-4705-a7cc-799f4e273b08.png)
After:
![after](https://user-images.githubusercontent.com/53645183/177538086-ba97984a-b2c3-4be0-bb8b-81c18534390a.png)
