### PR TITLE
Improve World::notifyNeighbourBlockUpdate() documentation

### DIFF
--- a/src/world/World.php
+++ b/src/world/World.php
@@ -1321,7 +1321,9 @@ class World implements ChunkManager{
 
 	/**
 	 * Notify the blocks at and around the position that the block at the position may have changed.
-	 * This will cause onNeighbourBlockUpdate() to be called for these blocks.
+	 * This will cause onNearbyBlockChange() to be called for these blocks.
+	 *
+	 * @see Block::onNearbyBlockChange()
 	 */
 	public function notifyNeighbourBlockUpdate(Vector3 $pos) : void{
 		$this->tryAddToNeighbourUpdateQueue($pos);


### PR DESCRIPTION
## Introduction
I noticed that the method mentioned in the documentation is not correct, it also adds @see tag