### PR TITLE
fix: canPlaceOn and canDestroy will be passed on conversion

### DIFF
--- a/src/network/mcpe/convert/TypeConverter.php
+++ b/src/network/mcpe/convert/TypeConverter.php
@@ -222,8 +222,8 @@ class TypeConverter{
 		}
 
 		$extraData = $id === $this->shieldRuntimeId ?
-			new ItemStackExtraDataShield($nbt, canPlaceOn: [], canDestroy: [], blockingTick: 0) :
-			new ItemStackExtraData($nbt, canPlaceOn: [], canDestroy: []);
+			new ItemStackExtraDataShield($nbt, canPlaceOn: $itemStack->getCanPlaceOn(), canDestroy: $itemStack->getCanDestroy(), blockingTick: 0) :
+			new ItemStackExtraData($nbt, canPlaceOn: $itemStack->getCanPlaceOn(), canDestroy: $itemStack->getCanDestroy());
 		$extraDataSerializer = PacketSerializer::encoder();
 		$extraData->write($extraDataSerializer);
 
@@ -266,6 +266,8 @@ class TypeConverter{
 				throw TypeConversionException::wrap($e, "Bad itemstack NBT data");
 			}
 		}
+		$itemResult->setCanPlaceOn($extraData->getCanPlaceOn());
+		$itemResult->setCanDestroy($extraData->getCanDestroy());
 
 		return $itemResult;
 	}


### PR DESCRIPTION
## Introduction
`TypeConverter` now also uses `canPlaceOn` and `canDestroy` parameters for item conversions.

### Relevant issues
* Fixes #6460

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
This is enough to fix #6460, but still has the following issues:

- Crashes when using new IDs such as `minecraft:grass_block`
- `ItemStack` extra data contains unnecessary NBT data:
  - Minecraft vanilla: `//8BCgAAAwYARGFtYWdlAAAAAAAAAAAAAQAAABUAbWluZWNyYWZ0OmdyYXNzX2Jsb2Nr`
  - pmmp: `//8BCgAACQoAQ2FuRGVzdHJveQgBAAAAFQBtaW5lY3JhZnQ6Z3Jhc3NfYmxvY2sAAAAAAAEAAAAVAG1pbmVjcmFmdDpncmFzc19ibG9jaw==`

## Tests
I tested this PR by doing the following (tick all that apply):
- [ ] Writing PHPUnit tests (commit these in the `tests/phpunit` folder)
- [x] Playtesting using a Minecraft client (provide screenshots or a video)
- [x] Writing a test plugin (provide the code and sample output)
- [ ] Other (provide details)

```php
$item = VanillaItems::IRON_HOE();
$item->setCanDestroy(["grass"]);  // minecraft:grass_block or grass_block will crash
$player->getInventory()->addItem($item);
```