### PR TITLE
Fix SmithingTableInventory size

### DIFF
--- a/src/block/inventory/SmithingTableInventory.php
+++ b/src/block/inventory/SmithingTableInventory.php
@@ -32,6 +32,6 @@ final class SmithingTableInventory extends SimpleInventory implements BlockInven
 
 	public function __construct(Position $holder){
 		$this->holder = $holder;
-		parent::__construct(2);
+		parent::__construct(3);
 	}
 }


### PR DESCRIPTION
Since 1.20 SmithingTable has a new Template slot, size is now 3

Fix debug error from InventoryManager

## Introduction
Debug error was thrown on adding a Template in the SmithingTable

### Relevant issues
wrong size in SmithingTableInventory

* setting to 3
