### PR TITLE
Position and Location function return now itself

### DIFF
--- a/src/block/TNT.php
+++ b/src/block/TNT.php
@@ -100,7 +100,7 @@ class TNT extends Opaque{
 
 		$mot = (new Random())->nextSignedFloat() * M_PI * 2;
 
-		$tnt = new PrimedTNT(Location::fromObject($this->position->add(0.5, 0, 0.5), $world));
+		$tnt = new PrimedTNT($this->position->add(0.5, 0, 0.5));
 		$tnt->setFuse($fuse);
 		$tnt->setWorksUnderwater($this->worksUnderwater);
 		$tnt->setMotion(new Vector3(-sin($mot) * 0.02, 0.2, -cos($mot) * 0.02));

--- a/src/block/TNT.php
+++ b/src/block/TNT.php
@@ -100,7 +100,7 @@ class TNT extends Opaque{
 
 		$mot = (new Random())->nextSignedFloat() * M_PI * 2;
 
-		$tnt = new PrimedTNT($this->position->add(0.5, 0, 0.5));
+		$tnt = new PrimedTNT(Location::fromObject($this->position->add(0.5, 0, 0.5), null));
 		$tnt->setFuse($fuse);
 		$tnt->setWorksUnderwater($this->worksUnderwater);
 		$tnt->setMotion(new Vector3(-sin($mot) * 0.02, 0.2, -cos($mot) * 0.02));

--- a/src/block/utils/FallableTrait.php
+++ b/src/block/utils/FallableTrait.php
@@ -25,7 +25,6 @@ namespace pocketmine\block\utils;
 
 use pocketmine\block\Block;
 use pocketmine\block\VanillaBlocks;
-use pocketmine\entity\Location;
 use pocketmine\entity\object\FallingBlock;
 use pocketmine\math\Facing;
 use pocketmine\utils\AssumptionFailedError;

--- a/src/block/utils/FallableTrait.php
+++ b/src/block/utils/FallableTrait.php
@@ -25,6 +25,7 @@ namespace pocketmine\block\utils;
 
 use pocketmine\block\Block;
 use pocketmine\block\VanillaBlocks;
+use pocketmine\entity\Location;
 use pocketmine\entity\object\FallingBlock;
 use pocketmine\math\Facing;
 use pocketmine\utils\AssumptionFailedError;
@@ -50,7 +51,7 @@ trait FallableTrait{
 			$block = $this;
 			if(!($block instanceof Block)) throw new AssumptionFailedError(__TRAIT__ . " should only be used by Blocks");
 
-			$fall = new FallingBlock($pos->add(0.5, 0, 0.5), $block);
+			$fall = new FallingBlock(Location::fromObject($pos->add(0.5, 0, 0.5), null), $block);
 			$fall->spawnToAll();
 		}
 	}

--- a/src/block/utils/FallableTrait.php
+++ b/src/block/utils/FallableTrait.php
@@ -51,7 +51,7 @@ trait FallableTrait{
 			$block = $this;
 			if(!($block instanceof Block)) throw new AssumptionFailedError(__TRAIT__ . " should only be used by Blocks");
 
-			$fall = new FallingBlock(Location::fromObject($pos->add(0.5, 0, 0.5), $world), $block);
+			$fall = new FallingBlock($pos->add(0.5, 0, 0.5), $block);
 			$fall->spawnToAll();
 		}
 	}

