### PR TITLE
Correct knockback from explosions

### DIFF
--- a/src/world/Explosion.php
+++ b/src/world/Explosion.php
@@ -195,7 +195,7 @@ class Explosion{
 				}
 
 				$entity->attack($ev);
-				$entity->addMotion($motion->multiply($impact));
+				$entity->addMotion($motion->x * $impact, $motion->y * $impact, $motion->z * $impact);
 			}
 		}
 

--- a/src/world/Explosion.php
+++ b/src/world/Explosion.php
@@ -195,7 +195,7 @@ class Explosion{
 				}
 
 				$entity->attack($ev);
-				$entity->addMotion($motion->x * $impact, $motion->y * $impact, $motion->z * $impact);
+				$entity->setMotion($entity->getMotion()->addVector($motion->multiply($impact)));
 			}
 		}
 

--- a/src/world/Explosion.php
+++ b/src/world/Explosion.php
@@ -195,7 +195,7 @@ class Explosion{
 				}
 
 				$entity->attack($ev);
-				$entity->setMotion($motion->multiply($impact));
+				$entity->addMotion($motion->multiply($impact));
 			}
 		}
 


### PR DESCRIPTION
## Introduction
According to the tests in Vanilla, motion is added to the entity's motion, allowing features such as TNT cannons.


### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
Explosion knockback has changed

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
N/A
