### PR TITLE
WoodenDoor can be a fuel

### DIFF
--- a/src/block/WoodenDoor.php
+++ b/src/block/WoodenDoor.php
@@ -27,4 +27,8 @@ use pocketmine\block\utils\WoodTypeTrait;
 
 class WoodenDoor extends Door{
 	use WoodTypeTrait;
+
+	public function getFuelTime() : int{
+		return $this->woodType->isFlammable() ? 200 : 0;
+	}
 }


### PR DESCRIPTION
## Introduction
Fixed #6100  

source: https://minecraft.fandom.com/wiki/Door#Fuel

## Changes
### API changes
Modify `getFuelTime` function in WoodenDoor