### PR TITLE
Do not always make the coral dead immediately after placement

### DIFF
--- a/src/block/BaseCoral.php
+++ b/src/block/BaseCoral.php
@@ -59,7 +59,7 @@ abstract class BaseCoral extends Transparent{
 
 	public function isSolid() : bool{ return false; }
 
-	public function isCoveredWithWater() : bool{
+	protected function isCoveredWithWater() : bool{
 		$world = $this->position->getWorld();
 
 		$hasWater = false;

--- a/src/block/BaseCoral.php
+++ b/src/block/BaseCoral.php
@@ -38,20 +38,13 @@ abstract class BaseCoral extends Transparent{
 
 	public function onNearbyBlockChange() : void{
 		if(!$this->dead){
-			$world = $this->position->getWorld();
+			$this->position->getWorld()->scheduleDelayedBlockUpdate($this->position, mt_rand(40, 200));
+		}
+	}
 
-			$hasWater = false;
-			foreach($this->position->sides() as $vector3){
-				if($world->getBlock($vector3) instanceof Water){
-					$hasWater = true;
-					break;
-				}
-			}
-
-			//TODO: check water inside the block itself (not supported on the API yet)
-			if(!$hasWater){
-				$world->setBlock($this->position, $this->setDead(true));
-			}
+	public function onScheduledUpdate() : void{
+		if(!$this->dead && !$this->hasWater()){
+			$this->position->getWorld()->setBlock($this->position, $this->setDead(true));
 		}
 	}
 
@@ -64,6 +57,21 @@ abstract class BaseCoral extends Transparent{
 	}
 
 	public function isSolid() : bool{ return false; }
+
+	public function hasWater() : bool{
+		$world = $this->position->getWorld();
+
+		$hasWater = false;
+		foreach($this->position->sides() as $vector3){
+			if($world->getBlock($vector3) instanceof Water){
+				$hasWater = true;
+				break;
+			}
+		}
+
+		//TODO: check water inside the block itself (not supported on the API yet)
+		return $hasWater;
+	}
 
 	protected function recalculateCollisionBoxes() : array{ return []; }
 

--- a/src/block/BaseCoral.php
+++ b/src/block/BaseCoral.php
@@ -27,6 +27,7 @@ use pocketmine\block\utils\CoralType;
 use pocketmine\block\utils\CoralTypeTrait;
 use pocketmine\block\utils\SupportType;
 use pocketmine\item\Item;
+use function mt_rand;
 
 abstract class BaseCoral extends Transparent{
 	use CoralTypeTrait;

--- a/src/block/BaseCoral.php
+++ b/src/block/BaseCoral.php
@@ -44,7 +44,7 @@ abstract class BaseCoral extends Transparent{
 	}
 
 	public function onScheduledUpdate() : void{
-		if(!$this->dead && !$this->hasWater()){
+		if(!$this->dead && !$this->isCoveredWithWater()){
 			$this->position->getWorld()->setBlock($this->position, $this->setDead(true));
 		}
 	}
@@ -59,7 +59,7 @@ abstract class BaseCoral extends Transparent{
 
 	public function isSolid() : bool{ return false; }
 
-	public function hasWater() : bool{
+	public function isCoveredWithWater() : bool{
 		$world = $this->position->getWorld();
 
 		$hasWater = false;

--- a/src/block/FloorCoralFan.php
+++ b/src/block/FloorCoralFan.php
@@ -74,6 +74,9 @@ final class FloorCoralFan extends BaseCoral{
 				$this->axis = Axis::Z;
 			}
 		}
+
+		$this->dead = !$this->hasWater();
+
 		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
 	}
 

--- a/src/block/FloorCoralFan.php
+++ b/src/block/FloorCoralFan.php
@@ -75,7 +75,7 @@ final class FloorCoralFan extends BaseCoral{
 			}
 		}
 
-		$this->dead = !$this->hasWater();
+		$this->dead = !$this->isCoveredWithWater();
 
 		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
 	}

--- a/src/block/WallCoralFan.php
+++ b/src/block/WallCoralFan.php
@@ -54,7 +54,7 @@ final class WallCoralFan extends BaseCoral{
 		}
 		$this->facing = $face;
 
-		$this->dead = !$this->hasWater();
+		$this->dead = !$this->isCoveredWithWater();
 
 		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
 	}

--- a/src/block/WallCoralFan.php
+++ b/src/block/WallCoralFan.php
@@ -53,6 +53,9 @@ final class WallCoralFan extends BaseCoral{
 			return false;
 		}
 		$this->facing = $face;
+
+		$this->dead = !$this->hasWater();
+
 		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
 	}
 


### PR DESCRIPTION
## Introduction
At the moment, after placing the coral, it will immediately turn out to be dead. This does not match the behavior in a single player game. This PR corrects this by making the behavior of corals the same as that of coral blocks.

## Changes
### API changes
The hasWater function has been added to the BaseCoral class, which checks for the existence of water around the coral.

### Behavioural changes
The coral will die only after some time out of the water. The exceptions are the coral wall and the coral floor, which die immediately.

## Backwards compatibility
No BC break

## Tests
https://youtu.be/anggFHTXkfE