### PR TITLE
Remove unnecessary HorizontalFacingTrait

### DIFF
--- a/src/block/CarvedPumpkin.php
+++ b/src/block/CarvedPumpkin.php
@@ -24,9 +24,7 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\block\utils\FacesOppositePlacingPlayerTrait;
-use pocketmine\block\utils\HorizontalFacingTrait;
 
 class CarvedPumpkin extends Opaque{
 	use FacesOppositePlacingPlayerTrait;
-	use HorizontalFacingTrait;
 }

--- a/src/block/ChemistryTable.php
+++ b/src/block/ChemistryTable.php
@@ -24,14 +24,12 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\block\utils\FacesOppositePlacingPlayerTrait;
-use pocketmine\block\utils\HorizontalFacingTrait;
 use pocketmine\item\Item;
 use pocketmine\math\Vector3;
 use pocketmine\player\Player;
 
 final class ChemistryTable extends Opaque{
 	use FacesOppositePlacingPlayerTrait;
-	use HorizontalFacingTrait;
 
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null, array &$returnedItems = []) : bool{
 		//TODO

--- a/src/block/Chest.php
+++ b/src/block/Chest.php
@@ -25,7 +25,6 @@ namespace pocketmine\block;
 
 use pocketmine\block\tile\Chest as TileChest;
 use pocketmine\block\utils\FacesOppositePlacingPlayerTrait;
-use pocketmine\block\utils\HorizontalFacingTrait;
 use pocketmine\block\utils\SupportType;
 use pocketmine\event\block\ChestPairEvent;
 use pocketmine\item\Item;
@@ -36,7 +35,6 @@ use pocketmine\player\Player;
 
 class Chest extends Transparent{
 	use FacesOppositePlacingPlayerTrait;
-	use HorizontalFacingTrait;
 
 	/**
 	 * @return AxisAlignedBB[]

--- a/src/block/EndPortalFrame.php
+++ b/src/block/EndPortalFrame.php
@@ -24,14 +24,12 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\block\utils\FacesOppositePlacingPlayerTrait;
-use pocketmine\block\utils\HorizontalFacingTrait;
 use pocketmine\data\runtime\RuntimeDataDescriber;
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Facing;
 
 class EndPortalFrame extends Opaque{
 	use FacesOppositePlacingPlayerTrait;
-	use HorizontalFacingTrait;
 
 	protected bool $eye = false;
 

--- a/src/block/EnderChest.php
+++ b/src/block/EnderChest.php
@@ -26,7 +26,6 @@ namespace pocketmine\block;
 use pocketmine\block\inventory\EnderChestInventory;
 use pocketmine\block\tile\EnderChest as TileEnderChest;
 use pocketmine\block\utils\FacesOppositePlacingPlayerTrait;
-use pocketmine\block\utils\HorizontalFacingTrait;
 use pocketmine\block\utils\SupportType;
 use pocketmine\item\Item;
 use pocketmine\math\AxisAlignedBB;
@@ -36,7 +35,6 @@ use pocketmine\player\Player;
 
 class EnderChest extends Transparent{
 	use FacesOppositePlacingPlayerTrait;
-	use HorizontalFacingTrait;
 
 	public function getLightLevel() : int{
 		return 7;

--- a/src/block/Furnace.php
+++ b/src/block/Furnace.php
@@ -25,7 +25,6 @@ namespace pocketmine\block;
 
 use pocketmine\block\tile\Furnace as TileFurnace;
 use pocketmine\block\utils\FacesOppositePlacingPlayerTrait;
-use pocketmine\block\utils\HorizontalFacingTrait;
 use pocketmine\crafting\FurnaceType;
 use pocketmine\data\runtime\RuntimeDataDescriber;
 use pocketmine\item\Item;
@@ -35,7 +34,6 @@ use function mt_rand;
 
 class Furnace extends Opaque{
 	use FacesOppositePlacingPlayerTrait;
-	use HorizontalFacingTrait;
 
 	protected FurnaceType $furnaceType;
 

--- a/src/block/GlazedTerracotta.php
+++ b/src/block/GlazedTerracotta.php
@@ -26,12 +26,10 @@ namespace pocketmine\block;
 use pocketmine\block\utils\ColoredTrait;
 use pocketmine\block\utils\DyeColor;
 use pocketmine\block\utils\FacesOppositePlacingPlayerTrait;
-use pocketmine\block\utils\HorizontalFacingTrait;
 
 class GlazedTerracotta extends Opaque{
 	use ColoredTrait;
 	use FacesOppositePlacingPlayerTrait;
-	use HorizontalFacingTrait;
 
 	public function __construct(BlockIdentifier $idInfo, string $name, BlockTypeInfo $typeInfo){
 		$this->color = DyeColor::BLACK();

--- a/src/block/Lectern.php
+++ b/src/block/Lectern.php
@@ -25,7 +25,6 @@ namespace pocketmine\block;
 
 use pocketmine\block\tile\Lectern as TileLectern;
 use pocketmine\block\utils\FacesOppositePlacingPlayerTrait;
-use pocketmine\block\utils\HorizontalFacingTrait;
 use pocketmine\block\utils\SupportType;
 use pocketmine\data\runtime\RuntimeDataDescriber;
 use pocketmine\item\Item;
@@ -39,7 +38,6 @@ use function count;
 
 class Lectern extends Transparent{
 	use FacesOppositePlacingPlayerTrait;
-	use HorizontalFacingTrait;
 
 	protected int $viewedPage = 0;
 	protected ?WritableBookBase $book = null;

--- a/src/block/Loom.php
+++ b/src/block/Loom.php
@@ -25,14 +25,12 @@ namespace pocketmine\block;
 
 use pocketmine\block\inventory\LoomInventory;
 use pocketmine\block\utils\FacesOppositePlacingPlayerTrait;
-use pocketmine\block\utils\HorizontalFacingTrait;
 use pocketmine\item\Item;
 use pocketmine\math\Vector3;
 use pocketmine\player\Player;
 
 final class Loom extends Opaque{
 	use FacesOppositePlacingPlayerTrait;
-	use HorizontalFacingTrait;
 
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null, array &$returnedItems = []) : bool{
 		if($player !== null){

--- a/src/block/Stonecutter.php
+++ b/src/block/Stonecutter.php
@@ -25,7 +25,6 @@ namespace pocketmine\block;
 
 use pocketmine\block\inventory\StonecutterInventory;
 use pocketmine\block\utils\FacesOppositePlacingPlayerTrait;
-use pocketmine\block\utils\HorizontalFacingTrait;
 use pocketmine\block\utils\SupportType;
 use pocketmine\item\Item;
 use pocketmine\math\AxisAlignedBB;
@@ -35,7 +34,6 @@ use pocketmine\player\Player;
 
 class Stonecutter extends Transparent{
 	use FacesOppositePlacingPlayerTrait;
-	use HorizontalFacingTrait;
 
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null, array &$returnedItems = []) : bool{
 		if($player !== null){


### PR DESCRIPTION
## Introduction
Because HorizontalFacingTrait exists in the FacesOppositePlacingPlayerTrait, it is not necessary when using FacesOppositePlacingPlayerTrait
