### PR TITLE
Implement proper pre-installed sign editing

### DIFF
--- a/src/block/BaseSign.php
+++ b/src/block/BaseSign.php
@@ -152,7 +152,7 @@ abstract class BaseSign extends Transparent{
 			return false;
 		}
 		$dyeColor = $this->getColorFromItem($item);
-		if($this->canOpenSign($item)){
+		if($this->canOpenSignEditor($item)){
 			$player->openSignEditor($this->position);
 			return true;
 		}
@@ -247,7 +247,7 @@ abstract class BaseSign extends Transparent{
 	/**
 	 * Returns whether player can open sign editor
 	 */
-	private function canOpenSign(Item $item) : bool{
+	private function canOpenSignEditor(Item $item) : bool{
 		$currentColor = $this->text->getBaseColor();
 		$newColor = $this->getColorFromItem($item);
 		if($newColor === null){

--- a/src/block/BaseSign.php
+++ b/src/block/BaseSign.php
@@ -251,14 +251,12 @@ abstract class BaseSign extends Transparent{
 		$currentColor = $this->text->getBaseColor();
 		$newColor = $this->getColorFromItem($item);
 		if($newColor === null){
-			if($item->getTypeId() === ItemTypeIds::GLOW_INK_SAC || $item->getTypeId() === ItemTypeIds::INK_SAC){
-				$wasGlowing = $this->text->isGlowing();
-				if($wasGlowing && $item->getTypeId() !== ItemTypeIds::GLOW_INK_SAC){
-					return false;
-				}
-				if(!$wasGlowing && $item->getTypeId() !== ItemTypeIds::INK_SAC){
-					return false;
-				}
+			$wasGlowing = $this->text->isGlowing();
+			if($wasGlowing && $item->getTypeId() !== ItemTypeIds::GLOW_INK_SAC){
+				return false;
+			}
+			if(!$wasGlowing && $item->getTypeId() !== ItemTypeIds::INK_SAC){
+				return false;
 			}
 			return true;
 		}

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -755,9 +755,9 @@ class InGamePacketHandler extends PacketHandler{
 				throw new PacketHandlingException("Invalid tag type " . get_debug_type($textBlobTag) . " for tag \"" . Sign::TAG_TEXT_BLOB . "\" in sign update data");
 			}
 
+			$baseColor = $block->getText()->getBaseColor();
+			$glowing = $block->getText()->isGlowing();
 			try{
-				$baseColor = $block->getText()->getBaseColor();
-				$glowing = $block->getText()->isGlowing();
 				$text = SignText::fromBlob($textBlobTag->getValue(), $baseColor, $glowing);
 			}catch(\InvalidArgumentException $e){
 				throw PacketHandlingException::wrap($e, "Invalid sign text update");

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -756,7 +756,9 @@ class InGamePacketHandler extends PacketHandler{
 			}
 
 			try{
-				$text = SignText::fromBlob($textBlobTag->getValue());
+				$baseColor = $block->getText()->getBaseColor();
+				$glowing = $block->getText()->isGlowing();
+				$text = SignText::fromBlob($textBlobTag->getValue(), $baseColor, $glowing);
 			}catch(\InvalidArgumentException $e){
 				throw PacketHandlingException::wrap($e, "Invalid sign text update");
 			}


### PR DESCRIPTION
## Introduction
This PR implements proper pre-installed sign editing.

Tested the following cases (which vanilla behaves):
* Interacting with dyes/(glow) ink sak
   * With same color/glowing state: Player can open sign editor.
   * Different color/glowing state: Sign color/glowing state will be changed.
* Interacting without any items on hand
   * Open sign editor.

### Relevant issues
N/A

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
N/A

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
* SignChangeEvent is now also fired when a player edited a pre-instlaled sign.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
N/A

## Follow-up
N/A

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
