### PR TITLE
Make weakness status effect only applicable for melee damage

### DIFF
--- a/src/event/entity/EntityDamageByEntityEvent.php
+++ b/src/event/entity/EntityDamageByEntityEvent.php
@@ -57,7 +57,7 @@ class EntityDamageByEntityEvent extends EntityDamageEvent{
 				$this->setModifier($this->getBaseDamage() * 0.3 * $strength->getEffectLevel(), self::MODIFIER_STRENGTH);
 			}
 
-			if(($weakness = $effects->get(VanillaEffects::WEAKNESS())) !== null){
+			if(($weakness = $effects->get(VanillaEffects::WEAKNESS())) !== null && $this->getCause() === EntityDamageEvent::CAUSE_ENTITY_ATTACK){
 				$this->setModifier(-($this->getBaseDamage() * 0.2 * $weakness->getEffectLevel()), self::MODIFIER_WEAKNESS);
 			}
 		}


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Weakness effect is supposed to be applicable only to melee damage according to Minecraft Wiki.
> Melee damage inflicted by the affected entity is reduced by 4 (♥♥) x level in Java Edition. Negative levels increase melee damage dealt.
> 
> In Bedrock Edition, melee damage under the Weakness effect can be found through the equation Base > Damage × (0.8^level) + (((0.8^level) - 1) / 0.4) where Base Damage is the default attack damage with > whatever weapon or tool is used to attack.
> https://minecraft.fandom.com/wiki/Weakness


### Relevant issues
* Fixes #6280: restricting weakness effect to only melee damage (CAUSE_ENTITY_ATTACK) means weakness no longer procs on damage through instant damage potions (CAUSE_MAGIC).

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
No changes to API were made.

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
Weakness effect only applies to melee damage. Prior to this, the effect amplified damage from all entity-inflicted causes (e.g., from projectiles).

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
No backwards incompatible changes.

## Tests
<!--
PRs which have not been tested MUST be marked as draft.
-->
I tested this PR by doing the following (tick all that apply):
- [ ] Writing PHPUnit tests (commit these in the `tests/phpunit` folder)
- [x] Playtesting using a Minecraft client (provide screenshots or a video)
- [ ] Writing a test plugin (provide the code and sample output)
- [ ] Other (provide details)

https://github.com/user-attachments/assets/3a9d1475-63a9-449a-8186-5a79ef08f91e


