### PR TITLE
Implemented the correct walking speed for the slime block

### DIFF
--- a/src/block/Slime.php
+++ b/src/block/Slime.php
@@ -28,6 +28,8 @@ use pocketmine\entity\Living;
 
 final class Slime extends Transparent{
 
+	private float $speedMultiplier = 0.4;
+
 	public function getFrictionFactor() : float{
 		return 0.8; //???
 	}
@@ -40,5 +42,16 @@ final class Slime extends Transparent{
 		return -$entity->getMotion()->y;
 	}
 
-	//TODO: slime blocks should slow entities walking on them to about 0.4x original speed
+	public function onEntityWalking(Entity $entity) : void{
+        $motion = $entity->getMotion();
+        $entity->setMotion($motion->multiply($this->speedMultiplier));
+    }
+
+    public function setSpeedMultiplier(float $multiplier) : void{
+        $this->speedMultiplier = $multiplier;
+    }
+
+    public function getSpeedMultiplier() : float{
+        return $this->speedMultiplier;
+    }
 }

--- a/src/block/Slime.php
+++ b/src/block/Slime.php
@@ -48,10 +48,13 @@ final class Slime extends Transparent{
     }
 
     public function setSpeedMultiplier(float $multiplier) : void{
+        if ($multiplier < 0) {
+            throw new \InvalidArgumentException("Speed multiplier cannot be negative: $multiplier");
+        }
         $this->speedMultiplier = $multiplier;
     }
 
-    public function getSpeedMultiplier() : float{
+    public function getSpeedMultiplier() : float {
         return $this->speedMultiplier;
     }
 }


### PR DESCRIPTION
<!-- Summarize your PR here. Keep it short and simple. -->
This PR implements the default walking speed of (0.4) as the “TODO” suggest and added new methods to modify the walking speed or get the walking speed of the slime block.

I sorta guessed what that “TODO” meant.
