### PR TITLE
Implemented method `onInteractEntity`

### DIFF
--- a/src/item/Item.php
+++ b/src/item/Item.php
@@ -555,7 +555,7 @@ class Item implements \JsonSerializable{
 	}
 
 	/**
-	 * Called when a player uses the item to interact with entity, for example by placing a name tag.
+	 * Called when a player uses the item to interact with entity, for example by using a name tag.
 	 */
 	public function onInteractEntity(Player $player, Entity $entity, Vector3 $directionVector) : bool{
 		return false;

--- a/src/item/Item.php
+++ b/src/item/Item.php
@@ -555,6 +555,13 @@ class Item implements \JsonSerializable{
 	}
 
 	/**
+	 * Called when a player uses the item to interact with entity, for example by placing a name tag.
+	 */
+	public function onInteractEntity(Player $player, Entity $entity, Vector3 $directionVector) : bool{
+		return false;
+	}
+
+	/**
 	 * Returns the number of ticks a player must wait before activating this item again.
 	 */
 	public function getCooldownTicks() : int{

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1814,7 +1814,10 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 
 		$ev->call();
 
+		$item = $this->inventory->getItemInHand();
 		if(!$ev->isCancelled()){
+			$item->interactEntity($this, $entity, $clickPos);
+
 			return $entity->onInteract($this, $clickPos);
 		}
 		return false;

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1815,9 +1815,16 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		$ev->call();
 
 		$item = $this->inventory->getItemInHand();
+		$oldItem = clone $item;
 		if(!$ev->isCancelled()){
-			$item->onInteractEntity($this, $entity, $clickPos);
-
+			if($item->onInteractEntity($this, $entity, $clickPos)){
+				if($this->hasFiniteResources() && !$item->equalsExact($oldItem) && $oldItem->equalsExact($this->inventory->getItemInHand())){
+					if($item instanceof Durable && $item->isBroken()){
+						$this->broadcastSound(new ItemBreakSound());
+					}
+					$this->inventory->setItemInHand($item);
+				}
+			}
 			return $entity->onInteract($this, $clickPos);
 		}
 		return false;

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1816,7 +1816,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 
 		$item = $this->inventory->getItemInHand();
 		if(!$ev->isCancelled()){
-			$item->interactEntity($this, $entity, $clickPos);
+			$item->onInteractEntity($this, $entity, $clickPos);
 
 			return $entity->onInteract($this, $clickPos);
 		}


### PR DESCRIPTION
## Introduction
This is related to the issue: https://github.com/pmmp/PocketMine-MP/issues/5431

It should be added as I mentioned, because currently there is no method for this, there is `onAttackEntity` but for this it is necessary to attack the entity, but `onInteractEntity` is called when the player does the interaction with `right-click`. In theory `onInteractEntity` should be called if the event is not cancelled, otherwise it would be pointless.

I think the `bool` return value is unnecessary, but I don't want to break the aesthetics of everything else.