### PR TITLE
Allow different axes to have different knockback forces

### DIFF
--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -546,14 +546,14 @@ abstract class Living extends Entity{
 			$e = $source->getChild();
 			if($e !== null){
 				$motion = $e->getMotion();
-				$this->knockBack($motion->x, $motion->z, $source->getKnockBack(), $source->getVerticalKnockBackLimit());
+				$this->knockBack($motion->x, $motion->z, $source->getKnockBack());
 			}
 		}elseif($source instanceof EntityDamageByEntityEvent){
 			$e = $source->getDamager();
 			if($e !== null){
 				$deltaX = $this->location->x - $e->location->x;
 				$deltaZ = $this->location->z - $e->location->z;
-				$this->knockBack($deltaX, $deltaZ, $source->getKnockBack(), $source->getVerticalKnockBackLimit());
+				$this->knockBack($deltaX, $deltaZ, $source->getKnockBack());
 			}
 		}
 

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -529,8 +529,9 @@ abstract class Living extends Entity{
 			//TODO: knockback should not just apply for entity damage sources
 			//this doesn't matter for TNT right now because the PrimedTNT entity is considered the source, not the block.
 			$base = $source->getKnockBack();
-			$force = $base - min($base, $base * $this->getHighestArmorEnchantmentLevel(VanillaEnchantments::BLAST_PROTECTION()) * 0.15);
-			$source->setKnockBack(new Vector3($force, $force, $force));
+			$knockBackResistance = $this->getHighestArmorEnchantmentLevel(VanillaEnchantments::BLAST_PROTECTION()) * 0.15;
+			$calculateNewValue = fn(float $baseValue) => $baseValue - min($baseValue, $baseValue * $knockBackResistance);
+			$source->setKnockBack(new Vector3($calculateNewValue($base->x), $calculateNewValue($base->y), $calculateNewValue($base->z)));
 		}
 
 		parent::attack($source);

--- a/src/event/entity/EntityDamageByEntityEvent.php
+++ b/src/event/entity/EntityDamageByEntityEvent.php
@@ -26,6 +26,7 @@ namespace pocketmine\event\entity;
 use pocketmine\entity\effect\VanillaEffects;
 use pocketmine\entity\Entity;
 use pocketmine\entity\Living;
+use pocketmine\math\Vector3;
 
 /**
  * Called when an entity takes damage from another entity.
@@ -36,7 +37,7 @@ class EntityDamageByEntityEvent extends EntityDamageEvent{
 	/**
 	 * @param float[] $modifiers
 	 */
