### PR TITLE
Fix Chiseled bookshelf book duplication

### DIFF
--- a/src/block/ChiseledBookshelf.php
+++ b/src/block/ChiseledBookshelf.php
@@ -113,7 +113,7 @@ class ChiseledBookshelf extends Opaque{
 			$this->setSlot($slot, false);
 		}elseif($item instanceof WritableBookBase || $item instanceof Book || $item instanceof EnchantedBook){
 			//TODO: type tags like blocks would be better for this
-			$inventory->setItem($slot->value, $item);
+			$inventory->setItem($slot->value, $item->pop());
 			$this->setSlot($slot, true);
 		}else{
 			return true;


### PR DESCRIPTION
## Introduction
This PR fixes a duplication bug.
Also fixes being able to put more than 1 book in the slot.

## Tests
Only 1 book is placed in the bookshelf
Book is removed from player inventory when placed