### PR TITLE
Remove method call to ReflectionProperty::setAccessible()

### DIFF
--- a/src/MemoryManager.php
+++ b/src/MemoryManager.php
@@ -316,9 +316,6 @@ class MemoryManager{
 					continue;
 				}
 
-				if(!$property->isPublic()){
-					$property->setAccessible(true);
-				}
 				if(!$property->isInitialized()){
 					continue;
 				}
@@ -441,9 +438,6 @@ class MemoryManager{
 								}else{
 									continue;
 								}
-							}
-							if(!$property->isPublic()){
-								$property->setAccessible(true);
 							}
 							if(!$property->isInitialized($object)){
 								continue;

--- a/src/crash/CrashDump.php
+++ b/src/crash/CrashDump.php
@@ -248,7 +248,6 @@ class CrashDump{
 			if(file_exists($filePath)){
 				$reflection = new \ReflectionClass(PluginBase::class);
 				$file = $reflection->getProperty("file");
-				$file->setAccessible(true);
 				foreach($this->server->getPluginManager()->getPlugins() as $plugin){
 					$filePath = Filesystem::cleanPath($file->getValue($plugin));
 					if(str_starts_with($frameCleanPath, $filePath)){


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
As of PHP 8.1, `ReflectionProperty::getValue()` and `ReflectionProperty::setValue()` do not require calling `ReflectionProperty::setAccessible(true)` ([rfc:make-reflection-setaccessible-no-op](https://wiki.php.net/rfc/make-reflection-setaccessible-no-op)).

### Relevant issues
No issues exist regarding PHP 8.1's reflection-setaccessible change as calling `ReflectionClass::setAccessible(true)` has [no effect](https://www.php.net/manual/en/reflectionproperty.setaccessible.php).

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
This PR does not introduce API changes.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
This PR does not introduce behavioural changes.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
This change is backward-incompatible with PHP versions < 8.1. However, this should not be an issue since 8.1 is now minimum version (https://github.com/pmmp/PocketMine-MP/commit/043350753b9c93a6a7e508fbaec0744e5d2d4beb).

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
Similar change may be made to dependency libraries that are now using PHP 8.1 as minimum version.

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
Using PHP 8.1, the following code does not result in an error due to `ReflectionProperty::setAccessible()` not being called.
https://3v4l.org/689D9#v8.1.19
```php
<?php

declare(strict_types=1);

final class IntObj{
    
    public function __construct(
        private int $value
    ){}
}

$obj = new IntObj(4);

$_value = new ReflectionProperty(IntObj::class, "value");
$value = $_value->getValue($obj);
assert($value === 4);
```