### PR TITLE
BlockFormEvent: Added getCausingBlock() method

### DIFF
--- a/src/block/ConcretePowder.php
+++ b/src/block/ConcretePowder.php
@@ -42,8 +42,8 @@ class ConcretePowder extends Opaque implements Fallable{
 	}
 
 	public function onNearbyBlockChange() : void{
-		if(($block = $this->checkAdjacentWater()) !== null){
-			$ev = new BlockFormEvent($this, $block);
+		if(($water = $this->getAdjacentWater()) !== null){
+			$ev = new BlockFormEvent($this, VanillaBlocks::CONCRETE()->setColor($this->color), $water);
 			$ev->call();
 			if(!$ev->isCancelled()){
 				$this->position->getWorld()->setBlock($this->position, $ev->getNewState());
@@ -54,16 +54,20 @@ class ConcretePowder extends Opaque implements Fallable{
 	}
 
 	public function tickFalling() : ?Block{
-		return $this->checkAdjacentWater();
+		if ($this->getAdjacentWater() === null) {
+			return null;
+		}
+		return VanillaBlocks::CONCRETE()->setColor($this->color);
 	}
 
-	private function checkAdjacentWater() : ?Block{
+	private function getAdjacentWater() : ?Water{
 		foreach(Facing::ALL as $i){
 			if($i === Facing::DOWN){
 				continue;
 			}
-			if($this->getSide($i) instanceof Water){
-				return VanillaBlocks::CONCRETE()->setColor($this->color);
+			$block = $this->getSide($i);
+			if($block instanceof Water){
+				return $block;
 			}
 		}
 

--- a/src/block/Liquid.php
+++ b/src/block/Liquid.php
@@ -366,7 +366,7 @@ abstract class Liquid extends Transparent{
 	}
 
 	protected function liquidCollide(Block $cause, Block $result) : bool{
-		$ev = new BlockFormEvent($this, $result);
+		$ev = new BlockFormEvent($this, $result, $cause);
 		$ev->call();
 		if(!$ev->isCancelled()){
 			$world = $this->position->getWorld();

--- a/src/event/block/BlockFormEvent.php
+++ b/src/event/block/BlockFormEvent.php
@@ -23,10 +23,26 @@ declare(strict_types=1);
 
 namespace pocketmine\event\block;
 
+use pocketmine\block\Block;
+
 /**
  * Called when a new block forms, usually as the result of some action.
  * This could be things like obsidian forming due to collision of lava and water.
  */
 class BlockFormEvent extends BaseBlockChangeEvent{
 
+	public function __construct(
+		Block $block,
+		Block $newState,
+		private Block $causingBlock
+	){
+		parent::__construct($block, $newState);
+	}
+
+	/**
+	 * Returns the block which caused the target block to form into a new state.
+	 */
+	public function getCausingBlock() : Block{
+		return $this->causingBlock;
+	}
 }


### PR DESCRIPTION
## Introduction
Fixes the later-mentioned issue and allows plugins to get the block, which caused a block to form into a new state, e.g. lava to obsidian or concrete powder to concrete.

### Relevant issues
* Fixes #5171 

## Changes
### API changes
- Through the new `getCausingBlock()` method within the `BlockFormEvent`, it is now possible to get the block which caused the target block to form into a new state.

### Behavioural changes
\---

## Backwards compatibility
This PR is not backwards compatible as it adds a third required parameter to the [`BlockFormEvent`'s constructor](https://github.com/ColinHDev/PocketMine-MP/blob/37724dbf85ecba030bdf67e284d0d922eaf2d8b9/src/event/block/BlockFormEvent.php#L37).

## Follow-up
\---

## Tests
```php
	public function onBlockForm(BlockFormEvent $event) : void{
		var_dump($event->getCausingBlock()->getName());
	}
```
Outputs e.g. `string(5) "Water"` when lava and water collide and form obsidian.