### PR TITLE
Fixed incorrect function visibility modifier in ChiseledBookshelf tile class

### DIFF
--- a/src/block/tile/ChiseledBookshelf.php
+++ b/src/block/tile/ChiseledBookshelf.php
@@ -59,7 +59,7 @@ class ChiseledBookshelf extends Tile implements Container{
 		$this->loadItems($nbt);
 	}
 
-	public function writeSaveData(CompoundTag $nbt) : void{
+	protected function writeSaveData(CompoundTag $nbt) : void{
 		$this->saveItems($nbt);
 	}
 


### PR DESCRIPTION
## Introduction
`writeSaveData()` is protected in the base class.

## Backwards compatibility
This is not a BC break change since no plugin should use this internal method.

## Tests
PHPStan tests are OK.
