### PR TITLE
Entity: Fixed some properties were not saved and loaded from NBT

### DIFF
--- a/src/entity/Entity.php
+++ b/src/entity/Entity.php
@@ -494,6 +494,11 @@ abstract class Entity{
 		$nbt->setFloat("FallDistance", $this->fallDistance);
 		$nbt->setShort("Fire", $this->fireTicks);
 		$nbt->setByte("OnGround", $this->onGround ? 1 : 0);
+		$nbt->setFloat("Scale", $this->scale);
+		$nbt->setByte("Immobile", $this->immobile ? 1 : 0);
+		$nbt->setByte("Invisible", $this->invisible ? 1 : 0);
+		$nbt->setByte("Silent", $this->silent ? 1 : 0);
+		$nbt->setByte("CanClimb", $this->canClimb ? 1 : 0);
 
 		return $nbt;
 	}
@@ -504,6 +509,12 @@ abstract class Entity{
 		$this->onGround = $nbt->getByte("OnGround", 0) !== 0;
 
 		$this->fallDistance = $nbt->getFloat("FallDistance", 0.0);
+
+		$this->setScale($nbt->getFloat("Scale", 1));
+		$this->setImmobile($nbt->getByte("Immobile", 0) !== 0);
+		$this->setInvisible($nbt->getByte("Invisible", 0) !== 0);
+		$this->setSilent($nbt->getByte("Silent", 0) !== 0);
+		$this->setCanClimb($nbt->getByte("CanClimb", 0) !== 0);
 
 		if(($customNameTag = $nbt->getTag("CustomName")) instanceof StringTag){
 			$this->setNameTag($customNameTag->getValue());


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Fixed some missing properties in Entity::saveNBT() and Entity::initEntity().

[Original Issue from Discord](https://discord.com/channels/373199722573201408/373199722573201410/995853360257319042)
### Relevant issues
N/A

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
N/A

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
N/A

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
N/A

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
N/A

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
