### PR TITLE
[PHP 8.4] Change `PHP_DEBUG` constant usage to `ZEND_DEBUG_BUILD`

### DIFF
--- a/src/PocketMine.php
+++ b/src/PocketMine.php
@@ -166,7 +166,7 @@ namespace pocketmine {
 	 * @return void
 	 */
 	function emit_performance_warnings(\Logger $logger){
-		if(PHP_DEBUG !== 0){
+		if(ZEND_DEBUG_BUILD){
 			$logger->warning("This PHP binary was compiled in debug mode. This has a major impact on performance.");
 		}
 		if(extension_loaded("xdebug") && (!function_exists('xdebug_info') || count(xdebug_info('mode')) !== 0)){


### PR DESCRIPTION
## Introduction
In PHP 8.4, the type of `PHP_ZTS` changes from `int` to `bool`. See [PHP.Watch: PHP 8.4: `PHP_ZTS` and `PHP_DEBUG` constant value type changed from `int` to `bool`](https://php.watch/versions/8.4/PHP_ZTS-PHP_DEBUG-const-type-change).



## Changes
This changes the constants to `ZEND_THREAD_SAFE`, which contains the same value but as a `bool` across all PHP versions.

### API changes
_none_

### Behavioural changes
_none_

## Backwards compatibility
_none_

## Follow-up
_none_

Requires translations:
_none_

## Tests
_none_