### PR TITLE
Fixes Issue #6164

### DIFF
--- a/src/world/World.php
+++ b/src/world/World.php
@@ -1011,26 +1011,51 @@ class World implements ChunkManager{
 
 		if(count($this->changedBlocks) > 0){
 			if(count($this->players) > 0){
-				foreach($this->changedBlocks as $index => $blocks){
-					if(count($blocks) === 0){ //blocks can be set normally and then later re-set with direct send
-						continue;
-					}
-					World::getXZ($index, $chunkX, $chunkZ);
-					if(!$this->isChunkLoaded($chunkX, $chunkZ)){
-						//a previous chunk may have caused this one to be unloaded by a ChunkListener
-						continue;
-					}
-					if(count($blocks) > 512){
-						$chunk = $this->getChunk($chunkX, $chunkZ) ?? throw new AssumptionFailedError("We already checked that the chunk is loaded");
-						foreach($this->getChunkPlayers($chunkX, $chunkZ) as $p){
-							$p->onChunkChanged($chunkX, $chunkZ, $chunk);
-						}
-					}else{
-						foreach($this->createBlockUpdatePackets($blocks) as $packet){
-							$this->broadcastPacketToPlayersUsingChunk($chunkX, $chunkZ, $packet);
-						}
-					}
-				}
+				foreach ($this->changedBlocks as $index => $blocks) {
+    if (count($blocks) === 0) {
+        continue;
+    }
+
+    World::getXZ($index, $chunkX, $chunkZ);
+
+    // Check if the chunk is loaded before processing block updates
+    if (!$this->isChunkLoaded($chunkX, $chunkZ)) {
+        continue;
+    }
+
+    $chunk = $this->getChunk($chunkX, $chunkZ) ?? throw new AssumptionFailedError("We already checked that the chunk is loaded");
+
+    // Group block updates into chunks for more efficient processing
+    $chunkUpdates = [];
+
+    foreach ($blocks as $block) {
+        $blockX = $block->getX();
+        $blockZ = $block->getZ();
+
+        $chunkX = $blockX >> 4;
+        $chunkZ = $blockZ >> 4;
+
+        // Use the instance of the Level class if available
+        $chunkIndex = $chunk->chunkHash($chunkX, $chunkZ);
+        $chunkUpdates[$chunkIndex][] = $block;
+    }
+
+    // Process chunk updates
+    foreach ($chunkUpdates as $chunkIndex => $blockUpdates) {
+        list($chunkX, $chunkZ) = $chunk->getChunkXZ($chunkIndex);
+
+        if (count($blockUpdates) > 512) {
+            foreach ($this->getChunkPlayers($chunkX, $chunkZ) as $player) {
+                $player->onChunkChanged($chunkX, $chunkZ, $chunk);
+            }
+        } else {
+            foreach ($this->createBlockUpdatePackets($blockUpdates) as $packet) {
+                $this->broadcastPacketToPlayersUsingChunk($chunkX, $chunkZ, $packet);
+            }
+        }
+    }
+}
+
 			}
 
 			$this->changedBlocks = [];


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

This modified code groups block updates based on the chunk they belong to before processing them. It aims to improve efficiency by minimizing redundant operations and sending fewer packets when updating multiple blocks within the same chunk. Keep in mind that the effectiveness of this optimization may vary based on the specific characteristics of your server and its usage patterns.

### Relevant issues
<!-- List relevant issues here -->
<!-- 

* Fixes #1 6164
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
