### PR TITLE
Fixed languages-not-found bug

### DIFF
--- a/src/lang/Language.php
+++ b/src/lang/Language.php
@@ -68,13 +68,13 @@ class Language{
 				$result = [];
 
 				foreach($files as $file){
-					try {
+					try{
 						$code = explode(".", $file)[0];
 						$strings = self::loadLang($path, $code);
 						if(isset($strings["language.name"])){
 							$result[$code] = $strings["language.name"];
 						}
-					} catch (LanguageNotFoundException $e) {
+					}catch(LanguageNotFoundException $e){
 						// no-op
 					}
 				}

--- a/src/lang/Language.php
+++ b/src/lang/Language.php
@@ -68,10 +68,14 @@ class Language{
 				$result = [];
 
 				foreach($files as $file){
-					$code = explode(".", $file)[0];
-					$strings = self::loadLang($path, $code);
-					if(isset($strings["language.name"])){
-						$result[$code] = $strings["language.name"];
+					try {
+						$code = explode(".", $file)[0];
+						$strings = self::loadLang($path, $code);
+						if(isset($strings["language.name"])){
+							$result[$code] = $strings["language.name"];
+						}
+					} catch (LanguageNotFoundException $e) {
+						// no-op
 					}
 				}
 


### PR DESCRIPTION
## Introduction
The commit b7a15b6e012ced87a4ca8ea976aa53802f1a17ed introduced a subtle bug where any empty file caused Language::getLanguageList() to exit with an exception. SetupWizard later catches the exception and falsly determines that no languages exist.

### Relevant issues
<!-- List relevant issues here -->
* Fixes #5271 
<!--

* Fixes #1
* Fixes #2

-->

## Changes
This PR only modifies Language::getLanguageList() so that the function properly catches an exception from Language::loadLang() when a language file is empty. This will not have any BC breaking changes.