### PR TITLE
Fix Iron & Gold ores not being affected by fortune

### DIFF
--- a/src/block/GoldOre.php
+++ b/src/block/GoldOre.php
@@ -23,13 +23,14 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\block\utils\FortuneDropHelper;
 use pocketmine\item\Item;
 use pocketmine\item\VanillaItems;
 
 final class GoldOre extends Opaque{
 
 	public function getDropsForCompatibleTool(Item $item) : array{
-		return [VanillaItems::RAW_GOLD()];
+		return [VanillaItems::RAW_GOLD()->setCount(FortuneDropHelper::weighted($item, min: 1, maxBase: 1))];
 	}
 
 	public function isAffectedBySilkTouch() : bool{ return true; }

--- a/src/block/IronOre.php
+++ b/src/block/IronOre.php
@@ -23,13 +23,14 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\block\utils\FortuneDropHelper;
 use pocketmine\item\Item;
 use pocketmine\item\VanillaItems;
 
 final class IronOre extends Opaque{
 
 	public function getDropsForCompatibleTool(Item $item) : array{
-		return [VanillaItems::RAW_IRON()];
+		return [VanillaItems::RAW_IRON()->setCount(FortuneDropHelper::weighted($item, min: 1, maxBase: 1))];
 	}
 
 	public function isAffectedBySilkTouch() : bool{ return true; }


### PR DESCRIPTION
## Introduction
According to [Minecraft Wiki](https://minecraft.fandom.com/wiki/Fortune) and my personal test in Vanilla Bedrock, Iron & Gold ores are affected by fortune enchantement and drop 1-4 items (with fortune level 3)

## Tests
https://www.youtube.com/watch?v=EG1Q8I6FoOs
