### PR TITLE
Optimise collision box checks by caching some basic info

### DIFF
--- a/src/block/RuntimeBlockStateRegistry.php
+++ b/src/block/RuntimeBlockStateRegistry.php
@@ -113,6 +113,70 @@ class RuntimeBlockStateRegistry{
 		}
 	}
 
+	/**
+	 * Checks if the given class method overrides a method in Block.
+	 * Used to determine if a block might need to disable fast path optimizations.
+	 *
+	 * @phpstan-param anyClosure $closure
+	 */
+	private static function overridesBlockMethod(\Closure $closure) : bool{
+		$declarer = (new \ReflectionFunction($closure))->getClosureScopeClass();
+		return $declarer !== null && $declarer->getName() !== Block::class;
+	}
+
+	/**
+	 * A big ugly hack to set up fast paths for handling collisions on blocks with common shapes.
+	 * The information returned here is stored in RuntimeBlockStateRegistry->collisionInfo, and is used during entity
+	 * collision box calculations to avoid complex logic and unnecessary block object allocations.
+	 * This hack allows significant performance improvements.
+	 *
+	 * TODO: We'll want to redesign block collision box handling and block shapes in the future, but that's a job for a
+	 * major version. For now, this hack nets major performance wins.
+	 */
+	private static function calculateCollisionInfo(Block $block) : int{
+		if(
+			self::overridesBlockMethod($block->getModelPositionOffset(...)) ||
+			self::overridesBlockMethod($block->readStateFromWorld(...))
+		){
+			//getModelPositionOffset() might cause AABBs to shift outside the cell
+			//readStateFromWorld() might cause overflow in ways we can't predict just by looking at known states
+			//TODO: excluding overriders of readStateFromWorld() also excludes blocks with tiles that don't do anything
+			//weird with their AABBs, but for now this is the best we can do.
+			return self::COLLISION_MAY_OVERFLOW;
+		}
+
+		//TODO: this could blow up if any recalculateCollisionBoxes() uses the world
+		//it shouldn't, but that doesn't mean that custom blocks won't...
+		$boxes = $block->getCollisionBoxes();
+		if(count($boxes) === 0){
+			return self::COLLISION_NONE;
+		}
+
+		if(
+			count($boxes) === 1 &&
+			$boxes[0]->minX === 0.0 &&
+			$boxes[0]->minY === 0.0 &&
+			$boxes[0]->minZ === 0.0 &&
+			$boxes[0]->maxX === 1.0 &&
+			$boxes[0]->maxY === 1.0 &&
+			$boxes[0]->maxZ === 1.0
+		){
+			return self::COLLISION_CUBE;
+		}
+
+		foreach($boxes as $box){
+			if(
+				$box->minX < 0 || $box->maxX > 1 ||
+				$box->minY < 0 || $box->maxY > 1 ||
+				$box->minZ < 0 || $box->maxZ > 1
+			){
+				return self::COLLISION_MAY_OVERFLOW;
+			}
+		}
+
+		return self::COLLISION_CUSTOM;
+	}
+
 	private function fillStaticArrays(int $index, Block $block) : void{
 		$fullId = $block->getStateId();
 		if($index !== $fullId){
@@ -126,44 +190,7 @@ class RuntimeBlockStateRegistry{
 				$this->blocksDirectSkyLight[$index] = true;
 			}
 
-			$declarer = (new \ReflectionFunction($block->getModelPositionOffset(...)))->getClosureScopeClass();
-			if($declarer === null){
-				throw new AssumptionFailedError("We know this is a class method");
-			}
-			if($declarer->getName() !== Block::class){
-				$this->collisionInfo[$index] = self::COLLISION_MAY_OVERFLOW;
-			}else{
-				//TODO: this could blow up if any recalculateCollisionBoxes() uses the world
-				//it shouldn't, but that doesn't mean that custom blocks won't...
-				$boxes = $block->getCollisionBoxes();
-				if(count($boxes) === 0){
-					$this->collisionInfo[$index] = self::COLLISION_NONE;
-				}elseif(
-					count($boxes) === 1 &&
-					$boxes[0]->minX === 0.0 &&
-					$boxes[0]->minY === 0.0 &&
-					$boxes[0]->minZ === 0.0 &&
-					$boxes[0]->maxX === 1.0 &&
-					$boxes[0]->maxY === 1.0 &&
-					$boxes[0]->maxZ === 1.0
-				){
-					$this->collisionInfo[$index] = self::COLLISION_CUBE;
-				}else{
-					$info = self::COLLISION_CUSTOM;
-					foreach($boxes as $box){
-						if(
-							$box->minX < 0 || $box->maxX > 1 ||
-							$box->minY < 0 || $box->maxY > 1 ||
-							$box->minZ < 0 || $box->maxZ > 1
-						){
-							$info = self::COLLISION_MAY_OVERFLOW;
-							break;
-						}
-					}
-
-					$this->collisionInfo[$index] = $info;
-				}
-			}
+			$this->collisionInfo[$index] = self::calculateCollisionInfo($block);
 		}
 	}
 

