### PR TITLE
Fix nether roots support

### DIFF
--- a/src/block/NetherRoots.php
+++ b/src/block/NetherRoots.php
@@ -34,6 +34,7 @@ final class NetherRoots extends Flowable{
 		$supportBlock = $block->getSide(Facing::DOWN);
 		return
 			$supportBlock->hasTypeTag(BlockTypeTags::DIRT) ||
-			$supportBlock->hasTypeTag(BlockTypeTags::MUD);
+			$supportBlock->hasTypeTag(BlockTypeTags::MUD) ||
+			$supportBlock->getTypeId() === BlockTypeIds::SOUL_SOIL;
 	}
 }


### PR DESCRIPTION
## Introduction
Nether roots can't actually be placed on soul soil.

## Tests
<!--
PRs which have not been tested MUST be marked as draft.
-->
I tested this PR by doing the following (tick all that apply):
- [X] Playtesting using a Minecraft client (provide screenshots or a video)

https://github.com/pmmp/PocketMine-MP/assets/66992287/af724e5d-1369-4141-a3fb-3aaaa98239a5

