### PR TITLE
Static support trait

### DIFF
--- a/src/block/Bamboo.php
+++ b/src/block/Bamboo.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
-use pocketmine\block\utils\FixedSupportTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\block\utils\SupportType;
 use pocketmine\data\runtime\RuntimeDataDescriber;
 use pocketmine\event\block\StructureGrowEvent;
@@ -47,7 +47,7 @@ use function mt_rand;
 use const PHP_INT_MAX;
 
 class Bamboo extends Transparent{
-	use FixedSupportTrait;
+	use StaticSupportTrait;
 
 	public const NO_LEAVES = 0;
 	public const SMALL_LEAVES = 1;

--- a/src/block/Bamboo.php
+++ b/src/block/Bamboo.php
@@ -123,12 +123,13 @@ class Bamboo extends Transparent{
 	}
 
 	private function canBeSupportedAt(Block $block) : bool{
+		$supportBlock = $block->getSide(Facing::DOWN);
 		return
-			$block->hasSameTypeId($this) ||
-			$block->getTypeId() === BlockTypeIds::GRAVEL ||
-			$block->hasTypeTag(BlockTypeTags::DIRT) ||
-			$block->hasTypeTag(BlockTypeTags::MUD) ||
-			$block->hasTypeTag(BlockTypeTags::SAND);
+			$supportBlock->hasSameTypeId($this) ||
+			$supportBlock->getTypeId() === BlockTypeIds::GRAVEL ||
+			$supportBlock->hasTypeTag(BlockTypeTags::DIRT) ||
+			$supportBlock->hasTypeTag(BlockTypeTags::MUD) ||
+			$supportBlock->hasTypeTag(BlockTypeTags::SAND);
 	}
 
 	private function seekToTop() : Bamboo{

--- a/src/block/Bamboo.php
+++ b/src/block/Bamboo.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\block\utils\FixedSupportTrait;
 use pocketmine\block\utils\SupportType;
 use pocketmine\data\runtime\RuntimeDataDescriber;
 use pocketmine\event\block\StructureGrowEvent;
@@ -46,6 +47,7 @@ use function mt_rand;
 use const PHP_INT_MAX;
 
 class Bamboo extends Transparent{
+	use FixedSupportTrait;
 
 	public const NO_LEAVES = 0;
 	public const SMALL_LEAVES = 1;
@@ -120,8 +122,9 @@ class Bamboo extends Transparent{
 		return new Vector3($retX, 0, $retZ);
 	}
 
-	private function canBeSupportedBy(Block $block) : bool{
+	private function canBeSupportedAt(Block $block) : bool{
 		return
+			$block->hasSameTypeId($this) ||
 			$block->getTypeId() === BlockTypeIds::GRAVEL ||
 			$block->hasTypeTag(BlockTypeTags::DIRT) ||
 			$block->hasTypeTag(BlockTypeTags::MUD) ||
@@ -151,14 +154,6 @@ class Bamboo extends Transparent{
 			}
 		}
 		return false;
-	}
-
-	public function onNearbyBlockChange() : void{
-		$world = $this->position->getWorld();
-		$below = $world->getBlock($this->position->down());
-		if(!$this->canBeSupportedBy($below) && !$below->hasSameTypeId($this)){
-			$world->useBreakOn($this->position);
-		}
 	}
 
 	private function grow(int $maxHeight, int $growAmount, ?Player $player) : bool{

--- a/src/block/BambooSapling.php
+++ b/src/block/BambooSapling.php
@@ -23,17 +23,21 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\block\utils\FixedSupportTrait;
 use pocketmine\data\runtime\RuntimeDataDescriber;
 use pocketmine\event\block\StructureGrowEvent;
 use pocketmine\item\Bamboo as ItemBamboo;
 use pocketmine\item\Fertilizer;
 use pocketmine\item\Item;
 use pocketmine\item\VanillaItems;
+use pocketmine\math\Facing;
 use pocketmine\math\Vector3;
 use pocketmine\player\Player;
 use pocketmine\world\BlockTransaction;
 
 final class BambooSapling extends Flowable{
+	use FixedSupportTrait;
+
 	private bool $ready = false;
 
 	protected function describeBlockOnlyState(RuntimeDataDescriber $w) : void{
@@ -48,19 +52,13 @@ final class BambooSapling extends Flowable{
 		return $this;
 	}
 
-	private function canBeSupportedBy(Block $block) : bool{
+	private function canBeSupportedAt(Block $block) : bool{
+		$supportBlock = $block->getSide(Facing::DOWN);
 		return
-			$block->getTypeId() === BlockTypeIds::GRAVEL ||
-			$block->hasTypeTag(BlockTypeTags::DIRT) ||
-			$block->hasTypeTag(BlockTypeTags::MUD) ||
-			$block->hasTypeTag(BlockTypeTags::SAND);
-	}
-
-	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		if(!$this->canBeSupportedBy($blockReplace->position->getWorld()->getBlock($blockReplace->position->down()))){
-			return false;
-		}
-		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
+			$supportBlock->getTypeId() === BlockTypeIds::GRAVEL ||
+			$supportBlock->hasTypeTag(BlockTypeTags::DIRT) ||
+			$supportBlock->hasTypeTag(BlockTypeTags::MUD) ||
+			$supportBlock->hasTypeTag(BlockTypeTags::SAND);
 	}
 
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null, array &$returnedItems = []) : bool{
@@ -71,13 +69,6 @@ final class BambooSapling extends Flowable{
 			}
 		}
 		return false;
-	}
-
-	public function onNearbyBlockChange() : void{
-		$world = $this->position->getWorld();
-		if(!$this->canBeSupportedBy($world->getBlock($this->position->down()))){
-			$world->useBreakOn($this->position);
-		}
 	}
 
 	private function grow(?Player $player) : bool{

--- a/src/block/BambooSapling.php
+++ b/src/block/BambooSapling.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
-use pocketmine\block\utils\FixedSupportTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\data\runtime\RuntimeDataDescriber;
 use pocketmine\event\block\StructureGrowEvent;
 use pocketmine\item\Bamboo as ItemBamboo;
@@ -36,7 +36,7 @@ use pocketmine\player\Player;
 use pocketmine\world\BlockTransaction;
 
 final class BambooSapling extends Flowable{
-	use FixedSupportTrait;
+	use StaticSupportTrait;
 
 	private bool $ready = false;
 

--- a/src/block/BaseCake.php
+++ b/src/block/BaseCake.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
-use pocketmine\block\utils\FixedSupportTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\block\utils\SupportType;
 use pocketmine\entity\effect\EffectInstance;
 use pocketmine\entity\FoodSource;
@@ -34,7 +34,7 @@ use pocketmine\math\Vector3;
 use pocketmine\player\Player;
 
 abstract class BaseCake extends Transparent implements FoodSource{
-	use FixedSupportTrait;
+	use StaticSupportTrait;
 
 	public function getSupportType(int $facing) : SupportType{
 		return SupportType::NONE;

--- a/src/block/BaseCake.php
+++ b/src/block/BaseCake.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\block\utils\FixedSupportTrait;
 use pocketmine\block\utils\SupportType;
 use pocketmine\entity\effect\EffectInstance;
 use pocketmine\entity\FoodSource;
@@ -31,27 +32,16 @@ use pocketmine\item\Item;
 use pocketmine\math\Facing;
 use pocketmine\math\Vector3;
 use pocketmine\player\Player;
-use pocketmine\world\BlockTransaction;
 
 abstract class BaseCake extends Transparent implements FoodSource{
+	use FixedSupportTrait;
 
 	public function getSupportType(int $facing) : SupportType{
 		return SupportType::NONE;
 	}
 
-	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		$down = $this->getSide(Facing::DOWN);
-		if($down->getTypeId() !== BlockTypeIds::AIR){
-			return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
-		}
-
-		return false;
-	}
-
-	public function onNearbyBlockChange() : void{
-		if($this->getSide(Facing::DOWN)->getTypeId() === BlockTypeIds::AIR){ //Replace with common break method
-			$this->position->getWorld()->useBreakOn($this->position);
-		}
+	private function canBeSupportedAt(Block $block) : bool{
+		return $block->getSide(Facing::DOWN)->getTypeId() !== BlockTypeIds::AIR;
 	}
 
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null, array &$returnedItems = []) : bool{

--- a/src/block/Cactus.php
+++ b/src/block/Cactus.php
@@ -25,19 +25,17 @@ namespace pocketmine\block;
 
 use pocketmine\block\utils\AgeableTrait;
 use pocketmine\block\utils\BlockEventHelper;
+use pocketmine\block\utils\FixedSupportTrait;
 use pocketmine\block\utils\SupportType;
 use pocketmine\entity\Entity;
 use pocketmine\event\entity\EntityDamageByBlockEvent;
 use pocketmine\event\entity\EntityDamageEvent;
-use pocketmine\item\Item;
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Facing;
-use pocketmine\math\Vector3;
-use pocketmine\player\Player;
-use pocketmine\world\BlockTransaction;
 
 class Cactus extends Transparent{
 	use AgeableTrait;
+	use FixedSupportTrait;
 
 	public const MAX_AGE = 15;
 
@@ -63,23 +61,18 @@ class Cactus extends Transparent{
 		return true;
 	}
 
-	private function canBeSupportedBy(Block $block) : bool{
-		return $block->hasSameTypeId($this) || $block->hasTypeTag(BlockTypeTags::SAND);
-	}
-
-	public function onNearbyBlockChange() : void{
-		$world = $this->position->getWorld();
-		if(!$this->canBeSupportedBy($this->getSide(Facing::DOWN))){
-			$world->useBreakOn($this->position);
-		}else{
-			foreach(Facing::HORIZONTAL as $side){
-				$b = $this->getSide($side);
-				if($b->isSolid()){
-					$world->useBreakOn($this->position);
-					break;
-				}
+	private function canBeSupportedAt(Block $block) : bool{
+		$supportBlock = $block->getSide(Facing::DOWN);
+		if(!$supportBlock->hasSameTypeId($this) && !$supportBlock->hasTypeTag(BlockTypeTags::SAND)){
+			return false;
+		}
+		foreach(Facing::HORIZONTAL as $side){
+			if($block->getSide($side)->isSolid()){
+				return false;
 			}
 		}
+
+		return true;
 	}
 
 	public function ticksRandomly() : bool{
@@ -108,19 +101,5 @@ class Cactus extends Transparent{
 				$world->setBlock($this->position, $this);
 			}
 		}
-	}
-
-	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		if($this->canBeSupportedBy($this->getSide(Facing::DOWN))){
-			foreach(Facing::HORIZONTAL as $side){
-				if($this->getSide($side)->isSolid()){
-					return false;
-				}
-			}
-
-			return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
-		}
-
-		return false;
 	}
 }

--- a/src/block/Cactus.php
+++ b/src/block/Cactus.php
@@ -25,7 +25,7 @@ namespace pocketmine\block;
 
 use pocketmine\block\utils\AgeableTrait;
 use pocketmine\block\utils\BlockEventHelper;
-use pocketmine\block\utils\FixedSupportTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\block\utils\SupportType;
 use pocketmine\entity\Entity;
 use pocketmine\event\entity\EntityDamageByBlockEvent;
@@ -35,7 +35,7 @@ use pocketmine\math\Facing;
 
 class Cactus extends Transparent{
 	use AgeableTrait;
-	use FixedSupportTrait;
+	use StaticSupportTrait;
 
 	public const MAX_AGE = 15;
 

--- a/src/block/Carpet.php
+++ b/src/block/Carpet.php
@@ -24,13 +24,13 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\block\utils\ColoredTrait;
-use pocketmine\block\utils\FixedSupportTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Facing;
 
 class Carpet extends Flowable{
 	use ColoredTrait;
-	use FixedSupportTrait;
+	use StaticSupportTrait;
 
 	public function isSolid() : bool{
 		return true;

--- a/src/block/Carpet.php
+++ b/src/block/Carpet.php
@@ -24,15 +24,13 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\block\utils\ColoredTrait;
-use pocketmine\item\Item;
+use pocketmine\block\utils\FixedSupportTrait;
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Facing;
-use pocketmine\math\Vector3;
-use pocketmine\player\Player;
-use pocketmine\world\BlockTransaction;
 
 class Carpet extends Flowable{
 	use ColoredTrait;
+	use FixedSupportTrait;
 
 	public function isSolid() : bool{
 		return true;
@@ -45,19 +43,8 @@ class Carpet extends Flowable{
 		return [AxisAlignedBB::one()->trim(Facing::UP, 15 / 16)];
 	}
 
-	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		$down = $this->getSide(Facing::DOWN);
-		if($down->getTypeId() !== BlockTypeIds::AIR){
-			return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
-		}
-
-		return false;
-	}
-
-	public function onNearbyBlockChange() : void{
-		if($this->getSide(Facing::DOWN)->getTypeId() === BlockTypeIds::AIR){
-			$this->position->getWorld()->useBreakOn($this->position);
-		}
+	private function canBeSupportedAt(Block $block) : bool{
+		return $block->getSide(Facing::DOWN)->getTypeId() !== BlockTypeIds::AIR;
 	}
 
 	public function getFlameEncouragement() : int{

--- a/src/block/CaveVines.php
+++ b/src/block/CaveVines.php
@@ -25,7 +25,7 @@ namespace pocketmine\block;
 
 use pocketmine\block\utils\AgeableTrait;
 use pocketmine\block\utils\BlockEventHelper;
-use pocketmine\block\utils\FixedSupportTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\block\utils\SupportType;
 use pocketmine\data\runtime\RuntimeDataDescriber;
 use pocketmine\entity\Entity;
@@ -41,7 +41,7 @@ use function mt_rand;
 
 class CaveVines extends Flowable{
 	use AgeableTrait;
-	use FixedSupportTrait;
+	use StaticSupportTrait;
 
 	public const MAX_AGE = 25;
 

--- a/src/block/CaveVines.php
+++ b/src/block/CaveVines.php
@@ -25,6 +25,7 @@ namespace pocketmine\block;
 
 use pocketmine\block\utils\AgeableTrait;
 use pocketmine\block\utils\BlockEventHelper;
+use pocketmine\block\utils\FixedSupportTrait;
 use pocketmine\block\utils\SupportType;
 use pocketmine\data\runtime\RuntimeDataDescriber;
 use pocketmine\entity\Entity;
@@ -40,6 +41,7 @@ use function mt_rand;
 
 class CaveVines extends Flowable{
 	use AgeableTrait;
+	use FixedSupportTrait;
 
 	public const MAX_AGE = 25;
 
@@ -81,16 +83,7 @@ class CaveVines extends Flowable{
 		return $supportBlock->getSupportType(Facing::DOWN) === SupportType::FULL || $supportBlock->hasSameTypeId($this);
 	}
 
-	public function onNearbyBlockChange() : void{
-		if(!$this->canBeSupportedAt($this)){
-			$this->position->getWorld()->useBreakOn($this->position);
-		}
-	}
-
 	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		if(!$this->canBeSupportedAt($blockReplace)){
-			return false;
-		}
 		$this->age = mt_rand(0, self::MAX_AGE);
 		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
 	}

--- a/src/block/ChorusFlower.php
+++ b/src/block/ChorusFlower.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\block\utils\AgeableTrait;
-use pocketmine\block\utils\FixedSupportTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\entity\projectile\Projectile;
 use pocketmine\event\block\StructureGrowEvent;
 use pocketmine\math\Axis;
@@ -42,7 +42,7 @@ use function mt_rand;
 
 final class ChorusFlower extends Flowable{
 	use AgeableTrait;
-	use FixedSupportTrait;
+	use StaticSupportTrait;
 
 	public const MIN_AGE = 0;
 	public const MAX_AGE = 5;

--- a/src/block/ChorusFlower.php
+++ b/src/block/ChorusFlower.php
@@ -24,17 +24,15 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\block\utils\AgeableTrait;
+use pocketmine\block\utils\FixedSupportTrait;
 use pocketmine\entity\projectile\Projectile;
 use pocketmine\event\block\StructureGrowEvent;
-use pocketmine\item\Item;
 use pocketmine\math\Axis;
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Facing;
 use pocketmine\math\RayTraceResult;
 use pocketmine\math\Vector3;
-use pocketmine\player\Player;
 use pocketmine\world\BlockTransaction;
-use pocketmine\world\Position;
 use pocketmine\world\sound\ChorusFlowerDieSound;
 use pocketmine\world\sound\ChorusFlowerGrowSound;
 use pocketmine\world\World;
@@ -44,6 +42,7 @@ use function mt_rand;
 
 final class ChorusFlower extends Flowable{
 	use AgeableTrait;
+	use FixedSupportTrait;
 
 	public const MIN_AGE = 0;
 	public const MAX_AGE = 5;
@@ -54,7 +53,8 @@ final class ChorusFlower extends Flowable{
 		return [AxisAlignedBB::one()];
 	}
 
-	private function canBeSupportedAt(Position $position) : bool{
+	private function canBeSupportedAt(Block $block) : bool{
+		$position = $block->getPosition();
 		$world = $position->getWorld();
 		$down = $world->getBlock($position->down());
 
@@ -77,19 +77,6 @@ final class ChorusFlower extends Flowable{
 		}
 
 		return $plantAdjacent;
-	}
-
-	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		if(!$this->canBeSupportedAt($blockReplace->getPosition())){
-			return false;
-		}
-		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
-	}
-
-	public function onNearbyBlockChange() : void{
-		if(!$this->canBeSupportedAt($this->position)){
-			$this->position->getWorld()->useBreakOn($this->position);
-		}
 	}
 
 	public function onProjectileHit(Projectile $projectile, RayTraceResult $hitResult) : void{

--- a/src/block/Coral.php
+++ b/src/block/Coral.php
@@ -23,11 +23,11 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
-use pocketmine\block\utils\FixedSupportTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\math\Facing;
 
 final class Coral extends BaseCoral{
-	use FixedSupportTrait;
+	use StaticSupportTrait;
 
 	private function canBeSupportedAt(Block $block) : bool{
 		return $block->getAdjacentSupportType(Facing::DOWN)->hasCenterSupport();

--- a/src/block/Coral.php
+++ b/src/block/Coral.php
@@ -23,29 +23,11 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
-use pocketmine\item\Item;
+use pocketmine\block\utils\FixedSupportTrait;
 use pocketmine\math\Facing;
-use pocketmine\math\Vector3;
-use pocketmine\player\Player;
-use pocketmine\world\BlockTransaction;
 
 final class Coral extends BaseCoral{
-
-	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		if(!$this->canBeSupportedAt($blockReplace)){
-			return false;
-		}
-		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
-	}
-
-	public function onNearbyBlockChange() : void{
-		$world = $this->position->getWorld();
-		if(!$this->canBeSupportedAt($this)){
-			$world->useBreakOn($this->position);
-		}else{
-			parent::onNearbyBlockChange();
-		}
-	}
+	use FixedSupportTrait;
 
 	private function canBeSupportedAt(Block $block) : bool{
 		return $block->getAdjacentSupportType(Facing::DOWN)->hasCenterSupport();

--- a/src/block/Crops.php
+++ b/src/block/Crops.php
@@ -25,25 +25,22 @@ namespace pocketmine\block;
 
 use pocketmine\block\utils\AgeableTrait;
 use pocketmine\block\utils\BlockEventHelper;
+use pocketmine\block\utils\FixedSupportTrait;
 use pocketmine\item\Fertilizer;
 use pocketmine\item\Item;
 use pocketmine\math\Facing;
 use pocketmine\math\Vector3;
 use pocketmine\player\Player;
-use pocketmine\world\BlockTransaction;
 use function mt_rand;
 
 abstract class Crops extends Flowable{
 	use AgeableTrait;
+	use FixedSupportTrait;
 
 	public const MAX_AGE = 7;
 
-	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		if($blockReplace->getSide(Facing::DOWN)->getTypeId() === BlockTypeIds::FARMLAND){
-			return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
-		}
-
-		return false;
+	private function canBeSupportedAt(Block $block) : bool{
+		return $block->getSide(Facing::DOWN)->getTypeId() === BlockTypeIds::FARMLAND;
 	}
 
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null, array &$returnedItems = []) : bool{
@@ -62,12 +59,6 @@ abstract class Crops extends Flowable{
 		}
 
 		return false;
-	}
-
-	public function onNearbyBlockChange() : void{
-		if($this->getSide(Facing::DOWN)->getTypeId() !== BlockTypeIds::FARMLAND){
-			$this->position->getWorld()->useBreakOn($this->position);
-		}
 	}
 
 	public function ticksRandomly() : bool{

--- a/src/block/Crops.php
+++ b/src/block/Crops.php
@@ -25,7 +25,7 @@ namespace pocketmine\block;
 
 use pocketmine\block\utils\AgeableTrait;
 use pocketmine\block\utils\BlockEventHelper;
-use pocketmine\block\utils\FixedSupportTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\item\Fertilizer;
 use pocketmine\item\Item;
 use pocketmine\math\Facing;
@@ -35,7 +35,7 @@ use function mt_rand;
 
 abstract class Crops extends Flowable{
 	use AgeableTrait;
-	use FixedSupportTrait;
+	use StaticSupportTrait;
 
 	public const MAX_AGE = 7;
 

--- a/src/block/DeadBush.php
+++ b/src/block/DeadBush.php
@@ -23,14 +23,14 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
-use pocketmine\block\utils\FixedSupportTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\item\Item;
 use pocketmine\item\VanillaItems;
 use pocketmine\math\Facing;
 use function mt_rand;
 
 class DeadBush extends Flowable{
-	use FixedSupportTrait;
+	use StaticSupportTrait;
 
 	public function getDropsForIncompatibleTool(Item $item) : array{
 		return [

--- a/src/block/DeadBush.php
+++ b/src/block/DeadBush.php
@@ -23,29 +23,14 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\block\utils\FixedSupportTrait;
 use pocketmine\item\Item;
 use pocketmine\item\VanillaItems;
 use pocketmine\math\Facing;
-use pocketmine\math\Vector3;
-use pocketmine\player\Player;
-use pocketmine\world\BlockTransaction;
 use function mt_rand;
 
 class DeadBush extends Flowable{
-
-	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		if($this->canBeSupportedBy($this->getSide(Facing::DOWN))){
-			return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
-		}
-
-		return false;
-	}
-
-	public function onNearbyBlockChange() : void{
-		if(!$this->canBeSupportedBy($this->getSide(Facing::DOWN))){
-			$this->position->getWorld()->useBreakOn($this->position);
-		}
-	}
+	use FixedSupportTrait;
 
 	public function getDropsForIncompatibleTool(Item $item) : array{
 		return [
@@ -65,14 +50,18 @@ class DeadBush extends Flowable{
 		return 100;
 	}
 
-	private function canBeSupportedBy(Block $block) : bool{
-		$blockId = $block->getTypeId();
-		return $blockId === BlockTypeIds::SAND
-			|| $blockId === BlockTypeIds::RED_SAND
-			|| $blockId === BlockTypeIds::PODZOL
-			|| $blockId === BlockTypeIds::MYCELIUM
-			|| $blockId === BlockTypeIds::DIRT
-			|| $blockId === BlockTypeIds::HARDENED_CLAY
-			|| $blockId === BlockTypeIds::STAINED_CLAY;
+	private function canBeSupportedAt(Block $block) : bool{
+		$supportBlock = $block->getSide(Facing::DOWN);
+		//TODO: can we use tags here?
+		return match($supportBlock->getTypeId()){
+			BlockTypeIds::SAND,
+			BlockTypeIds::RED_SAND,
+			BlockTypeIds::PODZOL,
+			BlockTypeIds::MYCELIUM,
+			BlockTypeIds::DIRT,
+			BlockTypeIds::HARDENED_CLAY,
+			BlockTypeIds::STAINED_CLAY => true,
+			default => false
+		};
 	}
 }

--- a/src/block/FloorCoralFan.php
+++ b/src/block/FloorCoralFan.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\block\utils\FixedSupportTrait;
 use pocketmine\data\runtime\RuntimeDataDescriber;
 use pocketmine\item\Item;
 use pocketmine\item\VanillaItems;
@@ -35,6 +36,8 @@ use function atan2;
 use function rad2deg;
 
 final class FloorCoralFan extends BaseCoral{
+	use FixedSupportTrait;
+
 	private int $axis = Axis::X;
 
 	protected function describeBlockOnlyState(RuntimeDataDescriber $w) : void{
@@ -53,9 +56,6 @@ final class FloorCoralFan extends BaseCoral{
 	}
 
 	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		if(!$this->canBeSupportedAt($blockReplace)){
-			return false;
-		}
 		if($player !== null){
 			$playerBlockPos = $player->getPosition()->floor();
 			$directionVector = $blockReplace->getPosition()->subtractVector($playerBlockPos)->normalize();
@@ -71,15 +71,6 @@ final class FloorCoralFan extends BaseCoral{
 		$this->dead = !$this->isCoveredWithWater();
 
 		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
-	}
-
-	public function onNearbyBlockChange() : void{
-		$world = $this->position->getWorld();
-		if(!$this->canBeSupportedAt($this)){
-			$world->useBreakOn($this->position);
-		}else{
-			parent::onNearbyBlockChange();
-		}
 	}
 
 	private function canBeSupportedAt(Block $block) : bool{

--- a/src/block/FloorCoralFan.php
+++ b/src/block/FloorCoralFan.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
-use pocketmine\block\utils\FixedSupportTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\data\runtime\RuntimeDataDescriber;
 use pocketmine\item\Item;
 use pocketmine\item\VanillaItems;
@@ -36,7 +36,7 @@ use function atan2;
 use function rad2deg;
 
 final class FloorCoralFan extends BaseCoral{
-	use FixedSupportTrait;
+	use StaticSupportTrait;
 
 	private int $axis = Axis::X;
 

--- a/src/block/Flower.php
+++ b/src/block/Flower.php
@@ -23,11 +23,11 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
-use pocketmine\block\utils\FixedSupportTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\math\Facing;
 
 class Flower extends Flowable{
-	use FixedSupportTrait;
+	use StaticSupportTrait;
 
 	private function canBeSupportedAt(Block $block) : bool{
 		$supportBlock = $block->getSide(Facing::DOWN);

--- a/src/block/Flower.php
+++ b/src/block/Flower.php
@@ -23,28 +23,15 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
-use pocketmine\item\Item;
+use pocketmine\block\utils\FixedSupportTrait;
 use pocketmine\math\Facing;
-use pocketmine\math\Vector3;
-use pocketmine\player\Player;
-use pocketmine\world\BlockTransaction;
 
 class Flower extends Flowable{
+	use FixedSupportTrait;
 
-	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		$down = $this->getSide(Facing::DOWN);
-		if($down->hasTypeTag(BlockTypeTags::DIRT) || $down->hasTypeTag(BlockTypeTags::MUD)){
-			return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
-		}
-
-		return false;
-	}
-
-	public function onNearbyBlockChange() : void{
-		$down = $this->getSide(Facing::DOWN);
-		if(!$down->hasTypeTag(BlockTypeTags::DIRT) && !$down->hasTypeTag(BlockTypeTags::MUD)){
-			$this->position->getWorld()->useBreakOn($this->position);
-		}
+	private function canBeSupportedAt(Block $block) : bool{
+		$supportBlock = $block->getSide(Facing::DOWN);
+		return $supportBlock->hasTypeTag(BlockTypeTags::DIRT) || $supportBlock->hasTypeTag(BlockTypeTags::MUD);
 	}
 
 	public function getFlameEncouragement() : int{

--- a/src/block/FlowerPot.php
+++ b/src/block/FlowerPot.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\block\tile\FlowerPot as TileFlowerPot;
-use pocketmine\block\utils\FixedSupportTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\item\Item;
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Facing;
@@ -33,7 +33,7 @@ use pocketmine\player\Player;
 use function assert;
 
 class FlowerPot extends Flowable{
-	use FixedSupportTrait;
+	use StaticSupportTrait;
 
 	protected ?Block $plant = null;
 

--- a/src/block/FlowerPot.php
+++ b/src/block/FlowerPot.php
@@ -24,15 +24,16 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\block\tile\FlowerPot as TileFlowerPot;
+use pocketmine\block\utils\FixedSupportTrait;
 use pocketmine\item\Item;
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Facing;
 use pocketmine\math\Vector3;
 use pocketmine\player\Player;
-use pocketmine\world\BlockTransaction;
 use function assert;
 
 class FlowerPot extends Flowable{
+	use FixedSupportTrait;
 
 	protected ?Block $plant = null;
 
@@ -87,20 +88,6 @@ class FlowerPot extends Flowable{
 	 */
 	protected function recalculateCollisionBoxes() : array{
 		return [AxisAlignedBB::one()->contract(3 / 16, 0, 3 / 16)->trim(Facing::UP, 5 / 8)];
-	}
-
-	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		if(!$this->canBeSupportedAt($blockReplace)){
-			return false;
-		}
-
-		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
-	}
-
-	public function onNearbyBlockChange() : void{
-		if(!$this->canBeSupportedAt($this)){
-			$this->position->getWorld()->useBreakOn($this->position);
-		}
 	}
 
 	private function canBeSupportedAt(Block $block) : bool{

--- a/src/block/HangingRoots.php
+++ b/src/block/HangingRoots.php
@@ -23,13 +23,13 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
-use pocketmine\block\utils\FixedSupportTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\item\enchantment\VanillaEnchantments;
 use pocketmine\item\Item;
 use pocketmine\math\Facing;
 
 final class HangingRoots extends Flowable{
-	use FixedSupportTrait;
+	use StaticSupportTrait;
 
 	private function canBeSupportedAt(Block $block) : bool{
 		return $block->getAdjacentSupportType(Facing::UP)->hasCenterSupport(); //weird I know, but they can be placed on the bottom of fences

--- a/src/block/HangingRoots.php
+++ b/src/block/HangingRoots.php
@@ -23,30 +23,16 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\block\utils\FixedSupportTrait;
 use pocketmine\item\enchantment\VanillaEnchantments;
 use pocketmine\item\Item;
 use pocketmine\math\Facing;
-use pocketmine\math\Vector3;
-use pocketmine\player\Player;
-use pocketmine\world\BlockTransaction;
 
 final class HangingRoots extends Flowable{
+	use FixedSupportTrait;
 
 	private function canBeSupportedAt(Block $block) : bool{
 		return $block->getAdjacentSupportType(Facing::UP)->hasCenterSupport(); //weird I know, but they can be placed on the bottom of fences
-	}
-
-	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		if(!$this->canBeSupportedAt($blockReplace)){
-			return false;
-		}
-		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
-	}
-
-	public function onNearbyBlockChange() : void{
-		if(!$this->canBeSupportedAt($this)){
-			$this->position->getWorld()->useBreakOn($this->position);
-		}
 	}
 
 	public function getDropsForIncompatibleTool(Item $item) : array{

--- a/src/block/NetherVines.php
+++ b/src/block/NetherVines.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\block\utils\AgeableTrait;
+use pocketmine\block\utils\FixedSupportTrait;
 use pocketmine\block\utils\FortuneDropHelper;
 use pocketmine\block\utils\SupportType;
 use pocketmine\entity\Entity;
@@ -42,6 +43,7 @@ use function mt_rand;
  */
 class NetherVines extends Flowable{
 	use AgeableTrait;
+	use FixedSupportTrait;
 
 	public const MAX_AGE = 25;
 
@@ -70,12 +72,6 @@ class NetherVines extends Flowable{
 		return $supportBlock->getSupportType($this->growthFace)->hasCenterSupport() || $supportBlock->hasSameTypeId($this);
 	}
 
-	public function onNearbyBlockChange() : void{
-		if(!$this->canBeSupportedAt($this)){
-			$this->position->getWorld()->useBreakOn($this->position);
-		}
-	}
-
 	/**
 	 * Returns the block at the end of the vine structure furthest from the supporting block.
 	 */
@@ -88,9 +84,6 @@ class NetherVines extends Flowable{
 	}
 
 	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		if(!$this->canBeSupportedAt($blockReplace)){
-			return false;
-		}
 		$this->age = mt_rand(0, self::MAX_AGE - 1);
 		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
 	}

--- a/src/block/NetherVines.php
+++ b/src/block/NetherVines.php
@@ -24,8 +24,8 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\block\utils\AgeableTrait;
-use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\block\utils\FortuneDropHelper;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\block\utils\SupportType;
 use pocketmine\entity\Entity;
 use pocketmine\event\block\StructureGrowEvent;

--- a/src/block/NetherVines.php
+++ b/src/block/NetherVines.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\block\utils\AgeableTrait;
-use pocketmine\block\utils\FixedSupportTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\block\utils\FortuneDropHelper;
 use pocketmine\block\utils\SupportType;
 use pocketmine\entity\Entity;
@@ -43,7 +43,7 @@ use function mt_rand;
  */
 class NetherVines extends Flowable{
 	use AgeableTrait;
-	use FixedSupportTrait;
+	use StaticSupportTrait;
 
 	public const MAX_AGE = 25;
 

--- a/src/block/NetherWartPlant.php
+++ b/src/block/NetherWartPlant.php
@@ -25,8 +25,8 @@ namespace pocketmine\block;
 
 use pocketmine\block\utils\AgeableTrait;
 use pocketmine\block\utils\BlockEventHelper;
-use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\block\utils\FortuneDropHelper;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\item\Item;
 use pocketmine\math\Facing;
 use function mt_rand;

--- a/src/block/NetherWartPlant.php
+++ b/src/block/NetherWartPlant.php
@@ -25,7 +25,7 @@ namespace pocketmine\block;
 
 use pocketmine\block\utils\AgeableTrait;
 use pocketmine\block\utils\BlockEventHelper;
-use pocketmine\block\utils\FixedSupportTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\block\utils\FortuneDropHelper;
 use pocketmine\item\Item;
 use pocketmine\math\Facing;
@@ -33,7 +33,7 @@ use function mt_rand;
 
 class NetherWartPlant extends Flowable{
 	use AgeableTrait;
-	use FixedSupportTrait;
+	use StaticSupportTrait;
 
 	public const MAX_AGE = 3;
 

--- a/src/block/NetherWartPlant.php
+++ b/src/block/NetherWartPlant.php
@@ -37,7 +37,7 @@ class NetherWartPlant extends Flowable{
 
 	public const MAX_AGE = 3;
 
-	private function canBeSupportedBy(Block $block) : bool{
+	private function canBeSupportedAt(Block $block) : bool{
 		return $block->getSide(Facing::DOWN)->getTypeId() === BlockTypeIds::SOUL_SAND;
 	}
 

--- a/src/block/NetherWartPlant.php
+++ b/src/block/NetherWartPlant.php
@@ -25,32 +25,20 @@ namespace pocketmine\block;
 
 use pocketmine\block\utils\AgeableTrait;
 use pocketmine\block\utils\BlockEventHelper;
+use pocketmine\block\utils\FixedSupportTrait;
 use pocketmine\block\utils\FortuneDropHelper;
 use pocketmine\item\Item;
 use pocketmine\math\Facing;
-use pocketmine\math\Vector3;
-use pocketmine\player\Player;
-use pocketmine\world\BlockTransaction;
 use function mt_rand;
 
 class NetherWartPlant extends Flowable{
 	use AgeableTrait;
+	use FixedSupportTrait;
 
 	public const MAX_AGE = 3;
 
-	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		$down = $this->getSide(Facing::DOWN);
-		if($down->getTypeId() === BlockTypeIds::SOUL_SAND){
-			return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
-		}
-
-		return false;
-	}
-
-	public function onNearbyBlockChange() : void{
-		if($this->getSide(Facing::DOWN)->getTypeId() !== BlockTypeIds::SOUL_SAND){
-			$this->position->getWorld()->useBreakOn($this->position);
-		}
+	private function canBeSupportedBy(Block $block) : bool{
+		return $block->getSide(Facing::DOWN)->getTypeId() === BlockTypeIds::SOUL_SAND;
 	}
 
 	public function ticksRandomly() : bool{

--- a/src/block/PinkPetals.php
+++ b/src/block/PinkPetals.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\block\utils\BlockEventHelper;
+use pocketmine\block\utils\FixedSupportTrait;
 use pocketmine\block\utils\HorizontalFacingTrait;
 use pocketmine\data\runtime\RuntimeDataDescriber;
 use pocketmine\item\Fertilizer;
@@ -35,6 +36,9 @@ use pocketmine\world\BlockTransaction;
 
 class PinkPetals extends Flowable{
 	use HorizontalFacingTrait;
+	use FixedSupportTrait {
+		canBePlacedAt as supportedWhenPlacedAt;
+	}
 
 	public const MIN_COUNT = 1;
 	public const MAX_COUNT = 4;
@@ -65,20 +69,11 @@ class PinkPetals extends Flowable{
 		return $supportBlock->hasTypeTag(BlockTypeTags::DIRT) || $supportBlock->hasTypeTag(BlockTypeTags::MUD);
 	}
 
-	public function onNearbyBlockChange() : void{
-		if(!$this->canBeSupportedAt($this)){
-			$this->position->getWorld()->useBreakOn($this->position);
-		}
-	}
-
 	public function canBePlacedAt(Block $blockReplace, Vector3 $clickVector, int $face, bool $isClickedBlock) : bool{
-		return ($blockReplace instanceof PinkPetals && $blockReplace->getCount() < self::MAX_COUNT) || parent::canBePlacedAt($blockReplace, $clickVector, $face, $isClickedBlock);
+		return ($blockReplace instanceof PinkPetals && $blockReplace->getCount() < self::MAX_COUNT) || $this->supportedWhenPlacedAt($blockReplace, $clickVector, $face, $isClickedBlock);
 	}
 
 	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		if(!$this->canBeSupportedAt($this)){
-			return false;
-		}
 		if($blockReplace instanceof PinkPetals && $blockReplace->getCount() < self::MAX_COUNT){
 			$this->count = $blockReplace->getCount() + 1;
 			$this->facing = $blockReplace->getFacing();

--- a/src/block/PinkPetals.php
+++ b/src/block/PinkPetals.php
@@ -24,8 +24,8 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\block\utils\BlockEventHelper;
-use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\block\utils\HorizontalFacingTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\data\runtime\RuntimeDataDescriber;
 use pocketmine\item\Fertilizer;
 use pocketmine\item\Item;

--- a/src/block/PinkPetals.php
+++ b/src/block/PinkPetals.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\block\utils\BlockEventHelper;
-use pocketmine\block\utils\FixedSupportTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\block\utils\HorizontalFacingTrait;
 use pocketmine\data\runtime\RuntimeDataDescriber;
 use pocketmine\item\Fertilizer;
@@ -36,7 +36,7 @@ use pocketmine\world\BlockTransaction;
 
 class PinkPetals extends Flowable{
 	use HorizontalFacingTrait;
-	use FixedSupportTrait {
+	use StaticSupportTrait {
 		canBePlacedAt as supportedWhenPlacedAt;
 	}
 

--- a/src/block/PressurePlate.php
+++ b/src/block/PressurePlate.php
@@ -23,21 +23,19 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\block\utils\FixedSupportTrait;
 use pocketmine\block\utils\SupportType;
 use pocketmine\entity\Entity;
 use pocketmine\event\block\PressurePlateUpdateEvent;
-use pocketmine\item\Item;
 use pocketmine\math\Axis;
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Facing;
-use pocketmine\math\Vector3;
-use pocketmine\player\Player;
-use pocketmine\world\BlockTransaction;
 use pocketmine\world\sound\PressurePlateActivateSound;
 use pocketmine\world\sound\PressurePlateDeactivateSound;
 use function count;
 
 abstract class PressurePlate extends Transparent{
+	use FixedSupportTrait;
 
 	private readonly int $deactivationDelayTicks;
 
@@ -63,21 +61,8 @@ abstract class PressurePlate extends Transparent{
 		return SupportType::NONE;
 	}
 
-	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		if($this->canBeSupportedAt($blockReplace)){
-			return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
-		}
-		return false;
-	}
-
 	private function canBeSupportedAt(Block $block) : bool{
 		return $block->getAdjacentSupportType(Facing::DOWN) !== SupportType::NONE;
-	}
-
-	public function onNearbyBlockChange() : void{
-		if(!$this->canBeSupportedAt($this)){
-			$this->position->getWorld()->useBreakOn($this->position);
-		}
 	}
 
 	public function hasEntityCollision() : bool{

--- a/src/block/PressurePlate.php
+++ b/src/block/PressurePlate.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
-use pocketmine\block\utils\FixedSupportTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\block\utils\SupportType;
 use pocketmine\entity\Entity;
 use pocketmine\event\block\PressurePlateUpdateEvent;
@@ -35,7 +35,7 @@ use pocketmine\world\sound\PressurePlateDeactivateSound;
 use function count;
 
 abstract class PressurePlate extends Transparent{
-	use FixedSupportTrait;
+	use StaticSupportTrait;
 
 	private readonly int $deactivationDelayTicks;
 

--- a/src/block/RedstoneComparator.php
+++ b/src/block/RedstoneComparator.php
@@ -25,6 +25,7 @@ namespace pocketmine\block;
 
 use pocketmine\block\tile\Comparator;
 use pocketmine\block\utils\AnalogRedstoneSignalEmitterTrait;
+use pocketmine\block\utils\FixedSupportTrait;
 use pocketmine\block\utils\HorizontalFacingTrait;
 use pocketmine\block\utils\PoweredByRedstoneTrait;
 use pocketmine\block\utils\SupportType;
@@ -41,6 +42,7 @@ class RedstoneComparator extends Flowable{
 	use HorizontalFacingTrait;
 	use AnalogRedstoneSignalEmitterTrait;
 	use PoweredByRedstoneTrait;
+	use FixedSupportTrait;
 
 	protected bool $isSubtractMode = false;
 
@@ -85,26 +87,16 @@ class RedstoneComparator extends Flowable{
 	}
 
 	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		if($this->canBeSupportedAt($blockReplace)){
-			if($player !== null){
-				$this->facing = Facing::opposite($player->getHorizontalFacing());
-			}
-			return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
+		if($player !== null){
+			$this->facing = Facing::opposite($player->getHorizontalFacing());
 		}
-
-		return false;
+		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
 	}
 
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null, array &$returnedItems = []) : bool{
 		$this->isSubtractMode = !$this->isSubtractMode;
 		$this->position->getWorld()->setBlock($this->position, $this);
 		return true;
-	}
-
-	public function onNearbyBlockChange() : void{
-		if(!$this->canBeSupportedAt($this)){
-			$this->position->getWorld()->useBreakOn($this->position);
-		}
 	}
 
 	private function canBeSupportedAt(Block $block) : bool{

--- a/src/block/RedstoneComparator.php
+++ b/src/block/RedstoneComparator.php
@@ -25,9 +25,9 @@ namespace pocketmine\block;
 
 use pocketmine\block\tile\Comparator;
 use pocketmine\block\utils\AnalogRedstoneSignalEmitterTrait;
-use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\block\utils\HorizontalFacingTrait;
 use pocketmine\block\utils\PoweredByRedstoneTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\block\utils\SupportType;
 use pocketmine\data\runtime\RuntimeDataDescriber;
 use pocketmine\item\Item;

--- a/src/block/RedstoneComparator.php
+++ b/src/block/RedstoneComparator.php
@@ -25,7 +25,7 @@ namespace pocketmine\block;
 
 use pocketmine\block\tile\Comparator;
 use pocketmine\block\utils\AnalogRedstoneSignalEmitterTrait;
-use pocketmine\block\utils\FixedSupportTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\block\utils\HorizontalFacingTrait;
 use pocketmine\block\utils\PoweredByRedstoneTrait;
 use pocketmine\block\utils\SupportType;
@@ -42,7 +42,7 @@ class RedstoneComparator extends Flowable{
 	use HorizontalFacingTrait;
 	use AnalogRedstoneSignalEmitterTrait;
 	use PoweredByRedstoneTrait;
-	use FixedSupportTrait;
+	use StaticSupportTrait;
 
 	protected bool $isSubtractMode = false;
 

--- a/src/block/RedstoneRepeater.php
+++ b/src/block/RedstoneRepeater.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
-use pocketmine\block\utils\FixedSupportTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\block\utils\HorizontalFacingTrait;
 use pocketmine\block\utils\PoweredByRedstoneTrait;
 use pocketmine\block\utils\SupportType;
@@ -38,7 +38,7 @@ use pocketmine\world\BlockTransaction;
 class RedstoneRepeater extends Flowable{
 	use HorizontalFacingTrait;
 	use PoweredByRedstoneTrait;
-	use FixedSupportTrait;
+	use StaticSupportTrait;
 
 	public const MIN_DELAY = 1;
 	public const MAX_DELAY = 4;

--- a/src/block/RedstoneRepeater.php
+++ b/src/block/RedstoneRepeater.php
@@ -23,9 +23,9 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
-use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\block\utils\HorizontalFacingTrait;
 use pocketmine\block\utils\PoweredByRedstoneTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\block\utils\SupportType;
 use pocketmine\data\runtime\RuntimeDataDescriber;
 use pocketmine\item\Item;

--- a/src/block/RedstoneRepeater.php
+++ b/src/block/RedstoneRepeater.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\block\utils\FixedSupportTrait;
 use pocketmine\block\utils\HorizontalFacingTrait;
 use pocketmine\block\utils\PoweredByRedstoneTrait;
 use pocketmine\block\utils\SupportType;
@@ -37,6 +38,7 @@ use pocketmine\world\BlockTransaction;
 class RedstoneRepeater extends Flowable{
 	use HorizontalFacingTrait;
 	use PoweredByRedstoneTrait;
+	use FixedSupportTrait;
 
 	public const MIN_DELAY = 1;
 	public const MAX_DELAY = 4;
@@ -68,15 +70,11 @@ class RedstoneRepeater extends Flowable{
 	}
 
 	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		if($this->canBeSupportedAt($blockReplace)){
-			if($player !== null){
-				$this->facing = Facing::opposite($player->getHorizontalFacing());
-			}
-
-			return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
+		if($player !== null){
+			$this->facing = Facing::opposite($player->getHorizontalFacing());
 		}
 
-		return false;
+		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
 	}
 
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null, array &$returnedItems = []) : bool{
@@ -85,12 +83,6 @@ class RedstoneRepeater extends Flowable{
 		}
 		$this->position->getWorld()->setBlock($this->position, $this);
 		return true;
-	}
-
-	public function onNearbyBlockChange() : void{
-		if(!$this->canBeSupportedAt($this)){
-			$this->position->getWorld()->useBreakOn($this->position);
-		}
 	}
 
 	private function canBeSupportedAt(Block $block) : bool{

--- a/src/block/RedstoneWire.php
+++ b/src/block/RedstoneWire.php
@@ -24,34 +24,20 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\block\utils\AnalogRedstoneSignalEmitterTrait;
+use pocketmine\block\utils\FixedSupportTrait;
 use pocketmine\item\Item;
 use pocketmine\item\VanillaItems;
 use pocketmine\math\Facing;
-use pocketmine\math\Vector3;
-use pocketmine\player\Player;
-use pocketmine\world\BlockTransaction;
 
 class RedstoneWire extends Flowable{
 	use AnalogRedstoneSignalEmitterTrait;
-
-	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		if($this->canBeSupportedAt($blockReplace)){
-			return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
-		}
-		return false;
-	}
+	use FixedSupportTrait;
 
 	public function readStateFromWorld() : Block{
 		parent::readStateFromWorld();
 		//TODO: check connections to nearby redstone components
 
 		return $this;
-	}
-
-	public function onNearbyBlockChange() : void{
-		if(!$this->canBeSupportedAt($this)){
-			$this->position->getWorld()->useBreakOn($this->position);
-		}
 	}
 
 	private function canBeSupportedAt(Block $block) : bool{

--- a/src/block/RedstoneWire.php
+++ b/src/block/RedstoneWire.php
@@ -24,14 +24,14 @@ declare(strict_types=1);
 namespace pocketmine\block;
 
 use pocketmine\block\utils\AnalogRedstoneSignalEmitterTrait;
-use pocketmine\block\utils\FixedSupportTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\item\Item;
 use pocketmine\item\VanillaItems;
 use pocketmine\math\Facing;
 
 class RedstoneWire extends Flowable{
 	use AnalogRedstoneSignalEmitterTrait;
-	use FixedSupportTrait;
+	use StaticSupportTrait;
 
 	public function readStateFromWorld() : Block{
 		parent::readStateFromWorld();

--- a/src/block/Sapling.php
+++ b/src/block/Sapling.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
-use pocketmine\block\utils\FixedSupportTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\block\utils\SaplingType;
 use pocketmine\data\runtime\RuntimeDataDescriber;
 use pocketmine\event\block\StructureGrowEvent;
@@ -37,7 +37,7 @@ use pocketmine\world\generator\object\TreeFactory;
 use function mt_rand;
 
 class Sapling extends Flowable{
-	use FixedSupportTrait;
+	use StaticSupportTrait;
 
 	protected bool $ready = false;
 

--- a/src/block/Sapling.php
+++ b/src/block/Sapling.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\block\utils\FixedSupportTrait;
 use pocketmine\block\utils\SaplingType;
 use pocketmine\data\runtime\RuntimeDataDescriber;
 use pocketmine\event\block\StructureGrowEvent;
@@ -32,11 +33,12 @@ use pocketmine\math\Facing;
 use pocketmine\math\Vector3;
 use pocketmine\player\Player;
 use pocketmine\utils\Random;
-use pocketmine\world\BlockTransaction;
 use pocketmine\world\generator\object\TreeFactory;
 use function mt_rand;
 
 class Sapling extends Flowable{
+	use FixedSupportTrait;
+
 	protected bool $ready = false;
 
 	private SaplingType $saplingType;
@@ -58,13 +60,9 @@ class Sapling extends Flowable{
 		return $this;
 	}
 
-	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		$down = $this->getSide(Facing::DOWN);
-		if($down->hasTypeTag(BlockTypeTags::DIRT) || $down->hasTypeTag(BlockTypeTags::MUD)){
-			return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
-		}
-
-		return false;
+	private function canBeSupportedAt(Block $block) : bool{
+		$supportBlock = $block->getSide(Facing::DOWN);
+		return $supportBlock->hasTypeTag(BlockTypeTags::DIRT) || $supportBlock->hasTypeTag(BlockTypeTags::MUD);
 	}
 
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null, array &$returnedItems = []) : bool{
@@ -75,13 +73,6 @@ class Sapling extends Flowable{
 		}
 
 		return false;
-	}
-
-	public function onNearbyBlockChange() : void{
-		$down = $this->getSide(Facing::DOWN);
-		if(!$down->hasTypeTag(BlockTypeTags::DIRT) && !$down->hasTypeTag(BlockTypeTags::MUD)){
-			$this->position->getWorld()->useBreakOn($this->position);
-		}
 	}
 
 	public function ticksRandomly() : bool{

--- a/src/block/Sapling.php
+++ b/src/block/Sapling.php
@@ -23,8 +23,8 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
-use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\block\utils\SaplingType;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\data\runtime\RuntimeDataDescriber;
 use pocketmine\event\block\StructureGrowEvent;
 use pocketmine\item\Fertilizer;

--- a/src/block/SnowLayer.php
+++ b/src/block/SnowLayer.php
@@ -91,11 +91,7 @@ class SnowLayer extends Flowable implements Fallable{
 			}
 			$this->layers = $blockReplace->layers + 1;
 		}
-		if($this->canBeSupportedAt($blockReplace)){
-			return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
-		}
-
-		return false;
+		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
 	}
 
 	public function ticksRandomly() : bool{

--- a/src/block/SnowLayer.php
+++ b/src/block/SnowLayer.php
@@ -91,7 +91,11 @@ class SnowLayer extends Flowable implements Fallable{
 			}
 			$this->layers = $blockReplace->layers + 1;
 		}
-		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
+		if($this->canBeSupportedAt($blockReplace)){
+			return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
+		}
+
+		return false;
 	}
 
 	public function ticksRandomly() : bool{

--- a/src/block/SporeBlossom.php
+++ b/src/block/SporeBlossom.php
@@ -23,30 +23,14 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\block\utils\FixedSupportTrait;
 use pocketmine\block\utils\SupportType;
-use pocketmine\item\Item;
 use pocketmine\math\Facing;
-use pocketmine\math\Vector3;
-use pocketmine\player\Player;
-use pocketmine\world\BlockTransaction;
 
 final class SporeBlossom extends Flowable{
+	use FixedSupportTrait;
 
 	private function canBeSupportedAt(Block $block) : bool{
 		return $block->getAdjacentSupportType(Facing::UP) === SupportType::FULL;
-	}
-
-	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		if(!$this->canBeSupportedAt($blockReplace)){
-			return false;
-		}
-
-		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
-	}
-
-	public function onNearbyBlockChange() : void{
-		if(!$this->canBeSupportedAt($this)){
-			$this->position->getWorld()->useBreakOn($this->position);
-		}
 	}
 }

--- a/src/block/SporeBlossom.php
+++ b/src/block/SporeBlossom.php
@@ -23,12 +23,12 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
-use pocketmine\block\utils\FixedSupportTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\block\utils\SupportType;
 use pocketmine\math\Facing;
 
 final class SporeBlossom extends Flowable{
-	use FixedSupportTrait;
+	use StaticSupportTrait;
 
 	private function canBeSupportedAt(Block $block) : bool{
 		return $block->getAdjacentSupportType(Facing::UP) === SupportType::FULL;

--- a/src/block/Sugarcane.php
+++ b/src/block/Sugarcane.php
@@ -25,7 +25,7 @@ namespace pocketmine\block;
 
 use pocketmine\block\utils\AgeableTrait;
 use pocketmine\block\utils\BlockEventHelper;
-use pocketmine\block\utils\FixedSupportTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\item\Fertilizer;
 use pocketmine\item\Item;
 use pocketmine\math\Facing;
@@ -36,7 +36,7 @@ use pocketmine\world\Position;
 
 class Sugarcane extends Flowable{
 	use AgeableTrait;
-	use FixedSupportTrait;
+	use StaticSupportTrait;
 
 	public const MAX_AGE = 15;
 

--- a/src/block/Sugarcane.php
+++ b/src/block/Sugarcane.php
@@ -25,6 +25,7 @@ namespace pocketmine\block;
 
 use pocketmine\block\utils\AgeableTrait;
 use pocketmine\block\utils\BlockEventHelper;
+use pocketmine\block\utils\FixedSupportTrait;
 use pocketmine\item\Fertilizer;
 use pocketmine\item\Item;
 use pocketmine\math\Facing;
@@ -35,6 +36,7 @@ use pocketmine\world\Position;
 
 class Sugarcane extends Flowable{
 	use AgeableTrait;
+	use FixedSupportTrait;
 
 	public const MAX_AGE = 15;
 
@@ -82,18 +84,12 @@ class Sugarcane extends Flowable{
 		return false;
 	}
 
-	private function canBeSupportedBy(Block $block) : bool{
-		return
-			$block->hasTypeTag(BlockTypeTags::MUD) ||
-			$block->hasTypeTag(BlockTypeTags::DIRT) ||
-			$block->hasTypeTag(BlockTypeTags::SAND);
-	}
-
-	public function onNearbyBlockChange() : void{
-		$down = $this->getSide(Facing::DOWN);
-		if(!$down->hasSameTypeId($this) && !$this->canBeSupportedBy($down)){
-			$this->position->getWorld()->useBreakOn($this->position);
-		}
+	private function canBeSupportedAt(Block $block) : bool{
+		$supportBlock = $block->getSide(Facing::DOWN);
+		return $supportBlock->hasSameTypeId($this) ||
+			$supportBlock->hasTypeTag(BlockTypeTags::MUD) ||
+			$supportBlock->hasTypeTag(BlockTypeTags::DIRT) ||
+			$supportBlock->hasTypeTag(BlockTypeTags::SAND);
 	}
 
 	public function ticksRandomly() : bool{
@@ -112,10 +108,10 @@ class Sugarcane extends Flowable{
 	}
 
 	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		$down = $this->getSide(Facing::DOWN);
+		$down = $blockReplace->getSide(Facing::DOWN);
 		if($down->hasSameTypeId($this)){
 			return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
-		}elseif($this->canBeSupportedBy($down)){
+		}elseif($this->canBeSupportedAt($blockReplace)){
 			foreach(Facing::HORIZONTAL as $side){
 				$sideBlock = $down->getSide($side);
 				if($sideBlock instanceof Water || $sideBlock instanceof FrostedIce){

--- a/src/block/Sugarcane.php
+++ b/src/block/Sugarcane.php
@@ -111,12 +111,13 @@ class Sugarcane extends Flowable{
 		$down = $blockReplace->getSide(Facing::DOWN);
 		if($down->hasSameTypeId($this)){
 			return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
-		}elseif($this->canBeSupportedAt($blockReplace)){
-			foreach(Facing::HORIZONTAL as $side){
-				$sideBlock = $down->getSide($side);
-				if($sideBlock instanceof Water || $sideBlock instanceof FrostedIce){
-					return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
-				}
+		}
+
+		//support criteria are checked by FixedSupportTrait, but this part applies to placement only
+		foreach(Facing::HORIZONTAL as $side){
+			$sideBlock = $down->getSide($side);
+			if($sideBlock instanceof Water || $sideBlock instanceof FrostedIce){
+				return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
 			}
 		}
 

--- a/src/block/SweetBerryBush.php
+++ b/src/block/SweetBerryBush.php
@@ -25,6 +25,7 @@ namespace pocketmine\block;
 
 use pocketmine\block\utils\AgeableTrait;
 use pocketmine\block\utils\BlockEventHelper;
+use pocketmine\block\utils\FixedSupportTrait;
 use pocketmine\block\utils\FortuneDropHelper;
 use pocketmine\entity\Entity;
 use pocketmine\entity\Living;
@@ -35,11 +36,11 @@ use pocketmine\item\VanillaItems;
 use pocketmine\math\Facing;
 use pocketmine\math\Vector3;
 use pocketmine\player\Player;
-use pocketmine\world\BlockTransaction;
 use function mt_rand;
 
 class SweetBerryBush extends Flowable{
 	use AgeableTrait;
+	use FixedSupportTrait;
 
 	public const STAGE_SAPLING = 0;
 	public const STAGE_BUSH_NO_BERRIES = 1;
@@ -56,16 +57,17 @@ class SweetBerryBush extends Flowable{
 		return 0;
 	}
 
+	/**
+	 * @deprecated
+	 */
 	protected function canBeSupportedBy(Block $block) : bool{
 		return $block->getTypeId() !== BlockTypeIds::FARMLAND && //bedrock-specific thing (bug?)
 			($block->hasTypeTag(BlockTypeTags::DIRT) || $block->hasTypeTag(BlockTypeTags::MUD));
 	}
 
-	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		if(!$this->canBeSupportedBy($blockReplace->getSide(Facing::DOWN))){
-			return false;
-		}
-		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
+	private function canBeSupportedAt(Block $block) : bool{
+		$supportBlock = $block->getSide(Facing::DOWN);
+		return $this->canBeSupportedBy($supportBlock);
 	}
 
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null, array &$returnedItems = []) : bool{
@@ -97,12 +99,6 @@ class SweetBerryBush extends Flowable{
 		return [
 			$this->asItem()->setCount($count)
 		];
-	}
-
-	public function onNearbyBlockChange() : void{
-		if(!$this->canBeSupportedBy($this->getSide(Facing::DOWN))){
-			$this->position->getWorld()->useBreakOn($this->position);
-		}
 	}
 
 	public function ticksRandomly() : bool{

--- a/src/block/SweetBerryBush.php
+++ b/src/block/SweetBerryBush.php
@@ -25,7 +25,7 @@ namespace pocketmine\block;
 
 use pocketmine\block\utils\AgeableTrait;
 use pocketmine\block\utils\BlockEventHelper;
-use pocketmine\block\utils\FixedSupportTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\block\utils\FortuneDropHelper;
 use pocketmine\entity\Entity;
 use pocketmine\entity\Living;
@@ -40,7 +40,7 @@ use function mt_rand;
 
 class SweetBerryBush extends Flowable{
 	use AgeableTrait;
-	use FixedSupportTrait;
+	use StaticSupportTrait;
 
 	public const STAGE_SAPLING = 0;
 	public const STAGE_BUSH_NO_BERRIES = 1;

--- a/src/block/SweetBerryBush.php
+++ b/src/block/SweetBerryBush.php
@@ -25,8 +25,8 @@ namespace pocketmine\block;
 
 use pocketmine\block\utils\AgeableTrait;
 use pocketmine\block\utils\BlockEventHelper;
-use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\block\utils\FortuneDropHelper;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\entity\Entity;
 use pocketmine\entity\Living;
 use pocketmine\event\entity\EntityDamageByBlockEvent;

--- a/src/block/TallGrass.php
+++ b/src/block/TallGrass.php
@@ -23,31 +23,16 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\block\utils\FixedSupportTrait;
 use pocketmine\block\utils\TallGrassTrait;
-use pocketmine\item\Item;
 use pocketmine\math\Facing;
-use pocketmine\math\Vector3;
-use pocketmine\player\Player;
-use pocketmine\world\BlockTransaction;
 
 class TallGrass extends Flowable{
 	use TallGrassTrait;
+	use FixedSupportTrait;
 
-	private function canBeSupportedBy(Block $block) : bool{
-		return $block->hasTypeTag(BlockTypeTags::DIRT) || $block->hasTypeTag(BlockTypeTags::MUD);
-	}
-
-	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		if($this->canBeSupportedBy($this->getSide(Facing::DOWN))){
-			return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
-		}
-
-		return false;
-	}
-
-	public function onNearbyBlockChange() : void{
-		if(!$this->canBeSupportedBy($this->getSide(Facing::DOWN))){ //Replace with common break method
-			$this->position->getWorld()->useBreakOn($this->position);
-		}
+	private function canBeSupportedAt(Block $block) : bool{
+		$supportBlock = $block->getSide(Facing::DOWN);
+		return $supportBlock->hasTypeTag(BlockTypeTags::DIRT) || $supportBlock->hasTypeTag(BlockTypeTags::MUD);
 	}
 }

--- a/src/block/TallGrass.php
+++ b/src/block/TallGrass.php
@@ -23,13 +23,13 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
-use pocketmine\block\utils\FixedSupportTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\block\utils\TallGrassTrait;
 use pocketmine\math\Facing;
 
 class TallGrass extends Flowable{
 	use TallGrassTrait;
-	use FixedSupportTrait;
+	use StaticSupportTrait;
 
 	private function canBeSupportedAt(Block $block) : bool{
 		$supportBlock = $block->getSide(Facing::DOWN);

--- a/src/block/WaterLily.php
+++ b/src/block/WaterLily.php
@@ -23,13 +23,13 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
-use pocketmine\block\utils\FixedSupportTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Facing;
 use pocketmine\math\Vector3;
 
 class WaterLily extends Flowable{
-	use FixedSupportTrait {
+	use StaticSupportTrait {
 		canBePlacedAt as supportedWhenPlacedAt;
 	}
 

--- a/src/block/WitherRose.php
+++ b/src/block/WitherRose.php
@@ -23,41 +23,27 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\block\utils\FixedSupportTrait;
 use pocketmine\entity\effect\EffectInstance;
 use pocketmine\entity\effect\VanillaEffects;
 use pocketmine\entity\Entity;
 use pocketmine\entity\Living;
-use pocketmine\item\Item;
 use pocketmine\math\Facing;
-use pocketmine\math\Vector3;
-use pocketmine\player\Player;
-use pocketmine\world\BlockTransaction;
 
 class WitherRose extends Flowable{
+	use FixedSupportTrait;
 
-	private function canBeSupportedBy(Block $block) : bool{
+	private function canBeSupportedAt(Block $block) : bool{
+		$supportBlock = $block->getSide(Facing::DOWN);
 		return
-			$block->hasTypeTag(BlockTypeTags::DIRT) ||
-			$block->hasTypeTag(BlockTypeTags::MUD) ||
-			match($block->getTypeId()){
+			$supportBlock->hasTypeTag(BlockTypeTags::DIRT) ||
+			$supportBlock->hasTypeTag(BlockTypeTags::MUD) ||
+			match($supportBlock->getTypeId()){
 				BlockTypeIds::NETHERRACK,
 				BlockTypeIds::SOUL_SAND,
 				BlockTypeIds::SOUL_SOIL => true,
 				default => false
 			};
-	}
-
-	public function onNearbyBlockChange() : void{
-		if(!$this->canBeSupportedBy($this->getSide(Facing::DOWN))){
-			$this->position->getWorld()->useBreakOn($this->position);
-		}
-	}
-
-	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		if(!$this->canBeSupportedBy($blockReplace->getSide(Facing::DOWN))){
-			return false;
-		}
-		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
 	}
 
 	public function hasEntityCollision() : bool{ return true; }

--- a/src/block/WitherRose.php
+++ b/src/block/WitherRose.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
-use pocketmine\block\utils\FixedSupportTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\entity\effect\EffectInstance;
 use pocketmine\entity\effect\VanillaEffects;
 use pocketmine\entity\Entity;
@@ -31,7 +31,7 @@ use pocketmine\entity\Living;
 use pocketmine\math\Facing;
 
 class WitherRose extends Flowable{
-	use FixedSupportTrait;
+	use StaticSupportTrait;
 
 	private function canBeSupportedAt(Block $block) : bool{
 		$supportBlock = $block->getSide(Facing::DOWN);

--- a/src/block/utils/FixedSupportTrait.php
+++ b/src/block/utils/FixedSupportTrait.php
@@ -21,30 +21,37 @@
 
 declare(strict_types=1);
 
-namespace pocketmine\block;
+namespace pocketmine\block\utils;
 
-use pocketmine\block\utils\FixedSupportTrait;
-use pocketmine\math\AxisAlignedBB;
-use pocketmine\math\Facing;
+use pocketmine\block\Block;
 use pocketmine\math\Vector3;
 
-class WaterLily extends Flowable{
-	use FixedSupportTrait {
-		canBePlacedAt as supportedWhenPlacedAt;
+/**
+ * Used by blocks which always have the same support requirements no matter what state they are in.
+ * Prevents placement if support isn't available, and automatically destroys itself if support is removed.
+ */
+trait FixedSupportTrait{
+
+	/**
+	 * Implement this to define the block's support requirements.
+	 */
+	abstract private function canBeSupportedAt(Block $block) : bool;
+
+	/**
+	 * @see Block::canBePlacedAt()
+	 */
+	public function canBePlacedAt(Block $blockReplace, Vector3 $clickVector, int $face, bool $isClickedBlock) : bool{
+		return $this->canBeSupportedAt($blockReplace) && parent::canBePlacedAt($blockReplace, $clickVector, $face, $isClickedBlock);
 	}
 
 	/**
-	 * @return AxisAlignedBB[]
+	 * @see Block::onNearbyBlockChange()
 	 */
-	protected function recalculateCollisionBoxes() : array{
-		return [AxisAlignedBB::one()->contract(1 / 16, 0, 1 / 16)->trim(Facing::UP, 63 / 64)];
-	}
-
-	public function canBePlacedAt(Block $blockReplace, Vector3 $clickVector, int $face, bool $isClickedBlock) : bool{
-		return !$blockReplace instanceof Water && $this->supportedWhenPlacedAt($blockReplace, $clickVector, $face, $isClickedBlock);
-	}
-
-	private function canBeSupportedAt(Block $block) : bool{
-		return $block->getSide(Facing::DOWN) instanceof Water;
+	public function onNearbyBlockChange() : void{
+		if(!$this->canBeSupportedAt($this)){
+			$this->position->getWorld()->useBreakOn($this->position);
+		}else{
+			parent::onNearbyBlockChange();
+		}
 	}
 }

--- a/src/block/utils/StaticSupportTrait.php
+++ b/src/block/utils/StaticSupportTrait.php
@@ -30,7 +30,7 @@ use pocketmine\math\Vector3;
  * Used by blocks which always have the same support requirements no matter what state they are in.
  * Prevents placement if support isn't available, and automatically destroys itself if support is removed.
  */
-trait FixedSupportTrait{
+trait StaticSupportTrait{
 
 	/**
 	 * Implement this to define the block's support requirements.


### PR DESCRIPTION
## Introduction
Many blocks require unconditional support from one of their neighbouring blocks.
The logic for this has been repeated and reinvented in many places, often with inconsistent results and various bugs.

This PR introduces `FixedSupportTrait`, which provides the placement precondition checks and the self-destruction behaviour when the block's support is removed.

## Changes
### API changes
- Added `FixedSupportTrait`
- Deprecated protected `SweetBerryBush->canBeSupportedBy()` (this should really have been private)

### Behavioural changes
Everything should work as it did before.

## Backwards compatibility
No BC issues known.

## Follow-up
Introduce a `DynamicSupportTrait` for blocks whose support requirements depends on a state property.

## Tests
This has been briefly playtested, but further testing is needed to ensure that no regressions have been introduced.