### PR TITLE
Block break progress improvement

### DIFF
--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -865,6 +865,29 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		Timings::$playerChunkSend->stopTiming();
 	}
 
+	/**
+	 * Checks if the player is currently on the ground. This is more accurate than {@link Player::isOnGround()} but slower.
+	 */
+	public function isActuallyOnGround() : bool{
+		$bb = $this->boundingBox->expandedCopy(0, 0.001, 0);
+		$maxY = (int) floor($this->location->y);
+		$minY = $maxY - 1;
+		$floorMinX = (int) floor($bb->minX);
+		$floorMinZ = (int) floor($bb->minZ);
+		$floorMaxX = (int) floor($bb->maxX);
+		$floorMaxZ = (int) floor($bb->maxZ);
+		for ($x = $floorMinX ; $x <= $floorMaxX ; $x++) {
+			for ($y = $minY ; $y <= $maxY ; $y++) {
+				for ($z = $floorMinZ ; $z <= $floorMaxZ ; $z++) {
+					if ($this->getWorld()->getBlockAt($x, $y, $z)->collidesWithBB($bb)) {
+						return true;
+					}
+				}
+			}
+		}
+		return false;
+	}
+
 	private function recheckBroadcastPermissions() : void{
 		foreach([
 			DefaultPermissionNames::BROADCAST_ADMIN => Server::BROADCAST_CHANNEL_ADMINISTRATIVE,

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -869,7 +869,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 	 * Checks if the player is currently on the ground. This is more accurate than {@link Player::isOnGround()} but slower.
 	 */
 	public function isActuallyOnGround() : bool{
-		$bb = $this->boundingBox->expandedCopy(0, 0.001, 0);
+		$bb = $this->boundingBox->expandedCopy(-0.001, 0.001, -0.001);
 		$maxY = (int) floor($this->location->y);
 		$minY = $maxY - 1;
 		$floorMinX = (int) floor($bb->minX);

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -876,10 +876,10 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 		$floorMinZ = (int) floor($bb->minZ);
 		$floorMaxX = (int) floor($bb->maxX);
 		$floorMaxZ = (int) floor($bb->maxZ);
-		for ($x = $floorMinX ; $x <= $floorMaxX ; $x++) {
-			for ($y = $minY ; $y <= $maxY ; $y++) {
-				for ($z = $floorMinZ ; $z <= $floorMaxZ ; $z++) {
-					if ($this->getWorld()->getBlockAt($x, $y, $z)->collidesWithBB($bb)) {
+		for ($x = $floorMinX ; $x <= $floorMaxX ; $x++){
+			for ($y = $minY ; $y <= $maxY ; $y++){
+				for ($z = $floorMinZ ; $z <= $floorMaxZ ; $z++){
+					if ($this->getWorld()->getBlockAt($x, $y, $z)->collidesWithBB($bb)){
 						return true;
 					}
 				}

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1787,7 +1787,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 			return true;
 		}
 
-		if(!$this->isCreative() && !$block->getBreakInfo()->breaksInstantly()){
+		if(!$this->isCreative() && !$target->getBreakInfo()->breaksInstantly()){
 			$this->blockBreakHandler = new SurvivalBlockBreakHandler($this, $pos, $target, $face, 16);
 		}
 

--- a/src/player/SurvivalBlockBreakHandler.php
+++ b/src/player/SurvivalBlockBreakHandler.php
@@ -76,14 +76,19 @@ final class SurvivalBlockBreakHandler{
 		}
 		if($breakTimePerTick > 0){
 			$progressPerTick = 1 / $breakTimePerTick;
-			if ($this->player->getEffects()->has(VanillaEffects::HASTE())){
-				$amplifier = $this->player->getEffects()->get(VanillaEffects::HASTE())->getAmplifier() + 1;
+
+			$haste = $this->player->getEffects()->get(VanillaEffects::HASTE());
+			if ($haste !== null){
+				$amplifier = $haste->getAmplifier() + 1;
 				$progressPerTick *= (1 + 0.2 * $amplifier) * (1.2 ** $amplifier);
 			}
-			if ($this->player->getEffects()->has(VanillaEffects::MINING_FATIGUE())){
-				$amplifier = $this->player->getEffects()->get(VanillaEffects::MINING_FATIGUE())->getAmplifier() + 1;
+
+			$miningFatigue = $this->player->getEffects()->get(VanillaEffects::MINING_FATIGUE());
+			if ($miningFatigue !== null){
+				$amplifier = $miningFatigue->getAmplifier() + 1;
 				$progressPerTick *= 0.21 ** $amplifier;
 			}
+
 			return $progressPerTick;
 		}
 		return 1;

--- a/src/player/SurvivalBlockBreakHandler.php
+++ b/src/player/SurvivalBlockBreakHandler.php
@@ -79,14 +79,14 @@ final class SurvivalBlockBreakHandler{
 
 			$haste = $this->player->getEffects()->get(VanillaEffects::HASTE());
 			if ($haste !== null){
-				$amplifier = $haste->getAmplifier() + 1;
-				$progressPerTick *= (1 + 0.2 * $amplifier) * (1.2 ** $amplifier);
+				$hasteLevel = $haste->getEffectLevel();
+				$progressPerTick *= (1 + 0.2 * $hasteLevel) * (1.2 ** $hasteLevel);
 			}
 
 			$miningFatigue = $this->player->getEffects()->get(VanillaEffects::MINING_FATIGUE());
 			if ($miningFatigue !== null){
-				$amplifier = $miningFatigue->getAmplifier() + 1;
-				$progressPerTick *= 0.21 ** $amplifier;
+				$miningFatigueLevel = $miningFatigue->getEffectLevel();
+				$progressPerTick *= 0.21 ** $miningFatigueLevel;
 			}
 
 			return $progressPerTick;

--- a/src/player/SurvivalBlockBreakHandler.php
+++ b/src/player/SurvivalBlockBreakHandler.php
@@ -64,23 +64,23 @@ final class SurvivalBlockBreakHandler{
 	 * Returns the calculated break speed as percentage progress per game tick.
 	 */
 	private function calculateBreakProgressPerTick() : float{
-		if(!$this->block->getBreakInfo()->isBreakable()) {
+		if(!$this->block->getBreakInfo()->isBreakable()){
 			return 0.0;
 		}
 		$breakTimePerTick = $this->block->getBreakInfo()->getBreakTime($this->player->getInventory()->getItemInHand()) * 20;
-		if (!$this->player->isActuallyOnGround() && !$this->player->isFlying()) {
+		if (!$this->player->isActuallyOnGround() && !$this->player->isFlying()){
 			$breakTimePerTick *= 5;
 		}
-		if ($this->player->isUnderwater() && !$this->player->getArmorInventory()->getHelmet()->hasEnchantment(VanillaEnchantments::AQUA_AFFINITY())) {
+		if ($this->player->isUnderwater() && !$this->player->getArmorInventory()->getHelmet()->hasEnchantment(VanillaEnchantments::AQUA_AFFINITY())){
 			$breakTimePerTick *= 5;
 		}
-		if($breakTimePerTick > 0) {
+		if($breakTimePerTick > 0){
 			$progressPerTick = 1 / $breakTimePerTick;
-			if ($this->player->getEffects()->has(VanillaEffects::HASTE())) {
+			if ($this->player->getEffects()->has(VanillaEffects::HASTE())){
 				$amplifier = $this->player->getEffects()->get(VanillaEffects::HASTE())->getAmplifier() + 1;
 				$progressPerTick *= (1 + 0.2 * $amplifier) * (1.2 ** $amplifier);
 			}
-			if ($this->player->getEffects()->has(VanillaEffects::MINING_FATIGUE())) {
+			if ($this->player->getEffects()->has(VanillaEffects::MINING_FATIGUE())){
 				$amplifier = $this->player->getEffects()->get(VanillaEffects::MINING_FATIGUE())->getAmplifier() + 1;
 				$progressPerTick *= 0.21 ** $amplifier;
 			}


### PR DESCRIPTION
Fixes block break progress being inaccurate when not on ground or swimming. Also fixes syncing block break speed with client.

### Related issues & PRs
* Related to #211 

## Changes
### API changes
Added Player::isActuallyOnGround(), more accurate than Player::isOnGround() but slower.

### Behavioural changes
Block breaking progress is now much closer to vanilla.

## In-Game Testing
Before:  
https://github.com/user-attachments/assets/22f50b6e-f994-4a17-8dfc-53df70a8d6eb  
After:  
https://github.com/user-attachments/assets/3341eaaf-2bbc-4ac1-ad35-39947e907080