### PR TITLE
AsyncTask: Fix retrieval of null data from the thread-local storage

### DIFF
--- a/src/scheduler/AsyncTask.php
+++ b/src/scheduler/AsyncTask.php
@@ -28,6 +28,7 @@ use pmmp\thread\Thread as NativeThread;
 use pmmp\thread\ThreadSafe;
 use pmmp\thread\ThreadSafeArray;
 use pocketmine\thread\NonThreadSafeValue;
+use function array_key_exists;
 use function assert;
 use function igbinary_serialize;
 use function igbinary_unserialize;
@@ -230,7 +231,7 @@ abstract class AsyncTask extends Runnable{
 	 */
 	protected function fetchLocal(string $key){
 		$id = spl_object_id($this);
-		if(!isset(self::$threadLocalStorage[$id][$key])){
+		if(!isset(self::$threadLocalStorage[$id]) || !array_key_exists($key, self::$threadLocalStorage[$id])){
 			throw new \InvalidArgumentException("No matching thread-local data found on this thread");
 		}
 

--- a/tests/phpunit/scheduler/AsyncPoolTest.php
+++ b/tests/phpunit/scheduler/AsyncPoolTest.php
@@ -122,9 +122,6 @@ class AsyncPoolTest extends TestCase{
 		}
 	}
 
-	/**
-	 * @doesNotPerformAssertions This test is checking for a crash condition, not a specific output.
-	 */
 	public function testNullComplexDataFetch() : void{
 		$this->pool->submitTask(new class extends AsyncTask{
 			public function __construct(){
@@ -136,7 +133,7 @@ class AsyncPoolTest extends TestCase{
 			}
 
 			public function onCompletion() : void{
-				$this->fetchLocal("null");
+				AsyncPoolTest::assertNull($this->fetchLocal("null"));
 			}
 		});
 		while($this->pool->collectTasks()){

--- a/tests/phpunit/scheduler/AsyncPoolTest.php
+++ b/tests/phpunit/scheduler/AsyncPoolTest.php
@@ -121,4 +121,26 @@ class AsyncPoolTest extends TestCase{
 			usleep(50 * 1000);
 		}
 	}
+
+	/**
+	 * @doesNotPerformAssertions This test is checking for a crash condition, not a specific output.
+	 */
+	public function testNullComplexDataFetch() : void{
+		$this->pool->submitTask(new class extends AsyncTask{
+			public function __construct(){
+				$this->storeLocal("null", null);
+			}
+
+			public function onRun() : void{
+				//dummy
+			}
+
+			public function onCompletion() : void{
+				$this->fetchLocal("null");
+			}
+		});
+		while($this->pool->collectTasks()){
+			usleep(50 * 1000);
+		}
+	}
 }


### PR DESCRIPTION
## Introduction
Sometimes it can be useful to be able to store null data with `AsyncTask->storeLocal()` (e.g. if you want to make some complex parameters of the constructor optional).
Currently, `AsyncTask->storeLocal()` allows to store null data in the thread-local storage. However, an error will occur when attempting to fetch this data later on because `isset()` doesn't distinguish between non-existing data and null data. This PR uses `array_key_exists()` to fix this problem.

## Changes
### API changes
None.

### Behavioural changes
Now the server doesn't crash anymore when attempting to fetch null data from the thread-local storage in an AsyncTask.

## Backwards compatibility
Yes.

## Tests
Tests have been done using a script plugin. Results can be seen here: https://gist.github.com/TheNewHEROBRINEX/516193c03a66332fede4cf126f20e8cf
