### PR TITLE
Take Health boost health

### DIFF
--- a/src/entity/effect/HealthBoostEffect.php
+++ b/src/entity/effect/HealthBoostEffect.php
@@ -33,7 +33,6 @@ class HealthBoostEffect extends Effect{
 
 	public function remove(Living $entity, EffectInstance $instance) : void{
 		$entity->setMaxHealth($entity->getMaxHealth() - 4 * $instance->getEffectLevel());
-		
 		if($entity->getHealth() > $entity->getMaxHealth()){
 			$entity->setHealth($entity->getMaxHealth());
 		}

--- a/src/entity/effect/HealthBoostEffect.php
+++ b/src/entity/effect/HealthBoostEffect.php
@@ -33,5 +33,9 @@ class HealthBoostEffect extends Effect{
 
 	public function remove(Living $entity, EffectInstance $instance) : void{
 		$entity->setMaxHealth($entity->getMaxHealth() - 4 * $instance->getEffectLevel());
+		
+		if($entity->getHealth() > $entity->getMaxHealth()){
+			$entity->setHealth($entity->getMaxHealth());
+		}
 	}
 }


### PR DESCRIPTION
Remove extra health given by health boost when removing the effect

## Introduction
When removing Health Boost it doesn't take your extra health it just sets your max health leaving you with some extra health

### Behavioural changes
Now health Boost takes the extra health from you