### PR TITLE
Correct calculation for non-arrow projectiles

### DIFF
--- a/src/entity/projectile/Arrow.php
+++ b/src/entity/projectile/Arrow.php
@@ -38,6 +38,7 @@ use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataCollection;
 use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataFlags;
 use pocketmine\player\Player;
 use pocketmine\world\sound\ArrowHitSound;
+use function ceil;
 use function mt_rand;
 use function sqrt;
 
@@ -103,7 +104,7 @@ class Arrow extends Projectile{
 	}
 
 	public function getResultDamage() : int{
-		$base = parent::getResultDamage();
+		$base = (int) ceil($this->motion->length() * parent::getResultDamage());
 		if($this->isCritical()){
 			return ($base + mt_rand(0, (int) ($base / 2) + 1));
 		}else{

--- a/src/entity/projectile/Projectile.php
+++ b/src/entity/projectile/Projectile.php
@@ -128,7 +128,7 @@ abstract class Projectile extends Entity{
 	 * Returns the amount of damage this projectile will deal to the entity it hits.
 	 */
 	public function getResultDamage() : int{
-		return (int) ceil($this->motion->length() * $this->damage);
+		return (int) ceil($this->damage);
 	}
 
 	public function saveNBT() : CompoundTag{


### PR DESCRIPTION
## Introduction
Non-arrow projectiles now deals the correct damage

### Relevant issues
* Fixes #5393 

