### PR TITLE
Block: (Walls) implement tall/short connections

### DIFF
--- a/src/block/Wall.php
+++ b/src/block/Wall.php
@@ -1,24 +1,5 @@
 <?php
 
-/*
- *
- *  ____            _        _   __  __ _                  __  __ ____
- * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
- * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
- * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
- * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * @author PocketMine Team
- * @link http://www.pocketmine.net/
- *
- *
- */
-
 declare(strict_types=1);
 
 namespace pocketmine\block;
@@ -100,15 +81,25 @@ class Wall extends Transparent{
 		foreach(Facing::HORIZONTAL as $facing){
 			$block = $this->getSide($facing);
 			if($block instanceof static || $block instanceof FenceGate || $block instanceof Thin || $block->getSupportType(Facing::opposite($facing)) === SupportType::FULL){
-				if(!isset($this->connections[$facing])){
-					if($this->getSide(Facing::UP)->getTypeId() == BlockTypeIds::AIR) {
-						$this->connections[$facing] = WallConnectionType::SHORT;
-					} else {
-						$this->connections[$facing] = WallConnectionType::TALL;
-					}
+				$aboveBlock = $this->getSide($facing)->getSide(Facing::UP);
+				$connectionType = ($aboveBlock->getTypeId() === BlockTypeIds::AIR)
+					? WallConnectionType::SHORT
+					: WallConnectionType::TALL;
+
+				if(!isset($this->connections[$facing]) || $this->connections[$facing] !== $connectionType){
+					$this->connections[$facing] = $connectionType;
 					$changed++;
 				}
-			}elseif(isset($this->connections[$facing])){
+
+				if ($connectionType === WallConnectionType::SHORT) {
+					$up = $this->getSide(Facing::UP)->getTypeId() !== BlockTypeIds::AIR;
+					if ($up !== $this->post) {
+						$this->post = $up;
+						$changed++;
+					}
+				}
+			}
+			elseif(isset($this->connections[$facing])){
 				unset($this->connections[$facing]);
 				$changed++;
 			}
@@ -126,7 +117,8 @@ class Wall extends Transparent{
 		$east = isset($this->connections[Facing::EAST]);
 
 		$inset = 0.25;
-		if(!$this->post && //if there is a block on top, it stays as a post
+		if(
+			!$this->post && //if there is a block on top, it stays as a post
 			(
 				($north && $south && !$west && !$east) ||
 				(!$north && !$south && $west && $east)

--- a/src/block/Wall.php
+++ b/src/block/Wall.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\block\utils\SlabType;
 use pocketmine\block\utils\SupportType;
 use pocketmine\block\utils\WallConnectionType;
 use pocketmine\data\runtime\RuntimeDataDescriber;
@@ -70,42 +71,129 @@ class Wall extends Transparent{
 	}
 
 	public function onNearbyBlockChange() : void{
-		if($this->recalculateConnections()){
+		$connectionsUpdated = $this->recalculateConnections();
+		$postUpdated = $this->recalculatePost();
+		if($connectionsUpdated || $postUpdated){
 			$this->position->getWorld()->setBlock($this->position, $this);
 		}
 	}
 
 	protected function recalculateConnections() : bool{
-		$changed = 0;
+		$updated = false;
+		$above = $this->getSide(Facing::UP);
+		$abovePos = $above->getPosition();
 
-		foreach(Facing::HORIZONTAL as $facing){
-			$block = $this->getSide($facing);
-			if($block instanceof static || $block instanceof FenceGate || $block instanceof Thin || $block->getSupportType(Facing::opposite($facing)) === SupportType::FULL){
-				$aboveBlock = $this->getSide($facing)->getSide(Facing::UP);
-				$connectionType = ($aboveBlock->getTypeId() === BlockTypeIds::AIR)
-					? WallConnectionType::SHORT
-					: WallConnectionType::TALL;
+		foreach(Facing::HORIZONTAL as $face) {
+			$side = $this->getSide($face);
+			$sidePos = $side->getPosition();
 
-				if(!isset($this->connections[$facing]) || $this->connections[$facing] !== $connectionType){
-					$this->connections[$facing] = $connectionType;
-					$changed++;
-				}
+			// TODO: Improve stair check by checking corners
 
-				if ($connectionType === WallConnectionType::SHORT) {
-					$up = $this->getSide(Facing::UP)->getTypeId() !== BlockTypeIds::AIR;
-					if ($up !== $this->post) {
-						$this->post = $up;
-						$changed++;
+			$connected = match (get_class($side)) {
+				Cake::class => false,
+				Campfire::class => Facing::opposite($face) === Facing::DOWN,
+				Fence::class => Facing::opposite($face) === Facing::DOWN || Facing::opposite($face) === Facing::UP,
+				Hopper::class => Facing::opposite($face) === Facing::UP,
+				Slab::class => $side->getSlabType() === SlabType::DOUBLE || ($side->getSlabType() === SlabType::TOP && Facing::opposite($face) === Facing::UP) || Facing::opposite($face) === Facing::DOWN,
+				Stair::class => (!$side->isUpsideDown() && Facing::opposite($face) === Facing::DOWN) ||
+					($side->isUpsideDown() && Facing::opposite($face) === Facing::UP) ||
+					in_array($face, [Facing::rotate($face, Axis::Y, false), $side->getFacing()]),
+				default => !$side->isTransparent()
+			};
+
+			if (!$connected){
+				if($side instanceof Wall || $side instanceof Thin) $connected = true;
+				if($side instanceof FenceGate && $side->getFacing() === $face) $connected = true;
+			}
+
+			$connectionType = null;
+			if ($connected) {
+				$connectionType = WallConnectionType::SHORT();
+				$boxes = $above->recalculateCollisionBoxes();
+
+				foreach($boxes as $bb) {
+					if ($bb->minY == 0) {
+						$xOverlap = $bb->minX < 0.75 && $bb->maxX > 0.25;
+						$zOverlap = $bb->minX < 0.75 && $bb->maxX > 0.25;
+
+						$tall = match($face) {
+							Facing::NORTH => $xOverlap && $bb->maxZ > 0.75,
+							Facing::EAST => $bb->minX < 0.25 && $zOverlap,
+							Facing::SOUTH => $xOverlap && $bb->minZ < 0.25,
+							Facing::WEST => $bb->maxX > 0.75 && $zOverlap,
+							default => false
+						};
+						if ($tall) {
+							$connectionType = WallConnectionType::TALL();
+						}
 					}
 				}
 			}
-			elseif(isset($this->connections[$facing])){
-				unset($this->connections[$facing]);
-				$changed++;
+
+			if ($above instanceof Wall){
+				if ($this->getSide($face) instanceof Wall) {
+					if ($above->getSide($face) instanceof Wall) $connectionType = WallConnectionType::TALL();
+					else if (!$this->post) {
+						$updated = true;
+						$connectionType = WallConnectionType::SHORT();
+						$this->post = true;
+					}
+				}
+			}
+
+			if ($this->getConnection($face) !== $connectionType) {
+				$updated = true;
+
+				$this->connections[$face] = $connectionType;
 			}
 		}
 
-		return $changed > 0;
+		return $updated;
+	}
+
+	public function recalculatePost(): bool
+	{
+		$updated = false;
+		$above = $this->getSide(Facing::UP);
+
+		$connections = count(array_filter(Facing::HORIZONTAL, function ($face) {
+			return $this->getConnection($face) !== WallConnectionType::NONE;
+		}));
+
+		// TODO: Lanterns and Hanging Signs
+		$post = false;
+		switch(get_class($above)) {
+			case Torch::class:
+				$post = $above->getFacing() === Facing::DOWN;
+				break;
+			case Trapdoor::class:
+				if ($above->isOpen()) {
+					$post = $this->getConnection($above->getFacing()) !== null;
+				}
+				break;
+			case Wall::class:
+				$post = $above->isPost();
+				break;
+		}
+
+		if (!$post) {
+			$post = $connections < 2;
+			if ($connections > 2){
+				if ($this->getConnection(Facing::NORTH) !== null && $this->getConnection(Facing::SOUTH) !== null) {
+					$post = $this->getConnection(Facing::EAST) !== null || $this->getConnection(Facing::WEST) !== null;
+				} else if ($this->getConnection(Facing::EAST) !== null && $this->getConnection(Facing::WEST) !== null) {
+					$post = $this->getConnection(Facing::NORTH) !== null || $this->getConnection(Facing::SOUTH) !== null;
+				} else $post = true;
+			}
+		}
+
+		if ($this->post !== $post) {
+			$updated = true;
+			$this->post = $post;
+		}
+
+		return $updated;
+
 	}
 
 	protected function recalculateCollisionBoxes() : array{

--- a/src/block/Wall.php
+++ b/src/block/Wall.php
@@ -97,25 +97,21 @@ class Wall extends Transparent{
 	protected function recalculateConnections() : bool{
 		$changed = 0;
 
-		//TODO: implement tall/short connections - right now we only support short as per pre-1.16
-
 		foreach(Facing::HORIZONTAL as $facing){
 			$block = $this->getSide($facing);
 			if($block instanceof static || $block instanceof FenceGate || $block instanceof Thin || $block->getSupportType(Facing::opposite($facing)) === SupportType::FULL){
 				if(!isset($this->connections[$facing])){
-					$this->connections[$facing] = WallConnectionType::SHORT;
+					if($this->getSide(Facing::UP)->getTypeId() == BlockTypeIds::AIR) {
+						$this->connections[$facing] = WallConnectionType::SHORT;
+					} else {
+						$this->connections[$facing] = WallConnectionType::TALL;
+					}
 					$changed++;
 				}
 			}elseif(isset($this->connections[$facing])){
 				unset($this->connections[$facing]);
 				$changed++;
 			}
-		}
-
-		$up = $this->getSide(Facing::UP)->getTypeId() !== BlockTypeIds::AIR;
-		if($up !== $this->post){
-			$this->post = $up;
-			$changed++;
 		}
 
 		return $changed > 0;
@@ -130,8 +126,7 @@ class Wall extends Transparent{
 		$east = isset($this->connections[Facing::EAST]);
 
 		$inset = 0.25;
-		if(
-			!$this->post && //if there is a block on top, it stays as a post
+		if(!$this->post && //if there is a block on top, it stays as a post
 			(
 				($north && $south && !$west && !$east) ||
 				(!$north && !$south && $west && $east)

--- a/src/block/utils/WallConnectionType.php
+++ b/src/block/utils/WallConnectionType.php
@@ -29,12 +29,14 @@ use pocketmine\utils\LegacyEnumShimTrait;
  * TODO: These tags need to be removed once we get rid of LegacyEnumShimTrait (PM6)
  *  These are retained for backwards compatibility only.
  *
+ * @method static WallConnectionType NONE()
  * @method static WallConnectionType SHORT()
  * @method static WallConnectionType TALL()
  */
 enum WallConnectionType{
 	use LegacyEnumShimTrait;
 
+	case NONE;
 	case SHORT;
 	case TALL;
 }


### PR DESCRIPTION
<!--Implement tall/short connections for walls when a block is on top of it. -->
<!-- Explain existing problems or why this pull request is necessary -->

### Related issues & PRs
* Fixes #6601 


### Behavioural changes
Changed how walls behave with block on top of them.

## Tests
![Minecraft 2_13_2025 8_09_47 AM](https://github.com/user-attachments/assets/37c40f98-db9f-46a6-89cb-3ee3033431a7)
![Minecraft 2_13_2025 8_10_02 AM](https://github.com/user-attachments/assets/5fc83096-b3f5-4291-9b12-ba0a31d919fa)
![Minecraft 2_13_2025 8_11_18 AM](https://github.com/user-attachments/assets/80051894-06b8-4c1d-8c28-a4b1c75b37c0)
