### PR TITLE
Alternative fix for /kill #4680

### DIFF
--- a/src/command/defaults/KillCommand.php
+++ b/src/command/defaults/KillCommand.php
@@ -53,7 +53,7 @@ class KillCommand extends VanillaCommand{
 			return true;
 		}
 
-		$player->attack(new EntityDamageEvent($player, EntityDamageEvent::CAUSE_SUICIDE, 1000));
+		$player->attack(new EntityDamageEvent($player, EntityDamageEvent::CAUSE_SUICIDE, $player->getHealth()));
 		if($player === $sender){
 			$sender->sendMessage(KnownTranslationFactory::commands_kill_successful($sender->getName()));
 		}else{

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -517,7 +517,9 @@ abstract class Living extends Entity{
 			$source->cancel();
 		}
 
-		$this->applyDamageModifiers($source);
+		if($source->getCause() !== EntityDamageEvent::CAUSE_SUICIDE){
+			$this->applyDamageModifiers($source);
+		}
 
 		if($source instanceof EntityDamageByEntityEvent && (
 			$source->getCause() === EntityDamageEvent::CAUSE_BLOCK_EXPLOSION ||


### PR DESCRIPTION
it doesn't really make sense to apply damage modifiers to suicide anyway.

Really I'm doubtful that suicide should even be considered a damage type (perhaps we should add an EntitySuicideEvent), but that's a discussion for another time.

## Relevant issues
Closes #5863
Fixes #4680

## Changes
### Behavioural changes
- `/kill` now delivers the player's health amount of damage.
- No damage modifiers apply to suicide damage sources now.

## Follow-up
I'm doubtful that suicide should be considered a damage source at all. Perhaps a separate EntitySuicideEvent is called for.

## Tests
Playtested using Health Boost effect.