### PR TITLE
Prevent spamming with broken sessions

### DIFF
--- a/src/network/mcpe/handler/LoginPacketHandler.php
+++ b/src/network/mcpe/handler/LoginPacketHandler.php
@@ -77,7 +77,7 @@ class LoginPacketHandler extends PacketHandler{
 				reason: "Invalid skin: " . $e->getMessage(),
 				disconnectScreenMessage: KnownTranslationFactory::disconnectionScreen_invalidSkin()
 			);
-
+            $this->server->getNetwork()->blockAddress($this->session->getIp());
 			return true;
 		}
 


### PR DESCRIPTION
## Introduction
Flooding with invalid sessions could freeze the server

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!--
PRs which have not been tested MUST be marked as draft.
-->
I tested this PR by doing the following (tick all that apply):
- [ ] Writing PHPUnit tests (commit these in the `tests/phpunit` folder)
- [ ] Playtesting using a Minecraft client (provide screenshots or a video)
- [ ] Writing a test plugin (provide the code and sample output)
- [ ] Other (provide details)
