### PR TITLE
Fix unmapped items crash

### DIFF
--- a/src/network/mcpe/convert/TypeConverter.php
+++ b/src/network/mcpe/convert/TypeConverter.php
@@ -188,7 +188,7 @@ class TypeConverter{
 			if($nbt === null){
 				$nbt = new CompoundTag();
 			}
-			$nbt->setInt(self::PM_ID_TAG, morton2d_encode($itemStack->getTypeId(), $itemStack->computeTypeData()));
+			$nbt->setLong(self::PM_ID_TAG, morton2d_encode($itemStack->getTypeId(), $itemStack->computeTypeData()));
 		}else{
 			[$id, $meta, $blockRuntimeId] = $idMeta;
 		}


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
`morton2d_encode` is 64-bit function when NBT int tag is 32-bit only, resulting in crash

### Relevant issues
Server does crash if unmapped item is provided to `TypeConverter::coreItemStackToNet`

```
[18:59:41.959] [Server thread/CRITICAL]: pocketmine\nbt\InvalidTagValueException: "Value 6148914691165143377 is outside the allowed range -2147483648 - 2147483647" (EXCEPTION) in "pmsrc/vendor/pocketmine/nbt/src/tag/IntegerishTagTrait" at line 46
--- Stack trace ---
  #0 pmsrc/vendor/pocketmine/nbt/src/tag/CompoundTag(229): pocketmine\nbt\tag\IntTag->__construct(int 6148914691165143377)
  #1 pmsrc/src/network/mcpe/convert/TypeConverter(160): pocketmine\nbt\tag\CompoundTag->setInt(string[8] ___Id___, int 6148914691165143377)
  #2 pmsrc/src/network/mcpe/InventoryManager(612): pocketmine\network\mcpe\convert\TypeConverter->coreItemStackToNet(object pocketmine\item\ItemBlock#139933)
  #3 pmsrc/src/network/mcpe/handler/PreSpawnPacketHandler(143): pocketmine\network\mcpe\InventoryManager->syncCreative()
```

## Changes

NBT long tag is now used instead of int tag

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