--- a/src/command/defaults/SpawnpointCommand.php
+++ b/src/command/defaults/SpawnpointCommand.php
@@ -67,7 +67,7 @@ class SpawnpointCommand extends VanillaCommand{
 			return true;
 		}elseif(count($args) <= 1 && $sender instanceof Player){
 			$cpos = $sender->getPosition();
-			$pos = Position::fromObject($cpos->floor(), $cpos->getWorld());
+			$pos = $cpos->floor();
 			$target->setSpawn($pos);
 
 			Command::broadcastCommandMessage($sender, KnownTranslationFactory::commands_spawnpoint_success($target->getName(), (string) round($pos->x, 2), (string) round($pos->y, 2), (string) round($pos->z, 2)));

--- a/src/entity/Location.php
+++ b/src/entity/Location.php
@@ -26,6 +26,7 @@ namespace pocketmine\entity;
 use pocketmine\math\Vector3;
 use pocketmine\world\Position;
 use pocketmine\world\World;
+use const PHP_ROUND_HALF_UP;
 
 class Location extends Position{
 

--- a/src/entity/Location.php
+++ b/src/entity/Location.php
@@ -38,10 +38,7 @@ class Location extends Position{
 		parent::__construct($x, $y, $z, $world);
 	}
 
-	/**
-	 * @return Location
-	 */
-	public static function fromObject(Vector3 $pos, ?World $world, float $yaw = 0.0, float $pitch = 0.0){
+	public static function fromObject(Vector3 $pos, ?World $world, float $yaw = 0.0, float $pitch = 0.0) : Location{
 		return new Location($pos->x, $pos->y, $pos->z, $world ?? (($pos instanceof Position) ? $pos->world : null), $yaw, $pitch);
 	}
 
@@ -69,5 +66,25 @@ class Location extends Position{
 			return parent::equals($v) && $v->yaw == $this->yaw && $v->pitch == $this->pitch;
 		}
 		return parent::equals($v);
+	}
+
+	public function add(float|int $x, float|int $y, float|int $z) : Location{
+		return Location::fromObject(parent::add($x, $y, $z), $this->world, $this->yaw, $this->pitch);
+	}
+
+	public function multiply(float $number) : Location{
+		return Location::fromObject(parent::multiply($number), $this->world, $this->yaw, $this->pitch);
+	}
+
+	public function divide(float $number) : Location{
+		return Location::fromObject(parent::divide($number), $this->world, $this->yaw, $this->pitch);
+	}
+
+	public function ceil() : Location{
+		return Location::fromObject(parent::ceil(), $this->world, $this->yaw, $this->pitch);
+	}
+
+	public function floor() : Location{
+		return Location::fromObject(parent::floor(), $this->world, $this->yaw, $this->pitch);
 	}
 }

--- a/src/entity/Location.php
+++ b/src/entity/Location.php
@@ -87,4 +87,15 @@ class Location extends Position{
 	public function floor() : Location{
 		return Location::fromObject(parent::floor(), $this->world, $this->yaw, $this->pitch);
 	}
+
+	/**
+	 * @phpstan-param 1|2|3|4 $mode
+	 */
+	public function round(int $precision = 0, int $mode = PHP_ROUND_HALF_UP) : Location{
+		return Location::fromObject(parent::round($precision, $mode), $this->world, $this->yaw, $this->pitch);
+	}
+
+	public function abs() : Location{
+		return Location::fromObject(parent::abs(), $this->world, $this->yaw, $this->pitch);
+	}
 }

--- a/src/entity/object/PrimedTNT.php
+++ b/src/entity/object/PrimedTNT.php
@@ -119,7 +119,7 @@ class PrimedTNT extends Entity implements Explosive{
 		$ev->call();
 		if(!$ev->isCancelled()){
 			//TODO: deal with underwater TNT (underwater TNT treats water as if it has a blast resistance of 0)
-			$explosion = new Explosion(Position::fromObject($this->location->add(0, $this->size->getHeight() / 2, 0), $this->getWorld()), $ev->getRadius(), $this);
+			$explosion = new Explosion($this->location->add(0, $this->size->getHeight() / 2, 0), $ev->getRadius(), $this);
 			if($ev->isBlockBreaking()){
 				$explosion->explodeA();
 			}

--- a/src/entity/object/PrimedTNT.php
+++ b/src/entity/object/PrimedTNT.php
@@ -35,7 +35,6 @@ use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataCollection;
 use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataFlags;
 use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataProperties;
 use pocketmine\world\Explosion;
-use pocketmine\world\Position;
 
 class PrimedTNT extends Entity implements Explosive{
 

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -2408,7 +2408,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 				$ev = new PlayerRespawnEvent($this, $safeSpawn);
 				$ev->call();
 
-				$realSpawn = Position::fromObject($ev->getRespawnPosition()->add(0.5, 0, 0.5), $ev->getRespawnPosition()->getWorld());
+				$realSpawn = $ev->getRespawnPosition()->add(0.5, 0, 0.5);
 				$this->teleport($realSpawn);
 
 				$this->setSprinting(false);

--- a/src/world/Position.php
+++ b/src/world/Position.php
@@ -26,6 +26,7 @@ namespace pocketmine\world;
 use pocketmine\math\Vector3;
 use pocketmine\utils\AssumptionFailedError;
 use function assert;
+use const PHP_ROUND_HALF_UP;
 
 class Position extends Vector3{
 	public ?World $world = null;

--- a/src/world/Position.php
+++ b/src/world/Position.php
@@ -102,7 +102,7 @@ class Position extends Vector3{
 	public function getSide(int $side, int $step = 1) : Position{
 		assert($this->isValid());
 
-		return parent::getSide($side, $step);
+		return Position::fromObject(parent::getSide($side, $step), $this->world);
 	}
 
 	public function __toString(){

--- a/src/world/Position.php
+++ b/src/world/Position.php
@@ -39,10 +39,27 @@ class Position extends Vector3{
 		$this->world = $world;
 	}
 
-	/**
-	 * @return Position
-	 */
-	public static function fromObject(Vector3 $pos, ?World $world){
+	public function add(float|int $x, float|int $y, float|int $z) : Position{
+		return Position::fromObject(parent::add($x, $y, $z), $this->world);
+	}
+
+	public function multiply(float $number) : Position{
+		return Position::fromObject(parent::multiply($number), $this->world);
+	}
+
+	public function divide(float $number) : Position{
+		return Position::fromObject(parent::divide($number), $this->world);
+	}
+
+	public function ceil() : Position{
+		return Position::fromObject(parent::ceil(), $this->world);
+	}
+
+	public function floor() : Position{
+		return Position::fromObject(parent::floor(), $this->world);
+	}
+
+	public static function fromObject(Vector3 $pos, ?World $world) : Position{
 		return new Position($pos->x, $pos->y, $pos->z, $world);
 	}
 
@@ -81,13 +98,11 @@ class Position extends Vector3{
 
 	/**
 	 * Returns a side Vector
-	 *
-	 * @return Position
 	 */
-	public function getSide(int $side, int $step = 1){
+	public function getSide(int $side, int $step = 1) : static{
 		assert($this->isValid());
 
-		return Position::fromObject(parent::getSide($side, $step), $this->world);
+		return parent::getSide($side, $step);
 	}
 
 	public function __toString(){

--- a/src/world/Position.php
+++ b/src/world/Position.php
@@ -99,7 +99,7 @@ class Position extends Vector3{
 	/**
 	 * Returns a side Vector
 	 */
-	public function getSide(int $side, int $step = 1) : static{
+	public function getSide(int $side, int $step = 1) : Position{
 		assert($this->isValid());
 
 		return parent::getSide($side, $step);

--- a/src/world/Position.php
+++ b/src/world/Position.php
@@ -59,6 +59,17 @@ class Position extends Vector3{
 		return Position::fromObject(parent::floor(), $this->world);
 	}
 
+	/**
+	 * @phpstan-param 1|2|3|4 $mode
+	 */
+	public function round(int $precision = 0, int $mode = PHP_ROUND_HALF_UP) : Position{
+		return Position::fromObject(parent::round($precision, $mode), $this->world);
+	}
+
+	public function abs() : Position{
+		return Position::fromObject(parent::abs(), $this->world);
+	}
+
 	public static function fromObject(Vector3 $pos, ?World $world) : Position{
 		return new Position($pos->x, $pos->y, $pos->z, $world);
 	}


### PR DESCRIPTION
## Introduction
Allow function like `add`, `ceil`... in `Position` ans `Location` to return corresponding class instead of `Vector3`
This change allow to simplified code.

### Before:
```
$pos = new Position(1, 1, 1, $world);
$pos = Position::fromObject($pos->add(0.5, 0.5, 0.5), $pos->getWorld());
```
### After:
```
$pos = new Position(1, 1, 1, $world)->add(0.5, 0.5, 0.5);
```
$pos is now `Position` instead of `Vector3`

## Changes
### API changes
Add function `add`, `multiply`, `divide`, `ceil`, `floor` in `Position` and `Location`
