### PR TITLE
Clean Falling blocks by moving `tickFalling()` default implementation to `FallableTrait`

### DIFF
--- a/src/block/Anvil.php
+++ b/src/block/Anvil.php
@@ -95,8 +95,4 @@ class Anvil extends Transparent implements Fallable{
 		}
 		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
 	}
-
-	public function tickFalling() : ?Block{
-		return null;
-	}
 }

--- a/src/block/DragonEgg.php
+++ b/src/block/DragonEgg.php
@@ -44,10 +44,6 @@ class DragonEgg extends Transparent implements Fallable{
 		return 1;
 	}
 
-	public function tickFalling() : ?Block{
-		return null;
-	}
-
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null, array &$returnedItems = []) : bool{
 		$this->teleport();
 		return true;

--- a/src/block/Gravel.php
+++ b/src/block/Gravel.php
@@ -45,8 +45,4 @@ class Gravel extends Opaque implements Fallable{
 	public function isAffectedBySilkTouch() : bool{
 		return true;
 	}
-
-	public function tickFalling() : ?Block{
-		return null;
-	}
 }

--- a/src/block/Sand.php
+++ b/src/block/Sand.php
@@ -28,8 +28,4 @@ use pocketmine\block\utils\FallableTrait;
 
 class Sand extends Opaque implements Fallable{
 	use FallableTrait;
-
-	public function tickFalling() : ?Block{
-		return null;
-	}
 }

--- a/src/block/SnowLayer.php
+++ b/src/block/SnowLayer.php
@@ -116,10 +116,6 @@ class SnowLayer extends Flowable implements Fallable{
 		}
 	}
 
-	public function tickFalling() : ?Block{
-		return null;
-	}
-
 	public function getDropsForCompatibleTool(Item $item) : array{
 		return [
 			VanillaItems::SNOWBALL()->setCount(max(1, (int) floor($this->layers / 2)))

--- a/src/block/utils/FallableTrait.php
+++ b/src/block/utils/FallableTrait.php
@@ -54,4 +54,8 @@ trait FallableTrait{
 			$fall->spawnToAll();
 		}
 	}
+
+	public function tickFalling() : ?Block{
+		return null;
+	}
 }


### PR DESCRIPTION
## Introduction
Due to it is only used in `ConcretePowder` it does not make sense to force other classes to implement `tickFalling()`.

## Backwards compatibility
In theory this does not contain BC Break.