### PR TITLE
Stem: fixed supporting block check issue

### DIFF
--- a/src/block/Stem.php
+++ b/src/block/Stem.php
@@ -55,6 +55,7 @@ abstract class Stem extends Crops{
 		if($this->facing !== Facing::UP && !$this->getSide($this->facing)->hasSameTypeId($this->getPlant())){
 			$this->position->getWorld()->setBlock($this->position, $this->setFacing(Facing::UP));
 		}
+		parent::onNearbyBlockChange();
 	}
 
 	public function onRandomTick() : void{


### PR DESCRIPTION
## Introduction
This bug was introduced in https://github.com/pmmp/PocketMine-MP/commit/dca752c72f8daeb669dacebf67b0e093cbe366c4 causing stems to not check their supporting block.