### PR TITLE
Change seed drops of age 7 wheat from 0-3 to 1-4

### DIFF
--- a/src/block/Wheat.php
+++ b/src/block/Wheat.php
@@ -33,7 +33,7 @@ class Wheat extends Crops{
 		if($this->age >= self::MAX_AGE){
 			return [
 				VanillaItems::WHEAT(),
-				VanillaItems::WHEAT_SEEDS()->setCount(mt_rand(0, 3))
+				VanillaItems::WHEAT_SEEDS()->setCount(mt_rand(1, 4))
 			];
 		}else{
 			return [


### PR DESCRIPTION
See: https://minecraft.fandom.com/wiki/Wheat_Seeds
This was apparently changed in 1.14

(see https://discord.com/channels/373199722573201408/546255162222706696/1106972752965013655 for discussion on discord)