### PR TITLE
Fixed vertical knock back not matching vanilla

### DIFF
--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -89,7 +89,7 @@ abstract class Living extends Entity{
 	 * Limit of an entity's vertical knockback velocity when hit by another entity. Without this limit, the entity
 	 * may be knocked far up into the air with large knockback forces.
 	 */
-	public const DEFAULT_KNOCKBACK_VERTICAL_LIMIT = 0.4;
+	public const DEFAULT_KNOCKBACK_VERTICAL_LIMIT = 0.3608;
 
 	private const TAG_LEGACY_HEALTH = "HealF"; //TAG_Float
 	private const TAG_HEALTH = "Health"; //TAG_Float


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
I tested the knockback in a vanilla server using [gophertunnel](https://github.com/Sandertv/gophertunnel) by logging the output of `SetActorMotionPacket` and it turns out the player has a vertical knockback limit of 0.3608. 
### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
None
## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
None
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
None
## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
None
## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
None
## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
```php
<?php

declare(strict_types=1);

namespace JavierLeon9966\KBTest;

use pocketmine\event\EventPriority;
use pocketmine\event\player\PlayerItemUseEvent;
use pocketmine\plugin\PluginBase;

class Main extends PluginBase{

	protected function onEnable(): void{
		$this->getServer()->getPluginManager()->registerEvent(PlayerItemUseEvent::class, function(PlayerItemUseEvent $event): void{
			$event->getPlayer()->knockBack(lcg_value() * 2 - 1, lcg_value() * 2 - 1);
		}, EventPriority::MONITOR, $this);
	}
}
```
https://github.com/pmmp/PocketMine-MP/assets/58715544/89d9dd34-13d7-4880-bd77-27b3711acc96

