### PR TITLE
Fix: implicitly nullable parameter declarations deprecated in PHP 8.4

### DIFF
--- a/src/world/World.php
+++ b/src/world/World.php
@@ -2037,7 +2037,7 @@ class World implements ChunkManager{
 	 * @param Item[] &$returnedItems Items to be added to the target's inventory (or dropped, if the inventory is full)
 	 * @phpstan-param-out Item $item
 	 */
-	public function useBreakOn(Vector3 $vector, Item &$item = null, ?Player $player = null, bool $createParticles = false, array &$returnedItems = []) : bool{
+	public function useBreakOn(Vector3 $vector, ?Item &$item = null, ?Player $player = null, bool $createParticles = false, array &$returnedItems = []) : bool{
 		$vector = $vector->floor();
 
 		$chunkX = $vector->getFloorX() >> Chunk::COORD_BIT_SIZE;


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecate-implicitly-nullable-types