### PR TITLE
Added `Server::broadcastToastNotification()`

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -1332,6 +1332,23 @@ class Server{
 
 		return count($recipients);
 	}
+	
+	/**
+     * Broadcasts a toast-notification (message in the top of the screen).
+     *
+	 * @param string $title
+	 * @param string $body
+	 * @param CommandSender[]|null $recipients
+	 */
+	public function broadcastToastNotification(string $title, string $body, ?array $recipients = null) : int{
+		$recipients = $recipients ?? $this->getPlayerBroadcastSubscribers(self::BROADCAST_CHANNEL_USERS);
+
+		foreach($recipients as $recipient){
+			$recipient->sendToastNotification($title, $body);
+		}
+
+		return count($recipients);
+	}
 
 	/**
 	 * @param Player[]            $players

--- a/src/Server.php
+++ b/src/Server.php
@@ -1338,7 +1338,7 @@ class Server{
      *
 	 * @param string $title
 	 * @param string $body
-	 * @param CommandSender[]|null $recipients
+	 * @param Player[]|null $recipients
 	 */
 	public function broadcastToastNotification(string $title, string $body, ?array $recipients = null) : int{
 		$recipients = $recipients ?? $this->getPlayerBroadcastSubscribers(self::BROADCAST_CHANNEL_USERS);


### PR DESCRIPTION
## Introduction
Plugin developers can use the broadcast methods for tips, titles, message but not for toast-notifications. This PR adds a method to broadcast toast-notifications.

## Changes
### API changes
- Added the `broadcastToastNotification()` method to the `Server` class

## Tests
I tested this on a clear PMMP-server and it worked well.