### PR TITLE
Process SkinData asynchronously

### DIFF
--- a/src/network/mcpe/ProcessSkinTask.php
+++ b/src/network/mcpe/ProcessSkinTask.php
@@ -31,7 +31,7 @@ use pocketmine\scheduler\AsyncTask;
 use pocketmine\thread\NonThreadSafeValue;
 
 class ProcessSkinTask extends AsyncTask{
-	private const KEY_ON_COMPLETION = "onCompletion";
+	private const TLS_KEY_ON_COMPLETION = "onCompletion";
 
 	private ?string $error = "Unknown";
 	/** @var NonThreadSafeValue<SkinData> */
@@ -45,7 +45,7 @@ class ProcessSkinTask extends AsyncTask{
 		\Closure $callback,
 	){
 		$this->skinData = new NonThreadSafeValue($skinData);
-		$this->storeLocal(self::KEY_ON_COMPLETION, $callback);
+		$this->storeLocal(self::TLS_KEY_ON_COMPLETION, $callback);
 	}
 
 	public function onRun() : void{
@@ -62,7 +62,7 @@ class ProcessSkinTask extends AsyncTask{
 		/** @var Skin|null $result */
 		$result = $this->getResult();
 		/** @var \Closure(?Skin $skin,?string $error) : void $callback */
-		$callback = $this->fetchLocal(self::KEY_ON_COMPLETION);
+		$callback = $this->fetchLocal(self::TLS_KEY_ON_COMPLETION);
 		($callback)($result, $this->error);
 	}
 }

--- a/src/network/mcpe/ProcessSkinTask.php
+++ b/src/network/mcpe/ProcessSkinTask.php
@@ -59,10 +59,8 @@ class ProcessSkinTask extends AsyncTask{
 	}
 
 	public function onCompletion() : void{
+		/** @var Skin|null $result */
 		$result = $this->getResult();
-		if(!($result instanceof Skin)){
-			$result = null;
-		}
 		/** @var \Closure(?Skin $skin,?string $error) : void $callback */
 		$callback = $this->fetchLocal(self::KEY_ON_COMPLETION);
 		($callback)($result, $this->error);

--- a/src/network/mcpe/ProcessSkinTask.php
+++ b/src/network/mcpe/ProcessSkinTask.php
@@ -63,6 +63,6 @@ class ProcessSkinTask extends AsyncTask{
 		$result = $this->getResult();
 		/** @var \Closure(?Skin $skin,?string $error) : void $callback */
 		$callback = $this->fetchLocal(self::TLS_KEY_ON_COMPLETION);
-		($callback)($result, $this->error);
+		$callback($result, $this->error);
 	}
 }

--- a/src/network/mcpe/ProcessSkinTask.php
+++ b/src/network/mcpe/ProcessSkinTask.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\network\mcpe;
+
+use pocketmine\entity\InvalidSkinException;
+use pocketmine\entity\Skin;
+use pocketmine\network\mcpe\convert\TypeConverter;
+use pocketmine\network\mcpe\protocol\types\skin\SkinData;
+use pocketmine\scheduler\AsyncTask;
+use pocketmine\thread\NonThreadSafeValue;
+
+class ProcessSkinTask extends AsyncTask{
+	private const KEY_ON_COMPLETION = "onCompletion";
+
+	private ?string $error = "Unknown";
+	/** @var NonThreadSafeValue<SkinData> */
+	private NonThreadSafeValue $skinData;
+
+	/**
+	 * @param \Closure(?Skin $skin,?string $error) : void $callback
+	 */
+	public function __construct(
+		SkinData $skinData,
+		\Closure $callback,
+	){
+		$this->skinData = new NonThreadSafeValue($skinData);
+		$this->storeLocal(self::KEY_ON_COMPLETION, $callback);
+	}
+
+	public function onRun() : void{
+		try{
+			$skin = TypeConverter::getInstance()->getSkinAdapter()->fromSkinData($this->skinData->deserialize());
+			$this->setResult($skin);
+			$this->error = null;
+		}catch(\InvalidArgumentException|InvalidSkinException $e){
+			$this->error = $e->getMessage();
+		}
+	}
+
+	public function onCompletion() : void{
+		$result = $this->getResult();
+		if(!($result instanceof Skin)){
+			$result = null;
+		}
+		/** @var \Closure(?Skin $skin,?string $error) : void $callback */
+		$callback = $this->fetchLocal(self::KEY_ON_COMPLETION);
+		($callback)($result, $this->error);
+	}
+}

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -848,6 +848,9 @@ class InGamePacketHandler extends PacketHandler{
 		$this->player->getServer()->getAsyncPool()->submitTask(new ProcessSkinTask(
 			$packet->skin,
 			function(?Skin $skin, ?string $error) use ($packet) : void{
+				if(!$this->session->isConnected()){
+					return;
+				}
 				if($error !== null){
 					$this->session->disconnectWithError(
 						reason: "Invalid skin: " . $error,

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -29,7 +29,7 @@ use pocketmine\block\tile\Sign;
 use pocketmine\block\utils\SignText;
 use pocketmine\entity\animation\ConsumingItemAnimation;
 use pocketmine\entity\Attribute;
-use pocketmine\entity\InvalidSkinException;
+use pocketmine\entity\Skin;
 use pocketmine\event\player\PlayerEditBookEvent;
 use pocketmine\inventory\transaction\action\DropItemAction;
 use pocketmine\inventory\transaction\InventoryTransaction;
@@ -40,12 +40,14 @@ use pocketmine\item\VanillaItems;
 use pocketmine\item\WritableBook;
 use pocketmine\item\WritableBookPage;
 use pocketmine\item\WrittenBook;
+use pocketmine\lang\KnownTranslationFactory;
 use pocketmine\math\Facing;
 use pocketmine\math\Vector3;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\StringTag;
 use pocketmine\network\mcpe\InventoryManager;
 use pocketmine\network\mcpe\NetworkSession;
+use pocketmine\network\mcpe\ProcessSkinTask;
 use pocketmine\network\mcpe\protocol\ActorEventPacket;
 use pocketmine\network\mcpe\protocol\ActorPickRequestPacket;
 use pocketmine\network\mcpe\protocol\AnimatePacket;
@@ -843,12 +845,23 @@ class InGamePacketHandler extends PacketHandler{
 		$this->lastRequestedFullSkinId = $packet->skin->getFullSkinId();
 
 		$this->session->getLogger()->debug("Processing skin change request");
-		try{
-			$skin = $this->session->getTypeConverter()->getSkinAdapter()->fromSkinData($packet->skin);
-		}catch(InvalidSkinException $e){
-			throw PacketHandlingException::wrap($e, "Invalid skin in PlayerSkinPacket");
-		}
-		return $this->player->changeSkin($skin, $packet->newSkinName, $packet->oldSkinName);
+		$this->player->getServer()->getAsyncPool()->submitTask(new ProcessSkinTask(
+			$packet->skin,
+			function(?Skin $skin, ?string $error) use ($packet) : void{
+				if($error !== null){
+					$this->session->disconnectWithError(
+						reason: "Invalid skin: " . $error,
+						disconnectScreenMessage: KnownTranslationFactory::disconnectionScreen_invalidSkin()
+					);
+					return;
+				}
+				if($skin !== null){
+					$this->player->changeSkin($skin, $packet->newSkinName, $packet->oldSkinName);
+					$this->session->getLogger()->debug("Skin change request processed");
+				}
+			}
+		));
+		return true;
 	}
 
 	public function handleSubClientLogin(SubClientLoginPacket $packet) : bool{

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -859,7 +859,7 @@ class InGamePacketHandler extends PacketHandler{
 					return;
 				}
 				if($skin !== null){
-					if ($currentFullSkinId !== $this->lastRequestedFullSkinId) {
+					if($currentFullSkinId !== $this->lastRequestedFullSkinId){
 						$this->session->getLogger()->debug("Skin change request ignored due to newer skin change");
 						return;
 					}

--- a/src/network/mcpe/handler/LoginPacketHandler.php
+++ b/src/network/mcpe/handler/LoginPacketHandler.php
@@ -99,7 +99,7 @@ class LoginPacketHandler extends PacketHandler{
 		if(!Uuid::isValid($extraData->identity)){
 			$this->session->disconnectWithError(
 				reason: "Invalid login uuid",
-				disconnectScreenMessage: KnownTranslationFactory::disconnectionScreen_notAuthenticated()
+				disconnectScreenMessage: KnownTranslationFactory::pocketmine_disconnect_error_badPacket()
 			);
 			return;
 		}

--- a/src/network/mcpe/handler/LoginPacketHandler.php
+++ b/src/network/mcpe/handler/LoginPacketHandler.php
@@ -75,6 +75,9 @@ class LoginPacketHandler extends PacketHandler{
 		$this->server->getAsyncPool()->submitTask(new ProcessSkinTask(
 			ClientDataToSkinDataHelper::fromClientData($clientData),
 			function(?Skin $skin, ?string $error) use ($packet, $clientData, $extraData){
+				if(!$this->session->isConnected()){
+					return;
+				}
 				if($error !== null){
 					$this->session->disconnectWithError(
 						reason: "Invalid skin: " . $error,


### PR DESCRIPTION
### Summary

https://github.com/pmmp/PocketMine-MP/blob/fbaa125d0ce21ffef98fc1630881a92bedfbaa73/src/entity/Skin.php#L69-L74

This pull request optimizes the processing of player geometry data by offloading skin decoding to a `ProcessSkinTask`. This change addresses potential server freezes caused by the decoding of overly complex JSON structures.

### Existing Problems
Decoding geometry data directly in the main thread was a time-intensive operation, especially when the JSON data was highly complex, leading to server performance issues or even temporary freezes.

- **Before patch**: [Timings report](https://timings.pmmp.io/?id=339888)  
- **After patch**: [Timings report](https://timings.pmmp.io/?id=339887)  

### Changes
- Offloaded the skin geometry decoding to an asynchronous task (`ProcessSkinTask`) to prevent the main thread from being froze.

### Behavioural Changes
- Players' skin geometry data will now be processed asynchronously.
- Reduced risk of server performance degradation during skin decoding.

### Backwards Compatibility
This change is fully backward compatible, as it does not modify the API or the format of geometry data. Existing player skins and data handling will continue to work without modification.

### Follow-up
- Monitor server performance post-deployment to ensure stability.

### Tests
- Verified that skin geometry data is correctly decoded when processed via `ProcessSkinTask`.
- Tested gameplay to confirm no adverse effects on player skins or entity rendering.
- Compared server performance before and after the patch, as reflected in the timings reports.