### PR TITLE
Add ability to get cause in EntityTeleportEvent (#5767)

### DIFF
--- a/src/command/defaults/TeleportCommand.php
+++ b/src/command/defaults/TeleportCommand.php
@@ -27,6 +27,7 @@ use pocketmine\command\Command;
 use pocketmine\command\CommandSender;
 use pocketmine\command\utils\InvalidCommandSyntaxException;
 use pocketmine\entity\Location;
+use pocketmine\event\entity\EntityTeleportEvent;
 use pocketmine\lang\KnownTranslationFactory;
 use pocketmine\permission\DefaultPermissionNames;
 use pocketmine\player\Player;
@@ -89,7 +90,7 @@ class TeleportCommand extends VanillaCommand{
 					return true;
 				}
 
-				$subject->teleport($targetPlayer->getLocation());
+				$subject->teleport($targetPlayer->getLocation(), null, null, EntityTeleportEvent::CAUSE_COMMAND);
 				Command::broadcastCommandMessage($sender, KnownTranslationFactory::commands_tp_success($subject->getName(), $targetPlayer->getName()));
 
 				return true;
@@ -109,7 +110,7 @@ class TeleportCommand extends VanillaCommand{
 				$z = $this->getRelativeDouble($base->z, $sender, $args[2]);
 				$targetLocation = new Location($x, $y, $z, $base->getWorld(), $yaw, $pitch);
 
-				$subject->teleport($targetLocation);
+				$subject->teleport($targetLocation, null, null, EntityTeleportEvent::CAUSE_COMMAND);
 				Command::broadcastCommandMessage($sender, KnownTranslationFactory::commands_tp_success_coordinates(
 					$subject->getName(),
 					(string) round($targetLocation->x, 2),

--- a/src/command/defaults/TeleportCommand.php
+++ b/src/command/defaults/TeleportCommand.php
@@ -90,7 +90,7 @@ class TeleportCommand extends VanillaCommand{
 					return true;
 				}
 
-				$subject->teleport($targetPlayer->getLocation(), null, null, EntityTeleportEvent::CAUSE_COMMAND);
+				$subject->teleport($targetPlayer->getLocation(), cause: EntityTeleportEvent::CAUSE_COMMAND);
 				Command::broadcastCommandMessage($sender, KnownTranslationFactory::commands_tp_success($subject->getName(), $targetPlayer->getName()));
 
 				return true;
@@ -110,7 +110,7 @@ class TeleportCommand extends VanillaCommand{
 				$z = $this->getRelativeDouble($base->z, $sender, $args[2]);
 				$targetLocation = new Location($x, $y, $z, $base->getWorld(), $yaw, $pitch);
 
-				$subject->teleport($targetLocation, null, null, EntityTeleportEvent::CAUSE_COMMAND);
+				$subject->teleport($targetLocation, cause: EntityTeleportEvent::CAUSE_COMMAND);
 				Command::broadcastCommandMessage($sender, KnownTranslationFactory::commands_tp_success_coordinates(
 					$subject->getName(),
 					(string) round($targetLocation->x, 2),

--- a/src/entity/Entity.php
+++ b/src/entity/Entity.php
@@ -1418,7 +1418,7 @@ abstract class Entity{
 	/**
 	 * @param Vector3|Position|Location $pos
 	 */
-	public function teleport(Vector3 $pos, ?float $yaw = null, ?float $pitch = null) : bool{
+	public function teleport(Vector3 $pos, ?float $yaw = null, ?float $pitch = null, int $cause = EntityTeleportEvent::CAUSE_PLUGIN) : bool{
 		Utils::checkVector3NotInfOrNaN($pos);
 		if($pos instanceof Location){
 			$yaw = $yaw ?? $pos->yaw;
@@ -1433,7 +1433,7 @@ abstract class Entity{
 
 		$from = $this->location->asPosition();
 		$to = Position::fromObject($pos, $pos instanceof Position ? $pos->getWorld() : $this->getWorld());
-		$ev = new EntityTeleportEvent($this, $from, $to);
+		$ev = new EntityTeleportEvent($this, $from, $to, $cause);
 		$ev->call();
 		if($ev->isCancelled()){
 			return false;

--- a/src/entity/projectile/EnderPearl.php
+++ b/src/entity/projectile/EnderPearl.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace pocketmine\entity\projectile;
 
 use pocketmine\event\entity\EntityDamageEvent;
+use pocketmine\event\entity\EntityTeleportEvent;
 use pocketmine\event\entity\ProjectileHitEvent;
 use pocketmine\network\mcpe\protocol\types\entity\EntityIds;
 use pocketmine\world\particle\EndermanTeleportParticle;
@@ -40,7 +41,7 @@ class EnderPearl extends Throwable{
 
 			$this->getWorld()->addParticle($origin = $owner->getPosition(), new EndermanTeleportParticle());
 			$this->getWorld()->addSound($origin, new EndermanTeleportSound());
-			$owner->teleport($target = $event->getRayTraceResult()->getHitVector());
+			$owner->teleport($target = $event->getRayTraceResult()->getHitVector(), null, null, EntityTeleportEvent::CAUSE_ITEM);
 			$this->getWorld()->addSound($target, new EndermanTeleportSound());
 
 			$owner->attack(new EntityDamageEvent($owner, EntityDamageEvent::CAUSE_FALL, 5));

--- a/src/entity/projectile/EnderPearl.php
+++ b/src/entity/projectile/EnderPearl.php
@@ -41,7 +41,7 @@ class EnderPearl extends Throwable{
 
 			$this->getWorld()->addParticle($origin = $owner->getPosition(), new EndermanTeleportParticle());
 			$this->getWorld()->addSound($origin, new EndermanTeleportSound());
-			$owner->teleport($target = $event->getRayTraceResult()->getHitVector(), null, null, EntityTeleportEvent::CAUSE_PROJECTILE);
+			$owner->teleport($target = $event->getRayTraceResult()->getHitVector(), cause: EntityTeleportEvent::CAUSE_PROJECTILE);
 			$this->getWorld()->addSound($target, new EndermanTeleportSound());
 
 			$owner->attack(new EntityDamageEvent($owner, EntityDamageEvent::CAUSE_FALL, 5));

--- a/src/entity/projectile/EnderPearl.php
+++ b/src/entity/projectile/EnderPearl.php
@@ -41,7 +41,7 @@ class EnderPearl extends Throwable{
 
 			$this->getWorld()->addParticle($origin = $owner->getPosition(), new EndermanTeleportParticle());
 			$this->getWorld()->addSound($origin, new EndermanTeleportSound());
-			$owner->teleport($target = $event->getRayTraceResult()->getHitVector(), null, null, EntityTeleportEvent::CAUSE_ITEM);
+			$owner->teleport($target = $event->getRayTraceResult()->getHitVector(), null, null, EntityTeleportEvent::CAUSE_PROJECTILE);
 			$this->getWorld()->addSound($target, new EndermanTeleportSound());
 
 			$owner->attack(new EntityDamageEvent($owner, EntityDamageEvent::CAUSE_FALL, 5));

--- a/src/event/entity/EntityTeleportEvent.php
+++ b/src/event/entity/EntityTeleportEvent.php
@@ -35,10 +35,18 @@ use pocketmine\world\Position;
 class EntityTeleportEvent extends EntityEvent implements Cancellable{
 	use CancellableTrait;
 
+    public const CAUSE_PLUGIN = 0;
+    public const CAUSE_ITEM = 1;
+    public const CAUSE_WORLD = 2;
+    public const CAUSE_RESPAWN = 3;
+    public const CAUSE_PATCH = 4;
+    public const CAUSE_COMMAND = 5;
+
 	public function __construct(
 		Entity $entity,
 		private Position $from,
-		private Position $to
+		private Position $to,
+        private int $cause
 	){
 		$this->entity = $entity;
 	}
@@ -50,6 +58,16 @@ class EntityTeleportEvent extends EntityEvent implements Cancellable{
 	public function getTo() : Position{
 		return $this->to;
 	}
+
+    public function getCause(): int
+    {
+        return $this->cause;
+    }
+
+    public function setCause(int $cause): void
+    {
+        $this->cause = $cause;
+    }
 
 	public function setTo(Position $to) : void{
 		Utils::checkVector3NotInfOrNaN($to);

--- a/src/event/entity/EntityTeleportEvent.php
+++ b/src/event/entity/EntityTeleportEvent.php
@@ -36,10 +36,10 @@ class EntityTeleportEvent extends EntityEvent implements Cancellable{
 	use CancellableTrait;
 
 	public const CAUSE_PLUGIN = 0;
-	public const CAUSE_ITEM = 1;
+	public const CAUSE_PROJECTILE = 1;
 	public const CAUSE_WORLD = 2;
 	public const CAUSE_RESPAWN = 3;
-	public const CAUSE_PATCH = 4;
+	public const CAUSE_CHORUS_FRUIT = 4;
 	public const CAUSE_COMMAND = 5;
 
 	public function __construct(
@@ -59,13 +59,11 @@ class EntityTeleportEvent extends EntityEvent implements Cancellable{
 		return $this->to;
 	}
 
-	public function getCause() : int
-	{
+	public function getCause() : int{
 		return $this->cause;
 	}
 
-	public function setCause(int $cause) : void
-	{
+	public function setCause(int $cause) : void{
 		$this->cause = $cause;
 	}
 

--- a/src/event/entity/EntityTeleportEvent.php
+++ b/src/event/entity/EntityTeleportEvent.php
@@ -59,12 +59,12 @@ class EntityTeleportEvent extends EntityEvent implements Cancellable{
 		return $this->to;
 	}
 
-	public function getCause(): int
+	public function getCause() : int
 	{
 		return $this->cause;
 	}
 
-	public function setCause(int $cause): void
+	public function setCause(int $cause) : void
 	{
 		$this->cause = $cause;
 	}

--- a/src/event/entity/EntityTeleportEvent.php
+++ b/src/event/entity/EntityTeleportEvent.php
@@ -35,18 +35,18 @@ use pocketmine\world\Position;
 class EntityTeleportEvent extends EntityEvent implements Cancellable{
 	use CancellableTrait;
 
-    public const CAUSE_PLUGIN = 0;
-    public const CAUSE_ITEM = 1;
-    public const CAUSE_WORLD = 2;
-    public const CAUSE_RESPAWN = 3;
-    public const CAUSE_PATCH = 4;
-    public const CAUSE_COMMAND = 5;
+	public const CAUSE_PLUGIN = 0;
+	public const CAUSE_ITEM = 1;
+	public const CAUSE_WORLD = 2;
+	public const CAUSE_RESPAWN = 3;
+	public const CAUSE_PATCH = 4;
+	public const CAUSE_COMMAND = 5;
 
 	public function __construct(
 		Entity $entity,
 		private Position $from,
 		private Position $to,
-        private int $cause
+		private int $cause
 	){
 		$this->entity = $entity;
 	}
@@ -59,15 +59,15 @@ class EntityTeleportEvent extends EntityEvent implements Cancellable{
 		return $this->to;
 	}
 
-    public function getCause(): int
-    {
-        return $this->cause;
-    }
+	public function getCause(): int
+	{
+		return $this->cause;
+	}
 
-    public function setCause(int $cause): void
-    {
-        $this->cause = $cause;
-    }
+	public function setCause(int $cause): void
+	{
+		$this->cause = $cause;
+	}
 
 	public function setTo(Position $to) : void{
 		Utils::checkVector3NotInfOrNaN($to);

--- a/src/item/ChorusFruit.php
+++ b/src/item/ChorusFruit.php
@@ -25,6 +25,7 @@ namespace pocketmine\item;
 
 use pocketmine\block\Liquid;
 use pocketmine\entity\Living;
+use pocketmine\event\entity\EntityTeleportEvent;
 use pocketmine\math\Vector3;
 use pocketmine\world\sound\EndermanTeleportSound;
 use function min;
@@ -76,7 +77,7 @@ class ChorusFruit extends Food{
 
 			//Sounds are broadcasted at both source and destination
 			$world->addSound($origin, new EndermanTeleportSound());
-			$consumer->teleport($target = new Vector3($x + 0.5, $y + 1, $z + 0.5));
+			$consumer->teleport($target = new Vector3($x + 0.5, $y + 1, $z + 0.5), null, null, EntityTeleportEvent::CAUSE_ITEM);
 			$world->addSound($target, new EndermanTeleportSound());
 
 			break;

--- a/src/item/ChorusFruit.php
+++ b/src/item/ChorusFruit.php
@@ -77,7 +77,7 @@ class ChorusFruit extends Food{
 
 			//Sounds are broadcasted at both source and destination
 			$world->addSound($origin, new EndermanTeleportSound());
-			$consumer->teleport($target = new Vector3($x + 0.5, $y + 1, $z + 0.5), null, null, EntityTeleportEvent::CAUSE_CHORUS_FRUIT);
+			$consumer->teleport($target = new Vector3($x + 0.5, $y + 1, $z + 0.5), cause: EntityTeleportEvent::CAUSE_CHORUS_FRUIT);
 			$world->addSound($target, new EndermanTeleportSound());
 
 			break;

--- a/src/item/ChorusFruit.php
+++ b/src/item/ChorusFruit.php
@@ -77,7 +77,7 @@ class ChorusFruit extends Food{
 
 			//Sounds are broadcasted at both source and destination
 			$world->addSound($origin, new EndermanTeleportSound());
-			$consumer->teleport($target = new Vector3($x + 0.5, $y + 1, $z + 0.5), null, null, EntityTeleportEvent::CAUSE_ITEM);
+			$consumer->teleport($target = new Vector3($x + 0.5, $y + 1, $z + 0.5), null, null, EntityTeleportEvent::CAUSE_CHORUS_FRUIT);
 			$world->addSound($target, new EndermanTeleportSound());
 
 			break;

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -45,6 +45,7 @@ use pocketmine\entity\projectile\Arrow;
 use pocketmine\entity\Skin;
 use pocketmine\event\entity\EntityDamageByEntityEvent;
 use pocketmine\event\entity\EntityDamageEvent;
+use pocketmine\event\entity\EntityTeleportEvent;
 use pocketmine\event\inventory\InventoryCloseEvent;
 use pocketmine\event\inventory\InventoryOpenEvent;
 use pocketmine\event\player\PlayerBedEnterEvent;
@@ -1339,7 +1340,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 			}
 
 			if($to->distanceSquared($ev->getTo()) > 0.01){ //If plugins modify the destination
-				$this->teleport($ev->getTo());
+				$this->teleport($ev->getTo(), null, null, EntityTeleportEvent::CAUSE_PATCH);
 				return;
 			}
 
@@ -2387,7 +2388,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 				$ev->call();
 
 				$realSpawn = Position::fromObject($ev->getRespawnPosition()->add(0.5, 0, 0.5), $ev->getRespawnPosition()->getWorld());
-				$this->teleport($realSpawn);
+				$this->teleport($realSpawn, null, null, EntityTeleportEvent::CAUSE_RESPAWN);
 
 				$this->setSprinting(false);
 				$this->setSneaking(false);
@@ -2487,8 +2488,8 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		$this->ySize = 0;
 	}
 
-	public function teleport(Vector3 $pos, ?float $yaw = null, ?float $pitch = null) : bool{
-		if(parent::teleport($pos, $yaw, $pitch)){
+	public function teleport(Vector3 $pos, ?float $yaw = null, ?float $pitch = null, int $cause = EntityTeleportEvent::CAUSE_PLUGIN) : bool{
+		if(parent::teleport($pos, $yaw, $pitch, $cause)){
 
 			$this->removeCurrentWindow();
 			$this->stopSleep();

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1340,7 +1340,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 			}
 
 			if($to->distanceSquared($ev->getTo()) > 0.01){ //If plugins modify the destination
-				$this->teleport($ev->getTo(), null, null, EntityTeleportEvent::CAUSE_PATCH);
+				$this->teleport($ev->getTo());
 				return;
 			}
 

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -2388,7 +2388,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 				$ev->call();
 
 				$realSpawn = Position::fromObject($ev->getRespawnPosition()->add(0.5, 0, 0.5), $ev->getRespawnPosition()->getWorld());
-				$this->teleport($realSpawn, null, null, EntityTeleportEvent::CAUSE_RESPAWN);
+				$this->teleport($realSpawn, cause: EntityTeleportEvent::CAUSE_RESPAWN);
 
 				$this->setSprinting(false);
 				$this->setSneaking(false);

--- a/src/world/WorldManager.php
+++ b/src/world/WorldManager.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace pocketmine\world;
 
 use pocketmine\entity\Entity;
+use pocketmine\event\entity\EntityTeleportEvent;
 use pocketmine\event\world\WorldInitEvent;
 use pocketmine\event\world\WorldLoadEvent;
 use pocketmine\event\world\WorldUnloadEvent;
@@ -150,7 +151,7 @@ class WorldManager{
 				if($safeSpawn === null){
 					$player->disconnect("Forced default world unload");
 				}else{
-					$player->teleport($safeSpawn);
+					$player->teleport($safeSpawn, null, null, EntityTeleportEvent::CAUSE_WORLD);
 				}
 			}
 		}

--- a/src/world/WorldManager.php
+++ b/src/world/WorldManager.php
@@ -151,7 +151,7 @@ class WorldManager{
 				if($safeSpawn === null){
 					$player->disconnect("Forced default world unload");
 				}else{
-					$player->teleport($safeSpawn, null, null, EntityTeleportEvent::CAUSE_WORLD);
+					$player->teleport($safeSpawn, cause: EntityTeleportEvent::CAUSE_WORLD);
 				}
 			}
 		}


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

### Relevant issues
<!-- List relevant issues here -->
#5767
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
The following method now accepts `int $cause` parameter. Defaults is 0 for EntityTeleportEvent::CAUSE_PLUGIN.
```php
Entity->teleport(Vector3 $pos, ?float $yaw, ?float $pitch, int $cause) : bool;
```

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
No BC-breaking changes, because there is a default parameter to this method signature change.