### PR TITLE
EnderPearls now teleports to the correct world

### DIFF
--- a/src/entity/projectile/EnderPearl.php
+++ b/src/entity/projectile/EnderPearl.php
@@ -27,8 +27,8 @@ use pocketmine\event\entity\EntityDamageEvent;
 use pocketmine\event\entity\ProjectileHitEvent;
 use pocketmine\network\mcpe\protocol\types\entity\EntityIds;
 use pocketmine\world\particle\EndermanTeleportParticle;
-use pocketmine\world\sound\EndermanTeleportSound;
 use pocketmine\world\Position;
+use pocketmine\world\sound\EndermanTeleportSound;
 
 class EnderPearl extends Throwable{
 	public static function getNetworkTypeId() : string{ return EntityIds::ENDER_PEARL; }

--- a/src/entity/projectile/EnderPearl.php
+++ b/src/entity/projectile/EnderPearl.php
@@ -28,6 +28,7 @@ use pocketmine\event\entity\ProjectileHitEvent;
 use pocketmine\network\mcpe\protocol\types\entity\EntityIds;
 use pocketmine\world\particle\EndermanTeleportParticle;
 use pocketmine\world\sound\EndermanTeleportSound;
+use pocketmine\world\Position;
 
 class EnderPearl extends Throwable{
 	public static function getNetworkTypeId() : string{ return EntityIds::ENDER_PEARL; }
@@ -38,9 +39,10 @@ class EnderPearl extends Throwable{
 			//TODO: check end gateways (when they are added)
 			//TODO: spawn endermites at origin
 
+			$target = $event->getRayTraceResult()->getHitVector();
 			$this->getWorld()->addParticle($origin = $owner->getPosition(), new EndermanTeleportParticle());
 			$this->getWorld()->addSound($origin, new EndermanTeleportSound());
-			$owner->teleport($target = $event->getRayTraceResult()->getHitVector());
+			$owner->teleport(Position::fromObject($target, $this->getWorld()));
 			$this->getWorld()->addSound($target, new EndermanTeleportSound());
 
 			$owner->attack(new EntityDamageEvent($owner, EntityDamageEvent::CAUSE_FALL, 5));


### PR DESCRIPTION
## Introduction
EnderPearls currently teleports the player where it landed in the player world when the projectile hit something.
Normal behaviour should be that player is teleported to the coordinates AND the world **of the ender pearl**.

## Changes
### API changes
None

### Behavioural changes
None except what's written in introduction.

## Backwards compatibility
Should not be a thing.

## Follow-up
This may be completed by a system to avoid teleporting player after it's death.

I tested this PR by doing the following (tick all that apply):
- [ ] Writing PHPUnit tests (commit these in the `tests/phpunit` folder)
- [ ] Playtesting using a Minecraft client (provide screenshots or a video)
- [ ] Writing a test plugin (provide the code and sample output)
- [x] Other (This was written in PhpStorm, no syntax issues, CIs runs well and there's no reason that it broke something.)
