### PR TITLE
Increase visibility of CocoaBlock->grow()

### DIFF
--- a/src/block/CocoaBlock.php
+++ b/src/block/CocoaBlock.php
@@ -100,7 +100,7 @@ class CocoaBlock extends Flowable{
 		}
 	}
 
-	private function grow(?Player $player = null) : bool{
+	protected function grow(?Player $player = null) : bool{
 		if($this->age < self::MAX_AGE){
 			$block = clone $this;
 			$block->age++;


### PR DESCRIPTION
### Related issues & PRs
* Fixes #5606

## Changes
### API changes
```CocoaBlock->grow()``` is now protected instead of private 

### Behavioural changes
None

## Backwards compatibility
None