### PR TITLE
Added handling for attack-air action

### DIFF
--- a/src/event/player/PlayerMissedSwingEvent.php
+++ b/src/event/player/PlayerMissedSwingEvent.php
@@ -28,7 +28,7 @@ use pocketmine\event\CancellableTrait;
 use pocketmine\player\Player;
 
 /**
- * Called when a player attacks air
+ * Called when a player attempts to perform the attack action (left-click) without a target entity.
  */
 class PlayerMissedSwingEvent extends PlayerEvent implements Cancellable{
 	use CancellableTrait;

--- a/src/event/player/PlayerMissedSwingEvent.php
+++ b/src/event/player/PlayerMissedSwingEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\event\player;
+
+use pocketmine\event\Cancellable;
+use pocketmine\event\CancellableTrait;
+use pocketmine\player\Player;
+
+/**
+ * Called when a player attacks air
+ */
+class PlayerMissedSwingEvent extends PlayerEvent implements Cancellable{
+	use CancellableTrait;
+
+	public function __construct(Player $player){
+		$this->player = $player;
+	}
+}

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -110,7 +110,6 @@ use pocketmine\utils\Limits;
 use pocketmine\utils\TextFormat;
 use pocketmine\utils\Utils;
 use pocketmine\world\format\Chunk;
-use pocketmine\world\sound\EntityAttackNoDamageSound;
 use function array_push;
 use function count;
 use function fmod;
@@ -238,7 +237,7 @@ class InGamePacketHandler extends PacketHandler{
 				$this->player->jump();
 			}
 			if($packet->hasFlag(PlayerAuthInputFlags::MISSED_SWING)){
-				$this->player->broadcastSound(new EntityAttackNoDamageSound());
+				$this->player->attackAir();
 			}
 		}
 

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -237,7 +237,7 @@ class InGamePacketHandler extends PacketHandler{
 				$this->player->jump();
 			}
 			if($packet->hasFlag(PlayerAuthInputFlags::MISSED_SWING)){
-				$this->player->attackAir();
+				$this->player->missSwing();
 			}
 		}
 

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -110,6 +110,7 @@ use pocketmine\utils\Limits;
 use pocketmine\utils\TextFormat;
 use pocketmine\utils\Utils;
 use pocketmine\world\format\Chunk;
+use pocketmine\world\sound\EntityAttackNoDamageSound;
 use function array_push;
 use function count;
 use function fmod;
@@ -235,6 +236,9 @@ class InGamePacketHandler extends PacketHandler{
 
 			if($packet->hasFlag(PlayerAuthInputFlags::START_JUMPING)){
 				$this->player->jump();
+			}
+			if($packet->hasFlag(PlayerAuthInputFlags::MISSED_SWING)){
+				$this->player->broadcastSound(new EntityAttackNoDamageSound());
 			}
 		}
 

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1899,7 +1899,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 	 * Performs a left-click (attack) action on air and plays sound
 	 * if it's been successfully
 	 */
-	public function attackAir() : void{
+	public function missSwing() : void{
 		$ev = new PlayerMissedSwingEvent($this);
 		$ev->call();
 		if(!$ev->isCancelled()){

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -66,6 +66,7 @@ use pocketmine\event\player\PlayerItemUseEvent;
 use pocketmine\event\player\PlayerJoinEvent;
 use pocketmine\event\player\PlayerJumpEvent;
 use pocketmine\event\player\PlayerKickEvent;
+use pocketmine\event\player\PlayerMissedSwingEvent;
 use pocketmine\event\player\PlayerMoveEvent;
 use pocketmine\event\player\PlayerPostChunkSendEvent;
 use pocketmine\event\player\PlayerQuitEvent;
@@ -1892,6 +1893,18 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		}
 
 		return true;
+	}
+
+	/**
+	 * Performs a left-click (attack) action on air and plays sound
+	 * if it's been successfully
+	 */
+	public function attackAir() : void{
+		$ev = new PlayerMissedSwingEvent($this);
+		$ev->call();
+		if(!$ev->isCancelled()){
+			$this->broadcastSound(new EntityAttackNoDamageSound());
+		}
 	}
 
 	/**

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1896,8 +1896,8 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 	}
 
 	/**
-	 * Performs a left-click (attack) action on air and plays sound
-	 * if it's been successfully
+	 * Performs actions associated with the attack action (left-click) without a target entity.
+	 * Under normal circumstances, this will play the no-damage attack sound and nothing else.
 	 */
 	public function missSwing() : void{
 		$ev = new PlayerMissedSwingEvent($this);


### PR DESCRIPTION
## Introduction
In vanilla when player hits air (performs a left-click-air action) this sound is played.

## API Changes
Added ```PlayerMissedSwingEvent```, called when player attacks air

## Tests
https://www.youtube.com/watch?v=iFfr5fehmjY
