### PR TITLE
Added the swift sneak enchantment

### DIFF
--- a/src/data/bedrock/EnchantmentIdMap.php
+++ b/src/data/bedrock/EnchantmentIdMap.php
@@ -73,6 +73,8 @@ final class EnchantmentIdMap{
 		$this->register(EnchantmentIds::MENDING, VanillaEnchantments::MENDING());
 
 		$this->register(EnchantmentIds::VANISHING, VanillaEnchantments::VANISHING());
+
+		$this->register(EnchantmentIds::SWIFT_SNEAK, VanillaEnchantments::SWIFT_SNEAK());
 	}
 
 	public function register(int $mcpeId, Enchantment $enchantment) : void{

--- a/src/data/bedrock/EnchantmentIds.php
+++ b/src/data/bedrock/EnchantmentIds.php
@@ -66,4 +66,5 @@ final class EnchantmentIds{
 	public const PIERCING = 34;
 	public const QUICK_CHARGE = 35;
 	public const SOUL_SPEED = 36;
+	public const SWIFT_SNEAK = 37;
 }

--- a/src/item/enchantment/StringToEnchantmentParser.php
+++ b/src/item/enchantment/StringToEnchantmentParser.php
@@ -53,6 +53,7 @@ final class StringToEnchantmentParser extends StringToTParser{
 		$result->register("respiration", fn() => VanillaEnchantments::RESPIRATION());
 		$result->register("sharpness", fn() => VanillaEnchantments::SHARPNESS());
 		$result->register("silk_touch", fn() => VanillaEnchantments::SILK_TOUCH());
+		$result->register("swift_sneak", fn() => VanillaEnchantments::SWIFT_SNEAK());
 		$result->register("thorns", fn() => VanillaEnchantments::THORNS());
 		$result->register("unbreaking", fn() => VanillaEnchantments::UNBREAKING());
 		$result->register("vanishing", fn() => VanillaEnchantments::VANISHING());

--- a/src/item/enchantment/VanillaEnchantments.php
+++ b/src/item/enchantment/VanillaEnchantments.php
@@ -49,6 +49,7 @@ use pocketmine\utils\RegistryTrait;
  * @method static Enchantment RESPIRATION()
  * @method static SharpnessEnchantment SHARPNESS()
  * @method static Enchantment SILK_TOUCH()
+ * @method static Enchantment SWIFT_SNEAK()
  * @method static Enchantment THORNS()
  * @method static Enchantment UNBREAKING()
  * @method static Enchantment VANISHING()
@@ -95,6 +96,8 @@ final class VanillaEnchantments{
 		self::register("MENDING", new Enchantment(KnownTranslationFactory::enchantment_mending(), Rarity::RARE, ItemFlags::NONE, ItemFlags::ALL, 1));
 
 		self::register("VANISHING", new Enchantment(KnownTranslationFactory::enchantment_curse_vanishing(), Rarity::MYTHIC, ItemFlags::NONE, ItemFlags::ALL, 1));
+
+		self::register("SWIFT_SNEAK", new Enchantment(KnownTranslationFactory::enchantment_swift_sneak(), Rarity::MYTHIC, ItemFlags::NONE, ItemFlags::LEGS, 3));
 	}
 
 	protected static function register(string $name, Enchantment $member) : void{


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Minecraft has added the Swift Sneak enchantment since 1.19 but it hasn't been implemented here yet. This pull request finally adds it.
### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
* Closes #5301 
## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
* Added `VanillaEnchantments::SWIFT_SNEAK()`
## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `enchantment.swift_sneak` | `Swift Sneak` |

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->

https://user-images.githubusercontent.com/58715544/201193643-1f273f79-17e7-424d-b815-1929dd452114.mp4

