### PR TITLE
Allow customizing socket instantiation

### DIFF
--- a/src/network/mcpe/raklib/RakLibServer.php
+++ b/src/network/mcpe/raklib/RakLibServer.php
@@ -49,13 +49,22 @@ class RakLibServer extends Thread{
 		protected \ThreadedLogger $logger,
 		protected \Threaded $mainToThreadBuffer,
 		protected \Threaded $threadToMainBuffer,
-		protected InternetAddress $address,
+		protected SocketFactory $socketFactory,
 		protected int $serverId,
 		protected int $maxMtuSize,
 		protected int $protocolVersion,
 		protected SleeperNotifier $mainThreadNotifier
 	){
 		$this->mainPath = \pocketmine\PATH;
+	}
+
+	/**
+	 * Sets the socket factory.
+	 *
+	 * This method must be called before the thread is started.
+	 */
+	public function setSocketFactory(SocketFactory $socketFactory) : void{
+		$this->socketFactory = $socketFactory;
 	}
 
 	/**
@@ -110,7 +119,7 @@ class RakLibServer extends Thread{
 			register_shutdown_function([$this, "shutdownHandler"]);
 
 			try{
-				$socket = new Socket($this->address);
+				$socket = $this->socketFactory->build();
 			}catch(SocketException $e){
 				$this->setCrashInfo(RakLibThreadCrashInfo::fromThrowable($e));
 				return;

--- a/src/network/mcpe/raklib/SocketFactory.php
+++ b/src/network/mcpe/raklib/SocketFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\network\mcpe\raklib;
+
+use raklib\generic\Socket;
+
+/**
+ * Allows instantiating a socket used in RakLib thread.
+ *
+ * Implementors must be serializable to send across threads.
+ */
+interface SocketFactory{
+	/**
+	 * Creates an instance of the Socket.
+	 */
+	public function build() : Socket;
+}


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

Allows plugins handling `NetworkInterfaceRegisterEvent` to change the way the RakLib `Socket` is constructed. This allows implementing features like #5372.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

- `RakLibServer` constructor signature changed to accept a `SocketFactory` instead of an `InternetAddress`.
- Expose methods to set the socket factory before the RakLib thread starts.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

No direct changes without plugins calling the new APIs.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

- `RakLibServer` constructor parameter type changed.

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
N/A