### PR TITLE
AsyncTask Avoid useless progressUpdates allocations

### DIFF
--- a/src/scheduler/AsyncPool.php
+++ b/src/scheduler/AsyncPool.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace pocketmine\scheduler;
 
 use pmmp\thread\Thread as NativeThread;
-use pmmp\thread\ThreadSafeArray;
 use pocketmine\snooze\SleeperHandler;
 use pocketmine\thread\log\ThreadSafeLogger;
 use pocketmine\thread\ThreadSafeClassLoader;
@@ -146,7 +145,6 @@ class AsyncPool{
 			throw new \InvalidArgumentException("Cannot submit the same AsyncTask instance more than once");
 		}
 
-		$task->progressUpdates = new ThreadSafeArray();
 		$task->setSubmitted();
 
 		$this->getWorker($worker)->submit($task);


### PR DESCRIPTION
## Introduction
The usually-unused `progressUpdates` member allocation caused an increase in AsyncTask overhead by anywhere from 10-40%.

Prior to pthreads 5.1, this was inescapable due to technical limitations, but as of pthreads 5.1 and pmmpthread, it's now possible to lazily initialize this when it's used, reducing the main-thread performance impact of AsyncTasks.

## Changes
### API changes
`AsyncTask->progressUpdates` is implicitly internal, although it was never documented as such, so this doesn't constitute an API change and is not likely to affect any plugins.

### Behavioural changes
The performance cost of submitting an async task is now reduced.

## Backwards compatibility
Fully backwards compatible.

## Tests
Existing tests should verify that this works as intended.