### PR TITLE
Update Composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
       "pocketmine/bedrock-block-upgrade-schema": "~5.1.0+bedrock-1.21.60",
       "pocketmine/bedrock-data": "5.0.0+bedrock-1.21.80",
       "pocketmine/bedrock-item-upgrade-schema": "~1.14.0+bedrock-1.21.50",
-      "pocketmine/bedrock-protocol": "38.0.0+bedrock-1.21.80",
+      "pocketmine/bedrock-protocol": "38.0.1+bedrock-1.21.80",
       "pocketmine/binaryutils": "^0.2.1",
       "pocketmine/callback-validator": "^1.0.2",
       "pocketmine/color": "^0.3.0",


### PR DESCRIPTION
The latest release still uses ```38.0.0+bedrock-1.21.80```.
The latest bedrock protocol https://github.com/pmmp/BedrockProtocol/commits/38.0.1%2Bbedrock-1.21.80/