### PR TITLE
Fixed server crash when applying a cooldown to any item with 1 count

### DIFF
--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1625,7 +1625,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 			return false;
 		}
 
-		$this->resetItemCooldown($item);
+		$this->resetItemCooldown($oldItem);
 		$this->returnItemsFromAction($oldItem, $item, $returnedItems);
 
 		$this->setUsingItem($item instanceof Releasable && $item->canStartUsingItem($this));
@@ -1654,7 +1654,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 			}
 
 			$this->setUsingItem(false);
-			$this->resetItemCooldown($slot);
+			$this->resetItemCooldown($oldItem);
 
 			$slot->pop();
 			$this->returnItemsFromAction($oldItem, $slot, [$slot->getResidue()]);
@@ -1682,7 +1682,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 			$returnedItems = [];
 			$result = $item->onReleaseUsing($this, $returnedItems);
 			if($result === ItemUseResult::SUCCESS){
-				$this->resetItemCooldown($item);
+				$this->resetItemCooldown($oldItem);
 				$this->returnItemsFromAction($oldItem, $item, $returnedItems);
 				return true;
 			}


### PR DESCRIPTION
## Introduction
This was introduced in #6405

The crash happens because `ItemSerializer` can not serialize an item with 0 count in `onItemCooldownChanged()`. This can happen when you have 1 ender pearl since `resetItemCooldown()` is called only after a successful item usage, so ender pearl count is already decreased at this stage.

### Relevant issues
#6490
#6488

## Tests
https://www.youtube.com/watch?v=KSZC6mmEGk4
