### PR TITLE
Ignore Spam PlayerAuthInputPacket while Waiting for Spawn Response

### DIFF
--- a/src/network/mcpe/handler/SpawnResponsePacketHandler.php
+++ b/src/network/mcpe/handler/SpawnResponsePacketHandler.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\network\mcpe\handler;
 
+use pocketmine\network\mcpe\protocol\PlayerAuthInputPacket;
 use pocketmine\network\mcpe\protocol\SetLocalPlayerAsInitializedPacket;
 
 final class SpawnResponsePacketHandler extends PacketHandler{
@@ -33,6 +34,12 @@ final class SpawnResponsePacketHandler extends PacketHandler{
 
 	public function handleSetLocalPlayerAsInitialized(SetLocalPlayerAsInitializedPacket $packet) : bool{
 		($this->responseCallback)();
+		return true;
+	}
+
+	public function handlePlayerAuthInput(PlayerAuthInputPacket $packet) : bool{
+		//the client will send this every tick once we start sending chunks, but we don't handle it in this stage
+		//this is very spammy so we filter it out
 		return true;
 	}
 }


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

While attempting to debug a player login issue with the new protocol I noticed the console log was so ridiculously full of `Unhandled PlayerAuthInputPacket`s that it was rather difficult to find the information I wanted to see. This PR silences the spam. 

## Changes

`Unhandled PlayerAuthInputPackets` will no longer flood the debug log during the "waiting for spawn response" phase.

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->

A log of before and after the change have been attached for reference.
[Before.txt](https://github.com/pmmp/PocketMine-MP/files/9885885/Before.txt)
[After.txt](https://github.com/pmmp/PocketMine-MP/files/9885886/After.txt)
