### PR TITLE
Fix floating point issue

### DIFF
--- a/src/world/World.php
+++ b/src/world/World.php
@@ -2328,7 +2328,7 @@ class World implements ChunkManager{
 		for($x = $minX; $x <= $maxX; ++$x){
 			for($z = $minZ; $z <= $maxZ; ++$z){
 				foreach($this->getChunkEntities($x, $z) as $ent){
-					if($ent !== $entity && $ent->boundingBox->intersectsWith($bb)){
+					if($ent !== $entity && $ent->boundingBox->intersectsWith($bb, 0.01)){
 						$nearby[] = $ent;
 					}
 				}


### PR DESCRIPTION


## Introduction
Fixes blocks not placing right next to the player at certain positions

### Relevant issues
Currently you cannot place blocks right next to yourself at some positions due to floating point issues


## Changes
### API changes
No significant API changes

### Behavioural changes
Might affect some extremely precise checks

## Backwards compatibility
No Backwards compatibility issues

## Tests
<!--
PRs which have not been tested MUST be marked as draft.
-->
I tested this PR by doing the following (tick all that apply):
- [ ] Writing PHPUnit tests (commit these in the `tests/phpunit` folder)
- [x] Playtesting using a Minecraft client (provide screenshots or a video)
- [ ] Writing a test plugin (provide the code and sample output)
- [ ] Other (provide details)
