### PR TITLE
Remove useless checks for plugins disabling other plugins

### DIFF
--- a/src/plugin/PluginManager.php
+++ b/src/plugin/PluginManager.php
@@ -490,9 +490,6 @@ class PluginManager{
 	public function disablePlugins() : void{
 		while(count($this->enabledPlugins) > 0){
 			foreach($this->enabledPlugins as $plugin){
-				if(!$plugin->isEnabled()){
-					continue; //in case a plugin disabled another plugin
-				}
 				$name = $plugin->getDescription()->getName();
 				if(isset($this->pluginDependents[$name]) && count($this->pluginDependents[$name]) > 0){
 					$this->server->getLogger()->debug("Deferring disable of plugin $name due to dependent plugins still enabled: " . implode(", ", array_keys($this->pluginDependents[$name])));
@@ -525,11 +522,7 @@ class PluginManager{
 
 	public function tickSchedulers(int $currentTick) : void{
 		foreach($this->enabledPlugins as $pluginName => $p){
-			if(isset($this->enabledPlugins[$pluginName])){
-				//the plugin may have been disabled as a result of updating other plugins' schedulers, and therefore
-				//removed from enabledPlugins; however, foreach will still see it due to copy-on-write
-				$p->getScheduler()->mainThreadHeartbeat($currentTick);
-			}
+			$p->getScheduler()->mainThreadHeartbeat($currentTick);
 		}
 	}
 


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Now that plugins can't disable other plugins in 6.0.0 we don't need to check if that happened.
### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
None
## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
None
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
None
## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
None
## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
None
## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
N/A