### PR TITLE
Fixed CrashDump incorrectly detecting phar core crashes as plugin crashes

### DIFF
--- a/build/server-phar-stub.php
+++ b/build/server-phar-stub.php
@@ -25,6 +25,7 @@ namespace pocketmine\server_phar_stub;
 
 use function clearstatcache;
 use function copy;
+use function define;
 use function fclose;
 use function fflush;
 use function flock;
@@ -165,4 +166,5 @@ $start = hrtime(true);
 $cacheName = preparePharCache($tmpDir, __FILE__);
 echo "Cache ready at $cacheName in " . number_format((hrtime(true) - $start) / 1e9, 2) . "s\n";
 
+define('pocketmine\ORIGINAL_PHAR_PATH', __FILE__);
 require 'phar://' . str_replace(DIRECTORY_SEPARATOR, '/', $cacheName) . '/src/PocketMine.php';

--- a/src/PocketMine.php
+++ b/src/PocketMine.php
@@ -282,6 +282,11 @@ JIT_WARNING
 			exit(0);
 		}
 
+		if(defined('pocketmine\ORIGINAL_PHAR_PATH')){
+			//if we're inside a phar cache, \pocketmine\PATH will not include the original phar
+			Filesystem::addCleanedPath(ORIGINAL_PHAR_PATH, Filesystem::CLEAN_PATH_SRC_PREFIX);
+		}
+
 		$cwd = Utils::assumeNotFalse(realpath(Utils::assumeNotFalse(getcwd())));
 		$dataPath = getopt_string(BootstrapOptions::DATA) ?? $cwd;
 		$pluginPath = getopt_string(BootstrapOptions::PLUGINS) ?? $cwd . DIRECTORY_SEPARATOR . "plugins";


### PR DESCRIPTION
fixes #6563

Since #6217 was merged, \pocketmine\PATH no longer includes the path of the original phar. This means that the frame originating from the phar stub would not get its path cleaned up, leading to it being incorrectly detected as a plugin frame.


<!-- Summarize your PR here. Keep it short and simple. -->
<!-- Explain existing problems or why this pull request is necessary -->

### Related issues & PRs
Fixes #6563 
Related to #6217 

## Changes
### Behavioural changes
Restored the original treatment of the phar stub pre merge of #6217.

## Follow-up

We should probably explore better methods of detecting plugin crashes in the future; however this fix should solve the immediate issue.

## Tests
Tested on Windows in phar and src form with the following modification:
```diff
diff --git a/src/Server.php b/src/Server.php
index 9003a7f9c..ed1f10ce4 100644
--- a/src/Server.php
+++ b/src/Server.php
@@ -1724,6 +1724,7 @@ class Server{
        }

        private function tickProcessor() : void{
+               throw new \RuntimeException();
                $this->nextTick = microtime(true);

                while($this->isRunning){
```
In src mode, no change is seen.
In phar mode, the following change is seen:
Before:
```
  #3 C:/Users/dylan-work/Documents/projects/pocketmine-mp/stable/PocketMine-MP.phar(172): require(string[107] phar://C:/Users/dylan-work/AppData/Local/Temp/PocketMine-MP-phar-cache.1/PMM8085)
```
After
```
  #3 pmsrc(170): require(string[107] phar://C:/Users/dylan-work/AppData/Local/Temp/PocketMine-MP-phar-cache.1/PMM1E60)
```
The line containing `PocketMine-MP.phar` is now reduced to `pmsrc` as it was before #6217, reversing the breakage.