### PR TITLE
Entity: mark getNetworkTypeId as non-static

### DIFF
--- a/src/entity/Entity.php
+++ b/src/entity/Entity.php
@@ -1473,7 +1473,7 @@ abstract class Entity{
 		return $this->hasSpawned;
 	}
 
-	abstract public static function getNetworkTypeId() : string;
+	abstract public function getNetworkTypeId() : string;
 
 	/**
 	 * Called by spawnTo() to send whatever packets needed to spawn the entity to the client.
@@ -1482,7 +1482,7 @@ abstract class Entity{
 		$player->getNetworkSession()->sendDataPacket(AddActorPacket::create(
 			$this->getId(), //TODO: actor unique ID
 			$this->getId(),
-			static::getNetworkTypeId(),
+			$this->getNetworkTypeId(),
 			$this->location->asVector3(),
 			$this->getMotion(),
 			$this->location->pitch,

--- a/src/entity/Human.php
+++ b/src/entity/Human.php
@@ -99,7 +99,7 @@ class Human extends Living implements ProjectileSource, InventoryHolder{
 	private const TAG_SKIN_GEOMETRY_NAME = "GeometryName"; //TAG_String
 	private const TAG_SKIN_GEOMETRY_DATA = "GeometryData"; //TAG_ByteArray
 
-	public static function getNetworkTypeId() : string{ return EntityIds::PLAYER; }
+	public function getNetworkTypeId() : string{ return EntityIds::PLAYER; }
 
 	protected PlayerInventory $inventory;
 	protected PlayerOffHandInventory $offHandInventory;

--- a/src/entity/Squid.php
+++ b/src/entity/Squid.php
@@ -37,7 +37,7 @@ use const M_PI;
 
 class Squid extends WaterAnimal{
 
-	public static function getNetworkTypeId() : string{ return EntityIds::SQUID; }
+	public function getNetworkTypeId() : string{ return EntityIds::SQUID; }
 
 	public ?Vector3 $swimDirection = null;
 	public float $swimSpeed = 0.1;

--- a/src/entity/Villager.php
+++ b/src/entity/Villager.php
@@ -38,7 +38,7 @@ class Villager extends Living implements Ageable{
 
 	private const TAG_PROFESSION = "Profession"; //TAG_Int
 
-	public static function getNetworkTypeId() : string{ return EntityIds::VILLAGER; }
+	public function getNetworkTypeId() : string{ return EntityIds::VILLAGER; }
 
 	private bool $baby = false;
 	private int $profession = self::PROFESSION_FARMER;

--- a/src/entity/Zombie.php
+++ b/src/entity/Zombie.php
@@ -29,7 +29,7 @@ use function mt_rand;
 
 class Zombie extends Living{
 
-	public static function getNetworkTypeId() : string{ return EntityIds::ZOMBIE; }
+	public function getNetworkTypeId() : string{ return EntityIds::ZOMBIE; }
 
 	protected function getInitialSizeInfo() : EntitySizeInfo{
 		return new EntitySizeInfo(1.8, 0.6); //TODO: eye height ??

--- a/src/entity/object/ExperienceOrb.php
+++ b/src/entity/object/ExperienceOrb.php
@@ -37,7 +37,7 @@ use function sqrt;
 
 class ExperienceOrb extends Entity{
 
-	public static function getNetworkTypeId() : string{ return EntityIds::XP_ORB; }
+	public function getNetworkTypeId() : string{ return EntityIds::XP_ORB; }
 
 	public const TAG_VALUE_PC = "Value"; //short
 	public const TAG_VALUE_PE = "experience value"; //int (WTF?)

--- a/src/entity/object/FallingBlock.php
+++ b/src/entity/object/FallingBlock.php
@@ -55,7 +55,7 @@ class FallingBlock extends Entity{
 	private const TAG_TILE = "Tile"; //TAG_Byte
 	private const TAG_DATA = "Data"; //TAG_Byte
 
-	public static function getNetworkTypeId() : string{ return EntityIds::FALLING_BLOCK; }
+	public function getNetworkTypeId() : string{ return EntityIds::FALLING_BLOCK; }
 
 	protected Block $block;
 

--- a/src/entity/object/ItemEntity.php
+++ b/src/entity/object/ItemEntity.php
@@ -52,7 +52,7 @@ class ItemEntity extends Entity{
 	private const TAG_THROWER = "Thrower"; //TAG_String
 	public const TAG_ITEM = "Item"; //TAG_Compound
 
-	public static function getNetworkTypeId() : string{ return EntityIds::ITEM; }
+	public function getNetworkTypeId() : string{ return EntityIds::ITEM; }
 
 	public const MERGE_CHECK_PERIOD = 2; //0.1 seconds
 	public const DEFAULT_DESPAWN_DELAY = 6000; //5 minutes

--- a/src/entity/object/Painting.php
+++ b/src/entity/object/Painting.php
@@ -48,7 +48,7 @@ class Painting extends Entity{
 	public const TAG_DIRECTION_BE = "Direction"; //TAG_Byte
 	public const TAG_MOTIVE = "Motive"; //TAG_String
 
-	public static function getNetworkTypeId() : string{ return EntityIds::PAINTING; }
+	public function getNetworkTypeId() : string{ return EntityIds::PAINTING; }
 
 	public const DATA_TO_FACING = [
 		0 => Facing::SOUTH,

--- a/src/entity/object/PrimedTNT.php
+++ b/src/entity/object/PrimedTNT.php
@@ -41,7 +41,7 @@ class PrimedTNT extends Entity implements Explosive{
 
 	private const TAG_FUSE = "Fuse"; //TAG_Short
 
-	public static function getNetworkTypeId() : string{ return EntityIds::TNT; }
+	public function getNetworkTypeId() : string{ return EntityIds::TNT; }
 
 	protected int $fuse;
 	protected bool $worksUnderwater = false;

--- a/src/entity/projectile/Arrow.php
+++ b/src/entity/projectile/Arrow.php
@@ -46,7 +46,7 @@ use function sqrt;
 
 class Arrow extends Projectile{
 
-	public static function getNetworkTypeId() : string{ return EntityIds::ARROW; }
+	public function getNetworkTypeId() : string{ return EntityIds::ARROW; }
 
 	public const PICKUP_NONE = 0;
 	public const PICKUP_ANY = 1;

--- a/src/entity/projectile/Egg.php
+++ b/src/entity/projectile/Egg.php
@@ -29,7 +29,7 @@ use pocketmine\network\mcpe\protocol\types\entity\EntityIds;
 use pocketmine\world\particle\ItemBreakParticle;
 
 class Egg extends Throwable{
-	public static function getNetworkTypeId() : string{ return EntityIds::EGG; }
+	public function getNetworkTypeId() : string{ return EntityIds::EGG; }
 
 	//TODO: spawn chickens on collision
 

--- a/src/entity/projectile/EnderPearl.php
+++ b/src/entity/projectile/EnderPearl.php
@@ -30,7 +30,7 @@ use pocketmine\world\particle\EndermanTeleportParticle;
 use pocketmine\world\sound\EndermanTeleportSound;
 
 class EnderPearl extends Throwable{
-	public static function getNetworkTypeId() : string{ return EntityIds::ENDER_PEARL; }
+	public function getNetworkTypeId() : string{ return EntityIds::ENDER_PEARL; }
 
 	protected function onHit(ProjectileHitEvent $event) : void{
 		$owner = $this->getOwningEntity();

--- a/src/entity/projectile/ExperienceBottle.php
+++ b/src/entity/projectile/ExperienceBottle.php
@@ -30,7 +30,7 @@ use pocketmine\world\sound\PotionSplashSound;
 use function mt_rand;
 
 class ExperienceBottle extends Throwable{
-	public static function getNetworkTypeId() : string{ return EntityIds::XP_BOTTLE; }
+	public function getNetworkTypeId() : string{ return EntityIds::XP_BOTTLE; }
 
 	protected function getInitialGravity() : float{ return 0.07; }
 

--- a/src/entity/projectile/Snowball.php
+++ b/src/entity/projectile/Snowball.php
@@ -28,7 +28,7 @@ use pocketmine\network\mcpe\protocol\types\entity\EntityIds;
 use pocketmine\world\particle\SnowballPoofParticle;
 
 class Snowball extends Throwable{
-	public static function getNetworkTypeId() : string{ return EntityIds::SNOWBALL; }
+	public function getNetworkTypeId() : string{ return EntityIds::SNOWBALL; }
 
 	protected function onHit(ProjectileHitEvent $event) : void{
 		for($i = 0; $i < 6; ++$i){

--- a/src/entity/projectile/SplashPotion.php
+++ b/src/entity/projectile/SplashPotion.php
@@ -52,7 +52,7 @@ class SplashPotion extends Throwable{
 
 	public const TAG_POTION_ID = "PotionId"; //TAG_Short
 
-	public static function getNetworkTypeId() : string{ return EntityIds::SPLASH_POTION; }
+	public function getNetworkTypeId() : string{ return EntityIds::SPLASH_POTION; }
 
 	protected bool $linger = false;
 	protected PotionType $potionType;

--- a/src/world/sound/EntityLandSound.php
+++ b/src/world/sound/EntityLandSound.php
@@ -44,7 +44,7 @@ class EntityLandSound implements Sound{
 			LevelSoundEvent::LAND,
 			$pos,
 			TypeConverter::getInstance()->getBlockTranslator()->internalIdToNetworkId($this->blockLandedOn->getStateId()),
-			$this->entity::getNetworkTypeId(),
+			$this->entity->getNetworkTypeId(),
 			false, //TODO: does isBaby have any relevance here?
 			false
 		)];

--- a/src/world/sound/EntityLongFallSound.php
+++ b/src/world/sound/EntityLongFallSound.php
@@ -40,7 +40,7 @@ class EntityLongFallSound implements Sound{
 			LevelSoundEvent::FALL_BIG,
 			$pos,
 			-1,
-			$this->entity::getNetworkTypeId(),
+			$this->entity->getNetworkTypeId(),
 			false, //TODO: is isBaby relevant here?
 			false
 		)];

--- a/src/world/sound/EntityShortFallSound.php
+++ b/src/world/sound/EntityShortFallSound.php
@@ -39,7 +39,7 @@ class EntityShortFallSound implements Sound{
 			LevelSoundEvent::FALL_SMALL,
 			$pos,
 			-1,
-			$this->entity::getNetworkTypeId(),
+			$this->entity->getNetworkTypeId(),
 			false, //TODO: does isBaby have any relevance here?
 			false
 		)];


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Until now, PocketMine-MP has adhered to a conventional entity registration system, where each entity necessitated a distinct class. While this approach has served its purpose, it has brought about several challenges:

**Class Overload**: The need to create a unique class for every entity has led to an excessive proliferation of classes within codebases, resulting in complexity and maintenance challenges.
**Lack of Flexibility**: Introducing user-configurable entities has been a cumbersome task, often involving intricate methods to circumvent the class-based limitations.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
`Entity::getNetworkTypeId(): string` is no longer static

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
The PR is not backwards incompatible, any entity-based plugins must remove the `static` keyword from the `getNetworkTypeId(): string` method

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
