### PR TITLE
Fixed Bamboo being not placeable on blocks it should be

### DIFF
--- a/src/block/Bamboo.php
+++ b/src/block/Bamboo.php
@@ -124,8 +124,11 @@ class Bamboo extends Transparent{
 	}
 
 	private function canBeSupportedBy(Block $block) : bool{
-		// TODO: Gravel
-		return $block->hasTypeTag(BlockTypeTags::DIRT) || $block->hasTypeTag(BlockTypeTags::MUD) || $block->hasTypeTag(BlockTypeTags::SAND);
+		return
+			$block->getTypeId() === BlockTypeIds::GRAVEL ||
+			$block->hasTypeTag(BlockTypeTags::DIRT) ||
+			$block->hasTypeTag(BlockTypeTags::MUD) ||
+			$block->hasTypeTag(BlockTypeTags::SAND);
 	}
 
 	private function seekToTop() : Bamboo{

--- a/src/block/Bamboo.php
+++ b/src/block/Bamboo.php
@@ -124,7 +124,8 @@ class Bamboo extends Transparent{
 	}
 
 	private function canBeSupportedBy(Block $block) : bool{
-		return $block->hasTypeTag(BlockTypeTags::DIRT) || $block->hasTypeTag(BlockTypeTags::MUD);
+		// TODO: Gravel
+		return $block->hasTypeTag(BlockTypeTags::DIRT) || $block->hasTypeTag(BlockTypeTags::MUD) || $block->hasTypeTag(BlockTypeTags::SAND);
 	}
 
 	private function seekToTop() : Bamboo{

--- a/src/block/BambooSapling.php
+++ b/src/block/BambooSapling.php
@@ -52,7 +52,8 @@ final class BambooSapling extends Flowable{
 	}
 
 	private function canBeSupportedBy(Block $block) : bool{
-		return $block->hasTypeTag(BlockTypeTags::DIRT) || $block->hasTypeTag(BlockTypeTags::MUD);
+		// TODO: Gravel
+		return $block->hasTypeTag(BlockTypeTags::DIRT) || $block->hasTypeTag(BlockTypeTags::MUD) || $block->hasTypeTag(BlockTypeTags::SAND);
 	}
 
 	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{

--- a/src/block/BambooSapling.php
+++ b/src/block/BambooSapling.php
@@ -52,8 +52,11 @@ final class BambooSapling extends Flowable{
 	}
 
 	private function canBeSupportedBy(Block $block) : bool{
-		// TODO: Gravel
-		return $block->hasTypeTag(BlockTypeTags::DIRT) || $block->hasTypeTag(BlockTypeTags::MUD) || $block->hasTypeTag(BlockTypeTags::SAND);
+		return
+			$block->getTypeId() === BlockTypeIds::GRAVEL ||
+			$block->hasTypeTag(BlockTypeTags::DIRT) ||
+			$block->hasTypeTag(BlockTypeTags::MUD) ||
+			$block->hasTypeTag(BlockTypeTags::SAND);
 	}
 
 	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{


### PR DESCRIPTION
## Introduction
Due to https://github.com/pmmp/PocketMine-MP/commit/d9b050fb688155ec962f574388eb48342fc8f9d1, Bamboo can no longer be placed on `sand` and `gravel` blocks.

### Relevant issues
\---

## Changes
### API changes
\---

### Behavioural changes
\---

## Backwards compatibility
\---

## Follow-up
After a `gravel` tag is added, the `Bamboo` and `BambooSapling` classes need to be updated, so their `canBeSupportedBy()` method checks for that tag.

## Tests
-> Bamboo can now be placed on blocks with the `sand` tag.