### PR TITLE
Allow players to place ItemFrames up and down

### DIFF
--- a/src/block/ItemFrame.php
+++ b/src/block/ItemFrame.php
@@ -175,7 +175,7 @@ class ItemFrame extends Flowable{
 	}
 
 	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		if($face === Facing::DOWN || $face === Facing::UP || !$blockClicked->isSolid()){
+		if(!$blockClicked->isSolid()){
 			return false;
 		}
 


### PR DESCRIPTION
## Introduction
Players can't place ItemFrames at the top or the ground because the UP and DOWN facing is blocked by pmmp. This PR allows players to place ItemFrames at the top and the ground

## Changes
### API changes
None

### Behavioural changes
Players can place ItemFrames with the facing UP and DOWN.

## Backwards compatibility
If a server owner downgrades his server there will be problems with the facing of item frames with the facing UP and DOWN.