--- a/src/block/RuntimeBlockStateRegistry.php
+++ b/src/block/RuntimeBlockStateRegistry.php
@@ -133,6 +133,8 @@ class RuntimeBlockStateRegistry{
 			if($declarer->getName() !== Block::class){
 				$this->collisionInfo[$index] = self::COLLISION_MAY_OVERFLOW;
 			}else{
+				//TODO: this could blow up if any recalculateCollisionBoxes() uses the world
+				//it shouldn't, but that doesn't mean that custom blocks won't...
 				$boxes = $block->getCollisionBoxes();
 				if(count($boxes) === 0){
 					$this->collisionInfo[$index] = self::COLLISION_NONE;
@@ -148,10 +150,7 @@ class RuntimeBlockStateRegistry{
 					$this->collisionInfo[$index] = self::COLLISION_CUBE;
 				}else{
 					$info = self::COLLISION_CUSTOM;
-
-					//TODO: this could blow up if any recalculateCollisionBoxes() uses the world
-					//it shouldn't, but that doesn't mean that custom blocks won't...
-					foreach($block->getCollisionBoxes() as $box){
+					foreach($boxes as $box){
 						if(
 							$box->minX < 0 || $box->maxX > 1 ||
 							$box->minY < 0 || $box->maxY > 1 ||

--- a/src/block/RuntimeBlockStateRegistry.php
+++ b/src/block/RuntimeBlockStateRegistry.php
@@ -40,6 +40,11 @@ use function min;
 class RuntimeBlockStateRegistry{
 	use SingletonTrait;
 
+	public const COLLISION_CUSTOM = 0;
+	public const COLLISION_CUBE = 1;
+	public const COLLISION_NONE = 2;
+	public const COLLISION_MAY_OVERFLOW = 3;
+
 	/**
 	 * @var Block[]
 	 * @phpstan-var array<int, Block>
@@ -73,6 +78,13 @@ class RuntimeBlockStateRegistry{
 	 * @phpstan-var array<int, float>
 	 */
 	public array $blastResistance = [];
+
+	/**
+	 * Map of state ID -> useful AABB info to avoid unnecessary block allocations
+	 * @var int[]
+	 * @phpstan-var array<int, int>
+	 */
+	public array $collisionInfo = [];
 
 	public function __construct(){
 		foreach(VanillaBlocks::getAll() as $block){
@@ -111,6 +123,46 @@ class RuntimeBlockStateRegistry{
 			$this->lightFilter[$index] = min(15, $block->getLightFilter() + LightUpdate::BASE_LIGHT_FILTER);
 			if($block->blocksDirectSkyLight()){
 				$this->blocksDirectSkyLight[$index] = true;
+			}
+
+			$declarer = (new \ReflectionFunction($block->getModelPositionOffset(...)))->getClosureScopeClass();
+			if($declarer === null){
+				throw new AssumptionFailedError("We know this is a class method");
+			}
+			if($declarer->getName() !== Block::class){
+				$this->collisionInfo[$index] = self::COLLISION_MAY_OVERFLOW;
+			}else{
+				$boxes = $block->getCollisionBoxes();
+				if(count($boxes) === 0){
+					$this->collisionInfo[$index] = self::COLLISION_NONE;
+				}elseif(
+					count($boxes) === 1 &&
+					$boxes[0]->minX === 0.0 &&
+					$boxes[0]->minY === 0.0 &&
+					$boxes[0]->minZ === 0.0 &&
+					$boxes[0]->maxX === 1.0 &&
+					$boxes[0]->maxY === 1.0 &&
+					$boxes[0]->maxZ === 1.0
+				){
+					$this->collisionInfo[$index] = self::COLLISION_CUBE;
+				}else{
+					$info = self::COLLISION_CUSTOM;
+
+					//TODO: this could blow up if any recalculateCollisionBoxes() uses the world
+					//it shouldn't, but that doesn't mean that custom blocks won't...
+					foreach($block->getCollisionBoxes() as $box){
+						if(
+							$box->minX < 0 || $box->maxX > 1 ||
+							$box->minY < 0 || $box->maxY > 1 ||
+							$box->minZ < 0 || $box->maxZ > 1
+						){
+							$info = self::COLLISION_MAY_OVERFLOW;
+							break;
+						}
+					}
+
+					$this->collisionInfo[$index] = $info;
+				}
 			}
 		}
 	}

--- a/src/block/RuntimeBlockStateRegistry.php
+++ b/src/block/RuntimeBlockStateRegistry.php
@@ -28,6 +28,7 @@ use pocketmine\block\BlockIdentifier as BID;
 use pocketmine\utils\AssumptionFailedError;
 use pocketmine\utils\SingletonTrait;
 use pocketmine\world\light\LightUpdate;
+use function count;
 use function min;
 
 /**

--- a/src/world/World.php
+++ b/src/world/World.php
@@ -1574,16 +1574,16 @@ class World implements ChunkManager{
 			->getChunk($x >> Chunk::COORD_BIT_SIZE, $z >> Chunk::COORD_BIT_SIZE)
 			?->getBlockStateId($x & Chunk::COORD_MASK, $y, $z & Chunk::COORD_MASK) ?? Block::EMPTY_STATE_ID;
 
-		$cellBB = null;
 		$stateCollisionInfo = $collisionInfo[$stateId] ?? throw new AssumptionFailedError("This should always exist");
 		$boxes = match($stateCollisionInfo){
 			RuntimeBlockStateRegistry::COLLISION_NONE => [],
-			RuntimeBlockStateRegistry::COLLISION_CUBE => [$cellBB = AxisAlignedBB::one()->offset($x, $y, $z)],
+			RuntimeBlockStateRegistry::COLLISION_CUBE => [AxisAlignedBB::one()->offset($x, $y, $z)],
 			default => $this->getBlockAt($x, $y, $z)->getCollisionBoxes()
 		};
 
 		//overlapping AABBs can't make any difference if this is a cube, so we can save some CPU cycles in this common case
 		if($stateCollisionInfo !== RuntimeBlockStateRegistry::COLLISION_CUBE){
+			$cellBB = null;
 			foreach(Facing::OFFSET as [$dx, $dy, $dz]){
 				$offsetY = $y + $dy;
 				if($offsetY < $this->minY || $offsetY > $this->maxY){
@@ -1593,6 +1593,7 @@ class World implements ChunkManager{
 					->getChunk(($x + $dx) >> Chunk::COORD_BIT_SIZE, ($z + $dz) >> Chunk::COORD_BIT_SIZE)
 					?->getBlockStateId(($x + $dx) & Chunk::COORD_MASK, $offsetY, ($z + $dz) & Chunk::COORD_MASK) ?? Block::EMPTY_STATE_ID;
 				if($collisionInfo[$stateId] === RuntimeBlockStateRegistry::COLLISION_MAY_OVERFLOW){
+					//avoid allocating this unless it's needed
 					$cellBB ??= AxisAlignedBB::one()->offset($x, $y, $z);
 					$extraBoxes = $this->getBlockAt($x + $dx, $offsetY, $z + $dz)->getCollisionBoxes();
 					foreach($extraBoxes as $extraBox){

--- a/src/world/World.php
+++ b/src/world/World.php
@@ -1575,26 +1575,30 @@ class World implements ChunkManager{
 			?->getBlockStateId($x & Chunk::COORD_MASK, $y, $z & Chunk::COORD_MASK) ?? Block::EMPTY_STATE_ID;
 
 		$cellBB = null;
-		$boxes = match($collisionInfo[$stateId]){
+		$stateCollisionInfo = $collisionInfo[$stateId] ?? throw new AssumptionFailedError("This should always exist");
+		$boxes = match($stateCollisionInfo){
 			RuntimeBlockStateRegistry::COLLISION_NONE => [],
 			RuntimeBlockStateRegistry::COLLISION_CUBE => [$cellBB = AxisAlignedBB::one()->offset($x, $y, $z)],
 			default => $this->getBlockAt($x, $y, $z)->getCollisionBoxes()
 		};
 
-		foreach(Facing::OFFSET as [$dx, $dy, $dz]){
-			$offsetY = $y + $dy;
-			if($offsetY < $this->minY || $offsetY > $this->maxY){
-				continue;
-			}
-			$stateId = $this
-				->getChunk(($x + $dx) >> Chunk::COORD_BIT_SIZE, ($z + $dz) >> Chunk::COORD_BIT_SIZE)
-				?->getBlockStateId(($x + $dx) & Chunk::COORD_MASK, $offsetY, ($z + $dz) & Chunk::COORD_MASK) ?? Block::EMPTY_STATE_ID;
-			if($collisionInfo[$stateId] === RuntimeBlockStateRegistry::COLLISION_MAY_OVERFLOW){
-				$cellBB ??= AxisAlignedBB::one()->offset($x, $y, $z);
-				$extraBoxes = $this->getBlockAt($x + $dx, $offsetY, $z + $dz)->getCollisionBoxes();
-				foreach($extraBoxes as $extraBox){
-					if($extraBox->intersectsWith($cellBB)){
-						$boxes[] = $extraBox;
+		//overlapping AABBs can't make any difference if this is a cube, so we can save some CPU cycles in this common case
+		if($stateCollisionInfo !== RuntimeBlockStateRegistry::COLLISION_CUBE){
+			foreach(Facing::OFFSET as [$dx, $dy, $dz]){
+				$offsetY = $y + $dy;
+				if($offsetY < $this->minY || $offsetY > $this->maxY){
+					continue;
+				}
+				$stateId = $this
+					->getChunk(($x + $dx) >> Chunk::COORD_BIT_SIZE, ($z + $dz) >> Chunk::COORD_BIT_SIZE)
+					?->getBlockStateId(($x + $dx) & Chunk::COORD_MASK, $offsetY, ($z + $dz) & Chunk::COORD_MASK) ?? Block::EMPTY_STATE_ID;
+				if($collisionInfo[$stateId] === RuntimeBlockStateRegistry::COLLISION_MAY_OVERFLOW){
+					$cellBB ??= AxisAlignedBB::one()->offset($x, $y, $z);
+					$extraBoxes = $this->getBlockAt($x + $dx, $offsetY, $z + $dz)->getCollisionBoxes();
+					foreach($extraBoxes as $extraBox){
+						if($extraBox->intersectsWith($cellBB)){
+							$boxes[] = $extraBox;
+						}
 					}
 				}
 			}

--- a/src/world/World.php
+++ b/src/world/World.php
@@ -1560,19 +1560,42 @@ class World implements ChunkManager{
 	 * This checks a padding of 1 block around the coordinates to account for oversized AABBs of blocks like fences.
 	 * Larger AABBs (>= 2 blocks on any axis) are not accounted for.
 	 *
+	 * @param int[] $collisionInfo
+	 * @phpstan-param array<int, int> $collisionInfo
+	 *
 	 * @return AxisAlignedBB[]
 	 * @phpstan-return list<AxisAlignedBB>
 	 */
-	private function getBlockCollisionBoxesForCell(int $x, int $y, int $z) : array{
-		$block = $this->getBlockAt($x, $y, $z);
-		$boxes = $block->getCollisionBoxes();
+	private function getBlockCollisionBoxesForCell(int $x, int $y, int $z, array $collisionInfo) : array{
+		if($y < $this->minY || $y > $this->maxY){
+			return [];
+		}
+		$stateId = $this
+			->getChunk($x >> Chunk::COORD_BIT_SIZE, $z >> Chunk::COORD_BIT_SIZE)
+			?->getBlockStateId($x & Chunk::COORD_MASK, $y, $z & Chunk::COORD_MASK) ?? Block::EMPTY_STATE_ID;
 
-		$cellBB = AxisAlignedBB::one()->offset($x, $y, $z);
+		$cellBB = null;
+		$boxes = match($collisionInfo[$stateId]){
+			RuntimeBlockStateRegistry::COLLISION_NONE => [],
+			RuntimeBlockStateRegistry::COLLISION_CUBE => [$cellBB = AxisAlignedBB::one()->offset($x, $y, $z)],
+			default => $this->getBlockAt($x, $y, $z)->getCollisionBoxes()
+		};
+
 		foreach(Facing::OFFSET as [$dx, $dy, $dz]){
-			$extraBoxes = $this->getBlockAt($x + $dx, $y + $dy, $z + $dz)->getCollisionBoxes();
-			foreach($extraBoxes as $extraBox){
-				if($extraBox->intersectsWith($cellBB)){
-					$boxes[] = $extraBox;
+			$offsetY = $y + $dy;
+			if($offsetY < $this->minY || $offsetY > $this->maxY){
+				continue;
+			}
+			$stateId = $this
+				->getChunk(($x + $dx) >> Chunk::COORD_BIT_SIZE, ($z + $dz) >> Chunk::COORD_BIT_SIZE)
+				?->getBlockStateId(($x + $dx) & Chunk::COORD_MASK, $offsetY, ($z + $dz) & Chunk::COORD_MASK) ?? Block::EMPTY_STATE_ID;
+			if($collisionInfo[$stateId] === RuntimeBlockStateRegistry::COLLISION_MAY_OVERFLOW){
+				$cellBB ??= AxisAlignedBB::one()->offset($x, $y, $z);
+				$extraBoxes = $this->getBlockAt($x + $dx, $offsetY, $z + $dz)->getCollisionBoxes();
+				foreach($extraBoxes as $extraBox){
+					if($extraBox->intersectsWith($cellBB)){
+						$boxes[] = $extraBox;
+					}
 				}
 			}
 		}
@@ -1593,6 +1616,8 @@ class World implements ChunkManager{
 		$maxZ = (int) floor($bb->maxZ);
 
 		$collides = [];
+
+		$collisionInfo = RuntimeBlockStateRegistry::getInstance()->collisionInfo;
 
 		for($z = $minZ; $z <= $maxZ; ++$z){
 			for($x = $minX; $x <= $maxX; ++$x){

--- a/src/world/World.php
+++ b/src/world/World.php
@@ -375,6 +375,8 @@ class World implements ChunkManager{
 
 	private \Logger $logger;
 
+	private RuntimeBlockStateRegistry $blockStateRegistry;
+
 	/**
 	 * @phpstan-return ChunkPosHash
 	 */
@@ -488,6 +490,7 @@ class World implements ChunkManager{
 		$this->displayName = $this->provider->getWorldData()->getName();
 		$this->logger = new \PrefixedLogger($server->getLogger(), "World: $this->displayName");
 
+		$this->blockStateRegistry = RuntimeBlockStateRegistry::getInstance();
 		$this->minY = $this->provider->getWorldMinY();
 		$this->maxY = $this->provider->getWorldMaxY();
 
@@ -559,7 +562,7 @@ class World implements ChunkManager{
 				}catch(BlockStateDeserializeException){
 					continue;
 				}
-				$block = RuntimeBlockStateRegistry::getInstance()->fromStateId(GlobalBlockStateHandlers::getDeserializer()->deserialize($blockStateData));
+				$block = $this->blockStateRegistry->fromStateId(GlobalBlockStateHandlers::getDeserializer()->deserialize($blockStateData));
 			}else{
 				//TODO: we probably ought to log an error here
 				continue;
@@ -570,7 +573,7 @@ class World implements ChunkManager{
 			}
 		}
 
-		foreach(RuntimeBlockStateRegistry::getInstance()->getAllKnownStates() as $state){
+		foreach($this->blockStateRegistry->getAllKnownStates() as $state){
 			$dontTickName = $dontTickBlocks[$state->getTypeId()] ?? null;
 			if($dontTickName === null && $state->ticksRandomly()){
 				$this->randomTickBlocks[$state->getStateId()] = true;
@@ -1394,7 +1397,7 @@ class World implements ChunkManager{
 			$entity->onRandomUpdate();
 		}
 
-		$blockFactory = RuntimeBlockStateRegistry::getInstance();
+		$blockFactory = $this->blockStateRegistry;
 		foreach($chunk->getSubChunks() as $Y => $subChunk){
 			if(!$subChunk->isEmptyFast()){
 				$k = 0;
@@ -1528,13 +1531,18 @@ class World implements ChunkManager{
 
 		$collides = [];
 
+		$collisionInfo = $this->blockStateRegistry->collisionInfo;
 		if($targetFirst){
 			for($z = $minZ; $z <= $maxZ; ++$z){
 				for($x = $minX; $x <= $maxX; ++$x){
 					for($y = $minY; $y <= $maxY; ++$y){
-						$block = $this->getBlockAt($x, $y, $z);
-						if($block->collidesWithBB($bb)){
-							return [$block];
+						$stateCollisionInfo = $this->getBlockCollisionInfo($x, $y, $z, $collisionInfo);
+						if(match($stateCollisionInfo){
+							RuntimeBlockStateRegistry::COLLISION_CUBE => true,
+							RuntimeBlockStateRegistry::COLLISION_NONE => false,
+							default => $this->getBlockAt($x, $y, $z)->collidesWithBB($bb)
+						}){
+							return [$this->getBlockAt($x, $y, $z)];
 						}
 					}
 				}
@@ -1543,9 +1551,13 @@ class World implements ChunkManager{
 			for($z = $minZ; $z <= $maxZ; ++$z){
 				for($x = $minX; $x <= $maxX; ++$x){
 					for($y = $minY; $y <= $maxY; ++$y){
-						$block = $this->getBlockAt($x, $y, $z);
-						if($block->collidesWithBB($bb)){
-							$collides[] = $block;
+						$stateCollisionInfo = $this->getBlockCollisionInfo($x, $y, $z, $collisionInfo);
+						if(match($stateCollisionInfo){
+							RuntimeBlockStateRegistry::COLLISION_CUBE => true,
+							RuntimeBlockStateRegistry::COLLISION_NONE => false,
+							default => $this->getBlockAt($x, $y, $z)->collidesWithBB($bb)
+						}){
+							$collides[] = $this->getBlockAt($x, $y, $z);
 						}
 					}
 				}
@@ -1553,6 +1565,28 @@ class World implements ChunkManager{
 		}
 
 		return $collides;
+	}
+
+	/**
+	 * @param int[] $collisionInfo
+	 * @phpstan-param array<int, int> $collisionInfo
+	 */
+	private function getBlockCollisionInfo(int $x, int $y, int $z, array $collisionInfo) : int{
+		if(!$this->isInWorld($x, $y, $z)){
+			return RuntimeBlockStateRegistry::COLLISION_NONE;
+		}
+		$chunk = $this->getChunk($x >> Chunk::COORD_BIT_SIZE, $z >> Chunk::COORD_BIT_SIZE);
+		if($chunk === null){
+			return RuntimeBlockStateRegistry::COLLISION_NONE;
+		}
+		$stateId = $chunk
+			->getSubChunk($y >> SubChunk::COORD_BIT_SIZE)
+			->getBlockStateId(
+				$x & SubChunk::COORD_MASK,
+				$y & SubChunk::COORD_MASK,
+				$z & SubChunk::COORD_MASK
+			);
+		return $collisionInfo[$stateId];
 	}
 
 	/**
@@ -1567,14 +1601,7 @@ class World implements ChunkManager{
 	 * @phpstan-return list<AxisAlignedBB>
 	 */
 	private function getBlockCollisionBoxesForCell(int $x, int $y, int $z, array $collisionInfo) : array{
-		if($y < $this->minY || $y > $this->maxY){
-			return [];
-		}
-		$stateId = $this
-			->getChunk($x >> Chunk::COORD_BIT_SIZE, $z >> Chunk::COORD_BIT_SIZE)
-			?->getBlockStateId($x & Chunk::COORD_MASK, $y, $z & Chunk::COORD_MASK) ?? Block::EMPTY_STATE_ID;
-
-		$stateCollisionInfo = $collisionInfo[$stateId] ?? throw new AssumptionFailedError("This should always exist");
+		$stateCollisionInfo = $this->getBlockCollisionInfo($x, $y, $z, $collisionInfo);
 		$boxes = match($stateCollisionInfo){
 			RuntimeBlockStateRegistry::COLLISION_NONE => [],
 			RuntimeBlockStateRegistry::COLLISION_CUBE => [AxisAlignedBB::one()->offset($x, $y, $z)],
@@ -1585,17 +1612,14 @@ class World implements ChunkManager{
 		if($stateCollisionInfo !== RuntimeBlockStateRegistry::COLLISION_CUBE){
 			$cellBB = null;
 			foreach(Facing::OFFSET as [$dx, $dy, $dz]){
+				$offsetX = $x + $dx;
 				$offsetY = $y + $dy;
-				if($offsetY < $this->minY || $offsetY > $this->maxY){
-					continue;
-				}
-				$stateId = $this
-					->getChunk(($x + $dx) >> Chunk::COORD_BIT_SIZE, ($z + $dz) >> Chunk::COORD_BIT_SIZE)
-					?->getBlockStateId(($x + $dx) & Chunk::COORD_MASK, $offsetY, ($z + $dz) & Chunk::COORD_MASK) ?? Block::EMPTY_STATE_ID;
-				if($collisionInfo[$stateId] === RuntimeBlockStateRegistry::COLLISION_MAY_OVERFLOW){
+				$offsetZ = $z + $dz;
+				$stateCollisionInfo = $this->getBlockCollisionInfo($offsetX, $offsetY, $offsetZ, $collisionInfo);
+				if($stateCollisionInfo === RuntimeBlockStateRegistry::COLLISION_MAY_OVERFLOW){
 					//avoid allocating this unless it's needed
 					$cellBB ??= AxisAlignedBB::one()->offset($x, $y, $z);
-					$extraBoxes = $this->getBlockAt($x + $dx, $offsetY, $z + $dz)->getCollisionBoxes();
+					$extraBoxes = $this->getBlockAt($offsetX, $offsetY, $offsetZ)->getCollisionBoxes();
 					foreach($extraBoxes as $extraBox){
 						if($extraBox->intersectsWith($cellBB)){
 							$boxes[] = $extraBox;
@@ -1622,7 +1646,7 @@ class World implements ChunkManager{
 
 		$collides = [];
 
-		$collisionInfo = RuntimeBlockStateRegistry::getInstance()->collisionInfo;
+		$collisionInfo = $this->blockStateRegistry->collisionInfo;
 
 		for($z = $minZ; $z <= $maxZ; ++$z){
 			for($x = $minX; $x <= $maxX; ++$x){
@@ -1825,7 +1849,7 @@ class World implements ChunkManager{
 			return;
 		}
 
-		$blockFactory = RuntimeBlockStateRegistry::getInstance();
+		$blockFactory = $this->blockStateRegistry;
 		$this->timings->doBlockSkyLightUpdates->startTiming();
 		if($this->skyLightUpdate === null){
 			$this->skyLightUpdate = new SkyLightUpdate(new SubChunkExplorer($this), $blockFactory->lightFilter, $blockFactory->blocksDirectSkyLight);
@@ -1944,7 +1968,7 @@ class World implements ChunkManager{
 
 			$chunk = $this->chunks[$chunkHash] ?? null;
 			if($chunk !== null){
-				$block = RuntimeBlockStateRegistry::getInstance()->fromStateId($chunk->getBlockStateId($x & Chunk::COORD_MASK, $y, $z & Chunk::COORD_MASK));
+				$block = $this->blockStateRegistry->fromStateId($chunk->getBlockStateId($x & Chunk::COORD_MASK, $y, $z & Chunk::COORD_MASK));
 			}else{
 				$addToCache = false;
 				$block = VanillaBlocks::AIR();
@@ -2603,7 +2627,7 @@ class World implements ChunkManager{
 				$localY = $tilePosition->getFloorY();
 				$localZ = $tilePosition->getFloorZ() & Chunk::COORD_MASK;
 
-				$newBlock = RuntimeBlockStateRegistry::getInstance()->fromStateId($chunk->getBlockStateId($localX, $localY, $localZ));
+				$newBlock = $this->blockStateRegistry->fromStateId($chunk->getBlockStateId($localX, $localY, $localZ));
 				$expectedTileClass = $newBlock->getIdInfo()->getTileClass();
 				if(
 					$expectedTileClass === null || //new block doesn't expect a tile

--- a/src/world/World.php
+++ b/src/world/World.php
@@ -1625,7 +1625,7 @@ class World implements ChunkManager{
 				for($y = $minY; $y <= $maxY; ++$y){
 					$relativeBlockHash = World::chunkBlockHash($x, $y, $z);
 
-					$boxes = $this->blockCollisionBoxCache[$chunkPosHash][$relativeBlockHash] ??= $this->getBlockCollisionBoxesForCell($x, $y, $z);
+					$boxes = $this->blockCollisionBoxCache[$chunkPosHash][$relativeBlockHash] ??= $this->getBlockCollisionBoxesForCell($x, $y, $z, $collisionInfo);
 
 					foreach($boxes as $blockBB){
 						if($blockBB->intersectsWith($bb)){


### PR DESCRIPTION
This PR significantly improves performance of entity movement calculation.

Previous attempts to optimise this were ineffective, as they used a cache to mitigate the cost of recomputing AABBs. Entities tend to move around randomly, so the non-cached pathway really needed to be optimized.

This change improves performance on multiple fronts:
1) avoiding Block allocations for blocks with 1x1x1 AABBs and with no AABBs (the most common)
2) avoiding Block allocations and overlapping intersection checks unless a stateID is specifically known to potentially exceed its cell boundaries (like fences)
3) avoiding overlapping AABB checks when overlaps can't make any difference anyway (cubes)

Together, these changes improve the performance of item entity movement (non-cached) by about 200%. We may be able to get further performance gains, but this is a good start.

### Related issues & PRs
- Fixes (hackily) #6604

## Changes
### API changes
Added public `RuntimeBlockStateRegistry->collisionInfo` and related constants

### Behavioural changes
This change is built on the assumption that `Block->recalculateCollisionBoxes()` and its overrides don't interact with any world. This is technically possible due to the crappy design of the `Block` architecture, but should be avoided. As a world is not available during `RuntimeBlockStateRegistry` initialization, attempting to interact with a world during `recalculateCollisionBoxes()` will now cause a crash.

This turned out to be a problem for `ChorusPlant`, which was fixed by 70fb9bbdfd06c7eda00b4cd2c2c3840755e6b8f6. The correct solution in this case was to use dynamic states similar to how we currently deal with fence connections.

As a result of this change, it's possible plugins implementing custom blocks may break if their blocks' AABB calculations depend on `$this->position`. However, I don't expect this to be an issue, and the problem will become quickly apparent during startup anyway.

Given the massive performance advantage on offer from this change, I think this is an OK risk to take.

## Backwards compatibility
See above section on behavioural changes.

## Follow-up
We may be able to get further improvements by tracking more info about oversized blocks, but this is a good enough start.

In the future, it might be worth requiring blocks to explicitly declare something like `Block->mayExceedCellBounds() : bool` when their AABBs could go outside the cell bounds, and have this enforced, throwing errors if `recalculateCollisionBoxes()` ever generates out-of-bounds AABBs. However, this would be tricky to implement due to the headaches presented by `getModelPositionOffset()`, which can currently offset an AABB outside of the block's cell.

We also really, really need to implement #6551. It should never have been possible to implement position-dependent logic in `recalculateCollisionBoxes`. This problem has appeared in a variety of issues by now.

## Tests
Tested in-game with item entities. My local server started to lag without the change at around 400 dropped items; with the change, around 1200.
