### PR TITLE
Fixed totem activating when having 1HP instead of 0HP

### DIFF
--- a/src/entity/Human.php
+++ b/src/entity/Human.php
@@ -356,7 +356,7 @@ class Human extends Living implements ProjectileSource, InventoryHolder{
 			&& ($this->inventory->getItemInHand() instanceof Totem || $this->offHandInventory->getItem(0) instanceof Totem)){
 
 			$compensation = $this->getHealth() - $source->getFinalDamage() - 1;
-			if($compensation < 0){
+			if($compensation <= -1){
 				$source->setModifier($compensation, EntityDamageEvent::MODIFIER_TOTEM);
 			}
 		}
@@ -365,7 +365,7 @@ class Human extends Living implements ProjectileSource, InventoryHolder{
 	protected function applyPostDamageEffects(EntityDamageEvent $source) : void{
 		parent::applyPostDamageEffects($source);
 		$totemModifier = $source->getModifier(EntityDamageEvent::MODIFIER_TOTEM);
-		if($totemModifier < 0){ //Totem prevented death
+		if($totemModifier <= -1){ //Totem prevented death
 			$this->effectManager->clear();
 
 			$this->effectManager->add(new EffectInstance(VanillaEffects::REGENERATION(), 40 * 20, 1));

--- a/src/entity/Human.php
+++ b/src/entity/Human.php
@@ -365,7 +365,7 @@ class Human extends Living implements ProjectileSource, InventoryHolder{
 	protected function applyPostDamageEffects(EntityDamageEvent $source) : void{
 		parent::applyPostDamageEffects($source);
 		$totemModifier = $source->getModifier(EntityDamageEvent::MODIFIER_TOTEM);
-		if($totemModifier <= -1){ //Totem prevented death
+		if($totemModifier < 0){ //Totem prevented death
 			$this->effectManager->clear();
 
 			$this->effectManager->add(new EffectInstance(VanillaEffects::REGENERATION(), 40 * 20, 1));


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
In a vanilla server/world (BDS) when you are less than or equal to half of a heart (1HP) the totem doesn't activate, only when reaching 0HP. This has been tested with full diamond armor, being half of a heart using poison and being attacked by a silverfish.

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Expected Behavior: https://3v4l.org/SKi83
Actual Behavior: https://3v4l.org/fT4v0