### PR TITLE
Modify and improve cake behavior to be similar to vanilla.

### DIFF
--- a/.github/workflows/discord-release-notify.yml
+++ b/.github/workflows/discord-release-notify.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup PHP and tools
-        uses: shivammathur/setup-php@2.25.2
+        uses: shivammathur/setup-php@2.25.4
         with:
           php-version: 8.1
 

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -18,7 +18,7 @@ jobs:
           submodules: true
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@2.25.2
+        uses: shivammathur/setup-php@2.25.4
         with:
           php-version: 8.1
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -173,7 +173,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup PHP and tools
-        uses: shivammathur/setup-php@2.25.2
+        uses: shivammathur/setup-php@2.25.4
         with:
           php-version: 8.1
           tools: php-cs-fixer:3.17

--- a/changelogs/4.23.md
+++ b/changelogs/4.23.md
@@ -30,3 +30,16 @@ Released 18th July 2023.
 
 ## Fixes
 - Fixed login errors due to a new `sandboxId` field appearing in the Xbox Live authentication data in `LoginPacket`. All clients, regardless of version, are affected by this change.
+
+# 4.23.3
+Released 24th July 2023.
+
+## Documentation
+- Fixed typo in `ChunkSelector::selectChunks()` documentation.
+
+## Fixes
+- Fixed the server not stopping properly during crash conditions on *nix platforms.
+- Fixed `HORSE_EQUIP` and `SMITHING_TABLE_TEMPLATE` container UI types not being handled by `ItemStackContainerIdTranslator`. This bug prevented plugins from implementing missing inventory types.
+- Player emotes no longer broadcast messages to other players. This was unintended behaviour caused by a client-side behavioural change.
+- Shulker boxes no longer support the placement of torches or other similar blocks.
+- Fire can now be placed on upper slabs and the top of upside-down stairs.

--- a/changelogs/5.3.md
+++ b/changelogs/5.3.md
@@ -47,3 +47,26 @@ Released 18th July 2023.
 
 ## Internals
 - Armor pieces are no longer set back into the armor inventory if no change was made. This reduces the number of slot updates sent to clients, as well as avoiding unnecessary updates for armor pieces which have Unbreaking enchantments.
