### PR TITLE
Allowing custom command to handle raw command line inputs

### DIFF
--- a/src/command/Command.php
+++ b/src/command/Command.php
@@ -82,8 +82,8 @@ abstract class Command{
 	}
 
 	public function executeRaw(CommandSender $sender, string $commandLabel, string $argLine) : void{
-		$args = CommandStringHelper::parseQuoteAware($argLine);
 		if($this->testPermission($sender)){
+			$args = CommandStringHelper::parseQuoteAware($argLine);
 			$this->execute($sender, $commandLabel, $args);
 		}
 	}

--- a/src/command/Command.php
+++ b/src/command/Command.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 namespace pocketmine\command;
 
 use pocketmine\command\utils\CommandException;
+use pocketmine\command\utils\CommandStringHelper;
 use pocketmine\lang\KnownTranslationFactory;
 use pocketmine\lang\Translatable;
 use pocketmine\permission\PermissionManager;
@@ -78,6 +79,13 @@ abstract class Command{
 		$this->setDescription($description);
 		$this->usageMessage = $usageMessage ?? ("/" . $name);
 		$this->setAliases($aliases);
+	}
+
+	public function executeRaw(CommandSender $sender, string $commandLabel, string $argLine) : void{
+		$args = CommandStringHelper::parseQuoteAware($argLine);
+		if($this->testPermission($sender)){
+			$this->execute($sender, $commandLabel, $args);
+		}
 	}
 
 	/**

--- a/src/command/Command.php
+++ b/src/command/Command.php
@@ -82,10 +82,8 @@ abstract class Command{
 	}
 
 	public function executeRaw(CommandSender $sender, string $commandLabel, string $argLine) : void{
-		if($this->testPermission($sender)){
-			$args = CommandStringHelper::parseQuoteAware($argLine);
-			$this->execute($sender, $commandLabel, $args);
-		}
+		$args = CommandStringHelper::parseQuoteAware($argLine);
+		$this->execute($sender, $commandLabel, $args);
 	}
 
 	/**

--- a/src/command/Command.php
+++ b/src/command/Command.php
@@ -81,8 +81,8 @@ abstract class Command{
 		$this->setAliases($aliases);
 	}
 
-	public function executeRaw(CommandSender $sender, string $commandLabel, string $argLine) : void{
-		$args = CommandStringHelper::parseQuoteAware($argLine);
+	public function executeRaw(CommandSender $sender, string $commandLabel, string $rawArgs) : void{
+		$args = CommandStringHelper::parseQuoteAware($rawArgs);
 		$this->execute($sender, $commandLabel, $args);
 	}
 

--- a/src/command/SimpleCommandMap.php
+++ b/src/command/SimpleCommandMap.php
@@ -207,26 +207,25 @@ class SimpleCommandMap implements CommandMap{
 	}
 
 	public function dispatch(CommandSender $sender, string $commandLine) : bool{
-		$args = CommandStringHelper::parseQuoteAware($commandLine);
+		$sentCommandLabel = "";
+		if(($parts = preg_split('/\s+/u', $commandLine, 2)) !== false){
+			$sentCommandLabel = $parts[0];
+			if(($target = $this->getCommand($sentCommandLabel)) !== null){
+				$timings = Timings::getCommandDispatchTimings($target->getLabel());
+				$timings->startTiming();
 
-		$sentCommandLabel = array_shift($args);
-		if($sentCommandLabel !== null && ($target = $this->getCommand($sentCommandLabel)) !== null){
-			$timings = Timings::getCommandDispatchTimings($target->getLabel());
-			$timings->startTiming();
-
-			try{
-				if($target->testPermission($sender)){
-					$target->execute($sender, $sentCommandLabel, $args);
+				try{
+					$target->execute($sender, $sentCommandLabel, array_slice($parts, 1));
+				}catch(InvalidCommandSyntaxException $e){
+					$sender->sendMessage($sender->getLanguage()->translate(KnownTranslationFactory::commands_generic_usage($target->getUsage())));
+				}finally{
+					$timings->stopTiming();
 				}
-			}catch(InvalidCommandSyntaxException $e){
-				$sender->sendMessage($sender->getLanguage()->translate(KnownTranslationFactory::commands_generic_usage($target->getUsage())));
-			}finally{
-				$timings->stopTiming();
+				return true;
 			}
-			return true;
-		}
+    	}
 
-		$sender->sendMessage(KnownTranslationFactory::pocketmine_command_notFound($sentCommandLabel ?? "", "/help")->prefix(TextFormat::RED));
+		$sender->sendMessage(KnownTranslationFactory::pocketmine_command_notFound($sentCommandLabel, "/help")->prefix(TextFormat::RED));
 		return false;
 	}
 

--- a/src/command/SimpleCommandMap.php
+++ b/src/command/SimpleCommandMap.php
@@ -223,7 +223,7 @@ class SimpleCommandMap implements CommandMap{
 				}
 				return true;
 			}
-    	}
+		}
 
 		$sender->sendMessage(KnownTranslationFactory::pocketmine_command_notFound($sentCommandLabel, "/help")->prefix(TextFormat::RED));
 		return false;

--- a/src/command/SimpleCommandMap.php
+++ b/src/command/SimpleCommandMap.php
@@ -75,8 +75,8 @@ use pocketmine\utils\Utils;
 use function array_shift;
 use function array_values;
 use function count;
+use function explode;
 use function implode;
-use function preg_split;
 use function str_contains;
 use function strcasecmp;
 use function strtolower;
@@ -208,7 +208,7 @@ class SimpleCommandMap implements CommandMap{
 	}
 
 	public function dispatch(CommandSender $sender, string $commandLine) : bool{
-		$parts = explode(" ", $commandLine);
+		$parts = explode(" ", $commandLine, 2);
 		$sentCommandLabel = $parts[0];
 		if(($target = $this->getCommand($sentCommandLabel)) !== null){
 			$timings = Timings::getCommandDispatchTimings($target->getLabel());

--- a/src/command/SimpleCommandMap.php
+++ b/src/command/SimpleCommandMap.php
@@ -208,24 +208,22 @@ class SimpleCommandMap implements CommandMap{
 	}
 
 	public function dispatch(CommandSender $sender, string $commandLine) : bool{
-		$sentCommandLabel = "";
-		if(($parts = preg_split('/\s+/u', $commandLine, 2)) !== false){
-			$sentCommandLabel = $parts[0];
-			if(($target = $this->getCommand($sentCommandLabel)) !== null){
-				$timings = Timings::getCommandDispatchTimings($target->getLabel());
-				$timings->startTiming();
+		$parts = explode(" ", $commandLine);
+		$sentCommandLabel = $parts[0];
+		if(($target = $this->getCommand($sentCommandLabel)) !== null){
+			$timings = Timings::getCommandDispatchTimings($target->getLabel());
+			$timings->startTiming();
 
-				try{
-					if($target->testPermission($sender)){
-						$target->executeRaw($sender, $sentCommandLabel, $parts[1] ?? "");
-					}
-				}catch(InvalidCommandSyntaxException $e){
-					$sender->sendMessage($sender->getLanguage()->translate(KnownTranslationFactory::commands_generic_usage($target->getUsage())));
-				}finally{
-					$timings->stopTiming();
+			try{
+				if($target->testPermission($sender)){
+					$target->executeRaw($sender, $sentCommandLabel, trim($parts[1] ?? ""));
 				}
-				return true;
+			}catch(InvalidCommandSyntaxException $e){
+				$sender->sendMessage($sender->getLanguage()->translate(KnownTranslationFactory::commands_generic_usage($target->getUsage())));
+			}finally{
+				$timings->stopTiming();
 			}
+			return true;
 		}
 
 		$sender->sendMessage(KnownTranslationFactory::pocketmine_command_notFound($sentCommandLabel, "/help")->prefix(TextFormat::RED));

--- a/src/command/SimpleCommandMap.php
+++ b/src/command/SimpleCommandMap.php
@@ -76,6 +76,7 @@ use function array_shift;
 use function array_values;
 use function count;
 use function implode;
+use function preg_split;
 use function str_contains;
 use function strcasecmp;
 use function strtolower;

--- a/src/command/SimpleCommandMap.php
+++ b/src/command/SimpleCommandMap.php
@@ -216,7 +216,9 @@ class SimpleCommandMap implements CommandMap{
 				$timings->startTiming();
 
 				try{
-					$target->executeRaw($sender, $sentCommandLabel, $parts[1] ?? "");
+					if($target->testPermission($sender)){
+						$target->executeRaw($sender, $sentCommandLabel, $parts[1] ?? "");
+					}
 				}catch(InvalidCommandSyntaxException $e){
 					$sender->sendMessage($sender->getLanguage()->translate(KnownTranslationFactory::commands_generic_usage($target->getUsage())));
 				}finally{

--- a/src/command/SimpleCommandMap.php
+++ b/src/command/SimpleCommandMap.php
@@ -215,7 +215,7 @@ class SimpleCommandMap implements CommandMap{
 				$timings->startTiming();
 
 				try{
-					$target->execute($sender, $sentCommandLabel, array_slice($parts, 1));
+					$target->executeRaw($sender, $sentCommandLabel, $parts[1] ?? "");
 				}catch(InvalidCommandSyntaxException $e){
 					$sender->sendMessage($sender->getLanguage()->translate(KnownTranslationFactory::commands_generic_usage($target->getUsage())));
 				}finally{


### PR DESCRIPTION
<!-- Summarize your PR here. Keep it short and simple. -->
<!-- Explain existing problems or why this pull request is necessary -->
Current PMMP handles the parsing of command lines in a hardcoded way without any non-hacky method for commands to handle the raw inputs. This PR tweaks the API a little so it will allow custom commands to do such things without harming the performance.

### Related issues & PRs
* Related to #6704

## Changes
### API changes
- Added a new method named `Command->executeRaw()` to Command class. This allowing custom command to handle the raw command inputs by override the parent method.

## Backwards compatibility
Yes
