### PR TITLE
Fixed unwanted sprinting and sneaking sync.

### DIFF
--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -212,27 +212,22 @@ abstract class Living extends Entity{
 		return $this->sneaking;
 	}
 
-	public function setSneaking(bool $value = true, bool $doSync = true) : void{
+	public function setSneaking(bool $value = true) : void{
 		$this->sneaking = $value;
-		if($doSync){
-			$this->networkPropertiesDirty = true;
-		}
+		$this->networkPropertiesDirty = true;
 	}
 
 	public function isSprinting() : bool{
 		return $this->sprinting;
 	}
 
-	public function setSprinting(bool $value = true, bool $doSync = true) : void{
+	public function setSprinting(bool $value = true) : void{
 		if($value !== $this->isSprinting()){
 			$this->sprinting = $value;
-			// Only do sync if the server wanted to, player's movement speed has already been synced.
-			if($doSync){
-				$this->networkPropertiesDirty = true;
-			}
+			$this->networkPropertiesDirty = true;
 			$moveSpeed = $this->getMovementSpeed();
 			$this->setMovementSpeed($value ? ($moveSpeed * 1.3) : ($moveSpeed / 1.3));
-			$this->moveSpeedAttr->markSynchronized(!$doSync);
+			$this->moveSpeedAttr->markSynchronized(false);
 		}
 	}
 

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -214,7 +214,6 @@ abstract class Living extends Entity{
 
 	public function setSneaking(bool $value = true, bool $doSync = true) : void{
 		$this->sneaking = $value;
-
 		if($doSync){
 			$this->networkPropertiesDirty = true;
 		}
@@ -227,14 +226,12 @@ abstract class Living extends Entity{
 	public function setSprinting(bool $value = true, bool $doSync = true) : void{
 		if($value !== $this->isSprinting()){
 			$this->sprinting = $value;
-			$moveSpeed = $this->getMovementSpeed();
-			$this->setMovementSpeed($value ? ($moveSpeed * 1.3) : ($moveSpeed / 1.3));
-
 			// Only do sync if the server wanted to, player's movement speed has already been synced.
 			if($doSync){
 				$this->networkPropertiesDirty = true;
 			}
-
+			$moveSpeed = $this->getMovementSpeed();
+			$this->setMovementSpeed($value ? ($moveSpeed * 1.3) : ($moveSpeed / 1.3));
 			$this->moveSpeedAttr->markSynchronized(!$doSync);
 		}
 	}

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -217,8 +217,6 @@ abstract class Living extends Entity{
 
 		if($doSync){
 			$this->networkPropertiesDirty = true;
-
-			print "DO SYNC 2" . PHP_EOL;
 		}
 	}
 

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -212,22 +212,32 @@ abstract class Living extends Entity{
 		return $this->sneaking;
 	}
 
-	public function setSneaking(bool $value = true) : void{
+	public function setSneaking(bool $value = true, bool $doSync = true) : void{
 		$this->sneaking = $value;
-		$this->networkPropertiesDirty = true;
+
+		if($doSync){
+			$this->networkPropertiesDirty = true;
+
+			print "DO SYNC 2" . PHP_EOL;
+		}
 	}
 
 	public function isSprinting() : bool{
 		return $this->sprinting;
 	}
 
-	public function setSprinting(bool $value = true) : void{
+	public function setSprinting(bool $value = true, bool $doSync = true) : void{
 		if($value !== $this->isSprinting()){
 			$this->sprinting = $value;
-			$this->networkPropertiesDirty = true;
 			$moveSpeed = $this->getMovementSpeed();
 			$this->setMovementSpeed($value ? ($moveSpeed * 1.3) : ($moveSpeed / 1.3));
-			$this->moveSpeedAttr->markSynchronized(false); //TODO: reevaluate this hack
+
+			// Only do sync if the server wanted to, player's movement speed has already been synced.
+			if($doSync){
+				$this->networkPropertiesDirty = true;
+			}
+
+			$this->moveSpeedAttr->markSynchronized(!$doSync);
 		}
 	}
 

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -210,12 +210,7 @@ class InGamePacketHandler extends PacketHandler{
 		$sprinting = $this->resolveOnOffInputFlags($packet, PlayerAuthInputFlags::START_SPRINTING, PlayerAuthInputFlags::STOP_SPRINTING);
 		$swimming = $this->resolveOnOffInputFlags($packet, PlayerAuthInputFlags::START_SWIMMING, PlayerAuthInputFlags::STOP_SWIMMING);
 		$gliding = $this->resolveOnOffInputFlags($packet, PlayerAuthInputFlags::START_GLIDING, PlayerAuthInputFlags::STOP_GLIDING);
-		$mismatch =
-			($sneaking !== null && !$this->player->toggleSneak($sneaking, false)) |
-			($sprinting !== null && !$this->player->toggleSprint($sprinting, false)) |
-			($swimming !== null && !$this->player->toggleSwim($swimming)) |
-			($gliding !== null && !$this->player->toggleGlide($gliding));
-		if((bool) $mismatch){
+		if(!$this->player->syncPlayerActions($sneaking, $sprinting, $swimming, $gliding)){
 			$this->player->sendData([$this->player]);
 		}
 

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -211,8 +211,8 @@ class InGamePacketHandler extends PacketHandler{
 		$swimming = $this->resolveOnOffInputFlags($packet, PlayerAuthInputFlags::START_SWIMMING, PlayerAuthInputFlags::STOP_SWIMMING);
 		$gliding = $this->resolveOnOffInputFlags($packet, PlayerAuthInputFlags::START_GLIDING, PlayerAuthInputFlags::STOP_GLIDING);
 		$mismatch =
-			($sneaking !== null && !$this->player->toggleSneak($sneaking)) |
-			($sprinting !== null && !$this->player->toggleSprint($sprinting)) |
+			($sneaking !== null && !$this->player->toggleSneak($sneaking, false)) |
+			($sprinting !== null && !$this->player->toggleSprint($sprinting, false)) |
 			($swimming !== null && !$this->player->toggleSwim($swimming)) |
 			($gliding !== null && !$this->player->toggleGlide($gliding));
 		if((bool) $mismatch){

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -2350,6 +2350,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 	 */
 	public function syncPlayerActions(?bool $sneaking, ?bool $sprinting, ?bool $swimming, ?bool $gliding) : bool{
 		$networkPropertiesDirty = $this->networkPropertiesDirty;
+		$isDesynchronized = $this->moveSpeedAttr->isDesynchronized();
 
 		$mismatch =
 			($sneaking !== null && !$this->toggleSneak($sneaking)) |
@@ -2367,7 +2368,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 			// In case the previous network properties was dirty.
 			$this->networkPropertiesDirty = $networkPropertiesDirty;
 
-			if($sprinting !== null){
+			if($sprinting !== null && !$isDesynchronized){
 				// Mark as synchronized, we accept them as-is
 				$this->moveSpeedAttr->markSynchronized();
 			}

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -2363,8 +2363,9 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		}
 
 		// We do not want to do anything with gliding and swimming,
-		// because it is syncing the player own bounding boxes.
-		if($sneaking !== null || $sprinting !== null){
+		// because it is syncing the player own bounding boxes, and if the movement speed is in range of the
+		// default movement speed (0.1 -> 0.13), we accept them as is. (Speed effect is still server-authoritative)
+		if($sneaking !== null || $sprinting !== null && $this->getMovementSpeed() <= 0.13){
 			// In case the previous network properties was dirty.
 			$this->networkPropertiesDirty = $networkPropertiesDirty;
 
@@ -2372,7 +2373,14 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 				// Mark as synchronized, we accept them as-is
 				$this->moveSpeedAttr->markSynchronized();
 			}
+		}else if($sprinting !== null && !$this->moveSpeedAttr->isDesynchronized()){
+			// Re-synchronize the player's speed attribute when we receive any sprint flag, since the player's
+			// sprint -> not-sprint will always set the player's own speed attribute to 0.1, they negate whatever value the
+			// previous attribute is set. (This can be tested when the player has food exhaustion while having speed before).
+			$this->networkPropertiesDirty = true;
+			$this->moveSpeedAttr->markSynchronized(false);
 		}
+
 		return true;
 	}
 

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -2373,7 +2373,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 				// Mark as synchronized, we accept them as-is
 				$this->moveSpeedAttr->markSynchronized();
 			}
-		}else if($sprinting !== null && !$this->moveSpeedAttr->isDesynchronized()){
+		}elseif($sprinting !== null && !$this->moveSpeedAttr->isDesynchronized()){
 			// Re-synchronize the player's speed attribute when we receive any sprint flag, since the player's
 			// sprint -> not-sprint will always set the player's own speed attribute to 0.1, they negate whatever value the
 			// previous attribute is set. (This can be tested when the player has food exhaustion while having speed before).

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1793,7 +1793,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		return false;
 	}
 
-	public function toggleSprint(bool $sprint) : bool{
+	public function toggleSprint(bool $sprint, bool $doSync = true) : bool{
 		if($sprint === $this->sprinting){
 			return true;
 		}
@@ -1802,11 +1802,11 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		if($ev->isCancelled()){
 			return false;
 		}
-		$this->setSprinting($sprint, false);
+		$this->setSprinting($sprint, $doSync);
 		return true;
 	}
 
-	public function toggleSneak(bool $sneak) : bool{
+	public function toggleSneak(bool $sneak, bool $doSync = true) : bool{
 		if($sneak === $this->sneaking){
 			return true;
 		}
@@ -1815,7 +1815,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		if($ev->isCancelled()){
 			return false;
 		}
-		$this->setSneaking($sneak, false);
+		$this->setSneaking($sneak, $doSync);
 		return true;
 	}
 

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1802,7 +1802,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		if($ev->isCancelled()){
 			return false;
 		}
-		$this->setSprinting($sprint);
+		$this->setSprinting($sprint, false);
 		return true;
 	}
 
@@ -1815,7 +1815,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		if($ev->isCancelled()){
 			return false;
 		}
-		$this->setSneaking($sneak);
+		$this->setSneaking($sneak, false);
 		return true;
 	}
 


### PR DESCRIPTION
## Introduction
This issue does not appear when the client latency to the server is low, but it does occur when the player latency to the server is high. The issue is that, the server forces the client to sync the movement speed/sneaking flag relative to the server. This is unnecessary since the client has the appropriate value/flag already set before. 

The problem itself causes unpleasant gameplay and unnecessary changes in momentum towards any players with higher latency. This PR aims to fix the problem.

## Changes
### API changes
* Added `$doSync = true` (By default, it will sync movement speed/sneaking flag) in `Living::setSprinting`, `Living::setSneaking`, `Player::toggleSprint`, and `Player::toggleSneak` however is for internal use only.

### Behavioural changes
It changes how toggling sprint and sneak when the client requested to, it does not change the behavior when the server wants to change the client's sprinting and/or sneaking flag (e.g.: food exhaustion). In other words, sync when necessary.

## Backwards compatibility
The changes should be backwards compatible without any significant changes to the underlying behavior of sprinting and sneaking.

## Tests
You will need this software to simulate lagging behaviour locally: https://github.com/jagt/clumsy

Hint: You need to watch the player's FOV

Before the proposed PR:
<video src='https://user-images.githubusercontent.com/15889642/178040340-612c2994-b39f-417f-93e1-8155e3d96ecb.mp4' />

After:
<video src='https://user-images.githubusercontent.com/15889642/178040399-cee4902e-dca3-4103-be3d-72fe36c2a713.mp4' />

