### PR TITLE
Add darkness effect

### DIFF
--- a/src/data/bedrock/EffectIdMap.php
+++ b/src/data/bedrock/EffectIdMap.php
@@ -74,6 +74,7 @@ final class EffectIdMap{
 		//TODO: SLOW_FALLING
 		//TODO: BAD_OMEN
 		//TODO: VILLAGE_HERO
+		$this->register(EffectIds::DARKNESS, VanillaEffects::DARKNESS());
 	}
 
 	//TODO: not a big fan of the code duplication here :(

--- a/src/data/bedrock/EffectIds.php
+++ b/src/data/bedrock/EffectIds.php
@@ -58,4 +58,5 @@ final class EffectIds{
 	public const SLOW_FALLING = 27;
 	public const BAD_OMEN = 28;
 	public const VILLAGE_HERO = 29;
+	public const DARKNESS = 30;
 }

--- a/src/entity/effect/StringToEffectParser.php
+++ b/src/entity/effect/StringToEffectParser.php
@@ -40,6 +40,7 @@ final class StringToEffectParser extends StringToTParser{
 		$result->register("absorption", fn() => VanillaEffects::ABSORPTION());
 		$result->register("blindness", fn() => VanillaEffects::BLINDNESS());
 		$result->register("conduit_power", fn() => VanillaEffects::CONDUIT_POWER());
+		$result->register("darkness", fn() => VanillaEffects::DARKNESS());
 		$result->register("fatal_poison", fn() => VanillaEffects::FATAL_POISON());
 		$result->register("fire_resistance", fn() => VanillaEffects::FIRE_RESISTANCE());
 		$result->register("haste", fn() => VanillaEffects::HASTE());

--- a/src/entity/effect/VanillaEffects.php
+++ b/src/entity/effect/VanillaEffects.php
@@ -69,7 +69,7 @@ final class VanillaEffects{
 		//TODO: bad_omen
 		self::register("blindness", new Effect(KnownTranslationFactory::potion_blindness(), new Color(0x1f, 0x1f, 0x23), true));
 		self::register("conduit_power", new Effect(KnownTranslationFactory::potion_conduitPower(), new Color(0x1d, 0xc2, 0xd1)));
-		self::register("darkness", new Effect("%potion.darkness", new Color(0x29, 0x27, 0x21), true));
+		self::register("darkness", new Effect(KnownTranslationFactory::effect_darkness(), new Color(0x29, 0x27, 0x21), true));
 		self::register("fatal_poison", new PoisonEffect(KnownTranslationFactory::potion_poison(), new Color(0x4e, 0x93, 0x31), true, 600, true, true));
 		self::register("fire_resistance", new Effect(KnownTranslationFactory::potion_fireResistance(), new Color(0xe4, 0x9a, 0x3a)));
 		self::register("haste", new Effect(KnownTranslationFactory::potion_digSpeed(), new Color(0xd9, 0xc0, 0x43)));

--- a/src/entity/effect/VanillaEffects.php
+++ b/src/entity/effect/VanillaEffects.php
@@ -36,6 +36,7 @@ use pocketmine\utils\RegistryTrait;
  * @method static AbsorptionEffect ABSORPTION()
  * @method static Effect BLINDNESS()
  * @method static Effect CONDUIT_POWER()
+ * @method static Effect DARKNESS()
  * @method static PoisonEffect FATAL_POISON()
  * @method static Effect FIRE_RESISTANCE()
  * @method static Effect HASTE()
@@ -68,6 +69,7 @@ final class VanillaEffects{
 		//TODO: bad_omen
 		self::register("blindness", new Effect(KnownTranslationFactory::potion_blindness(), new Color(0x1f, 0x1f, 0x23), true));
 		self::register("conduit_power", new Effect(KnownTranslationFactory::potion_conduitPower(), new Color(0x1d, 0xc2, 0xd1)));
+		self::register("darkness", new Effect("potion.darkness", new Color(0x29, 0x27, 0x21), true));
 		self::register("fatal_poison", new PoisonEffect(KnownTranslationFactory::potion_poison(), new Color(0x4e, 0x93, 0x31), true, 600, true, true));
 		self::register("fire_resistance", new Effect(KnownTranslationFactory::potion_fireResistance(), new Color(0xe4, 0x9a, 0x3a)));
 		self::register("haste", new Effect(KnownTranslationFactory::potion_digSpeed(), new Color(0xd9, 0xc0, 0x43)));

--- a/src/entity/effect/VanillaEffects.php
+++ b/src/entity/effect/VanillaEffects.php
@@ -69,7 +69,7 @@ final class VanillaEffects{
 		//TODO: bad_omen
 		self::register("blindness", new Effect(KnownTranslationFactory::potion_blindness(), new Color(0x1f, 0x1f, 0x23), true));
 		self::register("conduit_power", new Effect(KnownTranslationFactory::potion_conduitPower(), new Color(0x1d, 0xc2, 0xd1)));
-		self::register("darkness", new Effect(KnownTranslationFactory::effect_darkness(), new Color(0x29, 0x27, 0x21), true, false));
+		self::register("darkness", new Effect(KnownTranslationFactory::effect_darkness(), new Color(0x29, 0x27, 0x21), true, 600, false));
 		self::register("fatal_poison", new PoisonEffect(KnownTranslationFactory::potion_poison(), new Color(0x4e, 0x93, 0x31), true, 600, true, true));
 		self::register("fire_resistance", new Effect(KnownTranslationFactory::potion_fireResistance(), new Color(0xe4, 0x9a, 0x3a)));
 		self::register("haste", new Effect(KnownTranslationFactory::potion_digSpeed(), new Color(0xd9, 0xc0, 0x43)));

--- a/src/entity/effect/VanillaEffects.php
+++ b/src/entity/effect/VanillaEffects.php
@@ -69,7 +69,7 @@ final class VanillaEffects{
 		//TODO: bad_omen
 		self::register("blindness", new Effect(KnownTranslationFactory::potion_blindness(), new Color(0x1f, 0x1f, 0x23), true));
 		self::register("conduit_power", new Effect(KnownTranslationFactory::potion_conduitPower(), new Color(0x1d, 0xc2, 0xd1)));
-		self::register("darkness", new Effect("potion.darkness", new Color(0x29, 0x27, 0x21), true));
+		self::register("darkness", new Effect("%potion.darkness", new Color(0x29, 0x27, 0x21), true));
 		self::register("fatal_poison", new PoisonEffect(KnownTranslationFactory::potion_poison(), new Color(0x4e, 0x93, 0x31), true, 600, true, true));
 		self::register("fire_resistance", new Effect(KnownTranslationFactory::potion_fireResistance(), new Color(0xe4, 0x9a, 0x3a)));
 		self::register("haste", new Effect(KnownTranslationFactory::potion_digSpeed(), new Color(0xd9, 0xc0, 0x43)));

--- a/src/entity/effect/VanillaEffects.php
+++ b/src/entity/effect/VanillaEffects.php
@@ -69,7 +69,7 @@ final class VanillaEffects{
 		//TODO: bad_omen
 		self::register("blindness", new Effect(KnownTranslationFactory::potion_blindness(), new Color(0x1f, 0x1f, 0x23), true));
 		self::register("conduit_power", new Effect(KnownTranslationFactory::potion_conduitPower(), new Color(0x1d, 0xc2, 0xd1)));
-		self::register("darkness", new Effect(KnownTranslationFactory::effect_darkness(), new Color(0x29, 0x27, 0x21), true));
+		self::register("darkness", new Effect(KnownTranslationFactory::effect_darkness(), new Color(0x29, 0x27, 0x21), true, false));
 		self::register("fatal_poison", new PoisonEffect(KnownTranslationFactory::potion_poison(), new Color(0x4e, 0x93, 0x31), true, 600, true, true));
 		self::register("fire_resistance", new Effect(KnownTranslationFactory::potion_fireResistance(), new Color(0xe4, 0x9a, 0x3a)));
 		self::register("haste", new Effect(KnownTranslationFactory::potion_digSpeed(), new Color(0xd9, 0xc0, 0x43)));


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Minecraft has added the Darkness effect since 1.19 but it hasn't been implemented here yet. This pull request finally adds it.

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
- Added `VanillaEffects::DARKNESS()`

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `potion.darkness` | `Darkness` |

And then change `%potion.darkness` to `KnownTranslationFactory::potion_darkness()`.

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->

https://user-images.githubusercontent.com/58715544/200695141-6f4c6891-b5fe-42e7-b5ad-c0c9d9d09cbd.mp4

