### PR TITLE
Always drop spore blossom item when it is broken

### DIFF
--- a/src/block/SporeBlossom.php
+++ b/src/block/SporeBlossom.php
@@ -49,8 +49,4 @@ final class SporeBlossom extends Flowable{
 			$this->position->getWorld()->useBreakOn($this->position);
 		}
 	}
-
-	public function getDropsForCompatibleTool(Item $item) : array{
-		return [];
-	}
 }


### PR DESCRIPTION
## Introduction
As [wiki](https://minecraft.fandom.com/wiki/Spore_Blossom#Breaking) and gameplay tests, spore blossom should always being dropped when is broken

## Relevant issues
* Fixes #5795