+
+# 5.3.3
+Released 24th July 2023.
+
+## Included releases
+**This release includes changes from the following releases:**
+- [4.23.3](https://github.com/pmmp/PocketMine-MP/blob/4.23.3/changelogs/4.23.md#4233) - Various bug fixes
+
+## Fixes
+- Added a workaround for PM4 worlds with chunks corrupted by [Refaltor77/CustomItemAPI](https://github.com/Refaltor77/CustomItemAPI).
+  - While this was not the fault of PocketMine-MP itself, a significant number of users were affected by this problem.
+  - This error was not detected by PM4 due to missing validation of certain data which should not have existed in 1.12.
+  - An error will now be logged when this corruption is detected, but the affected chunks should otherwise load normally.
+- Relaxed validation of expected 3D biome array counts per chunk in LevelDB worlds.
+  - Vanilla Bedrock currently saves 24 palettes (and only 24 are required), but it saved 25, 32, or 64 biome palettes per chunk in older versions.
+  - Core validation for these padding biomes was very strict, enforcing exact compliance with vanilla.
+  - Since only 24 palettes are actually required, the remaining palettes may now be omitted irrespective of the chunk version.
+  - An error will still be logged when this mistake is detected, but the affected chunks will otherwise load normally.
+- Fixed `/kill` not working on players who had (re)spawned in the 3 seconds immediately after (re)spawning (due to `noDamageTicks`).
+- Fixed `/kill` not working correctly for players with high levels of Health Boost or other health-altering effects.
+- Fixed netherite items being destroyed by lava.
+- Fireproof entities no longer display the burning animation when in fire or lava. This does not apply to creative players, who are immortal rather than being fireproof.
+- Fixed frosted ice melting in certain conditions which didn't match vanilla Bedrock.

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
       "pocketmine/bedrock-block-upgrade-schema": "~3.1.0+bedrock-1.20.10",
       "pocketmine/bedrock-data": "~2.4.0+bedrock-1.20.10",
       "pocketmine/bedrock-item-upgrade-schema": "~1.4.0+bedrock-1.20.10",
-      "pocketmine/bedrock-protocol": "~23.0.0+bedrock-1.20.10",
+      "pocketmine/bedrock-protocol": "~23.0.2+bedrock-1.20.10",
       "pocketmine/binaryutils": "^0.2.1",
       "pocketmine/callback-validator": "^1.0.2",
       "pocketmine/classloader": "^0.2.0",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
       "pocketmine/bedrock-block-upgrade-schema": "~3.1.0+bedrock-1.20.10",
       "pocketmine/bedrock-data": "~2.4.0+bedrock-1.20.10",
       "pocketmine/bedrock-item-upgrade-schema": "~1.4.0+bedrock-1.20.10",
-      "pocketmine/bedrock-protocol": "~23.0.0+bedrock-1.20.10",
+      "pocketmine/bedrock-protocol": "~23.0.2+bedrock-1.20.10",
       "pocketmine/binaryutils": "^0.2.1",
       "pocketmine/callback-validator": "^1.0.2",
       "pocketmine/color": "^0.3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4524eed9bd1a33e650413fbf41382e20",
+    "content-hash": "2acf1299aa8b354c44495ae048aa8893",
     "packages": [
         {
             "name": "adhocore/json-comment",
@@ -276,16 +276,16 @@
         },
         {
             "name": "pocketmine/bedrock-protocol",
-            "version": "23.0.1+bedrock-1.20.10",
+            "version": "23.0.2+bedrock-1.20.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pmmp/BedrockProtocol.git",
-                "reference": "db48400736799cc3833a2644a02e308992a98fa8"
+                "reference": "69a309a2dd7dcf3ec8c316385b866397e8c2cbfd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pmmp/BedrockProtocol/zipball/db48400736799cc3833a2644a02e308992a98fa8",
-                "reference": "db48400736799cc3833a2644a02e308992a98fa8",
+                "url": "https://api.github.com/repos/pmmp/BedrockProtocol/zipball/69a309a2dd7dcf3ec8c316385b866397e8c2cbfd",
+                "reference": "69a309a2dd7dcf3ec8c316385b866397e8c2cbfd",
                 "shasum": ""
             },
             "require": {
@@ -317,9 +317,9 @@
             "description": "An implementation of the Minecraft: Bedrock Edition protocol in PHP",
             "support": {
                 "issues": "https://github.com/pmmp/BedrockProtocol/issues",
-                "source": "https://github.com/pmmp/BedrockProtocol/tree/23.0.1+bedrock-1.20.10"
+                "source": "https://github.com/pmmp/BedrockProtocol/tree/23.0.2+bedrock-1.20.10"
             },
-            "time": "2023-07-18T21:07:24+00:00"
+            "time": "2023-07-24T15:35:36+00:00"
         },
         {
             "name": "pocketmine/binaryutils",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ee46ec27f8dfc8c767527b7776fe9992",
+    "content-hash": "e14717125dd180235fb888662a48846d",
     "packages": [
         {
             "name": "adhocore/json-comment",
@@ -276,16 +276,16 @@
         },
         {
             "name": "pocketmine/bedrock-protocol",
-            "version": "23.0.1+bedrock-1.20.10",
+            "version": "23.0.2+bedrock-1.20.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pmmp/BedrockProtocol.git",
-                "reference": "db48400736799cc3833a2644a02e308992a98fa8"
+                "reference": "69a309a2dd7dcf3ec8c316385b866397e8c2cbfd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pmmp/BedrockProtocol/zipball/db48400736799cc3833a2644a02e308992a98fa8",
-                "reference": "db48400736799cc3833a2644a02e308992a98fa8",
+                "url": "https://api.github.com/repos/pmmp/BedrockProtocol/zipball/69a309a2dd7dcf3ec8c316385b866397e8c2cbfd",
+                "reference": "69a309a2dd7dcf3ec8c316385b866397e8c2cbfd",
                 "shasum": ""
             },
             "require": {
@@ -317,9 +317,9 @@
             "description": "An implementation of the Minecraft: Bedrock Edition protocol in PHP",
             "support": {
                 "issues": "https://github.com/pmmp/BedrockProtocol/issues",
-                "source": "https://github.com/pmmp/BedrockProtocol/tree/23.0.1+bedrock-1.20.10"
+                "source": "https://github.com/pmmp/BedrockProtocol/tree/23.0.2+bedrock-1.20.10"
             },
-            "time": "2023-07-18T21:07:24+00:00"
+            "time": "2023-07-24T15:35:36+00:00"
         },
         {
             "name": "pocketmine/binaryutils",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ee46ec27f8dfc8c767527b7776fe9992",
+    "content-hash": "e14717125dd180235fb888662a48846d",
     "packages": [
         {
             "name": "adhocore/json-comment",
@@ -276,16 +276,16 @@
         },
         {
             "name": "pocketmine/bedrock-protocol",
-            "version": "23.0.1+bedrock-1.20.10",
+            "version": "23.0.2+bedrock-1.20.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pmmp/BedrockProtocol.git",
-                "reference": "db48400736799cc3833a2644a02e308992a98fa8"
+                "reference": "69a309a2dd7dcf3ec8c316385b866397e8c2cbfd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pmmp/BedrockProtocol/zipball/db48400736799cc3833a2644a02e308992a98fa8",
-                "reference": "db48400736799cc3833a2644a02e308992a98fa8",
+                "url": "https://api.github.com/repos/pmmp/BedrockProtocol/zipball/69a309a2dd7dcf3ec8c316385b866397e8c2cbfd",
+                "reference": "69a309a2dd7dcf3ec8c316385b866397e8c2cbfd",
                 "shasum": ""
             },
             "require": {
@@ -317,9 +317,9 @@
             "description": "An implementation of the Minecraft: Bedrock Edition protocol in PHP",
             "support": {
                 "issues": "https://github.com/pmmp/BedrockProtocol/issues",
-                "source": "https://github.com/pmmp/BedrockProtocol/tree/23.0.1+bedrock-1.20.10"
+                "source": "https://github.com/pmmp/BedrockProtocol/tree/23.0.2+bedrock-1.20.10"
             },
-            "time": "2023-07-18T21:07:24+00:00"
+            "time": "2023-07-24T15:35:36+00:00"
         },
         {
             "name": "pocketmine/binaryutils",
@@ -2546,16 +2546,16 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "6.0.0",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "aab257c712de87b90194febd52e4d184551c2d44"
+                "reference": "7ea9ead78f6d380d2a667864c132c2f7b83055e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/aab257c712de87b90194febd52e4d184551c2d44",
-                "reference": "aab257c712de87b90194febd52e4d184551c2d44",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/7ea9ead78f6d380d2a667864c132c2f7b83055e4",
+                "reference": "7ea9ead78f6d380d2a667864c132c2f7b83055e4",
                 "shasum": ""
             },
             "require": {
@@ -2595,7 +2595,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.0"
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.1"
             },
             "funding": [
                 {
@@ -2603,7 +2604,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:07:38+00:00"
+            "time": "2023-07-19T07:19:23+00:00"
         },
         {
             "name": "sebastian/lines-of-code",

--- a/src/PocketMine.php
+++ b/src/PocketMine.php
@@ -341,7 +341,7 @@ JIT_WARNING
 
 			if(ThreadManager::getInstance()->stopAll() > 0){
 				$logger->debug("Some threads could not be stopped, performing a force-kill");
-				Process::kill(Process::pid(), true);
+				Process::kill(Process::pid());
 			}
 		}while(false);
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -1427,7 +1427,7 @@ class Server{
 
 	private function forceShutdownExit() : void{
 		$this->forceShutdown();
-		Process::kill(Process::pid(), true);
+		Process::kill(Process::pid());
 	}
 
 	public function forceShutdown() : void{
@@ -1495,7 +1495,7 @@ class Server{
 		}catch(\Throwable $e){
 			$this->logger->logException($e);
 			$this->logger->emergency("Crashed while crashing, killing process");
-			@Process::kill(Process::pid(), true);
+			@Process::kill(Process::pid());
 		}
 
 	}
@@ -1649,7 +1649,7 @@ class Server{
 			echo "--- Waiting $spacing seconds to throttle automatic restart (you can kill the process safely now) ---" . PHP_EOL;
 			sleep($spacing);
 		}
-		@Process::kill(Process::pid(), true);
+		@Process::kill(Process::pid());
 		exit(1);
 	}
 

--- a/src/VersionInfo.php
+++ b/src/VersionInfo.php
@@ -32,7 +32,7 @@ use function str_repeat;
 final class VersionInfo{
 	public const NAME = "PocketMine-MP";
 	public const BASE_VERSION = "5.3.3";
-	public const IS_DEVELOPMENT_BUILD = true;
+	public const IS_DEVELOPMENT_BUILD = false;
 	public const BUILD_CHANNEL = "stable";
 
 	/**

--- a/src/VersionInfo.php
+++ b/src/VersionInfo.php
@@ -32,7 +32,7 @@ use function str_repeat;
 final class VersionInfo{
 	public const NAME = "PocketMine-MP";
 	public const BASE_VERSION = "4.23.3";
-	public const IS_DEVELOPMENT_BUILD = true;
+	public const IS_DEVELOPMENT_BUILD = false;
 	public const BUILD_CHANNEL = "stable";
 
 	private function __construct(){

--- a/src/VersionInfo.php
+++ b/src/VersionInfo.php
@@ -31,8 +31,8 @@ use function str_repeat;
 
 final class VersionInfo{
 	public const NAME = "PocketMine-MP";
-	public const BASE_VERSION = "5.3.3";
-	public const IS_DEVELOPMENT_BUILD = false;
+	public const BASE_VERSION = "5.3.4";
+	public const IS_DEVELOPMENT_BUILD = true;
 	public const BUILD_CHANNEL = "stable";
 
 	/**

--- a/src/VersionInfo.php
+++ b/src/VersionInfo.php
@@ -31,8 +31,8 @@ use function str_repeat;
 
 final class VersionInfo{
 	public const NAME = "PocketMine-MP";
-	public const BASE_VERSION = "4.23.3";
-	public const IS_DEVELOPMENT_BUILD = false;
+	public const BASE_VERSION = "4.23.4";
+	public const IS_DEVELOPMENT_BUILD = true;
 	public const BUILD_CHANNEL = "stable";
 
 	private function __construct(){

--- a/src/VersionInfo.php
+++ b/src/VersionInfo.php
@@ -31,7 +31,7 @@ use function str_repeat;
 
 final class VersionInfo{
 	public const NAME = "PocketMine-MP";
-	public const BASE_VERSION = "5.3.3";
+	public const BASE_VERSION = "5.3.4";
 	public const IS_DEVELOPMENT_BUILD = true;
 	public const BUILD_CHANNEL = "stable";
 

--- a/src/block/BaseCake.php
+++ b/src/block/BaseCake.php
@@ -50,7 +50,7 @@ abstract class BaseCake extends Transparent implements FoodSource{
 
 	public function onNearbyBlockChange() : void{
 		if($this->getSide(Facing::DOWN)->getTypeId() === BlockTypeIds::AIR){ //Replace with common break method
-			$this->position->getWorld()->useBreakOn($this->position);
+			$this->position->getWorld()->useBreakOn($this->position, createParticles: true);
 		}
 	}
 

--- a/src/block/Cake.php
+++ b/src/block/Cake.php
@@ -75,7 +75,7 @@ class Cake extends BaseCake{
 			};
 
 			if($resultBlock !== null){
-				$this->getPosition()->getWorld()->setBlock($this->position, $resultBlock);
+				$this->position->getWorld()->setBlock($this->position, $resultBlock);
 				$item->pop();
 				return true;
 			}

--- a/src/block/CakeWithCandle.php
+++ b/src/block/CakeWithCandle.php
@@ -63,6 +63,10 @@ class CakeWithCandle extends BaseCake{
 		return [$this->getCandle()->asItem()];
 	}
 
+	public function getDropsForIncompatibleTool(Item $item) : array{
+		return [$this->getCandle()->asItem()];
+	}
+
 	public function getPickedItem(bool $addUserData = false) : Item{
 		return VanillaBlocks::CAKE()->asItem();
 	}
@@ -72,7 +76,7 @@ class CakeWithCandle extends BaseCake{
 	}
 
 	public function onConsume(Living $consumer) : void{
-		parent::onConsume($consumer);
 		$this->position->getWorld()->dropItem($this->position->add(0.5, 0.5, 0.5), $this->getCandle()->asItem());
+		parent::onConsume($consumer);
 	}
 }

--- a/src/block/Fire.php
+++ b/src/block/Fire.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\block\utils\SupportType;
 use pocketmine\data\runtime\RuntimeDataDescriber;
 use pocketmine\event\block\BlockBurnEvent;
 use pocketmine\event\block\BlockSpreadEvent;
@@ -58,12 +59,16 @@ class Fire extends BaseFire{
 		return 1;
 	}
 
+	private function canBeSupportedBy(Block $block) : bool{
+		return $block->getSupportType(Facing::UP)->equals(SupportType::FULL());
+	}
+
 	public function onNearbyBlockChange() : void{
 		$world = $this->position->getWorld();
 		$down = $this->getSide(Facing::DOWN);
 		if(SoulFire::canBeSupportedBy($down)){
 			$world->setBlock($this->position, VanillaBlocks::SOUL_FIRE());
-		}elseif($down->isTransparent() && !$this->hasAdjacentFlammableBlocks()){
+		}elseif(!$this->canBeSupportedBy($this->getSide(Facing::DOWN)) && !$this->hasAdjacentFlammableBlocks()){
 			$world->setBlock($this->position, VanillaBlocks::AIR());
 		}else{
 			$world->scheduleDelayedBlockUpdate($this->position, mt_rand(30, 40));

--- a/src/block/FrostedIce.php
+++ b/src/block/FrostedIce.php
@@ -48,12 +48,7 @@ class FrostedIce extends Ice{
 	}
 
 	public function onNearbyBlockChange() : void{
-		$world = $this->position->getWorld();
-		if(!$this->checkAdjacentBlocks(2)){
-			$world->useBreakOn($this->position);
-		}else{
-			$world->scheduleDelayedBlockUpdate($this->position, mt_rand(20, 40));
-		}
+		$this->position->getWorld()->scheduleDelayedBlockUpdate($this->position, mt_rand(20, 40));
 	}
 
 	public function onRandomTick() : void{

--- a/src/block/ShulkerBox.php
+++ b/src/block/ShulkerBox.php
@@ -25,6 +25,7 @@ namespace pocketmine\block;
 
 use pocketmine\block\tile\ShulkerBox as TileShulkerBox;
 use pocketmine\block\utils\AnyFacingTrait;
+use pocketmine\block\utils\SupportType;
 use pocketmine\data\runtime\RuntimeDataDescriber;
 use pocketmine\item\Item;
 use pocketmine\math\Vector3;
@@ -109,5 +110,9 @@ class ShulkerBox extends Opaque{
 		}
 
 		return true;
+	}
+
+	public function getSupportType(int $facing) : SupportType{
+		return SupportType::NONE();
 	}
 }

--- a/src/block/utils/CandleTrait.php
+++ b/src/block/utils/CandleTrait.php
@@ -54,11 +54,7 @@ trait CandleTrait{
 
 	public function isLit() : bool{ return $this->lit; }
 
-	/**
-	 * @param bool $lit
-	 *
-	 * @return CandleTrait|CakeWithCandle|Candle
-	 */
+	/** @return $this */
 	public function setLit(bool $lit) : self{
 		$this->lit = $lit;
 		return $this;

--- a/src/block/utils/CandleTrait.php
+++ b/src/block/utils/CandleTrait.php
@@ -24,8 +24,6 @@ declare(strict_types=1);
 namespace pocketmine\block\utils;
 
 use pocketmine\block\Block;
-use pocketmine\block\CakeWithCandle;
-use pocketmine\block\Candle;
 use pocketmine\data\runtime\RuntimeDataDescriber;
 use pocketmine\entity\projectile\Projectile;
 use pocketmine\item\Durable;

--- a/src/command/defaults/KillCommand.php
+++ b/src/command/defaults/KillCommand.php
@@ -53,7 +53,7 @@ class KillCommand extends VanillaCommand{
 			return true;
 		}
 
-		$player->attack(new EntityDamageEvent($player, EntityDamageEvent::CAUSE_SUICIDE, 1000));
+		$player->attack(new EntityDamageEvent($player, EntityDamageEvent::CAUSE_SUICIDE, $player->getHealth()));
 		if($player === $sender){
 			$sender->sendMessage(KnownTranslationFactory::commands_kill_successful($sender->getName()));
 		}else{

--- a/src/console/ConsoleReaderChildProcess.php
+++ b/src/console/ConsoleReaderChildProcess.php
@@ -94,4 +94,4 @@ while(!feof($socket)){
 //For simplicity's sake, we don't bother with a graceful shutdown here.
 //The parent process would normally forcibly terminate the child process anyway, so we only reach this point if the
 //parent process was terminated forcibly and didn't clean up after itself.
-Process::kill(Process::pid(), false);
+Process::kill(Process::pid());

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -520,7 +520,9 @@ abstract class Living extends Entity{
 			$source->cancel();
 		}
 
-		$this->applyDamageModifiers($source);
+		if($source->getCause() !== EntityDamageEvent::CAUSE_SUICIDE){
+			$this->applyDamageModifiers($source);
+		}
 
 		if($source instanceof EntityDamageByEntityEvent && (
 			$source->getCause() === EntityDamageEvent::CAUSE_BLOCK_EXPLOSION ||

--- a/src/network/mcpe/StandardEntityEventBroadcaster.php
+++ b/src/network/mcpe/StandardEntityEventBroadcaster.php
@@ -139,6 +139,6 @@ final class StandardEntityEventBroadcaster implements EntityEventBroadcaster{
 	}
 
 	public function onEmote(array $recipients, Human $from, string $emoteId) : void{
-		$this->sendDataPacket($recipients, EmotePacket::create($from->getId(), $emoteId, "", "", EmotePacket::FLAG_SERVER));
+		$this->sendDataPacket($recipients, EmotePacket::create($from->getId(), $emoteId, "", "", EmotePacket::FLAG_SERVER | EmotePacket::FLAG_MUTE_ANNOUNCEMENT));
 	}
 }

--- a/src/network/mcpe/handler/ItemStackContainerIdTranslator.php
+++ b/src/network/mcpe/handler/ItemStackContainerIdTranslator.php
@@ -70,6 +70,7 @@ final class ItemStackContainerIdTranslator{
 			ContainerUIIds::MATERIAL_REDUCER_OUTPUT,
 			ContainerUIIds::SMITHING_TABLE_INPUT,
 			ContainerUIIds::SMITHING_TABLE_MATERIAL,
+			ContainerUIIds::SMITHING_TABLE_TEMPLATE,
 			ContainerUIIds::STONECUTTER_INPUT,
 			ContainerUIIds::TRADE2_INGREDIENT1,
 			ContainerUIIds::TRADE2_INGREDIENT2,
@@ -84,6 +85,7 @@ final class ItemStackContainerIdTranslator{
 			ContainerUIIds::FURNACE_FUEL,
 			ContainerUIIds::FURNACE_INGREDIENT,
 			ContainerUIIds::FURNACE_RESULT,
+			ContainerUIIds::HORSE_EQUIP,
 			ContainerUIIds::LEVEL_ENTITY, //chest
 			ContainerUIIds::SHULKER_BOX,
 			ContainerUIIds::SMOKER_INGREDIENT => [$currentWindowId, $slotId],

--- a/src/player/ChunkSelector.php
+++ b/src/player/ChunkSelector.php
@@ -30,7 +30,7 @@ use const M_SQRT2;
 final class ChunkSelector{
 
 	/**
-	 * @preturn \Generator|int[]
+	 * @return \Generator|int[]
 	 * @phpstan-return \Generator<int, int, void, void>
 	 */
 	public function selectChunks(int $radius, int $centerX, int $centerZ) : \Generator{

--- a/src/utils/Process.php
+++ b/src/utils/Process.php
@@ -125,7 +125,10 @@ final class Process{
 		return count(ThreadManager::getInstance()->getAll()) + 2; //MainLogger + Main Thread
 	}
 
-	public static function kill(int $pid, bool $subprocesses) : void{
+	/**
+	 * @param bool $subprocesses @deprecated
+	 */
+	public static function kill(int $pid, bool $subprocesses = false) : void{
 		$logger = \GlobalLogger::get();
 		if($logger instanceof MainLogger){
 			$logger->syncFlushBuffer();

--- a/src/utils/ServerKiller.php
+++ b/src/utils/ServerKiller.php
@@ -42,7 +42,7 @@ class ServerKiller extends Thread{
 		});
 		if(time() - $start >= $this->time){
 			echo "\nTook too long to stop, server was killed forcefully!\n";
-			@Process::kill(Process::pid(), true);
+			@Process::kill(Process::pid());
 		}
 	}
 

--- a/src/world/format/io/leveldb/LevelDB.php
+++ b/src/world/format/io/leveldb/LevelDB.php
@@ -27,6 +27,7 @@ use pocketmine\block\Block;
 use pocketmine\data\bedrock\BiomeIds;
 use pocketmine\data\bedrock\block\BlockStateDeserializeException;
 use pocketmine\nbt\LittleEndianNbtSerializer;
+use pocketmine\nbt\NBT;
 use pocketmine\nbt\NbtDataException;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\TreeRoot;
@@ -155,7 +156,33 @@ class LevelDB extends BaseWorldProvider implements WritableWorldProvider{
 		$nbt = new LittleEndianNbtSerializer();
 		$palette = [];
 
-		$paletteSize = $bitsPerBlock === 0 ? 1 : $stream->getLInt();
+		if($bitsPerBlock === 0){
+			$paletteSize = 1;
+			/*
+			 * Due to code copy-paste in a public plugin, some PM4 worlds have 0 bpb palettes with a length prefix.
+			 * This is invalid and does not happen in vanilla.
+			 * These palettes were accepted by PM4 despite being invalid, but PM5 considered them corrupt, causing loss
+			 * of data. Since many users were affected by this, a workaround is therefore necessary to allow PM5 to read
+			 * these worlds without data loss.
+			 *
+			 * References:
+			 * - https://github.com/Refaltor77/CustomItemAPI/issues/68
+			 * - https://github.com/pmmp/PocketMine-MP/issues/5911
+			 */
+			$offset = $stream->getOffset();
+			$byte1 = $stream->getByte();
+			$stream->setOffset($offset); //reset offset
+
+			if($byte1 !== NBT::TAG_Compound){ //normally the first byte would be the NBT of the blockstate
+				$susLength = $stream->getLInt();
+				if($susLength !== 1){ //make sure the data isn't complete garbage
+					throw new CorruptedChunkException("CustomItemAPI borked 0 bpb palette should always have a length of 1");
+				}
+				$logger->error("Unexpected palette size for 0 bpb palette");
+			}
+		}else{
+			$paletteSize = $stream->getLInt();
+		}
 
 		for($i = 0; $i < $paletteSize; ++$i){
 			try{
@@ -276,6 +303,10 @@ class LevelDB extends BaseWorldProvider implements WritableWorldProvider{
 				$previous = $decoded;
 				if($nextIndex <= Chunk::MAX_SUBCHUNK_INDEX){ //older versions wrote additional superfluous biome palettes
 					$result[$nextIndex++] = $decoded;
+				}elseif($stream->feof()){
+					//not enough padding biome arrays for the given version - this is non-critical since we discard the excess anyway, but this should be logged
+					$logger->error("Wrong number of 3D biome palettes for this chunk version: expected $expectedCount, but got " . ($i + 1) . " - this is not a problem, but may indicate a corrupted chunk");
+					break;
 				}
 			}catch(BinaryDataException $e){
 				throw new CorruptedChunkException("Failed to deserialize biome palette $i: " . $e->getMessage(), 0, $e);


### PR DESCRIPTION
## Introduction
This PR version makes the cake work compatible with vanilla behaviors.

## Changes
- Cake can only be able to add candle when it's not used yet, `$this-bites === 0`.
- Cake drops nothing when destroyed.
- When supporting blocks get destroyed, it will show breaking particles instead of just disappearing like before.
- CakeWithCandle can be lit up using fire charge.
- Cake does not get eaten when trying to extinguish the candle.
- Added a calculation function to check if the player trying to extinguish the candle or eat the cake.
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
No
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
No
## Backwards compatibility
Maybe?

## Tests
https://github.com/pmmp/PocketMine-MP/assets/54394881/f6d3f828-d4b6-4fdd-9ed1-c6d2cc92771a



