### PR TITLE
Allow optional preloaded PluginDescription in loadPlugin method

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -53,7 +53,7 @@ jobs:
         run: echo NAME=$(echo "${GITHUB_REPOSITORY,,}") >> $GITHUB_OUTPUT
 
       - name: Build image for tag
-        uses: docker/build-push-action@v6.16.0
+        uses: docker/build-push-action@v6.18.0
         with:
           push: true
           context: ./pocketmine-mp
@@ -66,7 +66,7 @@ jobs:
 
       - name: Build image for major tag
         if: steps.channel.outputs.CHANNEL == 'stable'
-        uses: docker/build-push-action@v6.16.0
+        uses: docker/build-push-action@v6.18.0
         with:
           push: true
           context: ./pocketmine-mp
@@ -79,7 +79,7 @@ jobs:
 
       - name: Build image for minor tag
         if: steps.channel.outputs.CHANNEL == 'stable'
-        uses: docker/build-push-action@v6.16.0
+        uses: docker/build-push-action@v6.18.0
         with:
           push: true
           context: ./pocketmine-mp
@@ -92,7 +92,7 @@ jobs:
 
       - name: Build image for latest tag
         if: steps.channel.outputs.CHANNEL == 'stable'
-        uses: docker/build-push-action@v6.16.0
+        uses: docker/build-push-action@v6.18.0
         with:
           push: true
           context: ./pocketmine-mp

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
       "pocketmine/bedrock-block-upgrade-schema": "~5.1.0+bedrock-1.21.60",
       "pocketmine/bedrock-data": "~5.0.0+bedrock-1.21.80",
       "pocketmine/bedrock-item-upgrade-schema": "~1.14.0+bedrock-1.21.50",
-      "pocketmine/bedrock-protocol": "~38.0.0+bedrock-1.21.80",
+      "pocketmine/bedrock-protocol": "~38.1.0+bedrock-1.21.80",
       "pocketmine/binaryutils": "^0.2.1",
       "pocketmine/callback-validator": "^1.0.2",
       "pocketmine/color": "^0.3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ceb98091ac3f61f1a4b87708c48dc75a",
+    "content-hash": "fe62caebfdb35cd8bd57c8e61879b7c0",
     "packages": [
         {
             "name": "adhocore/json-comment",
@@ -256,16 +256,16 @@
         },
         {
             "name": "pocketmine/bedrock-protocol",
-            "version": "38.0.1+bedrock-1.21.80",
+            "version": "38.1.0+bedrock-1.21.80",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pmmp/BedrockProtocol.git",
-                "reference": "0c1c13e970a2e1ded1609d0b442b4fcfd24cd21f"
+                "reference": "a1fa215563517050045309bb779a67f75843b867"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pmmp/BedrockProtocol/zipball/0c1c13e970a2e1ded1609d0b442b4fcfd24cd21f",
-                "reference": "0c1c13e970a2e1ded1609d0b442b4fcfd24cd21f",
+                "url": "https://api.github.com/repos/pmmp/BedrockProtocol/zipball/a1fa215563517050045309bb779a67f75843b867",
+                "reference": "a1fa215563517050045309bb779a67f75843b867",
                 "shasum": ""
             },
             "require": {
@@ -296,9 +296,9 @@
             "description": "An implementation of the Minecraft: Bedrock Edition protocol in PHP",
             "support": {
                 "issues": "https://github.com/pmmp/BedrockProtocol/issues",
-                "source": "https://github.com/pmmp/BedrockProtocol/tree/38.0.1+bedrock-1.21.80"
+                "source": "https://github.com/pmmp/BedrockProtocol/tree/38.1.0+bedrock-1.21.80"
             },
-            "time": "2025-05-17T11:56:33+00:00"
+            "time": "2025-05-28T22:19:59+00:00"
         },
         {
             "name": "pocketmine/binaryutils",

--- a/src/inventory/BaseInventory.php
+++ b/src/inventory/BaseInventory.php
@@ -256,7 +256,7 @@ abstract class BaseInventory implements Inventory, SlotValidatedInventory{
 					$slotItem->setCount($slotItem->getCount() + $amount);
 					$this->setItem($i, $slotItem);
 					if($newItem->getCount() <= 0){
-						break;
+						return $newItem;
 					}
 				}
 			}
@@ -270,7 +270,7 @@ abstract class BaseInventory implements Inventory, SlotValidatedInventory{
 				$slotItem->setCount($amount);
 				$this->setItem($slotIndex, $slotItem);
 				if($newItem->getCount() <= 0){
-					break;
+					return $newItem;
 				}
 			}
 		}

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -211,7 +211,7 @@ class InGamePacketHandler extends PacketHandler{
 		}
 
 		$inputFlags = $packet->getInputFlags();
