### PR TITLE
SplashPotion: Use `getCollidingEntities()` for effect propagation

### DIFF
--- a/src/entity/projectile/SplashPotion.php
+++ b/src/entity/projectile/SplashPotion.php
@@ -98,8 +98,8 @@ class SplashPotion extends Throwable{
 
 		if($hasEffects){
 			if(!$this->willLinger()){
-				foreach($this->getWorld()->getNearbyEntities($this->boundingBox->expandedCopy(4.125, 2.125, 4.125), $this) as $entity){
-					if($entity instanceof Living && $entity->isAlive()){
+				foreach($this->getWorld()->getCollidingEntities($this->boundingBox->expandedCopy(4.125, 2.125, 4.125), $this) as $entity){
+					if($entity instanceof Living){
 						$distanceSquared = $entity->getEyePos()->distanceSquared($this->location);
 						if($distanceSquared > 16){ //4 blocks
 							continue;


### PR DESCRIPTION
## Introduction
Due to it currently uses `getNearbyEntities` erroneously, the effects is applied to entities that it should not such as spectators, also `isAlive()` is removed because `getCollidingEntities` already checks it.