### PR TITLE
Addition of new minecraft colours, deletion of colours that have been removed from the game

### DIFF
--- a/src/utils/Terminal.php
+++ b/src/utils/Terminal.php
@@ -37,8 +37,6 @@ abstract class Terminal{
 	public static string $FORMAT_BOLD = "";
 	public static string $FORMAT_OBFUSCATED = "";
 	public static string $FORMAT_ITALIC = "";
-	public static string $FORMAT_UNDERLINE = "";
-	public static string $FORMAT_STRIKETHROUGH = "";
 
 	public static string $FORMAT_RESET = "";
 
@@ -59,6 +57,16 @@ abstract class Terminal{
 	public static string $COLOR_YELLOW = "";
 	public static string $COLOR_WHITE = "";
 	public static string $COLOR_MINECOIN_GOLD = "";
+	public static string $COLOR_MATERIAL_QUARTZ = "";
+	public static string $COLOR_MATERIAL_IRON = "";
+	public static string $COLOR_MATERIAL_NETHERITE = "";
+	public static string $COLOR_MATERIAL_REDSTONE = "";
+	public static string $COLOR_MATERIAL_COPPER = "";
+	public static string $COLOR_MATERIAL_GOLD = "";
+	public static string $COLOR_MATERIAL_EMERALD = "";
+	public static string $COLOR_MATERIAL_DIAMOND = "";
+	public static string $COLOR_MATERIAL_LAPIS = "";
+	public static string $COLOR_MATERIAL_AMETHYST = "";
 
 	private static ?bool $formattingCodes = null;
 
@@ -87,8 +95,6 @@ abstract class Terminal{
 		self::$FORMAT_BOLD = "\x1b[1m";
 		self::$FORMAT_OBFUSCATED = "";
 		self::$FORMAT_ITALIC = "\x1b[3m";
-		self::$FORMAT_UNDERLINE = "\x1b[4m";
-		self::$FORMAT_STRIKETHROUGH = "\x1b[9m";
 
 		self::$FORMAT_RESET = "\x1b[m";
 
@@ -111,6 +117,16 @@ abstract class Terminal{
 		self::$COLOR_YELLOW = $color(227);
 		self::$COLOR_WHITE = $color(231);
 		self::$COLOR_MINECOIN_GOLD = $color(184);
+        self::$COLOR_MATERIAL_QUARTZ = $color(224);
+        self::$COLOR_MATERIAL_IRON = $color(251);
+        self::$COLOR_MATERIAL_NETHERITE = $color(234);
+        self::$COLOR_MATERIAL_REDSTONE = $color(1);
+        self::$COLOR_MATERIAL_COPPER = $color(216);
+        self::$COLOR_MATERIAL_GOLD = $color(220);
+        self::$COLOR_MATERIAL_EMERALD = $color(71);
+        self::$COLOR_MATERIAL_DIAMOND = $color(122);
+        self::$COLOR_MATERIAL_LAPIS = $color(4);
+        self::$COLOR_MATERIAL_AMETHYST = $color(171);
 	}
 
 	protected static function getEscapeCodes() : void{
@@ -120,8 +136,6 @@ abstract class Terminal{
 		self::$FORMAT_BOLD = $tput("bold");
 		self::$FORMAT_OBFUSCATED = $tput("smacs");
 		self::$FORMAT_ITALIC = $tput("sitm");
-		self::$FORMAT_UNDERLINE = $tput("smul");
-		self::$FORMAT_STRIKETHROUGH = "\x1b[9m"; //`tput `;
 
 		self::$FORMAT_RESET = $tput("sgr0");
 
@@ -144,15 +158,25 @@ abstract class Terminal{
 			self::$COLOR_YELLOW = $colors >= 256 ? $setaf(227) : $setaf(11);
 			self::$COLOR_WHITE = $colors >= 256 ? $setaf(231) : $setaf(15);
 			self::$COLOR_MINECOIN_GOLD = $colors >= 256 ? $setaf(184) : $setaf(11);
-		}else{
-			self::$COLOR_BLACK = self::$COLOR_DARK_GRAY = $setaf(0);
-			self::$COLOR_RED = self::$COLOR_DARK_RED = $setaf(1);
-			self::$COLOR_GREEN = self::$COLOR_DARK_GREEN = $setaf(2);
-			self::$COLOR_YELLOW = self::$COLOR_GOLD = self::$COLOR_MINECOIN_GOLD = $setaf(3);
-			self::$COLOR_BLUE = self::$COLOR_DARK_BLUE = $setaf(4);
-			self::$COLOR_LIGHT_PURPLE = self::$COLOR_PURPLE = $setaf(5);
-			self::$COLOR_AQUA = self::$COLOR_DARK_AQUA = $setaf(6);
-			self::$COLOR_GRAY = self::$COLOR_WHITE = $setaf(7);
+		    self::$COLOR_MATERIAL_QUARTZ = $colors >= 256 ? $setaf(224) : $setaf(14);
+			self::$COLOR_MATERIAL_IRON = $colors >= 256 ? $setaf(251) : $setaf(7);
+			self::$COLOR_MATERIAL_NETHERITE = $colors >= 256 ? $setaf(234) : $setaf(8);
+			self::$COLOR_MATERIAL_REDSTONE = $setaf(9);
+			self::$COLOR_MATERIAL_COPPER = $colors >= 256 ? $setaf(216) : $setaf(3);
+			self::$COLOR_MATERIAL_GOLD = $colors >= 256 ? $setaf(220) : $setaf(3);
+			self::$COLOR_MATERIAL_EMERALD = $colors >= 256 ? $setaf(71) : $setaf(2);
+			self::$COLOR_MATERIAL_DIAMOND = $colors >= 256 ? $setaf(122) : $setaf(6);
+			self::$COLOR_MATERIAL_LAPIS = $setaf(12);
+			self::$COLOR_MATERIAL_AMETHYST = $colors >= 256 ? $setaf(171) : $setaf(5);
+   		}else{
+			self::$COLOR_BLACK = self::$COLOR_DARK_GRAY = self::$COLOR_MATERIAL_NETHERITE = $setaf(0);
+			self::$COLOR_RED = self::$COLOR_DARK_RED = self::$COLOR_MATERIAL_REDSTONE = self::$COLOR_MATERIAL_COPPER = $setaf(1);
+			self::$COLOR_GREEN = self::$COLOR_DARK_GREEN = self::$COLOR_MATERIAL_EMERALD = $setaf(2);
+			self::$COLOR_YELLOW = self::$COLOR_GOLD = self::$COLOR_MINECOIN_GOLD = self::$COLOR_MATERIAL_GOLD = $setaf(3);
+			self::$COLOR_BLUE = self::$COLOR_DARK_BLUE = self::$COLOR_MATERIAL_LAPIS = $setaf(4);
+			self::$COLOR_LIGHT_PURPLE = self::$COLOR_PURPLE = self::$COLOR_MATERIAL_AMETHYST = $setaf(5);
+			self::$COLOR_AQUA = self::$COLOR_DARK_AQUA = self::$COLOR_MATERIAL_DIAMOND = $setaf(6);
+			self::$COLOR_GRAY = self::$COLOR_WHITE = self::$COLOR_MATERIAL_QUARTZ = self::$COLOR_MATERIAL_IRON = $setaf(7);
 		}
 	}
 
@@ -195,8 +219,6 @@ abstract class Terminal{
 				TextFormat::BOLD => Terminal::$FORMAT_BOLD,
 				TextFormat::OBFUSCATED => Terminal::$FORMAT_OBFUSCATED,
 				TextFormat::ITALIC => Terminal::$FORMAT_ITALIC,
-				TextFormat::UNDERLINE => Terminal::$FORMAT_UNDERLINE,
-				TextFormat::STRIKETHROUGH => Terminal::$FORMAT_STRIKETHROUGH,
 				TextFormat::RESET => Terminal::$FORMAT_RESET,
 				TextFormat::BLACK => Terminal::$COLOR_BLACK,
 				TextFormat::DARK_BLUE => Terminal::$COLOR_DARK_BLUE,
@@ -215,6 +237,16 @@ abstract class Terminal{
 				TextFormat::YELLOW => Terminal::$COLOR_YELLOW,
 				TextFormat::WHITE => Terminal::$COLOR_WHITE,
 				TextFormat::MINECOIN_GOLD => Terminal::$COLOR_MINECOIN_GOLD,
+                TextFormat::MATERIAL_QUARTZ => Terminal::$COLOR_MATERIAL_QUARTZ,
+                TextFormat::MATERIAL_IRON => seTerminallf::$COLOR_MATERIAL_IRON,
+                TextFormat::MATERIAL_NETHERITE => Terminal::$COLOR_MATERIAL_NETHERITE,
+                TextFormat::MATERIAL_REDSTONE => Terminal::$COLOR_MATERIAL_REDSTONE,
+                TextFormat::MATERIAL_COPPER => Terminal::$COLOR_MATERIAL_COPPER,
+                TextFormat::MATERIAL_GOLD => Terminal::$COLOR_MATERIAL_GOLD,
+                TextFormat::MATERIAL_EMERALD => Terminal::$COLOR_MATERIAL_EMERALD,
+                TextFormat::MATERIAL_DIAMOND => Terminal::$COLOR_MATERIAL_DIAMOND,
+                TextFormat::MATERIAL_LAPIS => Terminal::$COLOR_MATERIAL_LAPIS,
+                TextFormat::MATERIAL_AMETHYST => Terminal::$COLOR_MATERIAL_AMETHYST,
 				default => $token,
 			};
 		}

--- a/src/utils/TextFormat.php
+++ b/src/utils/TextFormat.php
@@ -62,7 +62,17 @@ abstract class TextFormat{
 	public const LIGHT_PURPLE = TextFormat::ESCAPE . "d";
 	public const YELLOW = TextFormat::ESCAPE . "e";
 	public const WHITE = TextFormat::ESCAPE . "f";
-	public const MINECOIN_GOLD = TextFormat::ESCAPE . "g";
+	public const MINECOIN_GOLD  = TextFormat::ESCAPE . "g";
+	public const MATERIAL_QUARTZ = TextFormat::ESCAPE . "h";
+	public const MATERIAL_IRON = TextFormat::ESCAPE . "i";
+	public const MATERIAL_NETHERITE = TextFormat::ESCAPE . "j";
+	public const MATERIAL_REDSTONE = TextFormat::ESCAPE . "m";
+	public const MATERIAL_COPPER = TextFormat::ESCAPE . "n";
+	public const MATERIAL_GOLD = TextFormat::ESCAPE . "p";
+	public const MATERIAL_EMERALD = TextFormat::ESCAPE . "q";
+	public const MATERIAL_DIAMOND = TextFormat::ESCAPE . "s";
+	public const MATERIAL_LAPIS = TextFormat::ESCAPE . "t";
+	public const MATERIAL_AMETHYST = TextFormat::ESCAPE . "u";
 
 	public const COLORS = [
 		self::BLACK => self::BLACK,
@@ -81,20 +91,26 @@ abstract class TextFormat{
 		self::LIGHT_PURPLE => self::LIGHT_PURPLE,
 		self::YELLOW => self::YELLOW,
 		self::WHITE => self::WHITE,
-		self::MINECOIN_GOLD => self::MINECOIN_GOLD,
+		self::MINECOIN_GOLD  => self::MINECOIN_GOLD ,
+		self::MATERIAL_QUARTZ => self::MATERIAL_QUARTZ,
+		self::MATERIAL_IRON => self::MATERIAL_IRON,
+		self::MATERIAL_NETHERITE => self::MATERIAL_NETHERITE,
+		self::MATERIAL_REDSTONE => self::MATERIAL_REDSTONE,
+		self::MATERIAL_COPPER => self::MATERIAL_COPPER,
+		self::MATERIAL_GOLD => self::MATERIAL_GOLD,
+		self::MATERIAL_EMERALD => self::MATERIAL_EMERALD,
+		self::MATERIAL_DIAMOND => self::MATERIAL_DIAMOND,
+		self::MATERIAL_LAPIS => self::MATERIAL_LAPIS,
+		self::MATERIAL_AMETHYST => self::MATERIAL_AMETHYST,
 	];
 
 	public const OBFUSCATED = TextFormat::ESCAPE . "k";
 	public const BOLD = TextFormat::ESCAPE . "l";
-	public const STRIKETHROUGH = TextFormat::ESCAPE . "m";
-	public const UNDERLINE = TextFormat::ESCAPE . "n";
 	public const ITALIC = TextFormat::ESCAPE . "o";
 
 	public const FORMATS = [
 		self::OBFUSCATED => self::OBFUSCATED,
 		self::BOLD => self::BOLD,
-		self::STRIKETHROUGH => self::STRIKETHROUGH,
-		self::UNDERLINE => self::UNDERLINE,
 		self::ITALIC => self::ITALIC,
 	];
 
@@ -130,7 +146,7 @@ abstract class TextFormat{
 	 * @return string[]
 	 */
 	public static function tokenize(string $string) : array{
-		$result = preg_split("/(" . TextFormat::ESCAPE . "[0-9a-gk-or])/u", $string, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
+		$result = preg_split("/(" . TextFormat::ESCAPE . "[0-9a-u])/u", $string, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
 		if($result === false) throw self::makePcreError();
 		return $result;
 	}
@@ -144,7 +160,7 @@ abstract class TextFormat{
 		$string = mb_scrub($string, 'UTF-8');
 		$string = self::preg_replace("/[\x{E000}-\x{F8FF}]/u", "", $string); //remove unicode private-use-area characters (they might break the console)
 		if($removeFormat){
-			$string = str_replace(TextFormat::ESCAPE, "", self::preg_replace("/" . TextFormat::ESCAPE . "[0-9a-gk-or]/u", "", $string));
+			$string = str_replace(TextFormat::ESCAPE, "", self::preg_replace("/" . TextFormat::ESCAPE . "[0-9a-u]/u", "", $string));
 		}
 		return str_replace("\x1b", "", self::preg_replace("/\x1b[\\(\\][[0-9;\\[\\(]+[Bm]/u", "", $string));
 	}
@@ -155,7 +171,7 @@ abstract class TextFormat{
 	 * @param string $placeholder default "&"
 	 */
 	public static function colorize(string $string, string $placeholder = "&") : string{
-		return self::preg_replace('/' . preg_quote($placeholder, "/") . '([0-9a-gk-or])/u', TextFormat::ESCAPE . '$1', $string);
+		return self::preg_replace('/' . preg_quote($placeholder, "/") . '([0-9a-u])/u', TextFormat::ESCAPE . '$1', $string);
 	}
 
 	/**
@@ -201,14 +217,6 @@ abstract class TextFormat{
 					break;
 				case TextFormat::ITALIC:
 					$newString .= "<span style=font-style:italic>";
-					++$tokens;
-					break;
-				case TextFormat::UNDERLINE:
-					$newString .= "<span style=text-decoration:underline>";
-					++$tokens;
-					break;
-				case TextFormat::STRIKETHROUGH:
-					$newString .= "<span style=text-decoration:line-through>";
 					++$tokens;
 					break;
 				case TextFormat::RESET:
@@ -281,8 +289,48 @@ abstract class TextFormat{
 					$newString .= "<span style=color:#FFF>";
 					++$tokens;
 					break;
-				case TextFormat::MINECOIN_GOLD:
+				case TextFormat::MINECOIN_GOLD :
 					$newString .= "<span style=color:#dd0>";
+					++$tokens;
+					break;
+				case TextFormat::MATERIAL_QUARTZ:
+					$newString .= "<span style=color:#e2d3d1>";
+					++$tokens;
+					break;
+				case TextFormat::MATERIAL_IRON:
+					$newString .= "<span style=color:#cec9c9>";
+					++$tokens;
+					break;
+				case TextFormat::MATERIAL_NETHERITE:
+					$newString .= "<span style=color:#44393a>";
+					++$tokens;
+					break;
+				case TextFormat::MATERIAL_REDSTONE:
+					$newString .= "<span style=color:#961506>";
+					++$tokens;
+					break;
+				case TextFormat::MATERIAL_COPPER:
+					$newString .= "<span style=color:#b4684d>";
+					++$tokens;
+					break;
+				case TextFormat::MATERIAL_GOLD:
+					$newString .= "<span style=color:#deb02c>";
+					++$tokens;
+					break;
+				case TextFormat::MATERIAL_EMERALD:
+					$newString .= "<span style=color:#119f36>";
+					++$tokens;
+					break;
+				case TextFormat::MATERIAL_DIAMOND:
+					$newString .= "<span style=color:#2cb9a8>";
+					++$tokens;
+					break;
+				case TextFormat::MATERIAL_LAPIS:
+					$newString .= "<span style=color:#20487a>";
+					++$tokens;
+					break;
+				case TextFormat::MATERIAL_AMETHYST:
+					$newString .= "<span style=color:#9a5cc5>";
 					++$tokens;
 					break;
 				default:


### PR DESCRIPTION
## Introduction
Minecraft has just added the colours that are linked to the materials (colours slightly modified from the classic ones) and Minecraft has removed a few other colours (I don't know since when) which are the underline and the strikethrough. 

## Tests
On this photo I realised that minecraft didn't have the underline and the strikethrough (I removed them).
![image](https://github.com/pmmp/PocketMine-MP/assets/40174895/f9832b69-85b3-4adf-a86c-5d41489e140c)

