### PR TITLE
Add lastdamage in durable item

### DIFF
--- a/src/item/Durable.php
+++ b/src/item/Durable.php
@@ -30,6 +30,8 @@ use function min;
 
 abstract class Durable extends Item{
 	protected int $damage = 0;
+	protected int $lastDamage = 0;
+
 	private bool $unbreakable = false;
 
 	/**
@@ -59,6 +61,7 @@ abstract class Durable extends Item{
 			return false;
 		}
 
+		$this->lastDamage = $amount;
 		$amount -= $this->getUnbreakingDamageReduction($amount);
 
 		$this->damage = min($this->damage + $amount, $this->getMaxDurability());
@@ -71,6 +74,10 @@ abstract class Durable extends Item{
 
 	public function getDamage() : int{
 		return $this->damage;
+	}
+
+	public function getLastDamage() : int{
+		return $this->lastDamage;
 	}
 
 	public function setDamage(int $damage) : Item{


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
At present, if we want to create a system for cleanly modifying items without overriding them, using events only and respecting pocketmie's "rules", we can't do it.

So I'm proposing a getLastDamage function to find out the last damage the item may have had
