### PR TITLE
Temporary resolve loading old skulls from storage

### DIFF
--- a/src/data/bedrock/item/upgrade/ItemDataUpgrader.php
+++ b/src/data/bedrock/item/upgrade/ItemDataUpgrader.php
@@ -154,7 +154,13 @@ final class ItemDataUpgrader{
 
 		//TODO: Dirty hack to load old skulls from disk: Put this into item upgrade schema's before Mojang makes something with a non 0 default state
 		if($blockStateData === null && ($blockId = $this->blockItemIdMap->lookupBlockId($newNameId)) !== null){
-			$blockStateData = $this->blockStateDictionary->generateDataFromStateId($this->blockStateDictionary->lookupStateIdFromIdMeta($blockId, 0));
+			$networkRuntimeId = $this->blockStateDictionary->lookupStateIdFromIdMeta($blockId, 0);
+
+			if($networkRuntimeId === null){
+				throw new SavedDataLoadingException("Failed to find blockstate for blockitem $newNameId");
+			}
+
+			$blockStateData = $this->blockStateDictionary->generateDataFromStateId($networkRuntimeId);
 		}
 
 		//TODO: this won't account for spawn eggs from before 1.16.100 - perhaps we're lucky and they just left the meta in there anyway?

--- a/src/data/bedrock/item/upgrade/ItemDataUpgrader.php
+++ b/src/data/bedrock/item/upgrade/ItemDataUpgrader.php
@@ -25,6 +25,7 @@ namespace pocketmine\data\bedrock\item\upgrade;
 
 use pocketmine\data\bedrock\block\BlockStateDeserializeException;
 use pocketmine\data\bedrock\block\upgrade\BlockDataUpgrader;
+use pocketmine\data\bedrock\item\BlockItemIdMap;
 use pocketmine\data\bedrock\item\SavedItemData;
 use pocketmine\data\bedrock\item\SavedItemStackData;
 use pocketmine\data\SavedDataLoadingException;
@@ -35,6 +36,7 @@ use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\ListTag;
 use pocketmine\nbt\tag\ShortTag;
 use pocketmine\nbt\tag\StringTag;
+use pocketmine\network\mcpe\convert\BlockStateDictionary;
 use pocketmine\utils\Binary;
 use function assert;
 
@@ -46,6 +48,8 @@ final class ItemDataUpgrader{
 		private LegacyItemIdToStringIdMap $legacyIntToStringIdMap,
 		private R12ItemIdToBlockIdMap $r12ItemIdToBlockIdMap,
 		private BlockDataUpgrader $blockDataUpgrader,
+		private BlockItemIdMap $blockItemIdMap,
+		private BlockStateDictionary $blockStateDictionary
 	){}
 
 	/**
@@ -147,6 +151,11 @@ final class ItemDataUpgrader{
 		}
 
 		[$newNameId, $newMeta] = $this->idMetaUpgrader->upgrade($rawNameId, $meta);
+
+		//TODO: Dirty hack to load old skulls from disk: Put this into item upgrade schema's before Mojang makes something with a non 0 default state
+		if($blockStateData === null && ($blockId = $this->blockItemIdMap->lookupBlockId($newNameId)) !== null){
+			$blockStateData = $this->blockStateDictionary->generateDataFromStateId($this->blockStateDictionary->lookupStateIdFromIdMeta($blockId, 0));
+		}
 
 		//TODO: this won't account for spawn eggs from before 1.16.100 - perhaps we're lucky and they just left the meta in there anyway?
 		//TODO: read version from VersionInfo::TAG_WORLD_DATA_VERSION - we may need it to fix up old items

--- a/src/world/format/io/GlobalItemDataHandlers.php
+++ b/src/world/format/io/GlobalItemDataHandlers.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\world\format\io;
 
+use pocketmine\data\bedrock\item\BlockItemIdMap;
 use pocketmine\data\bedrock\item\ItemDeserializer;
 use pocketmine\data\bedrock\item\ItemSerializer;
 use pocketmine\data\bedrock\item\upgrade\ItemDataUpgrader;
@@ -30,6 +31,7 @@ use pocketmine\data\bedrock\item\upgrade\ItemIdMetaUpgrader;
 use pocketmine\data\bedrock\item\upgrade\ItemIdMetaUpgradeSchemaUtils;
 use pocketmine\data\bedrock\item\upgrade\LegacyItemIdToStringIdMap;
 use pocketmine\data\bedrock\item\upgrade\R12ItemIdToBlockIdMap;
+use pocketmine\network\mcpe\convert\TypeConverter;
 use Symfony\Component\Filesystem\Path;
 use const PHP_INT_MAX;
 use const pocketmine\BEDROCK_ITEM_UPGRADE_SCHEMA_PATH;
@@ -54,7 +56,9 @@ final class GlobalItemDataHandlers{
 			new ItemIdMetaUpgrader(ItemIdMetaUpgradeSchemaUtils::loadSchemas(Path::join(BEDROCK_ITEM_UPGRADE_SCHEMA_PATH, 'id_meta_upgrade_schema'), PHP_INT_MAX)),
 			LegacyItemIdToStringIdMap::getInstance(),
 			R12ItemIdToBlockIdMap::getInstance(),
-			GlobalBlockStateHandlers::getUpgrader()
+			GlobalBlockStateHandlers::getUpgrader(),
+			BlockItemIdMap::getInstance(),
+			TypeConverter::getInstance()->getBlockTranslator()->getBlockStateDictionary()
 		);
 	}
 }

--- a/src/world/format/io/data/BedrockWorldData.php
+++ b/src/world/format/io/data/BedrockWorldData.php
@@ -51,12 +51,12 @@ use function time;
 class BedrockWorldData extends BaseNbtWorldData{
 
 	public const CURRENT_STORAGE_VERSION = 10;
-	public const CURRENT_STORAGE_NETWORK_VERSION = 729;
+	public const CURRENT_STORAGE_NETWORK_VERSION = 748;
 	public const CURRENT_CLIENT_VERSION_TARGET = [
 		1, //major
 		21, //minor
-		30, //patch
-		3, //revision
+		40, //patch
+		1, //revision
 		0 //is beta
 	];
 

--- a/src/world/format/io/leveldb/ChunkVersion.php
+++ b/src/world/format/io/leveldb/ChunkVersion.php
@@ -71,4 +71,5 @@ final class ChunkVersion{
 	public const v1_18_0_24_unused = 38;
 	public const v1_18_0_25_beta = 39;
 	public const v1_18_30 = 40;
+	public const v1_21_40 = 41;
 }

--- a/src/world/format/io/leveldb/LevelDB.php
+++ b/src/world/format/io/leveldb/LevelDB.php
@@ -78,7 +78,7 @@ class LevelDB extends BaseWorldProvider implements WritableWorldProvider{
 
 	protected const ENTRY_FLAT_WORLD_LAYERS = "game_flatworldlayers";
 
-	protected const CURRENT_LEVEL_CHUNK_VERSION = ChunkVersion::v1_18_30;
+	protected const CURRENT_LEVEL_CHUNK_VERSION = ChunkVersion::v1_21_40;
 	protected const CURRENT_LEVEL_SUBCHUNK_VERSION = SubChunkVersion::PALETTED_MULTI;
 
 	private const CAVES_CLIFFS_EXPERIMENTAL_SUBCHUNK_KEY_OFFSET = 4;
@@ -654,6 +654,8 @@ class LevelDB extends BaseWorldProvider implements WritableWorldProvider{
 		$hasBeenUpgraded = $chunkVersion < self::CURRENT_LEVEL_CHUNK_VERSION;
 
 		switch($chunkVersion){
+			case ChunkVersion::v1_21_40:
+				//TODO: BiomeStates became shorts instead of bytes
 			case ChunkVersion::v1_18_30:
 			case ChunkVersion::v1_18_0_25_beta:
 			case ChunkVersion::v1_18_0_24_unused:


### PR DESCRIPTION
## Introduction
The skulls before 1.21.40 didn't include any block data. However in 1.21.40 the skulls in vanilla include block data causing issues when loading old items from storage using Item::nbtDeserialize. This duct-tape PR picks the first state for every item id that has no block data but has a block id.

### Relevant issues
Fixes https://github.com/pmmp/PocketMine-MP/issues/6475

## Tests
- Put skulls in your inventory using PM https://github.com/pmmp/PocketMine-MP/releases/tag/5.19.0 and MCBE 1.21.30.
- Load the inventory using the new PM version (crashes due to No deserializer found for ID minecraft:* with * being a skull)
- Load the inventory using this PR (loads the first blockstate and places down normally)

I tested this PR by doing the following (tick all that apply):
- [ ] Writing PHPUnit tests (commit these in the `tests/phpunit` folder)
- [X] Playtesting using a Minecraft client (provide screenshots or a video)
- [ ] Writing a test plugin (provide the code and sample output)
- [ ] Other (provide details)
