### PR TITLE
Fix book placed in wrong slot in Chiseled Bookshelf

### DIFF
--- a/src/block/ChiseledBookshelf.php
+++ b/src/block/ChiseledBookshelf.php
@@ -97,8 +97,13 @@ class ChiseledBookshelf extends Opaque{
 			return false;
 		}
 
+		$x = Facing::axis($face) === Axis::X ? $clickVector->getZ() : $clickVector->getX();
+		$x = match ($face) {
+			Facing::NORTH, Facing::EAST => 1 - $x,
+			default => $x
+		};
 		$slot = ChiseledBookshelfSlot::fromBlockFaceCoordinates(
-			Facing::axis($face) === Axis::X ? $clickVector->getZ() : $clickVector->getX(),
+			$x,
 			$clickVector->y
 		);
 		$tile = $this->position->getWorld()->getTile($this->position);

--- a/src/block/ChiseledBookshelf.php
+++ b/src/block/ChiseledBookshelf.php
@@ -98,12 +98,8 @@ class ChiseledBookshelf extends Opaque{
 		}
 
 		$x = Facing::axis($face) === Axis::X ? $clickVector->getZ() : $clickVector->getX();
-		$x = match($face){
-			Facing::NORTH, Facing::EAST => 1 - $x,
-			default => $x
-		};
 		$slot = ChiseledBookshelfSlot::fromBlockFaceCoordinates(
-			$x,
+			Facing::isPositive(Facing::rotateY($face, true)) ? 1 - $x : $x,
 			$clickVector->y
 		);
 		$tile = $this->position->getWorld()->getTile($this->position);

--- a/src/block/ChiseledBookshelf.php
+++ b/src/block/ChiseledBookshelf.php
@@ -98,7 +98,7 @@ class ChiseledBookshelf extends Opaque{
 		}
 
 		$x = Facing::axis($face) === Axis::X ? $clickVector->getZ() : $clickVector->getX();
-		$x = match ($face) {
+		$x = match($face){
 			Facing::NORTH, Facing::EAST => 1 - $x,
 			default => $x
 		};


### PR DESCRIPTION
## Introduction
This PR corrects the slot when a book is placed in Chiseled Bookshelf

## Tests
Tested, the book is placed in the correct slot in all 4 facing directions
