### PR TITLE
Automatically fallback to PSR-0 when class list is unchanged

### DIFF
--- a/changelogs/4.23.md
+++ b/changelogs/4.23.md
@@ -60,3 +60,9 @@ Released 9th August 2023.
 - Fixed `PluginBase->saveResource()` leaking file resources when the data file already exists in the plugin's data folder. This bug existed since 2014 and was only discovered recently.
 - Fixed coral blocks becoming dead after calling `getDropsForCompatibleTool()` on them.
 - Fixed `BlockDeathEvent->getOldState()` returning a block which is already dead.
+
+# 4.23.6
+Released 21st August 2023.
+
+## Fixes
+- Added a workaround for armor and other inventories not working correctly after inventory sync. This is caused by a client bug.

--- a/changelogs/5.4.md
+++ b/changelogs/5.4.md
@@ -107,3 +107,15 @@ Released 9th August 2023.
 ## Fixes
 - Fixed cake accepting candle placement when slices have already been eaten.
 - Fixed fire charges not lighting candles.
+
+# 5.4.3
+Released 21st August 2023.
+
+## Included releases
+- [4.23.6](https://github.com/pmmp/PocketMine-MP/blob/4.23.6/changelogs/4.23.md#4236) - Armor inventory client bug workaround
+
+## Fixes
+- Fixed crashdumps not generating correctly on fatal errors.
+- Fixed `PotionCauldron::setPotionItem()` not validating the item type.
+- Fixed chorus fruit not considering teleport destinations below y=0.
+- Fixed cake dropping itself when mined.

--- a/src/VersionInfo.php
+++ b/src/VersionInfo.php
@@ -32,7 +32,7 @@ use function str_repeat;
 final class VersionInfo{
 	public const NAME = "PocketMine-MP";
 	public const BASE_VERSION = "4.23.6";
-	public const IS_DEVELOPMENT_BUILD = true;
+	public const IS_DEVELOPMENT_BUILD = false;
 	public const BUILD_CHANNEL = "stable";
 
 	private function __construct(){

--- a/src/VersionInfo.php
+++ b/src/VersionInfo.php
@@ -32,7 +32,7 @@ use function str_repeat;
 final class VersionInfo{
 	public const NAME = "PocketMine-MP";
 	public const BASE_VERSION = "5.4.3";
-	public const IS_DEVELOPMENT_BUILD = true;
+	public const IS_DEVELOPMENT_BUILD = false;
 	public const BUILD_CHANNEL = "stable";
 
 	/**

--- a/src/VersionInfo.php
+++ b/src/VersionInfo.php
@@ -31,8 +31,8 @@ use function str_repeat;
 
 final class VersionInfo{
 	public const NAME = "PocketMine-MP";
-	public const BASE_VERSION = "4.23.6";
-	public const IS_DEVELOPMENT_BUILD = false;
+	public const BASE_VERSION = "4.23.7";
+	public const IS_DEVELOPMENT_BUILD = true;
 	public const BUILD_CHANNEL = "stable";
 
 	private function __construct(){

--- a/src/thread/ThreadSafeClassLoader.php
+++ b/src/thread/ThreadSafeClassLoader.php
@@ -25,7 +25,6 @@ namespace pocketmine\thread;
 
 use pmmp\thread\ThreadSafe;
 use pmmp\thread\ThreadSafeArray;
-use ReflectionClass;
 use function class_exists;
 use function count;
 use function explode;
@@ -142,7 +141,7 @@ class ThreadSafeClassLoader extends ThreadSafe{
 				return false;
 			}
 
-			if(method_exists($name, "onClassLoaded") && (new ReflectionClass($name))->getMethod("onClassLoaded")->isStatic()){
+			if(method_exists($name, "onClassLoaded") && (new \ReflectionClass($name))->getMethod("onClassLoaded")->isStatic()){
 				$name::onClassLoaded();
 			}
 


### PR DESCRIPTION
## Introduction

Pharynx is the primary supporting tool for plugins being compiled with external libraries which need shaded. The tool itself is not designed only for pm plugin use though and so outputs PSR-0 plugins without changing the plugin manifest to comply with the changes.

This PR checks whether the known class list is updated after PSR-4 tries to autoload the plugin. If the list is unchanged then PSR-0 is automatically attempted.

### Relevant issues
<!-- List relevant issues here -->

* https://github.com/SOF3/pharynx/issues/5

## Changes

### Behavioral changes
<!-- Any change in how the server behaves, or its performance? -->
`ThreadSafeClassLoader::addPath()` now falls back on PSR-0 when PSR-4 loading returns no results.

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
TODO

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
TODO
