### PR TITLE
Fix: item frame placement with Flowable

### DIFF
--- a/src/block/ItemFrame.php
+++ b/src/block/ItemFrame.php
@@ -169,7 +169,7 @@ class ItemFrame extends Flowable{
 	}
 
 	public function onNearbyBlockChange() : void{
-		if(!$this->getSide(Facing::opposite($this->facing))->isSolid()){
+		if($this->getSide(Facing::opposite($this->facing)) instanceof Flowable){
 			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}

--- a/src/block/ItemFrame.php
+++ b/src/block/ItemFrame.php
@@ -175,7 +175,7 @@ class ItemFrame extends Flowable{
 	}
 
 	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		if($face === Facing::DOWN || $face === Facing::UP || !$blockReplace->getSide(Facing::opposite($face))->isSolid()){
+		if($face === Facing::DOWN || $face === Facing::UP || $blockReplace->getSide(Facing::opposite($face)) instanceof Flowable){
 			return false;
 		}
 


### PR DESCRIPTION
## Introduction
After some tests in vanilla survival, I could notice that the item frames could be placed on any block except the Flowable.

As PocketMine does not yet implement the item frames at the top and bottom of the blocks, only the faces work for the moment.

### Relevant issues
* Fixes #5734

## Tests

https://github.com/pmmp/PocketMine-MP/assets/66992287/2dc0d3f8-585a-4f88-b62d-f18e547dff1b