### PR TITLE
Update WallSign.php

### DIFF
--- a/src/block/WallSign.php
+++ b/src/block/WallSign.php
@@ -34,7 +34,7 @@ use pocketmine\world\BlockTransaction;
 final class WallSign extends BaseSign{
 	use HorizontalFacingTrait;
 
-	protected function getSupportingFace() : int{
+	public function getSupportingFace() : int{
 		return Facing::opposite($this->facing);
 	}
 


### PR DESCRIPTION
## Introduction
I, as a plugin developer needed to use this function to get the block from where the WallSign was standing, to make a subclaim system, for what i've seen i don't think this method has any reason to be a protected method.

## Changes
### API changes
- `WallSign::getSupportingFace()` is now a public method

### Behavioural changes
None

## Backwards compatibility
None

## Follow-up
- Review the other blocks that have a protected `getSupportingFace()` method.