### PR TITLE
 Lava burns entities for only 8 seconds

### DIFF
--- a/src/block/Lava.php
+++ b/src/block/Lava.php
@@ -94,7 +94,8 @@ class Lava extends Liquid{
 		$ev = new EntityDamageByBlockEvent($this, $entity, EntityDamageEvent::CAUSE_LAVA, 4);
 		$entity->attack($ev);
 
-		$ev = new EntityCombustByBlockEvent($this, $entity, 15);
+		//in java burns entities for 15 seconds - seems to be a parity issue in bedrock
+		$ev = new EntityCombustByBlockEvent($this, $entity, 8);
 		$ev->call();
 		if(!$ev->isCancelled()){
 			$entity->setOnFire($ev->getDuration());


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Set the time that entities are burned by lava according to vanilla bedrock.

### Relevant issues

* Fixes #5172

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
Lava burns entities for less time
