### PR TITLE
Rename `ExplosionPrimeEvent` to `EntityPreExplodeEvent`

### DIFF
--- a/src/entity/object/PrimedTNT.php
+++ b/src/entity/object/PrimedTNT.php
@@ -27,7 +27,7 @@ use pocketmine\entity\Entity;
 use pocketmine\entity\EntitySizeInfo;
 use pocketmine\entity\Explosive;
 use pocketmine\event\entity\EntityDamageEvent;
-use pocketmine\event\entity\ExplosionPrimeEvent;
+use pocketmine\event\entity\EntityPreExplodeEvent;
 use pocketmine\math\Vector3;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\network\mcpe\protocol\types\entity\EntityIds;
@@ -113,7 +113,7 @@ class PrimedTNT extends Entity implements Explosive{
 	}
 
 	public function explode() : void{
-		$ev = new ExplosionPrimeEvent($this, 4);
+		$ev = new EntityPreExplodeEvent($this, 4);
 		$ev->call();
 		if(!$ev->isCancelled()){
 			//TODO: deal with underwater TNT (underwater TNT treats water as if it has a blast resistance of 0)

--- a/src/event/entity/EntityExplodeEvent.php
+++ b/src/event/entity/EntityExplodeEvent.php
@@ -34,7 +34,7 @@ use pocketmine\world\Position;
  * Called when an entity explodes, after the explosion's impact has been calculated.
  * No changes have been made to the world at this stage.
  *
- * @see ExplosionPrimeEvent
+ * @see EntityPreExplodeEvent
  *
  * @phpstan-extends EntityEvent<Entity>
  */

--- a/src/event/entity/EntityPreExplodeEvent.php
+++ b/src/event/entity/EntityPreExplodeEvent.php
@@ -35,7 +35,7 @@ use pocketmine\event\CancellableTrait;
  *
  * @phpstan-extends EntityEvent<Entity>
  */
-class ExplosionPrimeEvent extends EntityEvent implements Cancellable{
+class EntityPreExplodeEvent extends EntityEvent implements Cancellable{
 	use CancellableTrait;
 
 	private bool $blockBreaking = true;


### PR DESCRIPTION
## Introduction

### Relevant issues

#5060 

## Changes
### API changes

### Behavioural changes

## Backwards compatibility

## Follow-up

## Tests
