### PR TITLE
fix: prevent item name color leak in /give output

### DIFF
--- a/src/command/defaults/GiveCommand.php
+++ b/src/command/defaults/GiveCommand.php
@@ -101,7 +101,7 @@ class GiveCommand extends VanillaCommand{
 		$player->getInventory()->addItem($item);
 
 		Command::broadcastCommandMessage($sender, KnownTranslationFactory::commands_give_success(
-			$item->getName() . " (" . $args[1] . ")",
+			TextFormat::addBase(TextFormat::WHITE, $item->getName()) . " (" . $args[1] . ")",
 			(string) $item->getCount(),
 			$player->getName()
 		));


### PR DESCRIPTION
### Related issues & PRs
* Fixes #5342 

## Changes
### Behavioural changes
Item name’s formatting is now isolated, preventing it from affecting the rest of the /give output

## Backwards compatibility
None
