### PR TITLE
PlayerDeathEvent add setScreenDeathMessage()

### DIFF
--- a/src/event/player/PlayerDeathEvent.php
+++ b/src/event/player/PlayerDeathEvent.php
@@ -39,6 +39,7 @@ class PlayerDeathEvent extends EntityDeathEvent{
 	protected $player;
 
 	private Translatable|string $deathMessage;
+	private Translatable|string $screenDeathMessage;
 	private bool $keepInventory = false;
 	private bool $keepXp = false;
 
@@ -50,6 +51,7 @@ class PlayerDeathEvent extends EntityDeathEvent{
 		parent::__construct($entity, $drops, $xp);
 		$this->player = $entity;
 		$this->deathMessage = $deathMessage ?? self::deriveMessage($entity->getDisplayName(), $entity->getLastDamageCause());
+		$this->screenDeathMessage = $this->deathMessage;
 	}
 
 	/**
@@ -69,6 +71,14 @@ class PlayerDeathEvent extends EntityDeathEvent{
 
 	public function setDeathMessage(Translatable|string $deathMessage) : void{
 		$this->deathMessage = $deathMessage;
+	}
+
+	public function getScreenDeathMessage() : Translatable|string{
+		return $this->screenDeathMessage;
+	}
+
+	public function setScreenDeathMessage(Translatable|string $screenDeathMessage) : void{
+		$this->screenDeathMessage = $screenDeathMessage;
 	}
 
 	public function getKeepInventory() : bool{

--- a/src/event/player/PlayerDeathEvent.php
+++ b/src/event/player/PlayerDeathEvent.php
@@ -39,7 +39,7 @@ class PlayerDeathEvent extends EntityDeathEvent{
 	protected $player;
 
 	private Translatable|string $deathMessage;
-	private Translatable|string $screenDeathMessage;
+	private Translatable|string $deathScreenMessage;
 	private bool $keepInventory = false;
 	private bool $keepXp = false;
 
@@ -51,7 +51,7 @@ class PlayerDeathEvent extends EntityDeathEvent{
 		parent::__construct($entity, $drops, $xp);
 		$this->player = $entity;
 		$this->deathMessage = $deathMessage ?? self::deriveMessage($entity->getDisplayName(), $entity->getLastDamageCause());
-		$this->screenDeathMessage = $this->deathMessage;
+		$this->deathScreenMessage = $this->deathMessage;
 	}
 
 	/**
@@ -73,12 +73,12 @@ class PlayerDeathEvent extends EntityDeathEvent{
 		$this->deathMessage = $deathMessage;
 	}
 
-	public function getScreenDeathMessage() : Translatable|string{
-		return $this->screenDeathMessage;
+	public function getDeathScreenMessage() : Translatable|string{
+		return $this->deathScreenMessage;
 	}
 
-	public function setScreenDeathMessage(Translatable|string $screenDeathMessage) : void{
-		$this->screenDeathMessage = $screenDeathMessage;
+	public function setDeathScreenMessage(Translatable|string $deathScreenMessage) : void{
+		$this->deathScreenMessage = $deathScreenMessage;
 	}
 
 	public function getKeepInventory() : bool{

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -2344,7 +2344,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 
 		$this->startDeathAnimation();
 
-		$this->getNetworkSession()->onServerDeath($ev->getDeathMessage());
+		$this->getNetworkSession()->onServerDeath($ev->getScreenDeathMessage());
 	}
 
 	protected function onDeathUpdate(int $tickDiff) : bool{

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -2344,7 +2344,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 
 		$this->startDeathAnimation();
 
-		$this->getNetworkSession()->onServerDeath($ev->getScreenDeathMessage());
+		$this->getNetworkSession()->onServerDeath($ev->getDeathScreenMessage());
 	}
 
 	protected function onDeathUpdate(int $tickDiff) : bool{


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

Currently its not possible to set different death messages in the chat and on the screen. Even if you try to send a new DeathInfoPacket, thats not gonna work because it can only be sent once.

Or if you want to hide the chat message and show only the screen message.
You can't just do setDeathMessage("""), because it will be sent in a DeathInfoPacket and you will not be able to send a new one.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
