### PR TITLE
CraftingDataCache: Fix Cartography's recipe block name

### DIFF
--- a/src/network/mcpe/cache/CraftingDataCache.php
+++ b/src/network/mcpe/cache/CraftingDataCache.php
@@ -87,7 +87,7 @@ final class CraftingDataCache{
 				$typeTag = match($recipe->getType()->id()){
 					ShapelessRecipeType::CRAFTING()->id() => CraftingRecipeBlockName::CRAFTING_TABLE,
 					ShapelessRecipeType::STONECUTTER()->id() => CraftingRecipeBlockName::STONECUTTER,
-					ShapelessRecipeType::CARTOGRAPHY()->id() => CraftingRecipeBlockName::SMITHING_TABLE,
+					ShapelessRecipeType::CARTOGRAPHY()->id() => CraftingRecipeBlockName::CARTOGRAPHY_TABLE,
 					ShapelessRecipeType::SMITHING()->id() => CraftingRecipeBlockName::SMITHING_TABLE,
 					default => throw new AssumptionFailedError("Unreachable"),
 				};


### PR DESCRIPTION
## Introduction
Fix block name in Cartography recipes sent over the network