### PR TITLE
implement separated asyncPool for world

### DIFF
--- a/resources/pocketmine.yml
+++ b/resources/pocketmine.yml
@@ -40,6 +40,11 @@ memory:
   #NOTE: THIS LIMIT APPLIES PER WORKER, NOT TO THE WHOLE PROCESS.
   async-worker-hard-limit: 256
 
+  #AsyncWorker for World threads' hard memory limit in megabytes. Set to 0 to disable
+  #This will crash the task currently executing on the worker if the task exceeds the limit
+  #NOTE: THIS LIMIT APPLIES PER WORKER, NOT TO THE WHOLE PROCESS.
+  async-worker-world-hard-limit": 256
+
   #Period in ticks to check memory (default 1 second)
   check-rate: 20
 

--- a/resources/pocketmine.yml
+++ b/resources/pocketmine.yml
@@ -43,7 +43,7 @@ memory:
   #AsyncWorker for World threads' hard memory limit in megabytes. Set to 0 to disable
   #This will crash the task currently executing on the worker if the task exceeds the limit
   #NOTE: THIS LIMIT APPLIES PER WORKER, NOT TO THE WHOLE PROCESS.
-  async-worker-world-hard-limit": 256
+  async-worker-world-hard-limit: 256
 
   #Period in ticks to check memory (default 1 second)
   check-rate: 20

--- a/src/Server.php
+++ b/src/Server.php
@@ -761,7 +761,7 @@ class Server{
 	}
 
 	public function __construct(
-		private ThreadSafeClassLoader $autoloader,
+		public  readonly ThreadSafeClassLoader $autoloader,
 		private AttachableThreadSafeLogger $logger,
 		string $dataPath,
 		string $pluginPath
@@ -888,7 +888,7 @@ class Server{
 				$poolSize = max(1, (int) $poolSize);
 			}
 
-			$this->asyncPool = new AsyncPool($poolSize, max(-1, $this->configGroup->getPropertyInt("memory.async-worker-hard-limit", 256)), $this->autoloader, $this->logger, $this->tickSleeper);
+			$this->asyncPool = new AsyncPool($poolSize, max(-1, $this->configGroup->getPropertyInt("memory.async-worker-world-hard-limit", 256)), $this->autoloader, $this->logger, $this->tickSleeper);
 
 			$netCompressionThreshold = -1;
 			if($this->configGroup->getPropertyInt("network.batch-threshold", 256) >= 0){

--- a/src/world/WorldManager.php
+++ b/src/world/WorldManager.php
@@ -29,6 +29,7 @@ use pocketmine\event\world\WorldLoadEvent;
 use pocketmine\event\world\WorldUnloadEvent;
 use pocketmine\lang\KnownTranslationFactory;
 use pocketmine\player\ChunkSelector;
+use pocketmine\scheduler\AsyncPool;
 use pocketmine\Server;
 use pocketmine\world\format\Chunk;
 use pocketmine\world\format\io\exception\CorruptedWorldException;
@@ -246,8 +247,7 @@ class WorldManager{
 			$this->server->getLogger()->notice($this->server->getLanguage()->translate(KnownTranslationFactory::pocketmine_level_conversion_finish($name, $converter->getBackupPath())));
 		}
 
-		$world = new World($this->server, $name, $provider, $this->server->getAsyncPool());
-
+		$world = new World($this->server, $name, $provider);
 		$this->worlds[$world->getId()] = $world;
 		$world->setAutoSave($this->autoSave);
 


### PR DESCRIPTION
## Introduction
The problem he had with this system was that the generation of the worlds stopped if he had an AsyncTask that was blocked for X time, all the pieces that had to generate had to wait this time for the asyncTask to finish, but I separated the asyncPool from the Server and from each world to have a better performance in the generation of the world.

## Changes
### API changes
Add the following functions to the `Server`class:

- `autoloader` is change in public readonly

Add the following functions to the `World`class:

- `workerPool` to `asyncPool`
- `getAsyncPool` can use on WorldLoadEvent

### Behavioural changes
to be tested on a larger scale
![image](https://github.com/pmmp/PocketMine-MP/assets/32621158/32b7daf3-a720-4c39-b063-2a887b7c2c9f)
enables parallel generation

## Backwards compatibility

then it will have porblems in the Block or Item adds that it will also have to be synchronized in each world

## Follow-up

then I think we should make a real AsyncPool with a different name because when we turn them off and put the World logger


