### PR TITLE
Utils(docs): fix incorrect case referencing an internal constant value of Linux OS

### DIFF
--- a/src/utils/Utils.php
+++ b/src/utils/Utils.php
@@ -269,7 +269,7 @@ final class Utils{
 	 * MacOS => mac
 	 * iOS => ios
 	 * Android => android
-	 * Linux => Linux
+	 * Linux => linux
 	 * BSD => bsd
 	 * Other => other
 	 */


### PR DESCRIPTION
The "linux" constant reference has wrong case ("linux" !== "Linux"). This got me in a micro stutter when looking at the doc.

## Changes

This small change to a Utils::getOS() phpdoc doesn't seem to break anything, including BC or FC.
