### PR TITLE
Added support for infinite duration effects

### DIFF
--- a/src/command/defaults/EffectCommand.php
+++ b/src/command/defaults/EffectCommand.php
@@ -73,12 +73,17 @@ class EffectCommand extends VanillaCommand{
 		}
 
 		$amplification = 0;
+		$infinite = false;
 
 		if(count($args) >= 3){
-			if(($d = $this->getBoundedInt($sender, $args[2], 0, (int) (Limits::INT32_MAX / 20))) === null){
+			if($args[2] === "infinite") {
+				$infinite = true;
+				$duration = null;
+			}elseif(($d = $this->getBoundedInt($sender, $args[2], 0, (int) (Limits::INT32_MAX / 20))) === null){
 				return false;
+			}else{
+				$duration = $d * 20; //ticks
 			}
-			$duration = $d * 20; //ticks
 		}else{
 			$duration = null;
 		}
@@ -112,8 +117,14 @@ class EffectCommand extends VanillaCommand{
 			$sender->sendMessage(KnownTranslationFactory::commands_effect_success_removed($effect->getName(), $player->getDisplayName()));
 		}else{
 			$instance = new EffectInstance($effect, $duration, $amplification, $visible);
+			if($infinite) {
+				$instance->setInfinite();
+			}
 			$effectManager->add($instance);
-			self::broadcastCommandMessage($sender, KnownTranslationFactory::commands_effect_success($effect->getName(), (string) $instance->getAmplifier(), $player->getDisplayName(), (string) ($instance->getDuration() / 20)));
+			self::broadcastCommandMessage($sender, $infinite
+				? KnownTranslationFactory::commands_effect_success_infinite($effect->getName(), (string) $instance->getAmplifier(), $player->getDisplayName())
+				: KnownTranslationFactory::commands_effect_success($effect->getName(), (string) $instance->getAmplifier(), $player->getDisplayName(), (string) ($instance->getDuration() / 20))
+			);
 		}
 
 		return true;

--- a/src/entity/effect/EffectInstance.php
+++ b/src/entity/effect/EffectInstance.php
@@ -66,8 +66,8 @@ class EffectInstance{
 	 * @return $this
 	 */
 	public function setDuration(int $duration) : EffectInstance{
-		if($duration < 0 || $duration > Limits::INT32_MAX){
-			throw new \InvalidArgumentException("Effect duration must be in range 0 - " . Limits::INT32_MAX . ", got $duration");
+		if($duration < -1 || $duration > Limits::INT32_MAX){
+			throw new \InvalidArgumentException("Effect duration must be in range -1 (infinite) - " . Limits::INT32_MAX . ", got $duration");
 		}
 		$this->duration = $duration;
 
@@ -80,7 +80,9 @@ class EffectInstance{
 	 * @return $this
 	 */
 	public function decreaseDuration(int $ticks) : EffectInstance{
-		$this->duration = max(0, $this->duration - $ticks);
+		if(!$this->isInfinite()) {
+			$this->duration = max(0, $this->duration - $ticks);
+		}
 
 		return $this;
 	}
@@ -89,7 +91,7 @@ class EffectInstance{
 	 * Returns whether the duration has run out.
 	 */
 	public function hasExpired() : bool{
-		return $this->duration <= 0;
+		return !$this->isInfinite() && $this->duration <= 0;
 	}
 
 	public function getAmplifier() : int{
@@ -173,5 +175,21 @@ class EffectInstance{
 		$this->color = $this->effectType->getColor();
 
 		return $this;
+	}
+
+	/**
+	 * Set if effect duration is infinite, does not expire.
+	 */
+	public function setInfinite() : EffectInstance{
+		$this->duration = -1;
+
+		return $this;
+	}
+
+	/**
+	 *	Returns if effect duration is infinite.
+	 */
+	public function isInfinite() : bool{
+		return $this->duration === -1;
 	}
 }

--- a/src/lang/KnownTranslationFactory.php
+++ b/src/lang/KnownTranslationFactory.php
@@ -235,6 +235,14 @@ final class KnownTranslationFactory{
 		]);
 	}
 
+	public static function commands_effect_success_infinite(Translatable|string $param0, Translatable|string $param1, Translatable|string $param2) : Translatable{
+		return new Translatable(KnownTranslationKeys::COMMANDS_EFFECT_SUCCESS_INFINITE, [
+			0 => $param0,
+			1 => $param1,
+			2 => $param2,
+		]);
+	}
+
 	public static function commands_effect_success_removed(Translatable|string $param0, Translatable|string $param1) : Translatable{
 		return new Translatable(KnownTranslationKeys::COMMANDS_EFFECT_SUCCESS_REMOVED, [
 			0 => $param0,

--- a/src/lang/KnownTranslationKeys.php
+++ b/src/lang/KnownTranslationKeys.php
@@ -68,6 +68,7 @@ final class KnownTranslationKeys{
 	public const COMMANDS_EFFECT_FAILURE_NOTACTIVE_ALL = "commands.effect.failure.notActive.all";
 	public const COMMANDS_EFFECT_NOTFOUND = "commands.effect.notFound";
 	public const COMMANDS_EFFECT_SUCCESS = "commands.effect.success";
+	public const COMMANDS_EFFECT_SUCCESS_INFINITE = "commands.effect.success.infinite";
 	public const COMMANDS_EFFECT_SUCCESS_REMOVED = "commands.effect.success.removed";
 	public const COMMANDS_EFFECT_SUCCESS_REMOVED_ALL = "commands.effect.success.removed.all";
 	public const COMMANDS_EFFECT_USAGE = "commands.effect.usage";


### PR DESCRIPTION
# Infinite effects

> Added setInfinite and isInfinite methods to EffectInstance.
> Added infinite argument to /effect command to make effect infinite.
> Added a new KnowTranslation: “commands.effect.success.infinite”.