### PR TITLE
BaseInventory: Validate given array to make sure correct items are given.

### DIFF
--- a/src/inventory/BaseInventory.php
+++ b/src/inventory/BaseInventory.php
@@ -27,6 +27,7 @@ use pocketmine\item\Item;
 use pocketmine\item\VanillaItems;
 use pocketmine\player\Player;
 use pocketmine\utils\ObjectSet;
+use pocketmine\utils\Utils;
 use function array_slice;
 use function count;
 use function max;
@@ -85,6 +86,7 @@ abstract class BaseInventory implements Inventory{
 	 * @phpstan-param array<int, Item> $items
 	 */
 	public function setContents(array $items) : void{
+		Utils::validateArrayValueType($items, function(Item $item) : void{});
 		if(count($items) > $this->getSize()){
 			$items = array_slice($items, 0, $this->getSize(), true);
 		}


### PR DESCRIPTION
## Introduction
`BaseInventory::setContents()` does not validate the given array, so when the server crashes due to an invalid array given, developers may hard to find what went wrong.

### Relevant issues
N/A

## Changes
### API changes

### Behavioural changes

## Backwards compatibility

## Follow-up

## Tests
