### PR TITLE
Implement PlayerPressurePlateTriggerEvent

### DIFF
--- a/src/block/PressurePlate.php
+++ b/src/block/PressurePlate.php
@@ -61,5 +61,20 @@ abstract class PressurePlate extends Transparent{
 		}
 	}
 
-	//TODO
+	public function onEntityInside(Entity $entity) : bool{
+		if($entity instanceof Player){
+			$ev = new PlayerPressurePlateTriggerEvent($entity, $this);
+			$ev->call();
+
+			if($ev->isCancelled()){
+				return false;
+			}
+		}
+
+		return parent::onEntityInside($entity);
+	}
+
+	public function hasEntityCollision() : bool{
+		return true;
+	}
 }

--- a/src/block/PressurePlate.php
+++ b/src/block/PressurePlate.php
@@ -24,6 +24,8 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\block\utils\SupportType;
+use pocketmine\entity\Entity;
+use pocketmine\event\player\PlayerPressurePlateTriggerEvent;
 use pocketmine\item\Item;
 use pocketmine\math\Facing;
 use pocketmine\math\Vector3;

--- a/src/event/player/PlayerPressurePlateTriggerEvent.php
+++ b/src/event/player/PlayerPressurePlateTriggerEvent.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\event\player;
+
+use pocketmine\block\Block;
+use pocketmine\event\Cancellable;
+use pocketmine\event\CancellableTrait;
+use pocketmine\player\Player;
+
+class PlayerPressurePlateTriggerEvent extends PlayerEvent implements Cancellable{
+	use CancellableTrait;
+
+	public function __construct(
+		Player $player,
+		private Block $block
+	){
+		$this->player = $player;
+	}
+
+	public function getBlock() : Block{
+		return $this->block;
+	}
+}


### PR DESCRIPTION
## Introduction
The `PlayerPressurePlateTriggerEvent` is an event that occurs when a player steps on or off a pressure plate block in the game world. It carries information about the player who triggered it and the specific pressure plate block that was activated. Other plugins or code can listen for this event and perform actions when it happens. Additionally, the event can be cancelled, preventing further processing, if needed.

## Changes
### API changes
Add `PlayerPressurePlateTriggerEvent`

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Tests
```php
public function onPressurePlateTrigger(PlayerPressurePlateTriggerEvent $event) {
    $player = $event->getPlayer();
    $player->sendMessage("You triggered a pressure plate!");
}
```