### PR TITLE
Allow to replace already registered Block and Item classes and serializers

### DIFF
--- a/src/block/RuntimeBlockStateRegistry.php
+++ b/src/block/RuntimeBlockStateRegistry.php
@@ -84,12 +84,12 @@ class RuntimeBlockStateRegistry{
 	 * Maps a block type's state permutations to its corresponding state IDs. This is necessary for the block to be
 	 * recognized when fetching it by its state ID from chunks at runtime.
 	 *
-	 * @throws \InvalidArgumentException if the desired block type ID is already registered
+	 * @throws \InvalidArgumentException if the desired block type ID is already registered and $replace is set to false
 	 */
-	public function register(Block $block) : void{
+	public function register(Block $block, bool $replace = false) : void{
 		$typeId = $block->getTypeId();
 
-		if(isset($this->typeIndex[$typeId])){
+		if(!$replace && isset($this->typeIndex[$typeId])){
 			throw new \InvalidArgumentException("Block ID $typeId is already used by another block");
 		}
 

--- a/src/data/bedrock/block/convert/BlockObjectToStateSerializer.php
+++ b/src/data/bedrock/block/convert/BlockObjectToStateSerializer.php
@@ -211,8 +211,8 @@ final class BlockObjectToStateSerializer implements BlockStateSerializer{
 	 * @phpstan-param TBlockType $block
 	 * @phpstan-param \Closure(TBlockType) : Writer $serializer
 	 */
-	public function map(Block $block, \Closure $serializer) : void{
-		if(isset($this->serializers[$block->getTypeId()])){
+	public function map(Block $block, \Closure $serializer, bool $replace = false) : void{
+		if(!$replace && isset($this->serializers[$block->getTypeId()])){
 			throw new \InvalidArgumentException("Block type ID " . $block->getTypeId() . " already has a serializer registered");
 		}
 		$this->serializers[$block->getTypeId()] = $serializer;

--- a/src/data/bedrock/block/convert/BlockStateToObjectDeserializer.php
+++ b/src/data/bedrock/block/convert/BlockStateToObjectDeserializer.php
@@ -93,8 +93,8 @@ final class BlockStateToObjectDeserializer implements BlockStateDeserializer{
 	}
 
 	/** @phpstan-param \Closure(Reader) : Block $c */
-	public function map(string $id, \Closure $c) : void{
-		if(array_key_exists($id, $this->deserializeFuncs)){
+	public function map(string $id, \Closure $c, bool $replace = false) : void{
+		if(!$replace && array_key_exists($id, $this->deserializeFuncs)){
 			throw new \InvalidArgumentException("Deserializer is already assigned for \"$id\"");
 		}
 		$this->deserializeFuncs[$id] = $c;

--- a/src/data/bedrock/item/ItemDeserializer.php
+++ b/src/data/bedrock/item/ItemDeserializer.php
@@ -50,8 +50,8 @@ final class ItemDeserializer{
 	/**
 	 * @phpstan-param \Closure(Data) : Item $deserializer
 	 */
-	public function map(string $id, \Closure $deserializer) : void{
-		if(isset($this->deserializers[$id])){
+	public function map(string $id, \Closure $deserializer, bool $replace = false) : void{
+		if(!$replace && isset($this->deserializers[$id])){
 			throw new \InvalidArgumentException("Deserializer is already assigned for \"$id\"");
 		}
 		$this->deserializers[$id] = $deserializer;

--- a/src/data/bedrock/item/ItemSerializer.php
+++ b/src/data/bedrock/item/ItemSerializer.php
@@ -62,9 +62,9 @@ final class ItemSerializer{
 	 * @phpstan-param TItemType $item
 	 * @phpstan-param \Closure(TItemType) : Data $serializer
 	 */
-	public function map(Item $item, \Closure $serializer) : void{
+	public function map(Item $item, \Closure $serializer, bool $replace = false) : void{
 		$index = $item->getTypeId();
-		if(isset($this->itemSerializers[$index])){
+		if(!$replace && isset($this->itemSerializers[$index])){
 			throw new \InvalidArgumentException("Item type ID " . $index . " already has a serializer registered");
 		}
 		$this->itemSerializers[$index] = $serializer;
@@ -75,9 +75,9 @@ final class ItemSerializer{
 	 * @phpstan-param TBlockType $block
 	 * @phpstan-param \Closure(TBlockType) : Data $serializer
 	 */
-	public function mapBlock(Block $block, \Closure $serializer) : void{
+	public function mapBlock(Block $block, \Closure $serializer, bool $replace = false) : void{
 		$index = $block->getTypeId();
-		if(isset($this->blockItemSerializers[$index])){
+		if(!$replace && isset($this->blockItemSerializers[$index])){
 			throw new \InvalidArgumentException("Block type ID " . $index . " already has a serializer registered");
 		}
 		$this->blockItemSerializers[$index] = $serializer;


### PR DESCRIPTION
## Introduction
Sometimes it is very necessary to make own implementation of some block or item, which is already registered in Pocketmine. For example, to implement an enchantment table with its own logic of enchanting an item. The changes given are minimal and can't harm in any way, but can be very useful for some developers (me included).

## Changes
### API changes
Added optional boolean argument $replace (false by default) for multiple methods that register block / item / serializer / deserializer.

## Backwards compatibility
Full backward compatibility
