### PR TITLE
feat(Server): add a setter for `maxPlayers`

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -343,6 +343,10 @@ class Server{
 		return $this->maxPlayers;
 	}
 
+	public function setMaxPlayers(int $maxPlayers) : void{
+		$this->maxPlayers = $maxPlayers;
+	}
+
 	/**
 	 * Returns whether the server requires that players be authenticated to Xbox Live. If true, connecting players who
 	 * are not logged into Xbox Live will be disconnected.


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This PR allows plugins to modify the server's max players count during runtime

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Added `Server::setMaxPlayers(int $maxPlayers): void`

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
PRs which have not been tested MUST be marked as draft.
-->
I tested this PR by doing the following (tick all that apply):
- [ ] Writing PHPUnit tests (commit these in the `tests/phpunit` folder)
- [x] Playtesting using a Minecraft client (provide screenshots or a video)
- [x] Writing a test plugin (provide the code and sample output)
- [ ] Other (provide details)
