### PR TITLE
Workaround for slot IDs not changing client side when old item == new…

### DIFF
--- a/src/network/mcpe/InventoryManager.php
+++ b/src/network/mcpe/InventoryManager.php
@@ -431,6 +431,50 @@ class InventoryManager{
 		unset($inventoryEntry->predictions[$slot]);
 	}
 
+	private function sendInventorySlotPackets(int $windowId, int $netSlot, ItemStackWrapper $itemStackWrapper) : void{
+		/*
+		 * TODO: HACK!
+		 * As of 1.20.12, the client ignores change of itemstackID in some cases when the old item == the new item.
+		 * Notably, this happens with armor, offhand and enchanting tables, but not with main inventory.
+		 * While we could track the items previously sent to the client, that's a waste of memory and would
+		 * cost performance. Instead, clear the slot(s) first, then send the new item(s).
+		 * The network cost of doing this is fortunately minimal, as an air itemstack is only 1 byte.
+		 */
+		if($itemStackWrapper->getStackId() !== 0){
+			$this->session->sendDataPacket(InventorySlotPacket::create(
+				$windowId,
+				$netSlot,
+				new ItemStackWrapper(0, ItemStack::null())
+			));
+		}
+		//now send the real contents
+		$this->session->sendDataPacket(InventorySlotPacket::create(
+			$windowId,
+			$netSlot,
+			$itemStackWrapper
+		));
+	}
+
+	/**
+	 * @param ItemStackWrapper[] $itemStackWrappers
+	 */
+	private function sendInventoryContentPackets(int $windowId, array $itemStackWrappers) : void{
+		/*
+		 * TODO: HACK!
+		 * As of 1.20.12, the client ignores change of itemstackID in some cases when the old item == the new item.
+		 * Notably, this happens with armor, offhand and enchanting tables, but not with main inventory.
+		 * While we could track the items previously sent to the client, that's a waste of memory and would
+		 * cost performance. Instead, clear the slot(s) first, then send the new item(s).
+		 * The network cost of doing this is fortunately minimal, as an air itemstack is only 1 byte.
+		 */
+		$this->session->sendDataPacket(InventoryContentPacket::create(
+			$windowId,
+			array_fill_keys(array_keys($itemStackWrappers), new ItemStackWrapper(0, ItemStack::null()))
+		));
+		//now send the real contents
+		$this->session->sendDataPacket(InventoryContentPacket::create($windowId, $itemStackWrappers));
+	}
+
 	public function syncSlot(Inventory $inventory, int $slot, ItemStack $itemStack) : void{
 		$entry = $this->inventories[spl_object_id($inventory)] ?? null;
 		if($entry === null){
@@ -455,24 +499,9 @@ class InventoryManager{
 			//This can cause a lot of problems (totems, arrows, and more...).
 			//The workaround is to send an InventoryContentPacket instead
 			//BDS (Bedrock Dedicated Server) also seems to work this way.
-			$this->session->sendDataPacket(InventoryContentPacket::create($windowId, [$itemStackWrapper]));
+			$this->sendInventoryContentPackets($windowId, [$itemStackWrapper]);
 		}else{
-			if($windowId === ContainerIds::ARMOR){
-				//TODO: HACK!
-				//When right-clicking to equip armour, the client predicts the content of the armour slot, but
-				//doesn't report it in the transaction packet. The server then sends an InventorySlotPacket to
-				//the client, assuming the slot changed for some other reason, since there is no prediction for
-				//the slot.
-				//However, later requests involving that itemstack will refer to the request ID in which the
-				//armour was equipped, instead of the stack ID provided by the server in the outgoing
-				//InventorySlotPacket. (Perhaps because the item is already the same as the client actually
-				//predicted, but didn't tell us?)
-				//We work around this bug by setting the slot to air and then back to the correct item. In
-				//theory, setting a different count and then back again (or changing any other property) would
-				//also work, but this is simpler.
-				$this->session->sendDataPacket(InventorySlotPacket::create($windowId, $netSlot, new ItemStackWrapper(0, ItemStack::null())));
-			}
-			$this->session->sendDataPacket(InventorySlotPacket::create($windowId, $netSlot, $itemStackWrapper));
+			$this->sendInventorySlotPackets($windowId, $netSlot, $itemStackWrapper);
 		}
 		unset($entry->predictions[$slot], $entry->pendingSyncs[$slot]);
 	}
@@ -506,31 +535,10 @@ class InventoryManager{
 					if($packetSlot === null){
 						continue;
 					}
-					/*
-					 * Due to a "feature" in the client, the old itemstack ID may persist client-side if the old item
-					 * is the same as the new item. To avoid this, clear the slot first, then set the new item.
-					 */
-					$this->session->sendDataPacket(InventorySlotPacket::create(
-						$windowId,
-						$packetSlot,
-						$clearSlotWrapper
-					));
-					$this->session->sendDataPacket(InventorySlotPacket::create(
-						$windowId,
-						$packetSlot,
-						$info
-					));
+					$this->sendInventorySlotPackets($windowId, $packetSlot, $info);
 				}
 			}else{
-				/*
-				 * Due to a "feature" in the client, the old itemstack ID may persist client-side if the old item
-				 * is the same as the new item. To avoid this, clear the inventory first, then send the real contents.
-				 */
-				$this->session->sendDataPacket(InventoryContentPacket::create(
-					$windowId,
-					array_fill_keys(array_keys($contents), $clearSlotWrapper)
-				));
-				$this->session->sendDataPacket(InventoryContentPacket::create($windowId, $contents));
+				$this->sendInventoryContentPackets($windowId, $contents);
 			}
 		}
 	}


### PR DESCRIPTION
… item

this is a really dumb bug and seems similar to the armor bug I fixed a while ago.

### Relevant issues
fixes #5987 
fixes (maybe) #5727?

## Changes
### API changes
None

### Behavioural changes
The server now sends a dummy InventoryContent/InventorySlot packet to clear out existing items from inventories on the client before sending the real new contents. This prevents the activation of whatever logic is causing the client to stick to the old ID when the new item is the same as the old one.

## Tests
Playtested using purposefully broken transactions in `InventoryTransaction.php`. Any interaction with the offhand with this code will trigger the bug.
```diff
                $this->shuffleActions();

+               $this->addAction(new SlotChangeAction($this->source->getOffHandInventory(), 0, VanillaItems::AIR(), VanillaItems::ARROW()));
                $this->validate();
```
