### PR TITLE
Wooden Button can be a fuel

### DIFF
--- a/src/block/WoodenButton.php
+++ b/src/block/WoodenButton.php
@@ -35,4 +35,8 @@ class WoodenButton extends Button{
 	public function hasEntityCollision() : bool{
 		return false; //TODO: arrows activate wooden buttons
 	}
+
+	public function getFuelTime() : int{
+		return $this->woodType->isFlammable() ? 100 : 0;
+	}
 }


### PR DESCRIPTION
## Introduction
Fixed #6098 

source: https://minecraft.fandom.com/wiki/Button#Fuel

## Changes
### API changes
Modify `getFuelTime` function in WoodenButton