### PR TITLE
Podzol should be affected by silk touch

### DIFF
--- a/src/block/Podzol.php
+++ b/src/block/Podzol.php
@@ -27,6 +27,10 @@ use pocketmine\item\Item;
 
 class Podzol extends Opaque{
 
+	public function isAffectedBySilkTouch() : bool{
+		return true;
+	}
+
 	public function getDropsForCompatibleTool(Item $item) : array{
 		return [
 			VanillaBlocks::DIRT()->asItem()


### PR DESCRIPTION
## Introduction
In vanilla podzol drops itself when mined with the silk touch enchantment

https://minecraft.fandom.com/wiki/Podzol#Breaking