### PR TITLE
Fix Durable not being broken

### DIFF
--- a/src/item/Durable.php
+++ b/src/item/Durable.php
@@ -121,7 +121,7 @@ abstract class Durable extends Item{
 	 * Returns whether the item is broken.
 	 */
 	public function isBroken() : bool{
-		return $this->damage >= $this->getMaxDurability();
+		return $this->damage >= $this->getMaxDurability() || $this->isNull();
 	}
 
 	protected function deserializeCompoundTag(CompoundTag $tag) : void{


### PR DESCRIPTION
## Introduction
The `isBroken()` function of the `Durable` class is only looking at the item damage. Since `4.10.1`, `isBroken()` isn't working properly because the damage property is set to 0 in `onBroken()`. 

The function now looks at the damage but also the count of the item using `isNull()`.


### Relevant issues
This is related to [#5378](https://github.com/pmmp/PocketMine-MP/issues/5378) and [this commit](https://github.com/pmmp/PocketMine-MP/commit/fe982c697bec3265c4222b73fe5ed17c9ef3b1ce)

## Changes
### API changes
- None

### Behavioural changes
- Updated the return condition of the `isBroken()` function

## Backwards compatibility
- None

## Follow-up
- None

## Tests
I used this code to test the change. Results are below
```php
$item = VanillaItems::DIAMOND_SWORD();
$item->setDamage(1561);

var_dump($item->getDamage());

$item->applyDamage(1);

var_dump($item->getDamage(), $item->isBroken());
```

- 4.10.0
```php
int(1561)
int(1562)
bool(true) <-
```

- 4.11.0
```php
int(1561)
int(0)
bool(false) <-
```

- 4.11.1 (PR)
```php
int(1561)
int(0)
bool(true) <-
```
