### PR TITLE
Implement a `Living::getDisplayName()`

### DIFF
--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -184,6 +184,13 @@ abstract class Living extends Entity{
 		$this->attributeMap->add($this->absorptionAttr = AttributeFactory::getInstance()->mustGet(Attribute::ABSORPTION));
 	}
 
+	/**
+	 * Returns the display name of this entity to use in stuff like death messages.
+	 */
+	public function getDisplayName() : string{
+		return $this->nameTag !== "" ? $this->nameTag : $this->getName();
+	}
+
 	public function setHealth(float $amount) : void{
 		$wasAlive = $this->isAlive();
 		parent::setHealth($amount);

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -185,7 +185,7 @@ abstract class Living extends Entity{
 	}
 
 	/**
-	 * Returns the display name of this entity to use in stuff like death messages.
+	 * Returns the name used to describe this entity in chat and command outputs.
 	 */
 	public function getDisplayName() : string{
 		return $this->nameTag !== "" ? $this->nameTag : $this->getName();

--- a/src/event/player/PlayerDeathEvent.php
+++ b/src/event/player/PlayerDeathEvent.php
@@ -98,17 +98,15 @@ class PlayerDeathEvent extends EntityDeathEvent{
 					if($e instanceof Player){
 						return KnownTranslationFactory::death_attack_player($name, $e->getDisplayName());
 					}elseif($e instanceof Living){
-						return KnownTranslationFactory::death_attack_mob($name, $e->getNameTag() !== "" ? $e->getNameTag() : $e->getName());
+						return KnownTranslationFactory::death_attack_mob($name, $e->getDisplayName());
 					}
 				}
 				break;
 			case EntityDamageEvent::CAUSE_PROJECTILE:
 				if($deathCause instanceof EntityDamageByEntityEvent){
 					$e = $deathCause->getDamager();
-					if($e instanceof Player){
+					if($e instanceof Living){
 						return KnownTranslationFactory::death_attack_arrow($name, $e->getDisplayName());
-					}elseif($e instanceof Living){
-						return KnownTranslationFactory::death_attack_arrow($name, $e->getNameTag() !== "" ? $e->getNameTag() : $e->getName());
 					}
 				}
 				break;
@@ -149,10 +147,8 @@ class PlayerDeathEvent extends EntityDeathEvent{
 			case EntityDamageEvent::CAUSE_ENTITY_EXPLOSION:
 				if($deathCause instanceof EntityDamageByEntityEvent){
 					$e = $deathCause->getDamager();
-					if($e instanceof Player){
+					if($e instanceof Living){
 						return KnownTranslationFactory::death_attack_explosion_player($name, $e->getDisplayName());
-					}elseif($e instanceof Living){
-						return KnownTranslationFactory::death_attack_explosion_player($name, $e->getNameTag() !== "" ? $e->getNameTag() : $e->getName());
 					}
 				}
 				return KnownTranslationFactory::death_attack_explosion($name);


### PR DESCRIPTION
## Introduction
While working on another PR I realized that the code to get the death message was really a mess,` if-elseif` and `ternary operators`, all over the place to get only the name of the entity to be displayed. Without a method like this, when adding more specific translations it really becomes hell.

## Changes
### API changes
The following api method has been added:
- `Living::getDisplayName() : string`