### PR TITLE
Rename ICopper interface

### DIFF
--- a/src/block/Copper.php
+++ b/src/block/Copper.php
@@ -23,9 +23,9 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\block\utils\CopperMaterial;
 use pocketmine\block\utils\CopperTrait;
-use pocketmine\block\utils\ICopper;
 
-class Copper extends Opaque implements ICopper{
+class Copper extends Opaque implements CopperMaterial{
 	use CopperTrait;
 }

--- a/src/block/CopperBulb.php
+++ b/src/block/CopperBulb.php
@@ -23,14 +23,14 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\block\utils\CopperMaterial;
 use pocketmine\block\utils\CopperOxidation;
 use pocketmine\block\utils\CopperTrait;
-use pocketmine\block\utils\ICopper;
 use pocketmine\block\utils\LightableTrait;
 use pocketmine\block\utils\PoweredByRedstoneTrait;
 use pocketmine\data\runtime\RuntimeDataDescriber;
 
-class CopperBulb extends Opaque implements ICopper{
+class CopperBulb extends Opaque implements CopperMaterial{
 	use CopperTrait;
 	use PoweredByRedstoneTrait;
 	use LightableTrait{

--- a/src/block/CopperDoor.php
+++ b/src/block/CopperDoor.php
@@ -23,14 +23,14 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\block\utils\CopperMaterial;
 use pocketmine\block\utils\CopperTrait;
-use pocketmine\block\utils\ICopper;
 use pocketmine\item\Item;
 use pocketmine\math\Facing;
 use pocketmine\math\Vector3;
 use pocketmine\player\Player;
 
-class CopperDoor extends Door implements ICopper{
+class CopperDoor extends Door implements CopperMaterial{
 	use CopperTrait{
 		onInteract as onInteractCopper;
 	}

--- a/src/block/CopperGrate.php
+++ b/src/block/CopperGrate.php
@@ -23,10 +23,10 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\block\utils\CopperMaterial;
 use pocketmine\block\utils\CopperTrait;
-use pocketmine\block\utils\ICopper;
 
-class CopperGrate extends Transparent implements ICopper{
+class CopperGrate extends Transparent implements CopperMaterial{
 	use CopperTrait;
 
 	//TODO: waterlogging!

--- a/src/block/CopperSlab.php
+++ b/src/block/CopperSlab.php
@@ -23,9 +23,9 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\block\utils\CopperMaterial;
 use pocketmine\block\utils\CopperTrait;
-use pocketmine\block\utils\ICopper;
 
-class CopperSlab extends Slab implements ICopper{
+class CopperSlab extends Slab implements CopperMaterial{
 	use CopperTrait;
 }

--- a/src/block/CopperStairs.php
+++ b/src/block/CopperStairs.php
@@ -23,9 +23,9 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\block\utils\CopperMaterial;
 use pocketmine\block\utils\CopperTrait;
-use pocketmine\block\utils\ICopper;
 
-class CopperStairs extends Stair implements ICopper{
+class CopperStairs extends Stair implements CopperMaterial{
 	use CopperTrait;
 }

--- a/src/block/CopperTrapdoor.php
+++ b/src/block/CopperTrapdoor.php
@@ -23,13 +23,13 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\block\utils\CopperMaterial;
 use pocketmine\block\utils\CopperTrait;
-use pocketmine\block\utils\ICopper;
 use pocketmine\item\Item;
 use pocketmine\math\Vector3;
 use pocketmine\player\Player;
 
-class CopperTrapdoor extends Trapdoor implements ICopper{
+class CopperTrapdoor extends Trapdoor implements CopperMaterial{
 	use CopperTrait{
 		onInteract as onInteractCopper;
 	}

--- a/src/block/utils/CopperMaterial.php
+++ b/src/block/utils/CopperMaterial.php
@@ -26,13 +26,13 @@ namespace pocketmine\block\utils;
 /**
  * Represents copper blocks that have oxidized and waxed variations.
  */
-interface ICopper{
+interface CopperMaterial{
 
 	public function getOxidation() : CopperOxidation;
 
-	public function setOxidation(CopperOxidation $oxidation) : ICopper;
+	public function setOxidation(CopperOxidation $oxidation) : CopperMaterial;
 
 	public function isWaxed() : bool;
 
-	public function setWaxed(bool $waxed) : ICopper;
+	public function setWaxed(bool $waxed) : CopperMaterial;
 }

--- a/src/data/bedrock/block/convert/BlockStateDeserializerHelper.php
+++ b/src/data/bedrock/block/convert/BlockStateDeserializerHelper.php
@@ -45,8 +45,8 @@ use pocketmine\block\Slab;
 use pocketmine\block\Stair;
 use pocketmine\block\Stem;
 use pocketmine\block\Trapdoor;
+use pocketmine\block\utils\CopperMaterial;
 use pocketmine\block\utils\CopperOxidation;
-use pocketmine\block\utils\ICopper;
 use pocketmine\block\utils\SlabType;
 use pocketmine\block\VanillaBlocks;
 use pocketmine\block\Wall;
@@ -98,24 +98,24 @@ final class BlockStateDeserializerHelper{
 	}
 
 	/**
-	 * @phpstan-template TBlock of ICopper
+	 * @phpstan-template TBlock of CopperMaterial
 	 *
 	 * @phpstan-param TBlock $block
 	 * @phpstan-return TBlock
 	 */
-	public static function decodeCopper(ICopper $block, CopperOxidation $oxidation) : ICopper{
+	public static function decodeCopper(CopperMaterial $block, CopperOxidation $oxidation) : CopperMaterial{
 		$block->setOxidation($oxidation);
 		$block->setWaxed(false);
 		return $block;
 	}
 
 	/**
-	 * @phpstan-template TBlock of ICopper
+	 * @phpstan-template TBlock of CopperMaterial
 	 *
 	 * @phpstan-param TBlock $block
 	 * @phpstan-return TBlock
 	 */
-	public static function decodeWaxedCopper(ICopper $block, CopperOxidation $oxidation) : ICopper{
+	public static function decodeWaxedCopper(CopperMaterial $block, CopperOxidation $oxidation) : CopperMaterial{
 		$block->setOxidation($oxidation);
 		$block->setWaxed(true);
 		return $block;


### PR DESCRIPTION
## Introduction
After some discussion about https://github.com/pmmp/PocketMine-MP/pull/6390 it turned out that `ICopper` is an inappropriate name for an interface that represents copper blocks that have oxidized and waxed variations. There were several new names proposed, but I think `CopperMaterial` would fit as it describes that the block is made of copper, has copper variations.