### PR TITLE
FallingBlock: Remove erroneous documentation

### DIFF
--- a/src/entity/object/FallingBlock.php
+++ b/src/entity/object/FallingBlock.php
@@ -117,7 +117,6 @@ class FallingBlock extends Entity{
 
 				$block = $world->getBlock($pos);
 				if(!$block->canBeReplaced() || !$world->isInWorld($pos->getFloorX(), $pos->getFloorY(), $pos->getFloorZ()) || ($this->onGround && abs($this->location->y - $this->location->getFloorY()) > 0.001)){
-					//FIXME: anvils are supposed to destroy torches
 					$world->dropItem($this->location, $this->block->asItem());
 				}else{
 					$ev = new EntityBlockChangeEvent($this, $block, $blockTarget ?? $this->block);


### PR DESCRIPTION
## Introduction
Added on 5c8297f4a16e0c25a5d12ec8e76e451dc4673875 and last edited on 92281da5147e068c667c75aebf903ad854413b37, I don't know if it was correct when it was added but while working with falling anvils for another PR I noticed that this documentation is erroneous and has remained so for years.

## Tests
Vanilla faliing anvil:
https://media.discordapp.net/attachments/373199722573201410/1031057946718765097/SVID_20221015_230101_1.mp4
