### PR TITLE
Added keep on death methods for items

### DIFF
--- a/src/entity/Human.php
+++ b/src/entity/Human.php
@@ -391,7 +391,7 @@ class Human extends Living implements ProjectileSource, InventoryHolder{
 			$this->inventory !== null ? array_values($this->inventory->getContents()) : [],
 			$this->armorInventory !== null ? array_values($this->armorInventory->getContents()) : [],
 			$this->offHandInventory !== null ? array_values($this->offHandInventory->getContents()) : [],
-		), function(Item $item) : bool{ return !$item->hasEnchantment(VanillaEnchantments::VANISHING()); });
+		), function(Item $item) : bool{ return !$item->hasEnchantment(VanillaEnchantments::VANISHING()) && !$item->keepOnDeath(); });
 	}
 
 	public function saveNBT() : CompoundTag{

--- a/src/item/Item.php
+++ b/src/item/Item.php
@@ -226,6 +226,9 @@ class Item implements \JsonSerializable{
 		}
 	}
 
+	/**
+	 * Returns whether players will retain this item on death. If a non-player dies it will be excluded from the drops.
+	 */
 	public function keepOnDeath() : bool{
 		return $this->keepOnDeath;
 	}

--- a/src/item/Item.php
+++ b/src/item/Item.php
@@ -65,6 +65,8 @@ class Item implements \JsonSerializable{
 	public const TAG_DISPLAY_NAME = "Name";
 	public const TAG_DISPLAY_LORE = "Lore";
 
+	public const TAG_KEEP_ON_DEATH = "minecraft:keep_on_death";
+
 	private ItemIdentifier $identifier;
 	private CompoundTag $nbt;
 
@@ -95,6 +97,8 @@ class Item implements \JsonSerializable{
 	 * @phpstan-var array<string, string>
 	 */
 	protected $canDestroy;
+
+	protected bool $keepOnDeath = false;
 
 	/**
 	 * Constructs a new Item type. This constructor should ONLY be used when constructing a new item TYPE to register
@@ -222,6 +226,14 @@ class Item implements \JsonSerializable{
 		}
 	}
 
+	public function keepOnDeath() : bool{
+		return $this->keepOnDeath;
+	}
+
+	public function setKeepOnDeath(bool $keepOnDeath) : void{
+		$this->keepOnDeath = $keepOnDeath;
+	}
+
 	/**
 	 * Returns whether this Item has a non-empty NBT.
 	 */
@@ -320,6 +332,8 @@ class Item implements \JsonSerializable{
 				$this->canDestroy[$entry->getValue()] = $entry->getValue();
 			}
 		}
+
+		$this->keepOnDeath = $tag->getByte(self::TAG_KEEP_ON_DEATH, 0) !== 0;
 	}
 
 	protected function serializeCompoundTag(CompoundTag $tag) : void{
@@ -376,6 +390,12 @@ class Item implements \JsonSerializable{
 			$tag->setTag("CanDestroy", $canDestroy);
 		}else{
 			$tag->removeTag("CanDestroy");
+		}
+
+		if($this->keepOnDeath){
+			$tag->setByte(self::TAG_KEEP_ON_DEATH, 1);
+		}else{
+			$tag->removeTag(self::TAG_KEEP_ON_DEATH);
 		}
 	}
 

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -2257,13 +2257,13 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 
 			if($this->inventory !== null){
 				$this->inventory->setHeldItemIndex(0);
-				$this->inventory->clearAll();
+				$this->inventory->setContents(array_filter($this->inventory->getContents(), fn(Item $item) => $item->keepOnDeath()));
 			}
 			if($this->armorInventory !== null){
-				$this->armorInventory->clearAll();
+				$this->armorInventory->setContents(array_filter($this->armorInventory->getContents(), fn(Item $item) => $item->keepOnDeath()));
 			}
 			if($this->offHandInventory !== null){
-				$this->offHandInventory->clearAll();
+				$this->offHandInventory->setContents(array_filter($this->offHandInventory->getContents(), fn(Item $item) => $item->keepOnDeath()));
 			}
 		}
 

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -2256,15 +2256,16 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 				$this->getWorld()->dropItem($this->location, $item);
 			}
 
+			$keepOnDeathItemsForInventory = fn(Inventory $inventory) => $inventory->setContents(array_filter($inventory->getContents(), fn(Item $item) => $item->keepOnDeath()));
 			if($this->inventory !== null){
 				$this->inventory->setHeldItemIndex(0);
-				$this->inventory->setContents(array_filter($this->inventory->getContents(), fn(Item $item) => $item->keepOnDeath()));
+				$keepOnDeathItemsForInventory($this->inventory);
 			}
 			if($this->armorInventory !== null){
-				$this->armorInventory->setContents(array_filter($this->armorInventory->getContents(), fn(Item $item) => $item->keepOnDeath()));
+				$keepOnDeathItemsForInventory($this->armorInventory);
 			}
 			if($this->offHandInventory !== null){
-				$this->offHandInventory->setContents(array_filter($this->offHandInventory->getContents(), fn(Item $item) => $item->keepOnDeath()));
+				$keepOnDeathItemsForInventory($this->offHandInventory);
 			}
 		}
 

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -2256,16 +2256,16 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 				$this->getWorld()->dropItem($this->location, $item);
 			}
 
-			$keepOnDeathItemsForInventory = fn(Inventory $inventory) => $inventory->setContents(array_filter($inventory->getContents(), fn(Item $item) => $item->keepOnDeath()));
+			$clearInventory = fn(Inventory $inventory) => $inventory->setContents(array_filter($inventory->getContents(), fn(Item $item) => $item->keepOnDeath()));
 			if($this->inventory !== null){
 				$this->inventory->setHeldItemIndex(0);
-				$keepOnDeathItemsForInventory($this->inventory);
+				$clearInventory($this->inventory);
 			}
 			if($this->armorInventory !== null){
-				$keepOnDeathItemsForInventory($this->armorInventory);
+				$clearInventory($this->armorInventory);
 			}
 			if($this->offHandInventory !== null){
-				$keepOnDeathItemsForInventory($this->offHandInventory);
+				$clearInventory($this->offHandInventory);
 			}
 		}
 

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -131,6 +131,7 @@ use pocketmine\world\sound\Sound;
 use pocketmine\world\World;
 use Ramsey\Uuid\UuidInterface;
 use function abs;
+use function array_filter;
 use function array_map;
 use function assert;
 use function count;


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
We need something that can keep the items of a player into their inventory when they die, for example an ability plugin. This pull request will add methods to allow plugins keep items on death and makes use of the vanilla component `minecraft:keep_on_death`.
## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
- `Item->keepOnDeath()`
- `Item->setKeepOnDeath()`
## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
https://user-images.githubusercontent.com/58715544/200150544-35dd71b8-0c9d-4129-8559-96c98a6c5e28.mp4