### PR TITLE
Remove unused if in WorldManager::unloadWorld()

### DIFF
--- a/src/world/WorldManager.php
+++ b/src/world/WorldManager.php
@@ -129,10 +129,6 @@ class WorldManager{
 		}
 
 		$ev = new WorldUnloadEvent($world);
-		if($world === $this->defaultWorld && !$forceUnload){
-			$ev->cancel();
-		}
-
 		$ev->call();
 
 		if(!$forceUnload && $ev->isCancelled()){


### PR DESCRIPTION
## Introduction
Removed dead if branch in `WorldManager::unloadWorld()`.

## Changes
No API or Behavioural changes. (Only dead code is being removed)
