### PR TITLE
Added Plugin::getResourceFolder()

### DIFF
--- a/src/plugin/PluginBase.php
+++ b/src/plugin/PluginBase.php
@@ -50,6 +50,8 @@ use const DIRECTORY_SEPARATOR;
 abstract class PluginBase implements Plugin, CommandExecutor{
 	private bool $isEnabled = false;
 
+	private string $resourceFolder;
+
 	private ?Config $config = null;
 	private string $configFile;
 
@@ -67,6 +69,8 @@ abstract class PluginBase implements Plugin, CommandExecutor{
 		$this->dataFolder = rtrim($dataFolder, "/" . DIRECTORY_SEPARATOR) . "/";
 		//TODO: this is accessed externally via reflection, not unused
 		$this->file = rtrim($file, "/" . DIRECTORY_SEPARATOR) . "/";
+		$this->resourceFolder = Path::join($this->file, "resources") . "/";
+
 		$this->configFile = Path::join($this->dataFolder, "config.yml");
 
 		$prefix = $this->getDescription()->getPrefix();
@@ -209,6 +213,17 @@ abstract class PluginBase implements Plugin, CommandExecutor{
 	}
 
 	/**
+	 * Returns the path to the folder where the plugin's embedded resource files are usually located.
+	 * Note: This is NOT the same as the data folder. The files in this folder should be considered read-only.
+	 */
+	public function getResourceFolder() : string{
+		return $this->resourceFolder;
+	}
+
+	/**
+	 * @deprecated Prefer using standard PHP functions with {@link PluginBase::getResourceFolder()}, like
+	 * file_get_contents() or fopen().
+	 *
 	 * Gets an embedded resource on the plugin file.
 	 * WARNING: You must close the resource given using fclose()
 	 *
@@ -219,6 +234,8 @@ abstract class PluginBase implements Plugin, CommandExecutor{
 	}
 
 	/**
+	 * @deprecated Prefer using standard PHP functions with {@link PluginBase::getResourceFolder()}, like copy().
+	 *
 	 * Saves an embedded resource to its relative location in the data folder
 	 */
 	public function saveResource(string $filename, bool $replace = false) : bool{

--- a/src/plugin/PluginBase.php
+++ b/src/plugin/PluginBase.php
@@ -221,7 +221,17 @@ abstract class PluginBase implements Plugin, CommandExecutor{
 	}
 
 	/**
-	 * @deprecated Prefer using standard PHP functions with {@link PluginBase::getResourceFolder()}, like
+	 * Returns the full path to a data file in the plugin's resources folder.
+	 * This path can be used with standard PHP functions like fopen() or file_get_contents().
+	 *
+	 * Note: Any path returned by this function should be considered READ-ONLY.
+	 */
+	public function getResourcePath(string $filename) : string{
+		return Path::join($this->getResourceFolder(), $filename);
+	}
+
+	/**
+	 * @deprecated Prefer using standard PHP functions with {@link PluginBase::getResourcePath()}, like
 	 * file_get_contents() or fopen().
 	 *
 	 * Gets an embedded resource on the plugin file.
@@ -234,8 +244,6 @@ abstract class PluginBase implements Plugin, CommandExecutor{
 	}
 
 	/**
-	 * @deprecated Prefer using standard PHP functions with {@link PluginBase::getResourceFolder()}, like copy().
-	 *
 	 * Saves an embedded resource to its relative location in the data folder
 	 */
 	public function saveResource(string $filename, bool $replace = false) : bool{


### PR DESCRIPTION
this is a first step towards #5958

to be honest, at this point I'm questioning whether getResourceFolder() is even necessary. Nothing stops people from just using getFile() and putting resource files wherever the hell they want.

### Relevant issues
#5958

## Changes
### API changes
- Added `PluginBase::getResourceFolder()`
- Deprecated `PluginBase::getResource()` (use `file_get_contents()` or `fopen()`)
- Deprecated `PluginBase::saveResource()` (use `copy()` and `file_exists()`)

### Behavioural changes
None.

## Backwards compatibility
Some deprecations which plugin devs will need to adapt to, but nothing will break BC until PM6.

## Follow-up
Get rid of `ResourceProvider` etc and absorb the logic back into `PluginBase`
Remove deprecated stuff in PM6

## Tests
This is a pretty trivial change, but here's some example dumps from Windows:
- `phar://C:/Users/dylan-work/Documents/projects/pocketmine-mp/minor-next/plugins/DevTools.phar/resources/`
- `C:/Users/dylan-work/Documents/projects/pocketmine-mp/minor-next/plugins/LiveXYZ/resources/`

As is standard with PM folder paths, they contain a trailing /. I don't like this, but it's better to be consistent with other folder-path-returning functions.
