### PR TITLE
Implement growth speed modifiers

### DIFF
--- a/src/block/Crops.php
+++ b/src/block/Crops.php
@@ -31,6 +31,9 @@ use pocketmine\item\Item;
 use pocketmine\math\Facing;
 use pocketmine\math\Vector3;
 use pocketmine\player\Player;
++use function floor;
++use function in_array;
++use function lcg_value;
 use function mt_rand;
 
 abstract class Crops extends Flowable{

--- a/src/block/Crops.php
+++ b/src/block/Crops.php
@@ -96,8 +96,8 @@ abstract class Crops extends Flowable{
 
 				$cropAbove = $block->getSide(Facing::UP);
 				if ($cropAbove instanceof Crops && $cropAbove->getTypeId() === $this->getTypeId()) {
-					if (in_array($side, [Facing::NORTH, Facing::SOUTH])) $nS = true;
-					if (in_array($side, [Facing::EAST, Facing::WEST])) $eW = true;
+					if (in_array($side, [Facing::NORTH, Facing::SOUTH], true)) $nS = true;
+					if (in_array($side, [Facing::EAST, Facing::WEST], true)) $eW = true;
 				}
 			}
 		}

--- a/src/block/Crops.php
+++ b/src/block/Crops.php
@@ -31,9 +31,9 @@ use pocketmine\item\Item;
 use pocketmine\math\Facing;
 use pocketmine\math\Vector3;
 use pocketmine\player\Player;
-+use function floor;
-+use function in_array;
-+use function lcg_value;
+use function floor;
+use function in_array;
+use function lcg_value;
 use function mt_rand;
 
 abstract class Crops extends Flowable{


### PR DESCRIPTION
## Introduction
Adds vanilla growth speed modifiers

### Relevant issues
Fixes #6070 

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
Checks the surrounding blocks of the original crop, and crops will no longer grow if below an opaque block, or if that block has a light level of less than 9

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
Cleaning up variable names, and the code

Requires translations:

## Tests
Max growth percent is 0.5 when by itself or in a row, with a minimum of 0.3, when surrounded by crops of the same type