### PR TITLE
ItemStackResponseBuilder: Remove unnecessary ternary operator

### DIFF
--- a/src/network/mcpe/handler/ItemStackResponseBuilder.php
+++ b/src/network/mcpe/handler/ItemStackResponseBuilder.php
@@ -91,7 +91,7 @@ final class ItemStackResponseBuilder{
 					$slotId,
 					$item->getCount(),
 					$itemStackInfo->getStackId(),
-					$item->hasCustomName() ? $item->getCustomName() : "",
+					$item->getCustomName(),
 					0
 				);
 			}


### PR DESCRIPTION
## Introduction

This operator is unnecessary because `Item::getCustomName()` already returns an empty string if it doesn't have a custom name.