### PR TITLE
Fixed dirt related blocks item interaction to match up with vanilla

### DIFF
--- a/src/block/Dirt.php
+++ b/src/block/Dirt.php
@@ -60,8 +60,8 @@ class Dirt extends Opaque{
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null, array &$returnedItems = []) : bool{
 		$world = $this->position->getWorld();
 		if($face !== Facing::DOWN && $item instanceof Hoe){
-			$down = $this->getSide(Facing::UP);
-			if($down->getTypeId() !== BlockTypeIds::AIR){
+			$up = $this->getSide(Facing::UP);
+			if($up->getTypeId() !== BlockTypeIds::AIR){
 				return true;
 			}
 
@@ -77,13 +77,13 @@ class Dirt extends Opaque{
 
 			return true;
 		}elseif($this->dirtType->equals(DirtType::ROOTED()) && $item instanceof Fertilizer){
-			$down = $this->getSide(Facing::DOWN);
-			if($down->getTypeId() !== BlockTypeIds::AIR){
+			$up = $this->getSide(Facing::DOWN);
+			if($up->getTypeId() !== BlockTypeIds::AIR){
 				return true;
 			}
 
 			$item->pop();
-			$world->setBlock($down->position, VanillaBlocks::HANGING_ROOTS());
+			$world->setBlock($up->position, VanillaBlocks::HANGING_ROOTS());
 			//TODO: bonemeal particles, growth sounds
 		}elseif(($item instanceof Potion || $item instanceof SplashPotion) && $item->getType()->equals(PotionType::WATER())){
 			$item->pop();

--- a/src/block/Dirt.php
+++ b/src/block/Dirt.php
@@ -59,7 +59,12 @@ class Dirt extends Opaque{
 
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null, array &$returnedItems = []) : bool{
 		$world = $this->position->getWorld();
-		if($face === Facing::UP && $item instanceof Hoe){
+		if($face !== Facing::DOWN && $item instanceof Hoe){
+			$down = $this->getSide(Facing::UP);
+			if($down->getTypeId() !== BlockTypeIds::AIR){
+				return true;
+			}
+
 			$item->applyDamage(1);
 
 			$newBlock = $this->dirtType->equals(DirtType::NORMAL()) ? VanillaBlocks::FARMLAND() : VanillaBlocks::DIRT();

--- a/src/block/Dirt.php
+++ b/src/block/Dirt.php
@@ -77,13 +77,13 @@ class Dirt extends Opaque{
 
 			return true;
 		}elseif($this->dirtType->equals(DirtType::ROOTED()) && $item instanceof Fertilizer){
-			$up = $this->getSide(Facing::DOWN);
-			if($up->getTypeId() !== BlockTypeIds::AIR){
+			$down = $this->getSide(Facing::DOWN);
+			if($down->getTypeId() !== BlockTypeIds::AIR){
 				return true;
 			}
 
 			$item->pop();
-			$world->setBlock($up->position, VanillaBlocks::HANGING_ROOTS());
+			$world->setBlock($down->position, VanillaBlocks::HANGING_ROOTS());
 			//TODO: bonemeal particles, growth sounds
 		}elseif(($item instanceof Potion || $item instanceof SplashPotion) && $item->getType()->equals(PotionType::WATER())){
 			$item->pop();

--- a/src/block/Grass.php
+++ b/src/block/Grass.php
@@ -92,23 +92,22 @@ class Grass extends Opaque{
 
 			return true;
 		}
-		if($face === Facing::DOWN){
-			return false;
-		}
-		if($item instanceof Hoe){
-			$item->applyDamage(1);
-			$newBlock = VanillaBlocks::FARMLAND();
-			$world->addSound($this->position->add(0.5, 0.5, 0.5), new ItemUseOnBlockSound($newBlock));
-			$world->setBlock($this->position, $newBlock);
+		if($face !== Facing::DOWN){
+			if($item instanceof Hoe){
+				$item->applyDamage(1);
+				$newBlock = VanillaBlocks::FARMLAND();
+				$world->addSound($this->position->add(0.5, 0.5, 0.5), new ItemUseOnBlockSound($newBlock));
+				$world->setBlock($this->position, $newBlock);
 
-			return true;
-		}elseif($item instanceof Shovel){
-			$item->applyDamage(1);
-			$newBlock = VanillaBlocks::GRASS_PATH();
-			$world->addSound($this->position->add(0.5, 0.5, 0.5), new ItemUseOnBlockSound($newBlock));
-			$world->setBlock($this->position, $newBlock);
+				return true;
+			}elseif($item instanceof Shovel){
+				$item->applyDamage(1);
+				$newBlock = VanillaBlocks::GRASS_PATH();
+				$world->addSound($this->position->add(0.5, 0.5, 0.5), new ItemUseOnBlockSound($newBlock));
+				$world->setBlock($this->position, $newBlock);
 
-			return true;
+				return true;
+			}
 		}
 
 		return false;

--- a/src/block/Grass.php
+++ b/src/block/Grass.php
@@ -82,7 +82,7 @@ class Grass extends Opaque{
 	}
 
 	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null, array &$returnedItems = []) : bool{
-		if($face !== Facing::UP){
+		if($this->getSide(Facing::UP)->getTypeId() !== BlockTypeIds::AIR){
 			return false;
 		}
 		$world = $this->position->getWorld();
@@ -91,14 +91,18 @@ class Grass extends Opaque{
 			TallGrassObject::growGrass($world, $this->position, new Random(mt_rand()), 8, 2);
 
 			return true;
-		}elseif($item instanceof Hoe){
+		}
+		if($face === Facing::DOWN){
+			return false;
+		}
+		if($item instanceof Hoe){
 			$item->applyDamage(1);
 			$newBlock = VanillaBlocks::FARMLAND();
 			$world->addSound($this->position->add(0.5, 0.5, 0.5), new ItemUseOnBlockSound($newBlock));
 			$world->setBlock($this->position, $newBlock);
 
 			return true;
-		}elseif($item instanceof Shovel && $this->getSide(Facing::UP)->getTypeId() === BlockTypeIds::AIR){
+		}elseif($item instanceof Shovel){
 			$item->applyDamage(1);
 			$newBlock = VanillaBlocks::GRASS_PATH();
 			$world->addSound($this->position->add(0.5, 0.5, 0.5), new ItemUseOnBlockSound($newBlock));


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
The grass and dirt block item interaction doesn't match up with vanilla.
### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
None
## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
None
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
None
## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
None
## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->
None
## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
None