-	public function __construct(Entity $damager, Entity $entity, int $cause, float $damage, array $modifiers = [], private float $knockBack = 0.4){
+	public function __construct(Entity $damager, Entity $entity, int $cause, float $damage, array $modifiers = [], private Vector3 $knockBack = new Vector3(0.4, 0.4, 0.4), private ?float $verticalKnockBackLimit = 0.4){
 		$this->damagerEntityId = $damager->getId();
 		parent::__construct($entity, $cause, $damage, $modifiers);
 		$this->addAttackerModifiers($damager);
@@ -62,11 +63,19 @@ class EntityDamageByEntityEvent extends EntityDamageEvent{
 		return $this->getEntity()->getWorld()->getServer()->getWorldManager()->findEntity($this->damagerEntityId);
 	}
 
-	public function getKnockBack() : float{
-		return $this->knockBack;
+	public function getKnockBack() : Vector3{
+		return clone $this->knockBack;
 	}
 
-	public function setKnockBack(float $knockBack) : void{
-		$this->knockBack = $knockBack;
+	public function setKnockBack(Vector3 $knockBack) : void{
+		$this->knockBack = clone $knockBack;
+	}
+
+	public function getVerticalKnockBackLimit() : ?float{
+		return $this->verticalKnockBackLimit;
+	}
+
+	public function setVerticalKnockBackLimit(?float $verticalKnockBackLimit) : void{
+		$this->verticalKnockBackLimit = $verticalKnockBackLimit;
 	}
 }

--- a/src/event/entity/EntityDamageByEntityEvent.php
+++ b/src/event/entity/EntityDamageByEntityEvent.php
@@ -37,7 +37,7 @@ class EntityDamageByEntityEvent extends EntityDamageEvent{
 	/**
 	 * @param float[] $modifiers
 	 */
-	public function __construct(Entity $damager, Entity $entity, int $cause, float $damage, array $modifiers = [], private Vector3 $knockBack = new Vector3(0.4, 0.4, 0.4), private ?float $verticalKnockBackLimit = 0.4){
+	public function __construct(Entity $damager, Entity $entity, int $cause, float $damage, array $modifiers = [], private Vector3 $knockBack = new Vector3(0.4, 0.4, 0.4)){
 		$this->damagerEntityId = $damager->getId();
 		parent::__construct($entity, $cause, $damage, $modifiers);
 		$this->addAttackerModifiers($damager);
@@ -69,13 +69,5 @@ class EntityDamageByEntityEvent extends EntityDamageEvent{
 
 	public function setKnockBack(Vector3 $knockBack) : void{
 		$this->knockBack = clone $knockBack;
-	}
-
-	public function getVerticalKnockBackLimit() : ?float{
-		return $this->verticalKnockBackLimit;
-	}
-
-	public function setVerticalKnockBackLimit(?float $verticalKnockBackLimit) : void{
-		$this->verticalKnockBackLimit = $verticalKnockBackLimit;
 	}
 }

--- a/src/item/enchantment/KnockbackEnchantment.php
+++ b/src/item/enchantment/KnockbackEnchantment.php
@@ -25,6 +25,7 @@ namespace pocketmine\item\enchantment;
 
 use pocketmine\entity\Entity;
 use pocketmine\entity\Living;
+use pocketmine\math\Vector3;
 
 class KnockbackEnchantment extends MeleeWeaponEnchantment{
 
@@ -39,7 +40,8 @@ class KnockbackEnchantment extends MeleeWeaponEnchantment{
 	public function onPostAttack(Entity $attacker, Entity $victim, int $enchantmentLevel) : void{
 		if($victim instanceof Living){
 			$diff = $victim->getPosition()->subtractVector($attacker->getPosition());
-			$victim->knockBack($diff->x, $diff->z, $enchantmentLevel * 0.5);
+			$force = $enchantmentLevel * 0.5;
+			$victim->knockBack($diff->x, $diff->z, new Vector3($force, $force, $force));
 		}
 	}
 }


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
There's no way to modify the knockback of a player, or living entity, without overriding them and causing conflicts. This pull request aims to let plugins easily modify specific knockback forces so they can implement their custom knockback easily without overriding them. Another reason is that iron golems and holgins/zoglins have vertical knockback and these changes will allow them to be implemented more easily.
### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
None
## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
The following methods' signatures were changed:
- Changed `EntityDamageByEntityEvent->__construct(Entity $damager, Entity $entity, int $cause, float $damage, array $modifiers = [], private float $knockBack = 0.4, private ?float $verticalKnockBackLimit = 0.4)` to `EntityDamageByEntityEvent->__construct((Entity $damager, Entity $entity, int $cause, float $damage, array $modifiers = [], private Vector3 $knockBack = new Vector3(0.4, 0.4, 0.4), private ?float $verticalKnockBackLimit = 0.4)`
- Changed `EntityDamageByEntityEvent->getKnockBack(): float` to `EntityDamageByEntityEvent->getknockBack(): Vector3`
- Changed `EntityDamageByEntityEvent->setKnockBack(float $knockBack): void` to `EntityDamageByEntityEvent->setKnockBack(Vector3 $knockBack): void`
- Changed `Living->knockBack(float $x, float $z, Vector3 $force = new Vector3(0.4, 0.4, 0.4), ?float $verticalLimit = 0.4)` to `Living->knockBack(float $x, float $z, Vector3 $force = new Vector3(0.4, 0.4, 0.4), ?float $verticalLimit = 0.4)`
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
None
## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Before:
```php
$event->setKnockBack($event->getKnockBack() * 2);
//...
$player->knockBack($deltaX, $deltaZ, 10);
```
After:
```php
$event->setKnockBack($event->getKnockBack()->multiply(2));
//...
$player->knockBack($deltaX, $deltaZ, new Vector3(10, 10, 10));
```
## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
Perhaps add a new static method to `Vector3` like `Vector3::fromScalar(0.4)` which returns a `Vector3` with X, Y and Z as 0.4 to prevent duplication.
## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
```php
<?php

declare(strict_types=1);

namespace JavierLeon9966\KnockBackTest;

use pocketmine\event\entity\EntityDamageByEntityEvent;
use pocketmine\event\EventPriority;
use pocketmine\math\Vector3;
use pocketmine\plugin\PluginBase;

class Main extends PluginBase{

	protected function onEnable() : void{
		$this->getServer()->getPluginManager()->registerEvent(EntityDamageByEntityEvent::class, static function(EntityDamageByEntityEvent $event): void{
			$event->setKnockBack(new Vector3(0.2, 0.7, 0.2));
		}, EventPriority::HIGHEST, $this);
	}
}
```

https://github.com/pmmp/PocketMine-MP/assets/58715544/b5be2445-5187-4034-9274-b88dbba9433c

