### PR TITLE
Include TitleID in player extraData

### DIFF
--- a/src/network/mcpe/handler/LoginPacketHandler.php
+++ b/src/network/mcpe/handler/LoginPacketHandler.php
@@ -82,7 +82,6 @@ class LoginPacketHandler extends PacketHandler{
 		if(!Uuid::isValid($extraData->identity)){
 			throw new PacketHandlingException("Invalid login UUID");
 		}
-		
 		$uuid = Uuid::fromString($extraData->identity);
 		$arrClientData = (array) $clientData;
 		$arrClientData["TitleID"] = $extraData->titleId;

--- a/src/network/mcpe/handler/LoginPacketHandler.php
+++ b/src/network/mcpe/handler/LoginPacketHandler.php
@@ -82,12 +82,11 @@ class LoginPacketHandler extends PacketHandler{
 		if(!Uuid::isValid($extraData->identity)){
 			throw new PacketHandlingException("Invalid login UUID");
 		}
-
 		
 		$uuid = Uuid::fromString($extraData->identity);
 		$arrClientData = (array) $clientData;
-
 		$arrClientData["TitleID"] = $extraData->titleId;
+
 		if($extraData->XUID !== ""){
 			$playerInfo = new XboxLivePlayerInfo(
 				$extraData->XUID,

--- a/src/network/mcpe/handler/LoginPacketHandler.php
+++ b/src/network/mcpe/handler/LoginPacketHandler.php
@@ -82,7 +82,12 @@ class LoginPacketHandler extends PacketHandler{
 		if(!Uuid::isValid($extraData->identity)){
 			throw new PacketHandlingException("Invalid login UUID");
 		}
+
+		
 		$uuid = Uuid::fromString($extraData->identity);
+		$clientData = (array) $clientData;
+
+		$clientData["TitleID"] = $extraData->titleId;
 		if($extraData->XUID !== ""){
 			$playerInfo = new XboxLivePlayerInfo(
 				$extraData->XUID,

--- a/src/network/mcpe/handler/LoginPacketHandler.php
+++ b/src/network/mcpe/handler/LoginPacketHandler.php
@@ -95,7 +95,7 @@ class LoginPacketHandler extends PacketHandler{
 				$uuid,
 				$skin,
 				$clientData->LanguageCode,
-				(array) $clientData
+				$clientData
 			);
 		}else{
 			$playerInfo = new PlayerInfo(
@@ -103,7 +103,7 @@ class LoginPacketHandler extends PacketHandler{
 				$uuid,
 				$skin,
 				$clientData->LanguageCode,
-				(array) $clientData
+				$clientData
 			);
 		}
 		($this->playerInfoConsumer)($playerInfo);

--- a/src/network/mcpe/handler/LoginPacketHandler.php
+++ b/src/network/mcpe/handler/LoginPacketHandler.php
@@ -85,9 +85,9 @@ class LoginPacketHandler extends PacketHandler{
 
 		
 		$uuid = Uuid::fromString($extraData->identity);
-		$clientData = (array) $clientData;
+		$arrClientData = (array) $clientData;
 
-		$clientData["TitleID"] = $extraData->titleId;
+		$arrClientData["TitleID"] = $extraData->titleId;
 		if($extraData->XUID !== ""){
 			$playerInfo = new XboxLivePlayerInfo(
 				$extraData->XUID,
@@ -95,7 +95,7 @@ class LoginPacketHandler extends PacketHandler{
 				$uuid,
 				$skin,
 				$clientData->LanguageCode,
-				$clientData
+				$arrClientData
 			);
 		}else{
 			$playerInfo = new PlayerInfo(
@@ -103,7 +103,7 @@ class LoginPacketHandler extends PacketHandler{
 				$uuid,
 				$skin,
 				$clientData->LanguageCode,
-				$clientData
+				$arrClientData
 			);
 		}
 		($this->playerInfoConsumer)($playerInfo);


### PR DESCRIPTION
## Introduction
The TitleID is lost throughout the chain validation process because its neither part of the PlayerInfo nor the ExtraData, and the AuthenticationData object never leaves the scope of the LoginPacketHandler.

### Relevant issues

## Changes
### API changes

### Behavioural changes

## Backwards compatibility

## Follow-up

Requires translations:

-->

## Tests

