### PR TITLE
Use str_starts_with and str_contains instead of strpos

### DIFF
--- a/src/command/defaults/ParticleCommand.php
+++ b/src/command/defaults/ParticleCommand.php
@@ -70,7 +70,7 @@ use function explode;
 use function max;
 use function microtime;
 use function mt_rand;
-use function strpos;
+use function str_starts_with;
 use function strtolower;
 
 class ParticleCommand extends VanillaCommand{
@@ -208,17 +208,17 @@ class ParticleCommand extends VanillaCommand{
 				return new EntityFlameParticle();
 		}
 
-		if(strpos($name, "iconcrack_") === 0){
+		if(str_starts_with($name, "iconcrack_")){
 			$d = explode("_", $name);
 			if(count($d) === 3){
 				return new ItemBreakParticle(ItemFactory::getInstance()->get((int) $d[1], (int) $d[2]));
 			}
-		}elseif(strpos($name, "blockcrack_") === 0){
+		}elseif(str_starts_with($name, "blockcrack_")){
 			$d = explode("_", $name);
 			if(count($d) === 2){
 				return new TerrainParticle(BlockFactory::getInstance()->get(((int) $d[1]) & 0xff, ((int) $d[1]) >> 12));
 			}
-		}elseif(strpos($name, "blockdust_") === 0){
+		}elseif(str_starts_with($name, "blockdust_")){
 			$d = explode("_", $name);
 			if(count($d) >= 4){
 				return new DustParticle(new Color(((int) $d[1]) & 0xff, ((int) $d[2]) & 0xff, ((int) $d[3]) & 0xff, isset($d[4]) ? ((int) $d[4]) & 0xff : 255));

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -125,8 +125,8 @@ use function mb_strlen;
 use function microtime;
 use function preg_match;
 use function sprintf;
+use function str_starts_with;
 use function strlen;
-use function strpos;
 use function substr;
 use function trim;
 use const JSON_THROW_ON_ERROR;
@@ -726,7 +726,7 @@ class InGamePacketHandler extends PacketHandler{
 	}
 
 	public function handleCommandRequest(CommandRequestPacket $packet) : bool{
-		if(strpos($packet->command, '/') === 0){
+		if(str_starts_with($packet->command, '/')){
 			$this->player->chat($packet->command);
 			return true;
 		}

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -145,8 +145,8 @@ use function min;
 use function preg_match;
 use function spl_object_id;
 use function sqrt;
+use function str_starts_with;
 use function strlen;
-use function strpos;
 use function strtolower;
 use function substr;
 use function trim;
@@ -1435,7 +1435,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		$message = TextFormat::clean($message, false);
 		foreach(explode("\n", $message, $this->messageCounter + 1) as $messagePart){
 			if(trim($messagePart) !== "" && strlen($messagePart) <= self::MAX_CHAT_BYTE_LENGTH && mb_strlen($messagePart, 'UTF-8') <= self::MAX_CHAT_CHAR_LENGTH && $this->messageCounter-- > 0){
-				if(strpos($messagePart, './') === 0){
+				if(str_starts_with($messagePart, './')){
 					$messagePart = substr($messagePart, 1);
 				}
 
@@ -1446,7 +1446,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 					break;
 				}
 
-				if(strpos($ev->getMessage(), "/") === 0){
+				if(str_starts_with($ev->getMessage(), "/")){
 					Timings::$playerCommand->startTiming();
 					$this->server->dispatchCommand($ev->getPlayer(), substr($ev->getMessage(), 1));
 					Timings::$playerCommand->stopTiming();

--- a/src/utils/Process.php
+++ b/src/utils/Process.php
@@ -38,8 +38,8 @@ use function posix_kill;
 use function preg_match;
 use function proc_close;
 use function proc_open;
+use function str_starts_with;
 use function stream_get_contents;
-use function strpos;
 use function trim;
 
 final class Process{
@@ -99,9 +99,9 @@ final class Process{
 			if($mappings === false) throw new AssumptionFailedError("/proc/self/maps should always be accessible");
 			foreach($mappings as $line){
 				if(preg_match("#([a-z0-9]+)\\-([a-z0-9]+) [rwxp\\-]{4} [a-z0-9]+ [^\\[]*\\[([a-zA-z0-9]+)\\]#", trim($line), $matches) > 0){
-					if(strpos($matches[3], "heap") === 0){
+					if(str_starts_with($matches[3], "heap")){
 						$heap += (int) hexdec($matches[2]) - (int) hexdec($matches[1]);
-					}elseif(strpos($matches[3], "stack") === 0){
+					}elseif(str_starts_with($matches[3], "stack")){
 						$stack += (int) hexdec($matches[2]) - (int) hexdec($matches[1]);
 					}
 				}

--- a/src/utils/Timezone.php
+++ b/src/utils/Timezone.php
@@ -37,7 +37,9 @@ use function json_decode;
 use function parse_ini_file;
 use function preg_match;
 use function readlink;
+use function str_contains;
 use function str_replace;
+use function str_starts_with;
 use function strpos;
 use function substr;
 use function timezone_abbreviations_list;
@@ -61,7 +63,7 @@ abstract class Timezone{
 			 * This is here so that people don't come to us complaining and fill up the issue tracker when they put
 			 * an incorrect timezone abbreviation in php.ini apparently.
 			 */
-			if(strpos($timezone, "/") === false){
+			if(!str_contains($timezone, "/")){
 				$default_timezone = timezone_name_from_abbr($timezone);
 				if($default_timezone !== false){
 					ini_set("date.timezone", $default_timezone);
@@ -165,7 +167,7 @@ abstract class Timezone{
 				return self::parseOffset($offset);
 			case Utils::OS_MACOS:
 				$filename = @readlink('/etc/localtime');
-				if($filename !== false && strpos($filename, '/usr/share/zoneinfo/') === 0){
+				if($filename !== false && str_starts_with($filename, '/usr/share/zoneinfo/')){
 					$timezone = substr($filename, 20);
 					return trim($timezone);
 				}

--- a/src/utils/Utils.php
+++ b/src/utils/Utils.php
@@ -81,9 +81,9 @@ use function shell_exec;
 use function spl_object_id;
 use function str_pad;
 use function str_split;
+use function str_starts_with;
 use function stripos;
 use function strlen;
-use function strpos;
 use function substr;
 use function sys_get_temp_dir;
 use function trim;
@@ -273,7 +273,7 @@ final class Utils{
 		if(self::$os === null || $recalculate){
 			$uname = php_uname("s");
 			if(stripos($uname, "Darwin") !== false){
-				if(strpos(php_uname("m"), "iP") === 0){
+				if(str_starts_with(php_uname("m"), "iP")){
 					self::$os = self::OS_IOS;
 				}else{
 					self::$os = self::OS_MACOS;


### PR DESCRIPTION
In PHP 8.0, the str_starts_with and str_contains functions were introduced. Their use improves the readability of the code.