### PR TITLE
Accept translatable permission messages in `Command`

### DIFF
--- a/src/command/Command.php
+++ b/src/command/Command.php
@@ -112,13 +112,12 @@ abstract class Command{
 			return true;
 		}
 
+		$message = null;
 		if($this->permissionMessage instanceof Translatable || $this->permissionMessage === null){
 			$message = $this->permissionMessage ?? KnownTranslationFactory::pocketmine_command_error_permission($this->name);
 			$message = $message->prefix(TextFormat::RED);
 		}elseif($this->permissionMessage !== ""){
 			$message = str_replace("<permission>", $permission ?? implode(";", $this->permission), $this->permissionMessage);
-		}else{
-			$message = null;
 		}
 
 		if($message !== null){

--- a/src/command/Command.php
+++ b/src/command/Command.php
@@ -114,9 +114,15 @@ abstract class Command{
 
 		if($this->permissionMessage instanceof Translatable || $this->permissionMessage === null){
 			$message = $this->permissionMessage ?? KnownTranslationFactory::pocketmine_command_error_permission($this->name);
-			$target->sendMessage($message->prefix(TextFormat::RED));
+			$message = $message->prefix(TextFormat::RED);
 		}elseif($this->permissionMessage !== ""){
-			$target->sendMessage(str_replace("<permission>", $permission ?? implode(";", $this->permission), $this->permissionMessage));
+			$message = str_replace("<permission>", $permission ?? implode(";", $this->permission), $this->permissionMessage);
+		}else{
+			$message = null;
+		}
+
+		if($message !== null){
+			$target->sendMessage($message);
 		}
 
 		return false;

--- a/src/command/Command.php
+++ b/src/command/Command.php
@@ -112,17 +112,14 @@ abstract class Command{
 			return true;
 		}
 
-		$message = null;
-		if($this->permissionMessage instanceof Translatable || $this->permissionMessage === null){
-			$message = $this->permissionMessage ?? KnownTranslationFactory::pocketmine_command_error_permission($this->name);
+		$message = $this->permissionMessage ?? KnownTranslationFactory::pocketmine_command_error_permission($this->name);
+		if($message instanceof Translatable){
 			$message = $message->prefix(TextFormat::RED);
-		}elseif($this->permissionMessage !== ""){
-			$message = str_replace("<permission>", $permission ?? implode(";", $this->permission), $this->permissionMessage);
+		}elseif($message !== ""){
+			$message = str_replace("<permission>", $permission ?? implode(";", $this->permission), $message);
 		}
 
-		if($message !== null){
-			$target->sendMessage($message);
-		}
+		$target->sendMessage($message);
 
 		return false;
 	}

--- a/src/command/Command.php
+++ b/src/command/Command.php
@@ -58,7 +58,7 @@ abstract class Command{
 
 	/** @var string[] */
 	private array $permission = [];
-	private null|string|Translatable $permissionMessage = null;
+	private Translatable|string|null $permissionMessage = null;
 
 	/**
 	 * @param string[] $aliases
@@ -190,7 +190,7 @@ abstract class Command{
 		return $this->activeAliases;
 	}
 
-	public function getPermissionMessage() : null|string|Translatable{
+	public function getPermissionMessage() : Translatable|string|null{
 		return $this->permissionMessage;
 	}
 
@@ -216,7 +216,7 @@ abstract class Command{
 		$this->description = $description;
 	}
 
-	public function setPermissionMessage(string|Translatable $permissionMessage) : void{
+	public function setPermissionMessage(Translatable|string $permissionMessage) : void{
 		$this->permissionMessage = $permissionMessage;
 	}
 

--- a/src/command/Command.php
+++ b/src/command/Command.php
@@ -112,7 +112,7 @@ abstract class Command{
 			return true;
 		}
 
-		if(!is_string($this->permissionMessage)){
+		if($this->permissionMessage instanceof Translatable || $this->permissionMessage === null){
 			$message = $this->permissionMessage ?? KnownTranslationFactory::pocketmine_command_error_permission($this->name);
 			$target->sendMessage($message->prefix(TextFormat::RED));
 		}elseif($this->permissionMessage !== ""){

--- a/src/command/Command.php
+++ b/src/command/Command.php
@@ -58,7 +58,7 @@ abstract class Command{
 
 	/** @var string[] */
 	private array $permission = [];
-	private ?string $permissionMessage = null;
+	private null|string|Translatable $permissionMessage = null;
 
 	/**
 	 * @param string[] $aliases
@@ -112,8 +112,9 @@ abstract class Command{
 			return true;
 		}
 
-		if($this->permissionMessage === null){
-			$target->sendMessage(KnownTranslationFactory::pocketmine_command_error_permission($this->name)->prefix(TextFormat::RED));
+		if(!is_string($this->permissionMessage)){
+			$message = $this->permissionMessage ?? KnownTranslationFactory::pocketmine_command_error_permission($this->name);
+			$target->sendMessage($message->prefix(TextFormat::RED));
 		}elseif($this->permissionMessage !== ""){
 			$target->sendMessage(str_replace("<permission>", $permission ?? implode(";", $this->permission), $this->permissionMessage));
 		}
@@ -187,7 +188,7 @@ abstract class Command{
 		return $this->activeAliases;
 	}
 
-	public function getPermissionMessage() : ?string{
+	public function getPermissionMessage() : null|string|Translatable{
 		return $this->permissionMessage;
 	}
 
@@ -213,7 +214,7 @@ abstract class Command{
 		$this->description = $description;
 	}
 
-	public function setPermissionMessage(string $permissionMessage) : void{
+	public function setPermissionMessage(string|Translatable $permissionMessage) : void{
 		$this->permissionMessage = $permissionMessage;
 	}
 

--- a/src/command/Command.php
+++ b/src/command/Command.php
@@ -114,12 +114,10 @@ abstract class Command{
 
 		$message = $this->permissionMessage ?? KnownTranslationFactory::pocketmine_command_error_permission($this->name);
 		if($message instanceof Translatable){
-			$message = $message->prefix(TextFormat::RED);
+			$target->sendMessage($message->prefix(TextFormat::RED));
 		}elseif($message !== ""){
-			$message = str_replace("<permission>", $permission ?? implode(";", $this->permission), $message);
+			$target->sendMessage(str_replace("<permission>", $permission ?? implode(";", $this->permission), $message));
 		}
-
-		$target->sendMessage($message);
 
 		return false;
 	}


### PR DESCRIPTION
## Introduction
Currently, if a plugin wishes to modify the message directly in the event of insufficient permission, it cannot pass an instance of Translatable.

## Changes
### API changes
- Accept ``Translatable`` in ``permissionMessage``

## Tests

```php
class TestCommand extends Command{
	public function __construct(string $name, Translatable|string $description = "", Translatable|string|null $usageMessage = null, array $aliases = []){
		parent::__construct($name, $description, $usageMessage, $aliases);
		$permission = new Permission("test.command", "Allows you to use the test command");
		PermissionManager::getInstance()->addPermission($permission);
		$this->setPermission("test.command");
		$this->setPermissionMessage(KnownTranslationFactory::ability_noclip());
	}

	public function execute(CommandSender $sender, string $commandLabel, array $args){
		$sender->sendMessage("You have permission to use this command!");
	}
}

// Will send No-clip because we haven't the permission
```