### PR TITLE
Fix shift crafting

### DIFF
--- a/src/network/mcpe/handler/ItemStackRequestExecutor.php
+++ b/src/network/mcpe/handler/ItemStackRequestExecutor.php
@@ -343,7 +343,7 @@ class ItemStackRequestExecutor{
 					$this->setNextCreatedItem($window->getOutput($optionId));
 				}
 			}else{
-				$this->beginCrafting($action->getRecipeId(), 1);
+				$this->beginCrafting($action->getRecipeId(), $action->getRepetitions());
 			}
 		}elseif($action instanceof CraftRecipeAutoStackRequestAction){
 			$this->beginCrafting($action->getRecipeId(), $action->getRepetitions());


### PR DESCRIPTION
## Introduction
In versions before 1.21.20, the client will send multiple CraftRecipeStackRequestActions to craft all the items in your inventory. However, since the 1.21.20 shift crafting would throw an error since it now uses repetitions instead of multiple actions and you'd be placing more items in your inventory than you actually crafted from that one action.

## Tests
https://github.com/user-attachments/assets/70b2dcfe-8fdd-4452-be3e-54881cfcc4d5


I tested this PR by doing the following (tick all that apply):
- [ ] Writing PHPUnit tests (commit these in the `tests/phpunit` folder)
- [x] Playtesting using a Minecraft client (provide screenshots or a video)
- [ ] Writing a test plugin (provide the code and sample output)
- [ ] Other (provide details)
