### PR TITLE
Cleans the string containing '&'

### DIFF
--- a/src/utils/TextFormat.php
+++ b/src/utils/TextFormat.php
@@ -144,7 +144,7 @@ abstract class TextFormat{
 		$string = mb_scrub($string, 'UTF-8');
 		$string = self::preg_replace("/[\x{E000}-\x{F8FF}]/u", "", $string); //remove unicode private-use-area characters (they might break the console)
 		if($removeFormat){
-			$string = str_replace(TextFormat::ESCAPE, "", self::preg_replace("/" . TextFormat::ESCAPE . "[0-9a-gk-or]/u", "", $string));
+			$string = str_replace([TextFormat::ESCAPE, "\x26"], "", self::preg_replace("/" . TextFormat::ESCAPE . "[0-9a-gk-or]/u", "", $string));
 		}
 		return str_replace("\x1b", "", self::preg_replace("/\x1b[\\(\\][[0-9;\\[\\(]+[Bm]/u", "", $string));
 	}


### PR DESCRIPTION
### The string containing '&' is cleaned since this and '§' are the most used characters
