### PR TITLE
ConsoleCommandSender is no longer responsible for forwarding broadcas…

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -93,6 +93,7 @@ use pocketmine\timings\Timings;
 use pocketmine\timings\TimingsHandler;
 use pocketmine\updater\UpdateChecker;
 use pocketmine\utils\AssumptionFailedError;
+use pocketmine\utils\BroadcastLoggerForwarder;
 use pocketmine\utils\Config;
 use pocketmine\utils\Filesystem;
 use pocketmine\utils\Internet;
@@ -1044,11 +1045,11 @@ class Server{
 			$this->logger->info($this->getLanguage()->translate(KnownTranslationFactory::pocketmine_server_donate(TextFormat::AQUA . "https://patreon.com/pocketminemp" . TextFormat::RESET)));
 			$this->logger->info($this->getLanguage()->translate(KnownTranslationFactory::pocketmine_server_startFinished(strval(round(microtime(true) - $this->startTime, 3)))));
 
-			//TODO: move console parts to a separate component
-			$consoleSender = new ConsoleCommandSender($this, $this->language);
-			$this->subscribeToBroadcastChannel(self::BROADCAST_CHANNEL_ADMINISTRATIVE, $consoleSender);
-			$this->subscribeToBroadcastChannel(self::BROADCAST_CHANNEL_USERS, $consoleSender);
+			$forwarder = new BroadcastLoggerForwarder($this, $this->logger, $this->language);
+			$this->subscribeToBroadcastChannel(self::BROADCAST_CHANNEL_ADMINISTRATIVE, $forwarder);
+			$this->subscribeToBroadcastChannel(self::BROADCAST_CHANNEL_USERS, $forwarder);
 
+			//TODO: move console parts to a separate component
 			if($this->configGroup->getPropertyBool("console.enable-input", true)){
 				$this->console = new ConsoleReaderChildProcessDaemon($this->logger);
 			}

--- a/src/command/Command.php
+++ b/src/command/Command.php
@@ -34,6 +34,7 @@ use pocketmine\permission\PermissionManager;
 use pocketmine\Server;
 use pocketmine\timings\Timings;
 use pocketmine\timings\TimingsHandler;
+use pocketmine\utils\BroadcastLoggerForwarder;
 use pocketmine\utils\TextFormat;
 use function explode;
 use function str_replace;
@@ -232,7 +233,7 @@ abstract class Command{
 		}
 
 		foreach($users as $user){
-			if($user instanceof ConsoleCommandSender){
+			if($user instanceof BroadcastLoggerForwarder){
 				$user->sendMessage($result);
 			}elseif($user !== $source){
 				$user->sendMessage($colored);

--- a/src/utils/BroadcastLoggerForwarder.php
+++ b/src/utils/BroadcastLoggerForwarder.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\utils;
+
+use pocketmine\command\CommandSender;
+use pocketmine\lang\Language;
+use pocketmine\lang\Translatable;
+use pocketmine\permission\PermissibleBase;
+use pocketmine\permission\PermissibleDelegateTrait;
+use pocketmine\Server;
+
+/**
+ * Forwards any messages it receives via sendMessage() to the given logger. Used for forwarding chat messages and
+ * command audit log messages to the server log file.
+ *
+ * Unfortunately, broadcast subscribers are currently required to implement CommandSender, so this class has to include
+ * a lot of useless methods.
+ */
+final class BroadcastLoggerForwarder implements CommandSender{
+	use PermissibleDelegateTrait;
+
+	public function __construct(
+		private Server $server, //annoying useless dependency
+		private \Logger $logger,
+		private Language $language
+	){
+		//this doesn't need any permissions
+		$this->perm = new PermissibleBase([]);
+	}
+
+	public function getLanguage() : Language{
+		return $this->language;
+	}
+
+	public function sendMessage(Translatable|string $message) : void{
+		if($message instanceof Translatable){
+			$this->logger->info($this->language->translate($message));
+		}else{
+			$this->logger->info($message);
+		}
+	}
+
+	public function getServer() : Server{
+		return $this->server;
+	}
+
+	public function getName() : string{
+		return "Broadcast Logger Forwarder";
+	}
+
+	public function getScreenLineHeight() : int{
+		return PHP_INT_MAX;
+	}
+
+	public function setScreenLineHeight(?int $height) : void{
+		//NOOP
+	}
+}


### PR DESCRIPTION
…t messages to the logger

This is a step towards implementing #2543.

## Introduction
Currently there's no way to differentiate between command output messages and actual log messages, either from a code perspective or a human perspective.

Ideally, we don't want console command outputs to be logged at all, only the audit messages (e.g. time changed, etc). The server.log file shouldn't be filled with random lines of output from the /help command.

One obstacle to fixing this problem is that ConsoleCommandSender->sendMessage() is indirectly used for two distinct purposes:
1) Emitting command output (which probably shouldn't be in the log file)
2) Emitting audit broadcast messages, which definitely _should_ be in the log file.

This PR fixes this problem by moving the responsibility for 2) to a new `BroadcastLoggerForwarder`, whose sole purpose is to relay those broadcast messages to `MainLogger->info()`. This reduces code spaghetti and also gets one step closer to modularizing the interactive terminal components.

Unfortunately, subscribing to a message broadcast channel right now requires a `CommandSender` implementation, so I had to implement a lot of useless crap to get it done.

### Relevant issues
#2543
#3046

## Changes
### API changes
- `utils\BroadcastLoggerForwarder` is introduced, but it's not expected that plugins will interact with it in any way.

### Behavioural changes
None currently. The server should behave exactly as before.

## Backwards compatibility
This PR is fully backwards compatible.

## Tests
This has been tested using audit log messages and in-game chat messages to verify the correct behaviour.

## Follow-up
- `ConsoleCommandSender->sendMessage()` should be updated to use `Terminal::writeLine()` directly, rather than using `Logger->info()`, since only command outputs will be generated there.
- Refactor the API of broadcast channels to allow a more generic `BroadcastReceiver` or similar, to reduce the useless code involved with making a change like this.