### PR TITLE
Remove old root key

### DIFF
--- a/src/network/mcpe/auth/ProcessLoginTask.php
+++ b/src/network/mcpe/auth/ProcessLoginTask.php
@@ -40,16 +40,6 @@ class ProcessLoginTask extends AsyncTask{
 	private const TLS_KEY_ON_COMPLETION = "completion";
 
 	/**
-	 * Old Mojang root auth key. This was used since the introduction of Xbox Live authentication in 0.15.0.
-	 * This key is expected to be replaced by the key below in the future, but this has not yet happened as of
-	 * 2023-07-01.
-	 * Ideally we would place a time expiry on this key, but since Mojang have not given a hard date for the key change,
-	 * and one bad guess has already caused a major outage, we can't do this.
-	 * TODO: This needs to be removed as soon as the new key is deployed by Mojang's authentication servers.
-	 */
-	public const MOJANG_OLD_ROOT_PUBLIC_KEY = "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE8ELkixyLcwlZryUQcu1TvPOmI2B7vX83ndnWRUaXm74wFfa5f/lwQNTfrLVHa2PmenpGI6JhIMUJaWZrjmMj90NoKNFSNBuKdm8rYiXsfaz3K36x/1U26HpG0ZxK/V1V";
-
-	/**
 	 * New Mojang root auth key. Mojang notified third-party developers of this change prior to the release of 1.20.0.
 	 * Expectations were that this would be used starting a "couple of weeks" after the release, but as of 2023-07-01,
 	 * it has not yet been deployed.
@@ -174,7 +164,7 @@ class ProcessLoginTask extends AsyncTask{
 			throw new VerifyLoginException($e->getMessage(), null, 0, $e);
 		}
 
-		if($headers->x5u === self::MOJANG_ROOT_PUBLIC_KEY || $headers->x5u === self::MOJANG_OLD_ROOT_PUBLIC_KEY){
+		if($headers->x5u === self::MOJANG_ROOT_PUBLIC_KEY){
 			$this->authenticated = true; //we're signed into xbox live
 		}
 

--- a/src/utils/ServerKiller.php
+++ b/src/utils/ServerKiller.php
@@ -24,7 +24,8 @@ declare(strict_types=1);
 namespace pocketmine\utils;
 
 use pocketmine\thread\Thread;
-use function time;
+use function hrtime;
+use function intdiv;
 
 class ServerKiller extends Thread{
 	private bool $stopped = false;
@@ -34,13 +35,15 @@ class ServerKiller extends Thread{
 	){}
 
 	protected function onRun() : void{
-		$start = time();
-		$this->synchronized(function() : void{
-			if(!$this->stopped){
-				$this->wait($this->time * 1000000);
+		$start = hrtime(true);
+		$remaining = $this->time * 1_000_000;
+		$this->synchronized(function() use (&$remaining, $start) : void{
+			while(!$this->stopped && $remaining > 0){
+				$this->wait($remaining);
+				$remaining -= intdiv(hrtime(true) - $start, 1000);
 			}
 		});
-		if(time() - $start >= $this->time){
+		if($remaining <= 0){
 			echo "\nTook too long to stop, server was killed forcefully!\n";
 			@Process::kill(Process::pid());
 		}


### PR DESCRIPTION
## Introduction
This should have been done a while ago, back in august when the new key was deployed.



## Changes
No API changes

### Behavioural changes
If the old key was compromised (which it probably was, why else would mojang change it) this change blocks logins using a compromised key

## Backwards compatibility
No issues