### PR TITLE
Fix effect bubbles not showing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
       "pocketmine/bedrock-block-upgrade-schema": "~4.2.0+bedrock-1.21.0",
       "pocketmine/bedrock-data": "~2.11.0+bedrock-1.21.0",
       "pocketmine/bedrock-item-upgrade-schema": "~1.10.0+bedrock-1.21.0",
-      "pocketmine/bedrock-protocol": "~32.1.0+bedrock-1.21.2",
+      "pocketmine/bedrock-protocol": "~32.2.0+bedrock-1.21.2",
       "pocketmine/binaryutils": "^0.2.1",
       "pocketmine/callback-validator": "^1.0.2",
       "pocketmine/color": "^0.3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cddee8096f4b575629ff671000543d3f",
+    "content-hash": "1088c04a8e6b841ff8aa88a3f28e0de6",
     "packages": [
         {
             "name": "adhocore/json-comment",
@@ -205,16 +205,16 @@
         },
         {
             "name": "pocketmine/bedrock-protocol",
-            "version": "32.1.0+bedrock-1.21.2",
+            "version": "32.2.0+bedrock-1.21.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pmmp/BedrockProtocol.git",
-                "reference": "bb23db51365bdc91d3135c3885986a691ae1cb44"
+                "reference": "229e5f3ae676a8601c576b7a57e56060b611d68d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pmmp/BedrockProtocol/zipball/bb23db51365bdc91d3135c3885986a691ae1cb44",
-                "reference": "bb23db51365bdc91d3135c3885986a691ae1cb44",
+                "url": "https://api.github.com/repos/pmmp/BedrockProtocol/zipball/229e5f3ae676a8601c576b7a57e56060b611d68d",
+                "reference": "229e5f3ae676a8601c576b7a57e56060b611d68d",
                 "shasum": ""
             },
             "require": {
@@ -245,9 +245,9 @@
             "description": "An implementation of the Minecraft: Bedrock Edition protocol in PHP",
             "support": {
                 "issues": "https://github.com/pmmp/BedrockProtocol/issues",
-                "source": "https://github.com/pmmp/BedrockProtocol/tree/32.1.0+bedrock-1.21.2"
+                "source": "https://github.com/pmmp/BedrockProtocol/tree/32.2.0+bedrock-1.21.2"
             },
-            "time": "2024-07-10T01:38:43+00:00"
+            "time": "2024-08-10T19:23:18+00:00"
         },
         {
             "name": "pocketmine/binaryutils",

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -897,10 +897,15 @@ abstract class Living extends Entity{
 		ksort($visibleEffects, SORT_NUMERIC);
 
 		$effectsData = 0;
-		foreach (array_slice($visibleEffects, 0, 8, true) as $effectId => $isAmbient) {
+		$packedEffectsCount = 0;
+		foreach ($visibleEffects as $effectId => $isAmbient) {
 			$effectsData = ($effectsData << 7) |
 				(($effectId & 0x3f) << 1) |
 				($isAmbient ? 1 : 0);
+
+			if (++$packedEffectsCount >= 8) {
+				break;
+			}
 		}
 		$properties->setLong(131, $effectsData); //TODO: Use the appropriate constant!
 

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -64,7 +64,6 @@ use pocketmine\world\sound\EntityLongFallSound;
 use pocketmine\world\sound\EntityShortFallSound;
 use pocketmine\world\sound\ItemBreakSound;
 use function array_shift;
-use function array_slice;
 use function atan2;
 use function ceil;
 use function count;

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -63,6 +63,8 @@ use pocketmine\world\sound\EntityLandSound;
 use pocketmine\world\sound\EntityLongFallSound;
 use pocketmine\world\sound\EntityShortFallSound;
 use pocketmine\world\sound\ItemBreakSound;
+use function array_filter;
+use function array_map;
 use function array_shift;
 use function atan2;
 use function ceil;
@@ -74,8 +76,10 @@ use function min;
 use function mt_getrandmax;
 use function mt_rand;
 use function round;
+use function sort;
 use function sqrt;
 use const M_PI;
+use const SORT_NUMERIC;
 
 abstract class Living extends Entity{
 	protected const DEFAULT_BREATH_TICKS = 300;

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -894,13 +894,14 @@ abstract class Living extends Entity{
 			$visibleEffects[EffectIdMap::getInstance()->toId($effect->getType())] = $effect->isAmbient();
 		}
 
+		//TODO: HACK! the client may not be able to identify effects if they are not sorted.
 		ksort($visibleEffects, SORT_NUMERIC);
 
 		$effectsData = 0;
 		$packedEffectsCount = 0;
 		foreach ($visibleEffects as $effectId => $isAmbient) {
 			$effectsData = ($effectsData << 7) |
-				(($effectId & 0x3f) << 1) |
+				(($effectId & 0x3f) << 1) | //Why not use 7 bits instead of only 6? mojang...
 				($isAmbient ? 1 : 0);
 
 			if (++$packedEffectsCount >= 8) {

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -907,7 +907,7 @@ abstract class Living extends Entity{
 				break;
 			}
 		}
-		$properties->setLong(131, $effectsData); //TODO: Use the appropriate constant!
+		$properties->setLong(EntityMetadataProperties::VISIBLE_MOB_EFFECTS, $effectsData);
 
 		$properties->setShort(EntityMetadataProperties::AIR, $this->breathTicks);
 		$properties->setShort(EntityMetadataProperties::MAX_AIR, $this->maxBreathTicks);


### PR DESCRIPTION
As of 1.21 bubbles for each effect are displayed separately (it is no longer a mix of all visible effect colors), so it requires that we send all visible effect ids.


## Tests
I tested this PR by doing the following (tick all that apply):
- [x] Playtesting using a Minecraft client (provide screenshots or a video)
- [x] Ensured that the values generated were identical to those generated by BDS.
