### PR TITLE
Added ability to change max players by a command

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -262,8 +262,6 @@ class Server{
 
 	private WorldManager $worldManager;
 
-	private int $maxPlayers;
-
 	private bool $onlineMode = true;
 
 	private Network $network;
@@ -338,7 +336,7 @@ class Server{
 	}
 
 	public function getMaxPlayers() : int{
-		return $this->maxPlayers;
+		return $this->configGroup->getConfigInt("max-players", self::DEFAULT_MAX_PLAYERS);
 	}
 
 	/**
@@ -931,8 +929,6 @@ class Server{
 			@touch($bannedIpsTxt);
 			$this->banByIP = new BanList($bannedIpsTxt);
 			$this->banByIP->load();
-
-			$this->maxPlayers = $this->configGroup->getConfigInt("max-players", self::DEFAULT_MAX_PLAYERS);
 
 			$this->onlineMode = $this->configGroup->getConfigBool("xbox-auth", true);
 			if($this->onlineMode){

--- a/src/command/SimpleCommandMap.php
+++ b/src/command/SimpleCommandMap.php
@@ -51,6 +51,7 @@ use pocketmine\command\defaults\SaveOffCommand;
 use pocketmine\command\defaults\SaveOnCommand;
 use pocketmine\command\defaults\SayCommand;
 use pocketmine\command\defaults\SeedCommand;
+use pocketmine\command\defaults\SetMaxPlayersCommand;
 use pocketmine\command\defaults\SetWorldSpawnCommand;
 use pocketmine\command\defaults\SpawnpointCommand;
 use pocketmine\command\defaults\StatusCommand;
@@ -117,6 +118,7 @@ class SimpleCommandMap implements CommandMap{
 			new SaveOnCommand(),
 			new SayCommand(),
 			new SeedCommand(),
+			new SetMaxPlayersCommand(),
 			new SetWorldSpawnCommand(),
 			new SpawnpointCommand(),
 			new StatusCommand(),

--- a/src/command/defaults/SetMaxPlayersCommand.php
+++ b/src/command/defaults/SetMaxPlayersCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\command\defaults;
+
+use pocketmine\command\Command;
+use pocketmine\command\CommandSender;
+use pocketmine\command\utils\InvalidCommandSyntaxException;
+use pocketmine\lang\KnownTranslationFactory;
+use pocketmine\permission\DefaultPermissionNames;
+
+class SetMaxPlayersCommand extends VanillaCommand{
+
+	public function __construct(){
+		parent::__construct(
+			"setmaxplayers",
+			KnownTranslationFactory::pocketmine_command_setmaxplayers_description(),
+			KnownTranslationFactory::commands_setmaxplayers_usage()
+		);
+		$this->setPermission(DefaultPermissionNames::COMMAND_SETMAXPLAYERS);
+	}
+
+	public function execute(CommandSender $sender, string $commandLabel, array $args){
+		if(count($args) === 0){
+			throw new InvalidCommandSyntaxException();
+		}
+
+		$maxPlayers = $this->getInteger($sender, $args[0], count($sender->getServer()->getOnlinePlayers()), PHP_INT_MAX);
+		$sender->getServer()->getConfigGroup()->setConfigInt("max-players", $maxPlayers);
+		Command::broadcastCommandMessage($sender, KnownTranslationFactory::commands_setmaxplayers_success((string) $maxPlayers));
+		if(((int) $args[0]) < $maxPlayers){
+			Command::broadcastCommandMessage($sender, KnownTranslationFactory::commands_setmaxplayers_success_lowerbound());
+		}
+		return true;
+	}
+}

--- a/src/permission/DefaultPermissionNames.php
+++ b/src/permission/DefaultPermissionNames.php
@@ -58,6 +58,7 @@ final class DefaultPermissionNames{
 	public const COMMAND_SAVE_PERFORM = "pocketmine.command.save.perform";
 	public const COMMAND_SAY = "pocketmine.command.say";
 	public const COMMAND_SEED = "pocketmine.command.seed";
+	public const COMMAND_SETMAXPLAYERS = "pocketmine.command.setmaxplayers";
 	public const COMMAND_SETWORLDSPAWN = "pocketmine.command.setworldspawn";
 	public const COMMAND_SPAWNPOINT_OTHER = "pocketmine.command.spawnpoint.other";
 	public const COMMAND_SPAWNPOINT_SELF = "pocketmine.command.spawnpoint.self";

--- a/src/permission/DefaultPermissions.php
+++ b/src/permission/DefaultPermissions.php
@@ -86,6 +86,7 @@ abstract class DefaultPermissions{
 		self::registerPermission(new Permission(Names::COMMAND_SAVE_PERFORM, l10n::pocketmine_permission_command_save_enable()), [$operatorRoot]);
 		self::registerPermission(new Permission(Names::COMMAND_SAY, l10n::pocketmine_permission_command_say()), [$operatorRoot]);
 		self::registerPermission(new Permission(Names::COMMAND_SEED, l10n::pocketmine_permission_command_seed()), [$operatorRoot]);
+		self::registerPermission(new Permission(Names::COMMAND_SETMAXPLAYERS, l10n::pocketmine_permission_command_setmaxplayers()), [$operatorRoot]);
 		self::registerPermission(new Permission(Names::COMMAND_SETWORLDSPAWN, l10n::pocketmine_permission_command_setworldspawn()), [$operatorRoot]);
 		self::registerPermission(new Permission(Names::COMMAND_SPAWNPOINT_OTHER, l10n::pocketmine_permission_command_spawnpoint_other()), [$operatorRoot]);
 		self::registerPermission(new Permission(Names::COMMAND_SPAWNPOINT_SELF, l10n::pocketmine_permission_command_spawnpoint_self()), [$operatorRoot]);


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Sometimes we want to limit the number of players that can join our server without needing to restart it and have to make them rejoin it and possibly make unwanted players join in the process. This pull request adds the /setmaxplayers command to change the max player count during runtime.
### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
None
## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
None
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
None
## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
None
## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `commands.setmaxplayers.success` | `Set max players to {%0}.` |
| `commands.setmaxplayers.success.lowerbound` | `(Bound to current player count)` |
| `commands.setmaxplayers.usage` | `/setmaxplayers <maxPlayers>` |
| `pocketmine.command.setmaxplayers.description` | `Sets the maximum number of players for this server.` |
| `pocketmine.permission.command.setmaxplayers` | `Allows the user to change the max player count` |

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
TODO