### PR TITLE
Facing::UP now required to extinguish cake candle

### DIFF
--- a/src/block/CakeWithCandle.php
+++ b/src/block/CakeWithCandle.php
@@ -52,7 +52,7 @@ class CakeWithCandle extends BaseCake{
 	}
 
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null, array &$returnedItems = []) : bool{
-		if($this->onInteractCandle($item, $face, $clickVector, $player, $returnedItems)){
+		if($face === Facing::UP && $this->onInteractCandle($item, $face, $clickVector, $player, $returnedItems)){
 			return true;
 		}
 


### PR DESCRIPTION
## Introduction
Fixed wrong cake with candle behavior that cake candle can be extinguished by clicking on faces other than top face.

I'm not good with codebase but I think code changes that I did isn't bad. Although issue author said that this issue is problematic to fix and I didn't found and problems fixing what can indicate that I'm very bad with codebase and dumb, I consider myself not dumb and I claim I fixed the problem in the best way possible. I did the facing check in CakeWithCandle.php because it's only cake relevant problem and this check shouldn't be done on any other candle extinguish because candles on blocks that isn't a cake can be extenguished from any face by clicking on candle.

### Relevant issues
* Fixes #5983

## Changes
### Behavioural changes
Behavior of cake candle was changed

## Tests
1. Place cake
2. Place candle on cake
3. Click on face other than top face
4. Confirm cake candle can't be extinguished that way
5. Click on top face
6. Cake candle extinguished!

I swear I did this tests in-game and they are real.