### PR TITLE
Implement a sound when drinking a potion

### DIFF
--- a/src/item/Potion.php
+++ b/src/item/Potion.php
@@ -26,6 +26,7 @@ namespace pocketmine\item;
 use pocketmine\data\runtime\RuntimeDataDescriber;
 use pocketmine\entity\Living;
 use pocketmine\player\Player;
+use pocketmine\world\sound\BottleEmptySound;
 
 class Potion extends Item implements ConsumableItem{
 
@@ -50,7 +51,7 @@ class Potion extends Item implements ConsumableItem{
 	}
 
 	public function onConsume(Living $consumer) : void{
-
+		$consumer->broadcastSound(new BottleEmptySound());
 	}
 
 	public function getAdditionalEffects() : array{

--- a/src/world/sound/BottleEmptySound.php
+++ b/src/world/sound/BottleEmptySound.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\world\sound;
+
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
+
+class BottleEmptySound implements Sound{
+
+	public function encode(Vector3 $pos) : array{
+		return [LevelSoundEventPacket::nonActorSound(LevelSoundEvent::BOTTLE_EMPTY, $pos, false)];
+	}
+}


### PR DESCRIPTION
## Introduction
This sound is played in vanilla when player drinks a potion.
## Changes
### API changes
Added `BottleEmptySound`.

## Tests
I tested this PR by doing the following:
- [X] Playtesting using a Minecraft client (https://github.com/user-attachments/assets/f4cf4ed6-8d2b-4c99-a125-11b2016fa647)