-		if($inputFlags !== $this->lastPlayerAuthInputFlags){
+		if($this->lastPlayerAuthInputFlags === null || !$inputFlags->equals($this->lastPlayerAuthInputFlags)){
 			$this->lastPlayerAuthInputFlags = $inputFlags;
 
 			$sneaking = $inputFlags->get(PlayerAuthInputFlags::SNEAKING);

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1641,7 +1641,10 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 			$newReplica = clone $oldHeldItem;
 			$newReplica->setCount($newHeldItem->getCount());
 			if($newReplica instanceof Durable && $newHeldItem instanceof Durable){
-				$newReplica->setDamage($newHeldItem->getDamage());
+				$newDamage = $newHeldItem->getDamage();
+				if($newDamage >= 0 && $newDamage <= $newReplica->getMaxDurability()){
+					$newReplica->setDamage($newDamage);
+				}
 			}
 			$damagedOrDeducted = $newReplica->equalsExact($newHeldItem);
 

--- a/src/plugin/PharPluginLoader.php
+++ b/src/plugin/PharPluginLoader.php
@@ -24,8 +24,12 @@ declare(strict_types=1);
 namespace pocketmine\plugin;
 
 use pocketmine\thread\ThreadSafeClassLoader;
+use function date;
+use function file_put_contents;
+use function getcwd;
 use function is_file;
 use function str_ends_with;
+use const FILE_APPEND;
 
 /**
  * Handles different types of plugins
@@ -42,8 +46,10 @@ class PharPluginLoader implements PluginLoader{
 	/**
 	 * Loads the plugin contained in $file
 	 */
-	public function loadPlugin(string $file) : void{
-		$description = $this->getPluginDescription($file);
+	public function loadPlugin(string $file, ?PluginDescription $description = null) : void{
+		if($description === null){
+			$description = $this->getPluginDescription($file);
+		}
 		if($description !== null){
 			$this->loader->addPath($description->getSrcNamespacePrefix(), "$file/src");
 		}
@@ -53,6 +59,8 @@ class PharPluginLoader implements PluginLoader{
 	 * Gets the PluginDescription from the file
 	 */
 	public function getPluginDescription(string $file) : ?PluginDescription{
+		// TEMPORARY LOG TO TRACK HOW MANY TIMES getPluginDescription IS CALLED
+		file_put_contents(getcwd() . '/plugin_description_log.txt', date('c') . " : getPluginDescription called for $file\n", FILE_APPEND);
 		$phar = new \Phar($file);
 		if(isset($phar["plugin.yml"])){
 			return new PluginDescription($phar["plugin.yml"]->getContent());

--- a/src/plugin/PharPluginLoader.php
+++ b/src/plugin/PharPluginLoader.php
@@ -59,8 +59,6 @@ class PharPluginLoader implements PluginLoader{
 	 * Gets the PluginDescription from the file
 	 */
 	public function getPluginDescription(string $file) : ?PluginDescription{
-		// TEMPORARY LOG TO TRACK HOW MANY TIMES getPluginDescription IS CALLED
-		file_put_contents(getcwd() . '/plugin_description_log.txt', date('c') . " : getPluginDescription called for $file\n", FILE_APPEND);
 		$phar = new \Phar($file);
 		if(isset($phar["plugin.yml"])){
 			return new PluginDescription($phar["plugin.yml"]->getContent());

--- a/src/plugin/PluginLoader.php
+++ b/src/plugin/PluginLoader.php
@@ -35,8 +35,9 @@ interface PluginLoader{
 
 	/**
 	 * Loads the plugin contained in $file
+	 * @param PluginDescription|null $description Optionally provide a preloaded PluginDescription to avoid reloading
 	 */
-	public function loadPlugin(string $file) : void;
+	public function loadPlugin(string $file, ?PluginDescription $description = null) : void;
 
 	/**
 	 * Gets the PluginDescription from the file

--- a/src/plugin/PluginManager.php
+++ b/src/plugin/PluginManager.php
@@ -150,7 +150,7 @@ class PluginManager{
 		}
 
 		$prefixed = $loader->getAccessProtocol() . $path;
-		$loader->loadPlugin($prefixed);
+		$loader->loadPlugin($prefixed, $description);
 
 		$mainClass = $description->getMain();
 		if(!class_exists($mainClass, true)){

--- a/src/plugin/ScriptPluginLoader.php
+++ b/src/plugin/ScriptPluginLoader.php
@@ -46,7 +46,7 @@ class ScriptPluginLoader implements PluginLoader{
 	/**
 	 * Loads the plugin contained in $file
 	 */
-	public function loadPlugin(string $file) : void{
+	public function loadPlugin(string $file, ?PluginDescription $description = null) : void{
 		include_once $file;
 	}
 


### PR DESCRIPTION
The issue reported in the `PluginDescription` is that it gets loaded twice, which causes a problem. **Dylan** suspects that this is due to the `src-namespace-prefix parameter`. **The solution Dylan suggested** — which I also believe is the best is **method B** 'b) loadPlugin() to accept an additional PluginDescription parameter (problematic due to BC break).' . Although it introduces a **`BC break`**, it is cleaner and more efficient than the first solution, which involves **loading it into a cache**.

### Related issues & PRs
https://github.com/pmmp/PocketMine-MP/issues/4593

## Changes
### API changes
loadPlugin() Now requests the `PluginDescription` parameter

## Follow-up
> [!CAUTION]
> I've left you the test I made to prove to you that it still works. It will of course be deleted once you've looked at my code.

Log File Temp
```txt
2025-06-02T17:05:39+00:00 : getPluginDescription called for D:\Projet\PocketMine-MP\plugins\EasyEdit.phar
```

## Tests
### You can always try it yourself
