### PR TITLE
Entity: Fire EntitySpawnEvent/ItemSpawnEvent on the first entity tick…

### DIFF
--- a/src/entity/Entity.php
+++ b/src/entity/Entity.php
@@ -249,10 +249,8 @@ abstract class Entity{
 		$this->getWorld()->addEntity($this);
 
 		$this->lastUpdate = $this->server->getTick();
-		(new EntitySpawnEvent($this))->call();
 
 		$this->scheduleUpdate();
-
 	}
 
 	abstract protected function getInitialSizeInfo() : EntitySizeInfo;
@@ -937,6 +935,14 @@ abstract class Entity{
 		return (new Vector2(-cos(deg2rad($this->location->yaw) - M_PI_2), -sin(deg2rad($this->location->yaw) - M_PI_2)))->normalize();
 	}
 
+	/**
+	 * Called from onUpdate() on the first tick of a new entity. This is called before any movement processing or
+	 * main ticking logic. Use this to fire any events related to spawning the entity.
+	 */
+	protected function onFirstUpdate(int $currentTick) : void{
+		(new EntitySpawnEvent($this))->call();
+	}
+
 	public function onUpdate(int $currentTick) : bool{
 		if($this->closed){
 			return false;
@@ -952,6 +958,10 @@ abstract class Entity{
 		}
 
 		$this->lastUpdate = $currentTick;
+
+		if($this->justCreated){
+			$this->onFirstUpdate($currentTick);
+		}
 
 		if(!$this->isAlive()){
 			if($this->onDeathUpdate($tickDiff)){

--- a/src/entity/object/ItemEntity.php
+++ b/src/entity/object/ItemEntity.php
@@ -92,8 +92,11 @@ class ItemEntity extends Entity{
 		$this->pickupDelay = $nbt->getShort("PickupDelay", $this->pickupDelay);
 		$this->owner = $nbt->getString("Owner", $this->owner);
 		$this->thrower = $nbt->getString("Thrower", $this->thrower);
+	}
 
-		(new ItemSpawnEvent($this))->call();
+	protected function onFirstUpdate(int $currentTick) : void{
+		(new ItemSpawnEvent($this))->call(); //this must be called before EntitySpawnEvent, to maintain backwards compatibility
+		parent::onFirstUpdate($currentTick);
 	}
 
 	protected function entityBaseTick(int $tickDiff = 1) : bool{

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1343,6 +1343,10 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 
 		$this->lastUpdate = $currentTick;
 
+		if($this->justCreated){
+			$this->onFirstUpdate($currentTick);
+		}
+
 		if(!$this->isAlive() && $this->spawned){
 			$this->onDeathUpdate($tickDiff);
 			return true;


### PR DESCRIPTION
…, instead of in the constructor

## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

This allows plugins to modify the entity via setters in EntitySpawnEvent without their changes getting overwritten by setter calls directly after the 'new YourEntity' statement.

As well as benefiting plugins, this also clears a path for a BC-breaking change in PM5 (to have the programmer use addEntity() to spawn entities, instead of the constructor doing it, which will improve on a number of data handling aspects).

fixes #4973

**Note: At the time of writing, it's not clear if this will have side effects. To the best of my ability to determine, it should not, but I can't be 100% sure.**

### Relevant issues
Fixes #4973

## Changes
### API changes
- The following new API methods have been added:
  - `protected Entity->onFirstUpdate(int $currentTick) : void`

### Behavioural changes
This should not affect behaviour in any way, other than fixing the problem seen in #4973. However, this targets `next-minor` out of an abundance of caution.

## Backwards compatibility
No known issues.

## Tests
Not yet tested.