### PR TITLE
Timings tree

### DIFF
--- a/src/timings/TimingsHandler.php
+++ b/src/timings/TimingsHandler.php
@@ -56,8 +56,9 @@ class TimingsHandler{
 				"Count: $count",
 				"Avg: $avg",
 				"Violations: " . $timings->getViolations(),
-				"Id: " . $timings->getId(),
-				"ParentId: " . ($timings->getParentId() ?? "none")
+				"RecordId: " . $timings->getId(),
+				"ParentRecordId: " . ($timings->getParentId() ?? "none"),
+				"TimerId: " . $timings->getTimerId()
 			]);
 		}
 		$result = [];

--- a/src/timings/TimingsHandler.php
+++ b/src/timings/TimingsHandler.php
@@ -56,8 +56,8 @@ class TimingsHandler{
 				"Count: $count",
 				"Avg: $avg",
 				"Violations: " . $timings->getViolations(),
-				"Id: " . $timings->getTimerId(),
-				"ParentId: " . ($timings->getParentTimerId() ?? "none")
+				"Id: " . $timings->getId(),
+				"ParentId: " . ($timings->getParentId() ?? "none")
 			]);
 		}
 		$result = [];
@@ -184,8 +184,8 @@ class TimingsHandler{
 
 		$record = TimingsRecord::getCurrentRecord();
 		if($record !== null){
-			if($record->getTimerId() !== spl_object_id($this)){
-				throw new \LogicException("Timer \"" . $record->getName() . "\" (ID " . $record->getTimerId() . ") should have been stopped before stopping timer \"" . $this->name . "\" (ID " . spl_object_id($this) . ")");
+			if($record->getId() !== spl_object_id($this)){
+				throw new \LogicException("Timer \"" . $record->getName() . "\" should have been stopped before stopping timer \"" . $this->name . "\"");
 			}
 			$record->stopTiming($now);
 		}

--- a/src/timings/TimingsHandler.php
+++ b/src/timings/TimingsHandler.php
@@ -184,7 +184,7 @@ class TimingsHandler{
 
 		$record = TimingsRecord::getCurrentRecord();
 		if($record !== null){
-			if($record->getId() !== spl_object_id($this)){
+			if($record->getTimerId() !== spl_object_id($this)){
 				throw new \LogicException("Timer \"" . $record->getName() . "\" should have been stopped before stopping timer \"" . $this->name . "\"");
 			}
 			$record->stopTiming($now);

--- a/src/timings/TimingsHandler.php
+++ b/src/timings/TimingsHandler.php
@@ -28,6 +28,8 @@ use pocketmine\Server;
 use pocketmine\utils\Utils;
 use function count;
 use function hrtime;
+use function implode;
+use function spl_object_id;
 
 class TimingsHandler{
 	private static bool $enabled = false;
@@ -48,7 +50,15 @@ class TimingsHandler{
 			$avg = $time / $count;
 
 			$group = $timings->getGroup();
-			$groups[$group][] = $timings->getName() . " Time: $time Count: " . $count . " Avg: $avg Violations: " . $timings->getViolations();
+			$groups[$group][] = implode(" ", [
+				$timings->getName(),
+				"Time: $time",
+				"Count: $count",
+				"Avg: $avg",
+				"Violations: " . $timings->getViolations(),
+				"Id: " . $timings->getTimerId(),
+				"ParentId: " . ($timings->getParentTimerId() ?? "none")
+			]);
 		}
 		$result = [];
 
@@ -107,8 +117,14 @@ class TimingsHandler{
 		}
 	}
 
-	private ?TimingsRecord $record = null;
+	private ?TimingsRecord $rootRecord = null;
 	private int $timingDepth = 0;
+
+	/**
+	 * @var TimingsRecord[]
+	 * @phpstan-var array<int, TimingsRecord>
+	 */
+	private array $recordsByParent = [];
 
 	public function __construct(
 		private string $name,
@@ -128,13 +144,24 @@ class TimingsHandler{
 
 	private function internalStartTiming(int $now) : void{
 		if(++$this->timingDepth === 1){
-			if($this->record === null){
-				$this->record = new TimingsRecord($this);
-			}
-			$this->record->startTiming($now);
 			if($this->parent !== null){
 				$this->parent->internalStartTiming($now);
 			}
+
+			$current = TimingsRecord::getCurrentRecord();
+			if($current !== null){
+				$record = $this->recordsByParent[spl_object_id($current)] ?? null;
+				if($record === null){
+					$record = new TimingsRecord($this, $current);
+					$this->recordsByParent[spl_object_id($current)] = $record;
+				}
+			}else{
+				if($this->rootRecord === null){
+					$this->rootRecord = new TimingsRecord($this, null);
+				}
+				$record = $this->rootRecord;
+			}
+			$record->startTiming($now);
 		}
 	}
 
@@ -155,9 +182,12 @@ class TimingsHandler{
 			return;
 		}
 
-		if($this->record !== null){
-			//this might be null if a timings reset occurred while the timer was running
-			$this->record->stopTiming($now);
+		$record = TimingsRecord::getCurrentRecord();
+		if($record !== null){
+			if($record->getTimerId() !== spl_object_id($this)){
+				throw new \LogicException("Timer \"" . $record->getName() . "\" (ID " . $record->getTimerId() . ") should have been stopped before stopping timer \"" . $this->name . "\" (ID " . spl_object_id($this) . ")");
+			}
+			$record->stopTiming($now);
 		}
 		if($this->parent !== null){
 			$this->parent->internalStopTiming($now);
@@ -184,6 +214,7 @@ class TimingsHandler{
 	 * @internal
 	 */
 	public function destroyCycles() : void{
-		$this->record = null;
+		$this->rootRecord = null;
+		$this->recordsByParent = [];
 	}
 }

--- a/src/timings/TimingsRecord.php
+++ b/src/timings/TimingsRecord.php
@@ -95,6 +95,8 @@ final class TimingsRecord{
 
 	public function getParentId() : ?int{ return $this->parentRecord?->getId(); }
 
+	public function getTimerId() : int{ return spl_object_id($this->handler); }
+
 	public function getName() : string{ return $this->handler->getName(); }
 
 	public function getGroup() : string{ return $this->handler->getGroup(); }

--- a/src/timings/TimingsRecord.php
+++ b/src/timings/TimingsRecord.php
@@ -96,7 +96,7 @@ final class TimingsRecord{
 		self::$records[spl_object_id($this)] = $this;
 	}
 
-	public function getTimerId() : int{ return spl_object_id($this->handler); }
+	public function getTimerId() : int{ return spl_object_id($this); }
 
 	public function getParentTimerId() : ?int{ return $this->parentRecord?->getTimerId(); }
 

--- a/src/timings/TimingsRecord.php
+++ b/src/timings/TimingsRecord.php
@@ -96,9 +96,9 @@ final class TimingsRecord{
 		self::$records[spl_object_id($this)] = $this;
 	}
 
-	public function getTimerId() : int{ return spl_object_id($this); }
+	public function getId() : int{ return spl_object_id($this); }
 
-	public function getParentTimerId() : ?int{ return $this->parentRecord?->getTimerId(); }
+	public function getParentId() : ?int{ return $this->parentRecord?->getId(); }
 
 	public function getName() : string{ return $this->handler->getName(); }
 

--- a/src/timings/TimingsRecord.php
+++ b/src/timings/TimingsRecord.php
@@ -47,6 +47,7 @@ final class TimingsRecord{
 			$record->handler->destroyCycles();
 		}
 		self::$records = [];
+		self::$currentRecord = null;
 	}
 
 	/**
@@ -120,6 +121,11 @@ final class TimingsRecord{
 			return;
 		}
 		if(self::$currentRecord !== $this){
+			if(self::$currentRecord === null){
+				//timings may have been stopped while this timer was running
+				return;
+			}
+
 			throw new AssumptionFailedError("stopTiming() called on a non-current timer");
 		}
 		self::$currentRecord = $this->parentRecord;


### PR DESCRIPTION
## Introduction
Currently, it's often difficult to identify problems in a timings report, since it's far from obvious which timers include which other timers.

## Changes
This PR:
- uses unique timings records for different call trees, so different parent timers will result in distinct timings records (e.g. `Command - status` will appear twice, once for the times it was called by the console, and a second time for times it was called as a result of a player using it)
- clearly identifies in timings reports which timers are counted by which other timers, allowing them to be potentially displayed in a tree breakdown

### Behavioural changes
Timings may now have a slightly larger performance impact when enabled, but I think the trade-off is more than worth it.

## Backwards compatibility
This is fully backwards compatible with timings.pmmp.io, which already aggregates timings from multiple timers with the same names.

No public non-internal APIs were changed by this PR.

## Unresolved research
It's not currently clear how "parent" timers (which are really timings groups or aggregators) will play into this, but there shouldn't be any issues.

## Follow-up
Implement a tree view for timings.pmmp.io.

## Tests
An example timings report can be seen here: https://timings.pmmp.io/?id=300261
and its raw version here: https://timings.pmmp.io/?id=300261&raw=1

You can see that `Command - status` appears multiple times in the raw view, but only once in the result.

**Note:** timings.pmmp.io does not _yet_ support displaying this information in a tree view, so it's currently expected that the timings report will look exactly the same as any other.