### PR TITLE
Fix RegistryTrait documentation

### DIFF
--- a/src/utils/EnumTrait.php
+++ b/src/utils/EnumTrait.php
@@ -28,7 +28,7 @@ namespace pocketmine\utils;
  * __callStatic().
  *
  * Classes using this trait need to include \@method tags in their class docblock for every enum member.
- * Alternatively, just put \@generate-registry-docblock in the docblock and run tools/generate-registry-annotations.php
+ * Alternatively, just put \@generate-registry-docblock in the docblock and run build/generate-registry-annotations.php
  *
  * @deprecated Use native PHP 8.1 enums instead. Use {@link LegacyEnumShimTrait} if you need to provide backwards
  * compatible EnumTrait-like API for migrated enums.

--- a/src/utils/RegistryTrait.php
+++ b/src/utils/RegistryTrait.php
@@ -33,7 +33,7 @@ use function preg_match;
  * These faux constants are exposed in static class methods, which are handled using __callStatic().
  *
  * Classes using this trait need to include \@method tags in their class docblock for every faux constant.
- * Alternatively, just put \@generate-registry-docblock in the docblock and run tools/generate-registry-annotations.php
+ * Alternatively, just put \@generate-registry-docblock in the docblock and run build/generate-registry-annotations.php
  */
 trait RegistryTrait{
 	/**


### PR DESCRIPTION
## Introduction
The file for `generate-registry-annotations.php` file can be found in directory `/build`, not `/tools`. This PR fixes the confusion.
