### PR TITLE
Fix loading of Chiseled Bookshelf tile from vanilla world

### DIFF
--- a/src/block/tile/ChiseledBookshelf.php
+++ b/src/block/tile/ChiseledBookshelf.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace pocketmine\block\tile;
 
 use pocketmine\block\utils\ChiseledBookshelfSlot;
+use pocketmine\data\bedrock\item\SavedItemData;
 use pocketmine\data\bedrock\item\SavedItemStackData;
 use pocketmine\data\SavedDataLoadingException;
 use pocketmine\inventory\SimpleInventory;
@@ -70,13 +71,13 @@ class ChiseledBookshelf extends Tile implements Container{
 
 			$newContents = [];
 			/** @var CompoundTag $itemNBT */
-			foreach($inventoryTag as $vanillaSlot => $itemNBT){
+			foreach($inventoryTag as $slot => $itemNBT){
 				try{
 					$count = $itemNBT->getByte(SavedItemStackData::TAG_COUNT);
 					if($count === 0){
 						continue;
 					}
-					$newContents[$itemNBT->getByte(SavedItemStackData::TAG_SLOT, $vanillaSlot)] = Item::nbtDeserialize($itemNBT);
+					$newContents[$slot] = Item::nbtDeserialize($itemNBT);
 				}catch(SavedDataLoadingException $e){
 					//TODO: not the best solution
 					\GlobalLogger::get()->logException($e);
@@ -90,6 +91,27 @@ class ChiseledBookshelf extends Tile implements Container{
 
 		if(($lockTag = $tag->getTag(Container::TAG_LOCK)) instanceof StringTag){
 			$this->lock = $lockTag->getValue();
+		}
+	}
+
+	protected function saveItems(CompoundTag $tag) : void{
+		$items = [];
+		foreach($this->getRealInventory()->getContents(true) as $slot => $item){
+			if($item->isNull()){
+				$items[$slot] = CompoundTag::create()
+					->setByte(SavedItemStackData::TAG_COUNT, 0)
+					->setShort(SavedItemData::TAG_DAMAGE, 0)
+					->setString(SavedItemData::TAG_NAME, "")
+					->setByte(SavedItemStackData::TAG_WAS_PICKED_UP, 0);
+			}else{
+				$items[$slot] = $item->nbtSerialize();
+			}
+		}
+
+		$tag->setTag(Container::TAG_ITEMS, new ListTag($items, NBT::TAG_Compound));
+
+		if($this->lock !== null){
+			$tag->setString(Container::TAG_LOCK, $this->lock);
 		}
 	}
 }


### PR DESCRIPTION
## Introduction
This PR fixes the error that occurs when a vanilla world containing Chiseled Bookshelf is loaded

```
[Server thread/ERROR]: [World: Test] [Loading chunk -1 0] Bad tile entity data at list position 7: Tag "Slot" does not exist
[Server thread/CRITICAL]: pocketmine\data\SavedDataLoadingException: "Tag "Slot" does not exist" (EXCEPTION) in "pmsrc/src/block/tile/TileFactory" at line 136
--- Stack trace ---
  #0 pmsrc/src/world/World(2857): pocketmine\block\tile\TileFactory->createFromData(object pocketmine\world\World#90986, object pocketmine\nbt\tag\CompoundTag#113678)
  #1 pmsrc/src/world/World(2801): pocketmine\world\World->initChunk(int -1, int 0, object pocketmine\world\format\io\ChunkData#113900)
  #2 pmsrc/src/world/World(821): pocketmine\world\World->loadChunk(int -1, int 0)
  #3 pmsrc/src/player/Player(816): pocketmine\world\World->registerChunkLoader(object anonymous@pmsrc/src/player/Player#L326#83372, int -1, int 0, true)
  #4 pmsrc/src/player/Player(1021): pocketmine\player\Player->requestChunks()
  #5 pmsrc/src/network/mcpe/NetworkSession(1182): pocketmine\player\Player->doChunkRequests()
  #6 pmsrc/src/network/NetworkSessionManager(90): pocketmine\network\mcpe\NetworkSession->tick()
  #7 pmsrc/src/network/Network(92): pocketmine\network\NetworkSessionManager->tick()
  #8 pmsrc/src/Server(1799): pocketmine\network\Network->tick()
  #9 pmsrc/src/Server(1678): pocketmine\Server->tick()
  #10 pmsrc/src/Server(1064): pocketmine\Server->tickProcessor()
--- Previous ---
pocketmine\nbt\NoSuchTagException: "Tag "Slot" does not exist" (EXCEPTION) in "pmsrc/vendor/pocketmine/nbt/src/tag/CompoundTag" at line 156
  #0 pmsrc/vendor/pocketmine/nbt/src/tag/CompoundTag(167): pocketmine\nbt\tag\CompoundTag->getTagValue(string[4] Slot, string[26] pocketmine\nbt\tag\ByteTag, null)
  #1 pmsrc/src/block/tile/ContainerTrait(55): pocketmine\nbt\tag\CompoundTag->getByte(string[4] Slot)
  #2 pmsrc/src/block/tile/ChiseledBookshelf(52): pocketmine\block\tile\ChiseledBookshelf->loadItems(object pocketmine\nbt\tag\CompoundTag#113678)
  #3 pmsrc/src/block/tile/TileFactory(134): pocketmine\block\tile\ChiseledBookshelf->readSaveData(object pocketmine\nbt\tag\CompoundTag#113678)
  #4 pmsrc/src/world/World(2857): pocketmine\block\tile\TileFactory->createFromData(object pocketmine\world\World#90986, object pocketmine\nbt\tag\CompoundTag#113678)
  #5 pmsrc/src/world/World(2801): pocketmine\world\World->initChunk(int -1, int 0, object pocketmine\world\format\io\ChunkData#113900)
  #6 pmsrc/src/world/World(821): pocketmine\world\World->loadChunk(int -1, int 0)
  #7 pmsrc/src/player/Player(816): pocketmine\world\World->registerChunkLoader(object anonymous@pmsrc/src/player/Player#L326#83372, int -1, int 0, true)
  #8 pmsrc/src/player/Player(1021): pocketmine\player\Player->requestChunks()
  #9 pmsrc/src/network/mcpe/NetworkSession(1182): pocketmine\player\Player->doChunkRequests()
  #10 pmsrc/src/network/NetworkSessionManager(90): pocketmine\network\mcpe\NetworkSession->tick()
  #11 pmsrc/src/network/Network(92): pocketmine\network\NetworkSessionManager->tick()
  #12 pmsrc/src/Server(1799): pocketmine\network\Network->tick()
  #13 pmsrc/src/Server(1678): pocketmine\Server->tick()
  #14 pmsrc/src/Server(1064): pocketmine\Server->tickProcessor()
--- End of exception information ---
```

## Tests
Able to load the world without error