### PR TITLE
Fix being able to pot flower pots

### DIFF
--- a/src/block/VanillaBlocks.php
+++ b/src/block/VanillaBlocks.php
@@ -853,7 +853,7 @@ final class VanillaBlocks{
 		self::register("pink_tulip", new Flower(new BID(Ids::PINK_TULIP), "Pink Tulip", $flowerTypeInfo));
 		self::register("red_tulip", new Flower(new BID(Ids::RED_TULIP), "Red Tulip", $flowerTypeInfo));
 		self::register("white_tulip", new Flower(new BID(Ids::WHITE_TULIP), "White Tulip", $flowerTypeInfo));
-		self::register("flower_pot", new FlowerPot(new BID(Ids::FLOWER_POT, TileFlowerPot::class), "Flower Pot", $flowerTypeInfo));
+		self::register("flower_pot", new FlowerPot(new BID(Ids::FLOWER_POT, TileFlowerPot::class), "Flower Pot", new Info(BreakInfo::instant())));
 		self::register("frosted_ice", new FrostedIce(new BID(Ids::FROSTED_ICE), "Frosted Ice", new Info(BreakInfo::pickaxe(2.5))));
 		self::register("furnace", new Furnace(new BID(Ids::FURNACE, TileNormalFurnace::class), "Furnace", new Info(BreakInfo::pickaxe(3.5, ToolTier::WOOD())), FurnaceType::FURNACE()));
 		self::register("blast_furnace", new Furnace(new BID(Ids::BLAST_FURNACE, TileBlastFurnace::class), "Blast Furnace", new Info(BreakInfo::pickaxe(3.5, ToolTier::WOOD())), FurnaceType::BLAST_FURNACE()));


### PR DESCRIPTION
## Introduction
Flower pots can currently be placed into flower pots (which isn't part of the vanilla game for obvious reasons).

### Relevant issues
Caused by d9b050fb688155ec962f574388eb48342fc8f9d1

## Changes
### API changes
--

### Behavioural changes
Flower pots aren't tagged as `pottable` anymore.

## Backwards compatibility
--

## Tests

1. Place a flower pot
2. Click on the flower pot using another flower pot (if it places down, repeat)
3. Break the flower pots and look if they drop two flower pots

Before:
https://github.com/pmmp/PocketMine-MP/assets/51201131/67601322-0a2f-4cd9-bdc1-5c11ed8eaa3c

After:
https://github.com/pmmp/PocketMine-MP/assets/51201131/2e4c7a67-7fdc-41e6-9fcf-d7e76be6ed2c