### PR TITLE
Implement pressure plate activation logic and events

### DIFF
--- a/src/block/PressurePlate.php
+++ b/src/block/PressurePlate.php
@@ -33,8 +33,8 @@ use pocketmine\math\Facing;
 use pocketmine\math\Vector3;
 use pocketmine\player\Player;
 use pocketmine\world\BlockTransaction;
-use pocketmine\world\sound\RedstonePowerOffSound;
-use pocketmine\world\sound\RedstonePowerOnSound;
+use pocketmine\world\sound\PressurePlateActivateSound;
+use pocketmine\world\sound\PressurePlateDeactivateSound;
 use function count;
 
 abstract class PressurePlate extends Transparent{
@@ -155,8 +155,8 @@ abstract class PressurePlate extends Transparent{
 				$world->setBlock($this->position, $newState);
 				if($pressedChange !== null){
 					$world->addSound($this->position, $pressedChange ?
-						new RedstonePowerOnSound() :
-						new RedstonePowerOffSound()
+						new PressurePlateActivateSound($this) :
+						new PressurePlateDeactivateSound($this)
 					);
 				}
 			}

--- a/src/block/SimplePressurePlate.php
+++ b/src/block/SimplePressurePlate.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\data\runtime\RuntimeDataDescriber;
-use pocketmine\entity\Entity;
 use function count;
 
 abstract class SimplePressurePlate extends PressurePlate{
@@ -46,17 +45,8 @@ abstract class SimplePressurePlate extends PressurePlate{
 		return $this->pressed;
 	}
 
-	/**
-	 * TODO: make this abstract in PM6
-	 *
-	 * @param Entity[] $entities
-	 */
-	protected function calculatePressed(array $entities) : bool{
-		return count($entities) > 0;
-	}
-
 	protected function calculatePlateState(array $entities) : array{
-		$newPressed = $this->calculatePressed($entities);
+		$newPressed = count($entities) > 0;
 		if($newPressed === $this->pressed){
 			return [$this, null];
 		}

--- a/src/block/SimplePressurePlate.php
+++ b/src/block/SimplePressurePlate.php
@@ -24,6 +24,8 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\data\runtime\RuntimeDataDescriber;
+use pocketmine\entity\Entity;
+use function count;
 
 abstract class SimplePressurePlate extends PressurePlate{
 	protected bool $pressed = false;
@@ -38,5 +40,29 @@ abstract class SimplePressurePlate extends PressurePlate{
 	public function setPressed(bool $pressed) : self{
 		$this->pressed = $pressed;
 		return $this;
+	}
+
+	protected function hasOutputSignal() : bool{
+		return $this->pressed;
+	}
+
+	/**
+	 * TODO: make this abstract in PM6
+	 *
+	 * @param Entity[] $entities
+	 */
+	protected function calculatePressed(array $entities) : bool{
+		return count($entities) > 0;
+	}
+
+	protected function calculatePlateState(array $entities) : array{
+		$newPressed = $this->calculatePressed($entities);
+		if($newPressed === $this->pressed){
+			return [$this, null];
+		}
+		return [
+			(clone $this)->setPressed($newPressed),
+			$newPressed
+		];
 	}
 }

--- a/src/block/StonePressurePlate.php
+++ b/src/block/StonePressurePlate.php
@@ -23,6 +23,13 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\entity\Entity;
+use pocketmine\entity\Living;
+use function array_filter;
+
 class StonePressurePlate extends SimplePressurePlate{
 
+	protected function filterIrrelevantEntities(array $entities) : array{
+		return array_filter($entities, fn(Entity $e) => $e instanceof Living); //TODO: armor stands should activate stone plates too
+	}
 }

--- a/src/block/VanillaBlocks.php
+++ b/src/block/VanillaBlocks.php
@@ -1113,8 +1113,20 @@ final class VanillaBlocks{
 		self::register("lily_pad", new WaterLily(new BID(Ids::LILY_PAD), "Lily Pad", new Info(BreakInfo::instant())));
 
 		$weightedPressurePlateBreakInfo = new Info(BreakInfo::pickaxe(0.5, ToolTier::WOOD()));
-		self::register("weighted_pressure_plate_heavy", new WeightedPressurePlateHeavy(new BID(Ids::WEIGHTED_PRESSURE_PLATE_HEAVY), "Weighted Pressure Plate Heavy", $weightedPressurePlateBreakInfo));
-		self::register("weighted_pressure_plate_light", new WeightedPressurePlateLight(new BID(Ids::WEIGHTED_PRESSURE_PLATE_LIGHT), "Weighted Pressure Plate Light", $weightedPressurePlateBreakInfo));
+		self::register("weighted_pressure_plate_heavy", new WeightedPressurePlateHeavy(
+			new BID(Ids::WEIGHTED_PRESSURE_PLATE_HEAVY),
+			"Weighted Pressure Plate Heavy",
+			$weightedPressurePlateBreakInfo,
+			deactivationDelayTicks: 10,
+			signalStrengthFactor: 0.1
+		));
+		self::register("weighted_pressure_plate_light", new WeightedPressurePlateLight(
+			new BID(Ids::WEIGHTED_PRESSURE_PLATE_LIGHT),
+			"Weighted Pressure Plate Light",
+			$weightedPressurePlateBreakInfo,
+			deactivationDelayTicks: 10,
+			signalStrengthFactor: 1.0
+		));
 		self::register("wheat", new Wheat(new BID(Ids::WHEAT), "Wheat Block", new Info(BreakInfo::instant())));
 
 		$leavesBreakInfo = new Info(new class(0.2, ToolType::HOE) extends BreakInfo{
@@ -1265,7 +1277,7 @@ final class VanillaBlocks{
 			self::register($idName("door"), new WoodenDoor(WoodLikeBlockIdHelper::getDoorIdentifier($woodType), $name . " Door", $woodenDoorBreakInfo, $woodType));
 
 			self::register($idName("button"), new WoodenButton(WoodLikeBlockIdHelper::getButtonIdentifier($woodType), $name . " Button", $woodenButtonBreakInfo, $woodType));
-			self::register($idName("pressure_plate"), new WoodenPressurePlate(WoodLikeBlockIdHelper::getPressurePlateIdentifier($woodType), $name . " Pressure Plate", $woodenPressurePlateBreakInfo, $woodType));
+			self::register($idName("pressure_plate"), new WoodenPressurePlate(WoodLikeBlockIdHelper::getPressurePlateIdentifier($woodType), $name . " Pressure Plate", $woodenPressurePlateBreakInfo, $woodType, 20));
 			self::register($idName("trapdoor"), new WoodenTrapdoor(WoodLikeBlockIdHelper::getTrapdoorIdentifier($woodType), $name . " Trapdoor", $woodenDoorBreakInfo, $woodType));
 
 			[$floorSignId, $wallSignId, $signAsItem] = WoodLikeBlockIdHelper::getSignInfo($woodType);
@@ -1490,7 +1502,7 @@ final class VanillaBlocks{
 		$prefix = fn(string $thing) => "Polished Blackstone" . ($thing !== "" ? " $thing" : "");
 		self::register("polished_blackstone", new Opaque(new BID(Ids::POLISHED_BLACKSTONE), $prefix(""), $blackstoneBreakInfo));
 		self::register("polished_blackstone_button", new StoneButton(new BID(Ids::POLISHED_BLACKSTONE_BUTTON), $prefix("Button"), new Info(BreakInfo::pickaxe(0.5))));
-		self::register("polished_blackstone_pressure_plate", new StonePressurePlate(new BID(Ids::POLISHED_BLACKSTONE_PRESSURE_PLATE), $prefix("Pressure Plate"), new Info(BreakInfo::pickaxe(0.5, ToolTier::WOOD()))));
+		self::register("polished_blackstone_pressure_plate", new StonePressurePlate(new BID(Ids::POLISHED_BLACKSTONE_PRESSURE_PLATE), $prefix("Pressure Plate"), new Info(BreakInfo::pickaxe(0.5, ToolTier::WOOD())), 20));
 		self::register("polished_blackstone_slab", new Slab(new BID(Ids::POLISHED_BLACKSTONE_SLAB), $prefix(""), $slabBreakInfo));
 		self::register("polished_blackstone_stairs", new Stair(new BID(Ids::POLISHED_BLACKSTONE_STAIRS), $prefix("Stairs"), $blackstoneBreakInfo));
 		self::register("polished_blackstone_wall", new Wall(new BID(Ids::POLISHED_BLACKSTONE_WALL), $prefix("Wall"), $blackstoneBreakInfo));

--- a/src/block/WeightedPressurePlate.php
+++ b/src/block/WeightedPressurePlate.php
@@ -24,7 +24,43 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\block\utils\AnalogRedstoneSignalEmitterTrait;
+use function ceil;
+use function count;
+use function max;
+use function min;
 
-abstract class WeightedPressurePlate extends PressurePlate{
+class WeightedPressurePlate extends PressurePlate{
 	use AnalogRedstoneSignalEmitterTrait;
+
+	private readonly float $signalStrengthFactor;
+
+	/**
+	 * @param float $signalStrengthFactor Number of entities on the plate is divided by this value to get signal strength
+	 */
+	public function __construct(BlockIdentifier $idInfo, string $name, BlockTypeInfo $typeInfo, int $deactivationDelayTicks, float $signalStrengthFactor = 1.0){
+		parent::__construct($idInfo, $name, $typeInfo, $deactivationDelayTicks);
+		$this->signalStrengthFactor = $signalStrengthFactor;
+	}
+
+	protected function hasOutputSignal() : bool{
+		return $this->signalStrength > 0;
+	}
+
+	protected function calculatePlateState(array $entities) : array{
+		$newSignalStrength = min(15, max(0,
+			(int) ceil(count($entities) * $this->signalStrengthFactor)
+		));
+		if($newSignalStrength === $this->signalStrength){
+			return [$this, null];
+		}
+		return [
+			(clone $this)->setOutputSignalStrength($newSignalStrength),
+			//I dare anyone to simplify this without breaking it
+			match(true){
+				$this->signalStrength === 0 && $newSignalStrength !== 0 => true,
+				$this->signalStrength !== 0 && $newSignalStrength === 0 => false,
+				default => null,
+			}
+		];
+	}
 }

--- a/src/block/WeightedPressurePlate.php
+++ b/src/block/WeightedPressurePlate.php
@@ -53,14 +53,11 @@ class WeightedPressurePlate extends PressurePlate{
 		if($newSignalStrength === $this->signalStrength){
 			return [$this, null];
 		}
+		$wasActive = $this->signalStrength !== 0;
+		$isActive = $newSignalStrength !== 0;
 		return [
 			(clone $this)->setOutputSignalStrength($newSignalStrength),
-			//I dare anyone to simplify this without breaking it
-			match(true){
-				$this->signalStrength === 0 && $newSignalStrength !== 0 => true,
-				$this->signalStrength !== 0 && $newSignalStrength === 0 => false,
-				default => null,
-			}
+			$wasActive !== $isActive ? $isActive : null
 		];
 	}
 }

--- a/src/block/WeightedPressurePlateHeavy.php
+++ b/src/block/WeightedPressurePlateHeavy.php
@@ -23,6 +23,9 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+/**
+ * @deprecated
+ */
 class WeightedPressurePlateHeavy extends WeightedPressurePlate{
 
 }

--- a/src/block/WeightedPressurePlateLight.php
+++ b/src/block/WeightedPressurePlateLight.php
@@ -23,6 +23,9 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+/**
+ * @deprecated
+ */
 class WeightedPressurePlateLight extends WeightedPressurePlate{
 
 }

--- a/src/block/WoodenPressurePlate.php
+++ b/src/block/WoodenPressurePlate.php
@@ -23,10 +23,22 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\block\utils\WoodType;
 use pocketmine\block\utils\WoodTypeTrait;
 
 class WoodenPressurePlate extends SimplePressurePlate{
 	use WoodTypeTrait;
+
+	public function __construct(
+		BlockIdentifier $idInfo,
+		string $name,
+		BlockTypeInfo $typeInfo,
+		WoodType $woodType,
+		int $deactivationDelayTicks = 20 //TODO: make this mandatory in PM6
+	){
+		$this->woodType = $woodType;
+		parent::__construct($idInfo, $name, $typeInfo, $deactivationDelayTicks);
+	}
 
 	public function getFuelTime() : int{
 		return 300;

--- a/src/event/block/PressurePlateUpdateEvent.php
+++ b/src/event/block/PressurePlateUpdateEvent.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\event\block;
+
+use pocketmine\block\Block;
+use pocketmine\entity\Entity;
+use pocketmine\event\Cancellable;
+
+/**
+ * Called whenever the list of entities on a pressure plate changes.
+ * Depending on the type of pressure plate, this might turn on/off its signal, or change the signal strength.
+ */
+final class PressurePlateUpdateEvent extends BaseBlockChangeEvent implements Cancellable{
+	/**
+	 * @param Entity[] $activatingEntities
+	 */
+	public function __construct(
+		Block $block,
+		Block $newState,
+		private array $activatingEntities
+	){
+		parent::__construct($block, $newState);
+	}
+
+	/**
+	 * Returns a list of entities intersecting the pressure plate's activation box.
+	 * If the pressure plate is about to deactivate, this list will be empty.
+	 *
+	 * @return Entity[]
+	 */
+	public function getActivatingEntities() : array{ return $this->activatingEntities; }
+}

--- a/src/world/sound/PressurePlateActivateSound.php
+++ b/src/world/sound/PressurePlateActivateSound.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\world\sound;
+
+use pocketmine\block\Block;
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\convert\TypeConverter;
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
+
+final class PressurePlateActivateSound implements Sound{
+
+	public function __construct(
+		private readonly Block $block
+	){}
+
+	public function encode(Vector3 $pos) : array{
+		return [LevelSoundEventPacket::nonActorSound(
+			LevelSoundEvent::PRESSURE_PLATE_CLICK_ON,
+			$pos,
+			false,
+			TypeConverter::getInstance()->getBlockTranslator()->internalIdToNetworkId($this->block->getStateId())
+		)];
+	}
+}

--- a/src/world/sound/PressurePlateDeactivateSound.php
+++ b/src/world/sound/PressurePlateDeactivateSound.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\world\sound;
+
+use pocketmine\block\Block;
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\convert\TypeConverter;
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
+
+final class PressurePlateDeactivateSound implements Sound{
+
+	public function __construct(
+		private readonly Block $block
+	){}
+
+	public function encode(Vector3 $pos) : array{
+		return [LevelSoundEventPacket::nonActorSound(
+			LevelSoundEvent::PRESSURE_PLATE_CLICK_OFF,
+			$pos,
+			false,
+			TypeConverter::getInstance()->getBlockTranslator()->internalIdToNetworkId($this->block->getStateId())
+		)];
+	}
+}


### PR DESCRIPTION
## Introduction
This makes it easier for plugins to implement redstone and other custom functionality without needing to overwrite blocks.

### Relevant issues
Closes #5936

## Changes
### API changes
- Added `PressurePlateUpdateEvent`
  - This event is called on pressure plate activation, signal strength change (for weighted pressure plates) and deactivation.
  - If an entity stands on the pressure plate without moving, the event will be fired once every few ticks, depending on the plate's deactivation delay (20 ticks for simple pressure plates, 10 for weighted).
  - The event extends `BaseBlockChangeEvent`, presenting `getBlock()` and `getNewState()`.
  - `getActivatingEntities()` is also provided, giving the list of entities which are causing the pressure plate to have its new state.
  - While active, the event will be fired even if the pressure plate's state has not changed.
- Deprecated `WeightedPressurePlateLight` and `WeightedPressurePlateHeavy`. These classes have no obvious purpose and will be removed in PM6.
- `WeightedPressurePlate` is no longer abstract.
- `WeightedPressurePlate->__construct()` accepts 2 new parameters: `int $deactivationDelayTicks` and `float $signalStrengthFactor`. Currently optional, these will become mandatory in PM6.
- `PressurePlate->__construct()` accepts 1 new parameter: `int $deactivationDelayTicks`. Currently optional, will become mandatory in PM6.
- Added the following methods to `PressurePlate`:
  - `protected function getActivationBox() : AxisAlignedBB`
  - `protected function hasOutputSignal() : bool` - to become abstract in PM6
  - `protected function calculatePlateState(list<Entity> $entities) : list<Entity>` - to become abstract in PM6
  - `protected function filterIrrelevantEntities(list<Entity> $entities) : list<Entity>`

### Behavioural changes
Pressure plates now behave as expected.

## Backwards compatibility
None, although some BC breaks should be made in PM6 where existing code has been changed.

## Tests
This has been playtested extensively.

Events have not yet been tested as of writing this.