### PR TITLE
Use PlayerAuthInputPacket::SNEAKING flag to test for sneaking

### DIFF
--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -215,7 +215,10 @@ class InGamePacketHandler extends PacketHandler{
 		if($inputFlags !== $this->lastPlayerAuthInputFlags){
 			$this->lastPlayerAuthInputFlags = $inputFlags;
 
-			$sneaking = $this->resolveOnOffInputFlags($inputFlags, PlayerAuthInputFlags::START_SNEAKING, PlayerAuthInputFlags::STOP_SNEAKING);
+			$sneaking = $packet->hasFlag(PlayerAuthInputFlags::SNEAKING);
+			if($this->player->isSneaking() === $sneaking){
+				$sneaking = null;
+			}
 			$sprinting = $this->resolveOnOffInputFlags($inputFlags, PlayerAuthInputFlags::START_SPRINTING, PlayerAuthInputFlags::STOP_SPRINTING);
 			$swimming = $this->resolveOnOffInputFlags($inputFlags, PlayerAuthInputFlags::START_SWIMMING, PlayerAuthInputFlags::STOP_SWIMMING);
 			$gliding = $this->resolveOnOffInputFlags($inputFlags, PlayerAuthInputFlags::START_GLIDING, PlayerAuthInputFlags::STOP_GLIDING);


### PR DESCRIPTION
`PlayerAuthInputPacket::SNEAKING` flag covers the case where a player is sneaking during flight, something which `START_SNEAKING` & `STOP_SNEAKING` currently do not.

<!-- Summarize your PR here. Keep it short and simple. -->
<!-- Explain existing problems or why this pull request is necessary -->

### Related issues & PRs
<!--
* Fixes #1
* Related to #2
-->
* Fixes #5792 - sneaking during flight would cause ghost block to appear when placing block against a chest
* Fixes #5903 - players could not place blocks when within the 1.5 block space (i.e., under a slab)

## Changes
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
<!-- If not, you can delete this section -->
The server now correctly recognizes players who are sneaking while flying. Players are once again able to place blocks against interactable blocks (like chests and item frames) while in this state (without triggering block interaction). When under a slab (1.5 block space), players can place blocks and must explicitly sneak (on PC, by pressing shift key) to perform the usual sneak functionality.

## Tests
<!--
If this PR affects gameplay or user experience in some way, it must be manually tested.
Include any screenshots or videos of manual testing here.
Any test plugin code should also be pasted here if it can't be adapted to a PHPUnit test.
-->
```php
// Debug chat message to test whether PlayerToggleSneakEvent is triggered as expected
// (i.e., no duplicate event calls, sneak event is initiated and terminated at proper times)
$plugin->getServer()->getPluginManager()->registerEvent(PlayerToggleSneakEvent::class, function(PlayerToggleSneakEvent $event) : void{
	$event->getPlayer()->sendMessage(gmdate("Y-m-d H:i:s.v") . ": sneaking=" . ($event->isSneaking() ? "yes" : "no"));
}, EventPriority::MONITOR, $plugin);
```
https://github.com/user-attachments/assets/dd4ec2fb-6785-4dbd-8f86-ad215943a406

https://github.com/user-attachments/assets/309a87ea-0503-44f2-b668-d7e70827fb28