### PR TITLE
Fix insta break check

### DIFF
--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1764,7 +1764,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 			return true;
 		}
 
-		if(!$this->isCreative() && !$block->getBreakInfo()->breaksInstantly()){
+		if(!$this->isCreative() && !$target->getBreakInfo()->breaksInstantly()){
 			$this->blockBreakHandler = new SurvivalBlockBreakHandler($this, $pos, $target, $face, 16);
 		}
 


### PR DESCRIPTION
Makes the insta break check run on the correct block when mining

### Related issues & PRs
<!--
* Related to #6500
-->

## Changes

### Behavioural changes
When mining a block behind a block that breaks instantly such as a torch the break progress indicator will now show


See https://github.com/pmmp/PocketMine-MP/pull/6500#discussion_r1848990909