### PR TITLE
Give an extra month of life to the old auth key

### DIFF
--- a/src/network/mcpe/auth/ProcessLoginTask.php
+++ b/src/network/mcpe/auth/ProcessLoginTask.php
@@ -39,7 +39,7 @@ class ProcessLoginTask extends AsyncTask{
 	private const TLS_KEY_ON_COMPLETION = "completion";
 
 	public const MOJANG_OLD_ROOT_PUBLIC_KEY = "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE8ELkixyLcwlZryUQcu1TvPOmI2B7vX83ndnWRUaXm74wFfa5f/lwQNTfrLVHa2PmenpGI6JhIMUJaWZrjmMj90NoKNFSNBuKdm8rYiXsfaz3K36x/1U26HpG0ZxK/V1V";
-	public const MOJANG_OLD_KEY_EXPIRY = 1688169600; //2023-07-01 00:00:00 UTC - there is no official date for the changeover to the new key, so this is a guess
+	public const MOJANG_OLD_KEY_EXPIRY = 1690848000; //2023-08-01 00:00:00 UTC - there is no official date for the changeover to the new key, so this is a guess
 
 	public const MOJANG_ROOT_PUBLIC_KEY = "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAECRXueJeTDqNRRgJi/vlRufByu/2G0i2Ebt6YMar5QX/R0DIIyrJMcUpruK4QveTfJSTp3Shlq4Gk34cD/4GUWwkv0DVuzeuB+tXija7HBxii03NHDbPAD0AKnLr2wdAp";
 


### PR DESCRIPTION
Server in some time zones are getting players unable to connect due to PM has decided to change keys before mojang starts using the new one.

This PR expands the expiration time given by PM to the old key by one month, to workaround the mentioned above.