### PR TITLE
Fix ancient debris not being fireproof

### DIFF
--- a/src/block/VanillaBlocks.php
+++ b/src/block/VanillaBlocks.php
@@ -1495,7 +1495,9 @@ final class VanillaBlocks{
 		//for some reason, slabs have weird hardness like the legacy ones
 		$slabBreakInfo = new Info(BreakInfo::pickaxe(2.0, ToolTier::WOOD, 30.0));
 
-		self::register("ancient_debris", new Opaque(new BID(Ids::ANCIENT_DEBRIS), "Ancient Debris", new Info(BreakInfo::pickaxe(30, ToolTier::DIAMOND, 3600.0))));
+		self::register("ancient_debris", new class(new BID(Ids::ANCIENT_DEBRIS), "Ancient Debris", new Info(BreakInfo::pickaxe(30, ToolTier::DIAMOND, 3600.0))) extends Opaque{
+			public function isFireProofAsItem() : bool{ return true; }
+		});
 		$netheriteBreakInfo = new Info(BreakInfo::pickaxe(50, ToolTier::DIAMOND, 3600.0));
 		self::register("netherite", new class(new BID(Ids::NETHERITE), "Netherite Block", $netheriteBreakInfo) extends Opaque{
 			public function isFireProofAsItem() : bool{ return true; }


### PR DESCRIPTION
## Introduction
Ancient debris does not burn in lava in vanilla.

## Tests
https://www.youtube.com/watch?v=cGHDNOks7sk
