### PR TITLE
Use str_starts_with, str_ends_with and str_contains instead of strpos

### DIFF
--- a/build/generate-registry-annotations.php
+++ b/build/generate-registry-annotations.php
@@ -36,8 +36,8 @@ use function ksort;
 use function mb_strtoupper;
 use function preg_match;
 use function sprintf;
+use function str_ends_with;
 use function str_replace;
-use function substr;
 use const SORT_STRING;
 use const STDERR;
 
@@ -121,7 +121,7 @@ require dirname(__DIR__) . '/vendor/autoload.php';
 if(is_dir($argv[1])){
 	/** @var string $file */
 	foreach(new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($argv[1], \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::CURRENT_AS_PATHNAME)) as $file){
-		if(substr($file, -4) !== ".php"){
+		if(!str_ends_with($file, ".php")){
 			continue;
 		}
 

--- a/src/block/utils/SignText.php
+++ b/src/block/utils/SignText.php
@@ -30,7 +30,7 @@ use function array_slice;
 use function count;
 use function explode;
 use function is_int;
-use function strpos;
+use function str_contains;
 
 class SignText{
 	public const LINE_COUNT = 4;
@@ -54,7 +54,7 @@ class SignText{
 			foreach($lines as $k => $line){
 				$this->checkLineIndex($k);
 				Utils::checkUTF8($line);
-				if(strpos($line, "\n") !== false){
+				if(str_contains($line, "\n")){
 					throw new \InvalidArgumentException("Line must not contain newlines");
 				}
 				//TODO: add length checks

--- a/src/command/SimpleCommandMap.php
+++ b/src/command/SimpleCommandMap.php
@@ -72,8 +72,8 @@ use pocketmine\utils\TextFormat;
 use function array_shift;
 use function count;
 use function implode;
+use function str_contains;
 use function strcasecmp;
-use function strpos;
 use function strtolower;
 use function trim;
 
@@ -238,7 +238,7 @@ class SimpleCommandMap implements CommandMap{
 		$values = $this->server->getCommandAliases();
 
 		foreach($values as $alias => $commandStrings){
-			if(strpos($alias, ":") !== false){
+			if(str_contains($alias, ":")){
 				$this->server->getLogger()->warning($this->server->getLanguage()->translate(KnownTranslationFactory::pocketmine_command_alias_illegal($alias)));
 				continue;
 			}

--- a/src/crafting/ShapedRecipe.php
+++ b/src/crafting/ShapedRecipe.php
@@ -29,8 +29,8 @@ use pocketmine\utils\Utils;
 use function array_values;
 use function count;
 use function implode;
+use function str_contains;
 use function strlen;
-use function strpos;
 
 class ShapedRecipe implements CraftingRecipe{
 	/** @var string[] */
@@ -86,7 +86,7 @@ class ShapedRecipe implements CraftingRecipe{
 		$this->shape = $shape;
 
 		foreach($ingredients as $char => $i){
-			if(strpos(implode($this->shape), $char) === false){
+			if(!str_contains(implode($this->shape), $char)){
 				throw new \InvalidArgumentException("Symbol '$char' does not appear in the recipe shape");
 			}
 

--- a/src/crash/CrashDump.php
+++ b/src/crash/CrashDump.php
@@ -55,6 +55,7 @@ use function phpversion;
 use function preg_replace;
 use function sprintf;
 use function str_split;
+use function str_starts_with;
 use function strpos;
 use function substr;
 use function zend_version;
@@ -237,7 +238,7 @@ class CrashDump{
 
 	private function determinePluginFromFile(string $filePath, bool $crashFrame) : bool{
 		$frameCleanPath = Filesystem::cleanPath($filePath);
-		if(strpos($frameCleanPath, Filesystem::CLEAN_PATH_SRC_PREFIX) !== 0){
+		if(!str_starts_with($frameCleanPath, Filesystem::CLEAN_PATH_SRC_PREFIX)){
 			if($crashFrame){
 				$this->data->plugin_involvement = self::PLUGIN_INVOLVEMENT_DIRECT;
 			}else{
@@ -250,7 +251,7 @@ class CrashDump{
 				$file->setAccessible(true);
 				foreach($this->server->getPluginManager()->getPlugins() as $plugin){
 					$filePath = Filesystem::cleanPath($file->getValue($plugin));
-					if(strpos($frameCleanPath, $filePath) === 0){
+					if(str_starts_with($frameCleanPath, $filePath)){
 						$this->data->plugin = $plugin->getName();
 						break;
 					}

--- a/src/lang/Language.php
+++ b/src/lang/Language.php
@@ -34,7 +34,9 @@ use function is_dir;
 use function ord;
 use function parse_ini_file;
 use function scandir;
+use function str_ends_with;
 use function str_replace;
+use function str_starts_with;
 use function strlen;
 use function strpos;
 use function strtolower;
@@ -62,7 +64,7 @@ class Language{
 
 			if($allFiles !== false){
 				$files = array_filter($allFiles, function(string $filename) : bool{
-					return substr($filename, -4) === ".ini";
+					return str_ends_with($filename, ".ini");
 				});
 
 				$result = [];
@@ -143,7 +145,7 @@ class Language{
 	 */
 	public function translateString(string $str, array $params = [], ?string $onlyPrefix = null) : string{
 		$baseText = $this->get($str);
-		$baseText = $this->parseTranslation(($onlyPrefix === null || strpos($str, $onlyPrefix) === 0) ? $baseText : $str, $onlyPrefix);
+		$baseText = $this->parseTranslation(($onlyPrefix === null || str_starts_with($str, $onlyPrefix)) ? $baseText : $str, $onlyPrefix);
 
 		foreach($params as $i => $p){
 			$replacement = $p instanceof Translatable ? $this->translate($p) : (string) $p;

--- a/src/plugin/PharPluginLoader.php
+++ b/src/plugin/PharPluginLoader.php
@@ -35,8 +35,7 @@ class PharPluginLoader implements PluginLoader{
 	){}
 
 	public function canLoadPlugin(string $path) : bool{
-		$ext = ".phar";
-		return is_file($path) && str_ends_with($path, $ext);
+		return is_file($path) && str_ends_with($path, ".phar");
 	}
 
 	/**

--- a/src/plugin/PharPluginLoader.php
+++ b/src/plugin/PharPluginLoader.php
@@ -24,8 +24,7 @@ declare(strict_types=1);
 namespace pocketmine\plugin;
 
 use function is_file;
-use function strlen;
-use function substr;
+use function str_ends_with;
 
 /**
  * Handles different types of plugins
@@ -37,7 +36,7 @@ class PharPluginLoader implements PluginLoader{
 
 	public function canLoadPlugin(string $path) : bool{
 		$ext = ".phar";
-		return is_file($path) && substr($path, -strlen($ext)) === $ext;
+		return is_file($path) && str_ends_with($path, $ext);
 	}
 
 	/**

--- a/src/plugin/PluginBase.php
+++ b/src/plugin/PluginBase.php
@@ -41,8 +41,8 @@ use function file_exists;
 use function fopen;
 use function mkdir;
 use function rtrim;
+use function str_contains;
 use function stream_copy_to_stream;
-use function strpos;
 use function strtolower;
 use function trim;
 use const DIRECTORY_SEPARATOR;
@@ -145,7 +145,7 @@ abstract class PluginBase implements Plugin, CommandExecutor{
 		$pluginCmds = [];
 
 		foreach(Utils::stringifyKeys($this->getDescription()->getCommands()) as $key => $data){
-			if(strpos($key, ":") !== false){
+			if(str_contains($key, ":")){
 				$this->logger->error($this->server->getLanguage()->translate(KnownTranslationFactory::pocketmine_plugin_commandError($key, $this->getDescription()->getFullName(), ":")));
 				continue;
 			}
@@ -161,7 +161,7 @@ abstract class PluginBase implements Plugin, CommandExecutor{
 
 			$aliasList = [];
 			foreach($data->getAliases() as $alias){
-				if(strpos($alias, ":") !== false){
+				if(str_contains($alias, ":")){
 					$this->logger->error($this->server->getLanguage()->translate(KnownTranslationFactory::pocketmine_plugin_aliasError($alias, $this->getDescription()->getFullName(), ":")));
 					continue;
 				}

--- a/src/plugin/PluginLoadabilityChecker.php
+++ b/src/plugin/PluginLoadabilityChecker.php
@@ -34,6 +34,7 @@ use function extension_loaded;
 use function implode;
 use function in_array;
 use function phpversion;
+use function str_starts_with;
 use function stripos;
 use function strlen;
 use function substr;
@@ -96,7 +97,7 @@ final class PluginLoadabilityChecker{
 				}
 				foreach(["<=", "le", "<>", "!=", "ne", "<", "lt", "==", "=", "eq", ">=", "ge", ">", "gt"] as $comparator){
 					// warning: the > character should be quoted in YAML
-					if(substr($constr, 0, strlen($comparator)) === $comparator){
+					if(str_starts_with($constr, $comparator)){
 						$version = substr($constr, strlen($comparator));
 						if(!version_compare($gotVersion, $version, $comparator)){
 							return KnownTranslationFactory::pocketmine_plugin_incompatibleExtensionVersion(extensionName: $extensionName, extensionVersion: $gotVersion, pluginRequirement: $constr);

--- a/src/plugin/PluginManager.php
+++ b/src/plugin/PluginManager.php
@@ -62,7 +62,7 @@ use function mkdir;
 use function realpath;
 use function shuffle;
 use function sprintf;
-use function strpos;
+use function str_contains;
 use function strtolower;
 
 /**
@@ -296,7 +296,7 @@ class PluginManager{
 					continue;
 				}
 
-				if(strpos($name, " ") !== false){
+				if(str_contains($name, " ")){
 					$this->server->getLogger()->warning($this->server->getLanguage()->translate(KnownTranslationFactory::pocketmine_plugin_spacesDiscouraged($name)));
 				}
 

--- a/src/plugin/ScriptPluginLoader.php
+++ b/src/plugin/ScriptPluginLoader.php
@@ -28,9 +28,8 @@ use function count;
 use function file;
 use function implode;
 use function is_file;
-use function strlen;
-use function strpos;
-use function substr;
+use function str_contains;
+use function str_ends_with;
 use const FILE_IGNORE_NEW_LINES;
 use const FILE_SKIP_EMPTY_LINES;
 
@@ -42,7 +41,7 @@ class ScriptPluginLoader implements PluginLoader{
 
 	public function canLoadPlugin(string $path) : bool{
 		$ext = ".php";
-		return is_file($path) && substr($path, -strlen($ext)) === $ext;
+		return is_file($path) && str_ends_with($path, $ext);
 	}
 
 	/**
@@ -66,7 +65,7 @@ class ScriptPluginLoader implements PluginLoader{
 		$docCommentLines = [];
 		foreach($content as $line){
 			if(!$insideHeader){
-				if(strpos($line, "/**") !== false){
+				if(str_contains($line, "/**")){
 					$insideHeader = true;
 				}else{
 					continue;
@@ -75,7 +74,7 @@ class ScriptPluginLoader implements PluginLoader{
 
 			$docCommentLines[] = $line;
 
-			if(strpos($line, "*/") !== false){
+			if(str_contains($line, "*/")){
 				break;
 			}
 		}

--- a/src/plugin/ScriptPluginLoader.php
+++ b/src/plugin/ScriptPluginLoader.php
@@ -40,8 +40,7 @@ use const FILE_SKIP_EMPTY_LINES;
 class ScriptPluginLoader implements PluginLoader{
 
 	public function canLoadPlugin(string $path) : bool{
-		$ext = ".php";
-		return is_file($path) && str_ends_with($path, $ext);
+		return is_file($path) && str_ends_with($path, ".php");
 	}
 
 	/**

--- a/src/utils/Filesystem.php
+++ b/src/utils/Filesystem.php
@@ -48,9 +48,9 @@ use function rmdir;
 use function rtrim;
 use function scandir;
 use function str_replace;
+use function str_starts_with;
 use function stream_get_contents;
 use function strlen;
-use function strpos;
 use function uksort;
 use function unlink;
 use const DIRECTORY_SEPARATOR;
@@ -172,7 +172,7 @@ final class Filesystem{
 		//this should probably never have integer keys, but it's safer than making PHPStan ignore it
 		foreach(Utils::stringifyKeys(self::$cleanedPaths) as $cleanPath => $replacement){
 			$cleanPath = rtrim(str_replace([DIRECTORY_SEPARATOR, "phar://"], ["/", ""], $cleanPath), "/");
-			if(strpos($result, $cleanPath) === 0){
+			if(str_starts_with($result, $cleanPath)){
 				$result = ltrim(str_replace($cleanPath, $replacement, $result), "/");
 			}
 		}

--- a/src/utils/Timezone.php
+++ b/src/utils/Timezone.php
@@ -184,11 +184,11 @@ abstract class Timezone{
 	 */
 	private static function parseOffset($offset){
 		//Make signed offsets unsigned for date_parse
-		if(str_contains($offset, '-')){
+		if(str_starts_with($offset, '-')){
 			$negative_offset = true;
 			$offset = str_replace('-', '', $offset);
 		}else{
-			if(str_contains($offset, '+')){
+			if(str_starts_with($offset, '+')){
 				$negative_offset = false;
 				$offset = str_replace('+', '', $offset);
 			}else{

--- a/src/utils/Timezone.php
+++ b/src/utils/Timezone.php
@@ -40,7 +40,6 @@ use function readlink;
 use function str_contains;
 use function str_replace;
 use function str_starts_with;
-use function strpos;
 use function substr;
 use function timezone_abbreviations_list;
 use function timezone_name_from_abbr;
@@ -185,11 +184,11 @@ abstract class Timezone{
 	 */
 	private static function parseOffset($offset){
 		//Make signed offsets unsigned for date_parse
-		if(strpos($offset, '-') !== false){
+		if(str_contains($offset, '-')){
 			$negative_offset = true;
 			$offset = str_replace('-', '', $offset);
 		}else{
-			if(strpos($offset, '+') !== false){
+			if(str_contains($offset, '+')){
 				$negative_offset = false;
 				$offset = str_replace('+', '', $offset);
 			}else{

--- a/src/utils/Utils.php
+++ b/src/utils/Utils.php
@@ -79,6 +79,7 @@ use function preg_match_all;
 use function preg_replace;
 use function shell_exec;
 use function spl_object_id;
+use function str_ends_with;
 use function str_pad;
 use function str_split;
 use function str_starts_with;
@@ -119,7 +120,7 @@ final class Utils{
 	 */
 	public static function getNiceClosureName(\Closure $closure) : string{
 		$func = new \ReflectionFunction($closure);
-		if(substr($func->getName(), -strlen('{closure}')) !== '{closure}'){
+		if(!str_ends_with($func->getName(), '{closure}')){
 			//closure wraps a named function, can be done with reflection or fromCallable()
 			//isClosure() is useless here because it just tells us if $func is reflecting a Closure object
 


### PR DESCRIPTION
In PHP 8.0, the str_starts_with, str_ends_with and str_contains functions were introduced. Their use improves the readability of the code.

This Pull Request considers the missed cases in #5482