### PR TITLE
ci: add appimage build to release flow

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -48,6 +48,10 @@ jobs:
       - name: Build PocketMine-MP.phar
         run: php -dphar.readonly=0 build/server-phar.php --git ${{ github.sha }} --build ${{ steps.build-number.outputs.BUILD_NUMBER }}
 
+      - name: Build appimage
+        run: build-appimage.sh
+        working-directory: build
+
       - name: Get PocketMine-MP release version
         id: get-pm-version
         run: |
@@ -66,13 +70,14 @@ jobs:
           name: release_artifacts
           path: |
             ${{ github.workspace }}/PocketMine-MP.phar
+            ${{ github.workspace }}/build/PocketMine-*.AppImage
             ${{ github.workspace }}/start.*
             ${{ github.workspace }}/build_info.json
 
       - name: Create draft release
         uses: ncipollo/release-action@v1.12.0
         with:
-          artifacts: ${{ github.workspace }}/PocketMine-MP.phar,${{ github.workspace }}/start.*,${{ github.workspace }}/build_info.json
+          artifacts: ${{ github.workspace }}/PocketMine-MP.phar,${{ github.workspace }}/build/PocketMine-*.AppImage,${{ github.workspace }}/start.*,${{ github.workspace }}/build_info.json
           commit: ${{ github.sha }}
           draft: true
           name: PocketMine-MP ${{ steps.get-pm-version.outputs.PM_VERSION }}

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,0 +1,3 @@
+*.AppImage
+/PocketMine.AppDir
+/appimagetool

--- a/build/build-appimage.sh
+++ b/build/build-appimage.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+set -eu
+
+if false; then ####
+
+[ ! -d PocketMine.AppDir ] || rm -r PocketMine.AppDir
+mkdir PocketMine.AppDir
+
+(cd PocketMine.AppDir && ../php/compile.sh \
+	-t linux64 \
+	-j $(nproc) \
+	-f \
+	-g \
+	-P ${PM_VERSION_MAJOR:-4})
+
+fi ####
+
+PHP=$(realpath ./PocketMine.AppDir/bin/php7/bin/php)
+
+[ -f composer.phar ] || (wget -O - https://getcomposer.org/installer | ${PHP})
+(cd .. && $PHP build/composer.phar install --no-dev)
+
+$PHP -dphar.readonly=0 ./server-phar.php && mv PocketMine-MP.phar PocketMine.AppDir
+
+cat >./PocketMine.AppDir/AppRun <<EOF
+#!/bin/sh
+\$(dirname \$0)/bin/php7/bin/php \$(dirname \$0)/PocketMine-MP.phar "\$@"
+EOF
+chmod +x ./PocketMine.AppDir/AppRun
+
+cat >./PocketMine.AppDir/PocketMine.desktop <<EOF
+[Desktop Entry]
+Name=PocketMine-MP
+Exec=pocketmine
+Icon=pocketmine
+Type=Application
+Categories=Game;
+EOF
+
+wget -O ./PocketMine.AppDir/pocketmine.png "https://github.com/PocketMine.png?size=256"
+
+[ -f appimagetool ] || (wget -O appimagetool \
+	https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-x86_64.AppImage \
+	&& chmod +x appimagetool)
+./appimagetool PocketMine.AppDir/


### PR DESCRIPTION
Provide a simple binary download for Linux without the complexity of setting up docker or using an installer.

Replaces the accidentally-closed #5537