### PR TITLE
Bowl can be a fuel

### DIFF
--- a/src/item/Bowl.php
+++ b/src/item/Bowl.php
@@ -25,5 +25,7 @@ namespace pocketmine\item;
 
 class Bowl extends Item{
 
-	//TODO: check fuel
+	public function getFuelTime() : int{
+		return 200;
+	}
 }


### PR DESCRIPTION
## Introduction
Bowl can be used as a fuel in furnaces
source: https://minecraft.wiki/w/Bowl#Fuel

## Changes
### API changes
Modify `getFuelTime` function in `Bowl`