### PR TITLE
Spectating players no longer break blocks

### DIFF
--- a/src/network/mcpe/convert/TypeConverter.php
+++ b/src/network/mcpe/convert/TypeConverter.php
@@ -82,10 +82,11 @@ class TypeConverter{
 			case GameMode::SURVIVAL()->id():
 				return ProtocolGameMode::SURVIVAL;
 			case GameMode::CREATIVE()->id():
-			case GameMode::SPECTATOR()->id():
 				return ProtocolGameMode::CREATIVE;
 			case GameMode::ADVENTURE()->id():
 				return ProtocolGameMode::ADVENTURE;
+			case GameMode::SPECTATOR()->id():
+				return ProtocolGameMode::CREATIVE_VIEWER;
 			default:
 				throw new AssumptionFailedError("Unknown game mode");
 		}


### PR DESCRIPTION
## Introduction
Players can no longer break blocks on the client side while spectating.

### Relevant issues
* Fixes #3636

## Changes
### API changes
N/A

### Behavioural changes
The server now sends game mode `CREATIVE_VIEWER` instead of `CREATIVE` for the spectator.

## Backwards compatibility
It does not break backward compatibility.

## Tests
