### PR TITLE
Made TallGrass placeable again

### DIFF
--- a/src/block/TallGrass.php
+++ b/src/block/TallGrass.php
@@ -48,7 +48,7 @@ class TallGrass extends Flowable{
 
 	public function onNearbyBlockChange() : void{
 		$down = $this->getSide(Facing::DOWN);
-		if($down->hasTypeTag(BlockTypeTags::DIRT) || $down->hasTypeTag(BlockTypeTags::MUD)){ //Replace with common break method
+		if(!$down->hasTypeTag(BlockTypeTags::DIRT) && !$down->hasTypeTag(BlockTypeTags::MUD)){ //Replace with common break method
 			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}

--- a/src/block/TallGrass.php
+++ b/src/block/TallGrass.php
@@ -37,9 +37,12 @@ class TallGrass extends Flowable{
 		return true;
 	}
 
+	private function canBeSupportedBy(Block $block) : bool{
+		return $block->hasTypeTag(BlockTypeTags::DIRT) || $block->hasTypeTag(BlockTypeTags::MUD);
+	}
+
 	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		$down = $this->getSide(Facing::DOWN);
-		if($down->hasTypeTag(BlockTypeTags::DIRT) || $down->hasTypeTag(BlockTypeTags::MUD)){
+		if($this->canBeSupportedBy($this->getSide(Facing::DOWN))){
 			return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
 		}
 
@@ -47,8 +50,7 @@ class TallGrass extends Flowable{
 	}
 
 	public function onNearbyBlockChange() : void{
-		$down = $this->getSide(Facing::DOWN);
-		if(!$down->hasTypeTag(BlockTypeTags::DIRT) && !$down->hasTypeTag(BlockTypeTags::MUD)){ //Replace with common break method
+		if(!$this->canBeSupportedBy($this->getSide(Facing::DOWN))){ //Replace with common break method
 			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}


### PR DESCRIPTION
## Introduction
Due to https://github.com/pmmp/PocketMine-MP/commit/d9b050fb688155ec962f574388eb48342fc8f9d1, `TallGrass` got accidentally made unplaceable since immediately after it getting placed, the neighbour block update called on that block will break it.

### Relevant issues
\---

## Changes
### API changes
\---

### Behavioural changes
\---

## Backwards compatibility
\---

## Follow-up
\---

## Tests
TallGrass won't immediately break after it gets placed. (Also fixes using bone meal on grass blocks not spawning `TallGrass` blocks, as they immediately break.)