### PR TITLE
Proposed event for items when damaged

### DIFF
--- a/src/event/inventory/ItemDamageEvent.php
+++ b/src/event/inventory/ItemDamageEvent.php
@@ -23,62 +23,41 @@ declare(strict_types=1);
 
 namespace pocketmine\event\inventory;
 
-use pocketmine\crafting\CraftingRecipe;
 use pocketmine\event\Cancellable;
 use pocketmine\event\CancellableTrait;
 use pocketmine\event\Event;
-use pocketmine\inventory\transaction\CraftingTransaction;
 use pocketmine\item\Durable;
-use pocketmine\item\Item;
-use pocketmine\player\Player;
-use pocketmine\utils\Utils;
 
+/**
+ * Called when an item is damaged
+ */
 class ItemDamageEvent extends Event implements Cancellable{
-    use CancellableTrait;
+	use CancellableTrait;
 
-    public function __construct(
-        private Durable $item,
-        private int $damage,
-        private int $unbreakingDamageReduction = 0
-    ){}
+	public function __construct(
+		private Durable $item,
+		private int $damage,
+		private int $unbreakingDamageReduction = 0
+	){
+	}
 
-    /**
-     * @return int
-     */
-    public function getDamage(): int
-    {
-        return $this->damage;
-    }
+	public function getDamage() : int{
+		return $this->damage;
+	}
 
-    /**
-     * @return Durable
-     */
-    public function getItem(): Durable
-    {
-        return $this->item;
-    }
+	public function getItem() : Durable{
+		return $this->item;
+	}
 
-    /**
-     * @return int
-     */
-    public function getUnbreakingDamageReduction(): int
-    {
-        return $this->unbreakingDamageReduction;
-    }
+	public function getUnbreakingDamageReduction() : int{
+		return $this->unbreakingDamageReduction;
+	}
 
-    /**
-     * @param int $damage
-     */
-    public function setDamage(int $damage): void
-    {
-        $this->damage = $damage;
-    }
+	public function setDamage(int $damage) : void{
+		$this->damage = $damage;
+	}
 
-    /**
-     * @param int $unbreakingDamageReduction
-     */
-    public function setUnbreakingDamageReduction(int $unbreakingDamageReduction): void
-    {
-        $this->unbreakingDamageReduction = $unbreakingDamageReduction;
-    }
+	public function setUnbreakingDamageReduction(int $unbreakingDamageReduction) : void{
+		$this->unbreakingDamageReduction = $unbreakingDamageReduction;
+	}
 }

--- a/src/event/inventory/ItemDamageEvent.php
+++ b/src/event/inventory/ItemDamageEvent.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\event\inventory;
+
+use pocketmine\crafting\CraftingRecipe;
+use pocketmine\event\Cancellable;
+use pocketmine\event\CancellableTrait;
+use pocketmine\event\Event;
+use pocketmine\inventory\transaction\CraftingTransaction;
+use pocketmine\item\Durable;
+use pocketmine\item\Item;
+use pocketmine\player\Player;
+use pocketmine\utils\Utils;
+
+class ItemDamageEvent extends Event implements Cancellable{
+    use CancellableTrait;
+
+    public function __construct(
+        private Durable $item,
+        private int $damage,
+        private int $unbreakingDamageReduction = 0
+    ){}
+
+    /**
+     * @return int
+     */
+    public function getDamage(): int
+    {
+        return $this->damage;
+    }
+
+    /**
+     * @return Durable
+     */
+    public function getItem(): Durable
+    {
+        return $this->item;
+    }
+
+    /**
+     * @return int
+     */
+    public function getUnbreakingDamageReduction(): int
+    {
+        return $this->unbreakingDamageReduction;
+    }
+
+    /**
+     * @param int $damage
+     */
+    public function setDamage(int $damage): void
+    {
+        $this->damage = $damage;
+    }
+
+    /**
+     * @param int $unbreakingDamageReduction
+     */
+    public function setUnbreakingDamageReduction(int $unbreakingDamageReduction): void
+    {
+        $this->unbreakingDamageReduction = $unbreakingDamageReduction;
+    }
+}

--- a/src/item/Durable.php
+++ b/src/item/Durable.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\item;
 
+use pocketmine\event\inventory\ItemDamageEvent;
 use pocketmine\item\enchantment\VanillaEnchantments;
 use pocketmine\nbt\tag\CompoundTag;
 use function lcg_value;
@@ -59,7 +60,14 @@ abstract class Durable extends Item{
 			return false;
 		}
 
-		$amount -= $this->getUnbreakingDamageReduction($amount);
+		$ev = new ItemDamageEvent($this, $amount, $this->getUnbreakingDamageReduction($amount));
+		$ev->call();
+
+		if ($ev->isCancelled()) {
+			return false;
+		}
+
+		$amount = $ev->getDamage() - $ev->getUnbreakingDamageReduction();
 
 		$this->damage = min($this->damage + $amount, $this->getMaxDurability());
 		if($this->isBroken()){


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

At the moment, when we want to modify the durability of an item, we have to override items

But overriding items can be inconvenient in several cases (sometimes)

The event here allows you to change the durability of items when they are damaged, but could be even more developed (for example, to modify durability via a position where the item is in use)

If you need more questions or additions to the event to be "more relevant", ask me