### PR TITLE
Getter and setter for gravity

### DIFF
--- a/src/entity/Entity.php
+++ b/src/entity/Entity.php
@@ -808,6 +808,7 @@ abstract class Entity{
 	}
 
 	public function setGravity(float $gravity) : void{
+		Utils::checkFloatNotInfOrNaN("gravity", $gravity);
 		$this->gravity = $gravity;
 	}
 

--- a/src/entity/Entity.php
+++ b/src/entity/Entity.php
@@ -803,6 +803,14 @@ abstract class Entity{
 		$this->server->broadcastPackets($this->hasSpawned, [SetActorMotionPacket::create($this->id, $this->getMotion())]);
 	}
 
+	public function getGravity() : float{
+		return $this->gravity;
+	}
+
+	public function setGravity(float $gravity) : void{
+		$this->gravity = $gravity;
+	}
+
 	public function hasGravity() : bool{
 		return $this->gravityEnabled;
 	}


### PR DESCRIPTION
## Introduction
Adds the ability to get and set the gravity of an Entity. Gravity is a big part of the movement and is needed to create a custom movement for Entities. Examples include different planets, knockback, etc.

### Relevant issues
Fixes #5525 

## Changes
### API changes
Addition of ``Entity->getGravity()`` and ``Entity->setGravity()``

### Behavioural changes
n/a

## Backwards compatibility
n/a

## Follow-up
n/a

## Tests
```php
final class Main extends PluginBase implements Listener {

	public function onEnable() : void {
		$this->getServer()->getPluginManager()->registerEvents($this, $this);

		$this->getServer()->getCommandMap()->register("gravitytest", new class() extends Command {
			public function __construct() {
				parent::__construct("gravitytest", "Test gravity", "/gravitytest");
			}

			public function execute(CommandSender $sender, string $commandLabel, array $args) : bool {
				if(!$sender instanceof Player) {
					$sender->sendMessage("Please run this command in-game");
					return true;
				}

				if (count($args) < 1) {
					$sender->sendMessage("Usage: /gravitytest list|set <gravity>");
					return true;
				}

				switch ($args[0]) {
					case "list":
						$sender->sendMessage("Gravity: " . $sender->getGravity());
						break;
					case "set":
						if (count($args) < 2) {
							$sender->sendMessage("Usage: /gravitytest set <gravity>");
							return true;
						}

						$sender->setGravity((float) $args[1]);
						$sender->sendMessage("Gravity set to " . $sender->getGravity());
						break;
					default:
						$sender->sendMessage("Usage: /gravitytest list|set <gravity>");
						break;
				}
				return true;
			}
		});
	}

	public function onJoin(PlayerJoinEvent $e) {
		$e->getPlayer()->setGravity(20);
	}
}
```