### PR TITLE
Don't mention enchantments in generic StringToTParser doc-comment

### DIFF
--- a/src/utils/StringToTParser.php
+++ b/src/utils/StringToTParser.php
@@ -59,7 +59,7 @@ abstract class StringToTParser{
 	}
 
 	/**
-	 * Tries to parse the specified string into a value of T.
+	 * Tries to parse the specified string into a corresponding instance of T.
 	 * @phpstan-return T|null
 	 */
 	public function parse(string $input){

--- a/src/utils/StringToTParser.php
+++ b/src/utils/StringToTParser.php
@@ -59,7 +59,7 @@ abstract class StringToTParser{
 	}
 
 	/**
-	 * Tries to parse the specified string into an enchantment.
+	 * Tries to parse the specified string into a value of T.
 	 * @phpstan-return T|null
 	 */
 	public function parse(string $input){


### PR DESCRIPTION
The new comment may not be the best, but I'm pretty sure the thing with "enchantments" was accidentally copied over from `StringToEnchantmentParser` or something like that.

Is "an instance of T" better than "a value of T"? Or any other ideas?