### PR TITLE
feat: implements a way to enable vibrant visuals

### DIFF
--- a/src/event/player/PlayerResourcePackOfferEvent.php
+++ b/src/event/player/PlayerResourcePackOfferEvent.php
@@ -46,7 +46,8 @@ class PlayerResourcePackOfferEvent extends Event{
 		private readonly PlayerInfo $playerInfo,
 		private array $resourcePacks,
 		private array $encryptionKeys,
-		private bool $mustAccept
+		private bool $mustAccept,
+		private bool $forceDisableVibrantVisuals = true
 	){}
 
 	public function getPlayerInfo() : PlayerInfo{
@@ -102,5 +103,19 @@ class PlayerResourcePackOfferEvent extends Event{
 
 	public function mustAccept() : bool{
 		return $this->mustAccept;
+	}
+
+	/**
+	 * Sets whether vibrant visuals should be forcibly disabled.
+	 */
+	public function setForceDisableVibrantVisuals(bool $forceDisable) : void{
+		$this->forceDisableVibrantVisuals = $forceDisable;
+	}
+
+	/**
+	 * Returns whether vibrant visuals should be forcibly disabled.
+	 */
+	public function forceDisableVibrantVisuals() : bool{
+		return $this->forceDisableVibrantVisuals;
 	}
 }

--- a/src/network/mcpe/NetworkSession.php
+++ b/src/network/mcpe/NetworkSession.php
@@ -932,7 +932,7 @@ class NetworkSession{
 		}
 		$event = new PlayerResourcePackOfferEvent($this->info, $resourcePacks, $keys, $packManager->resourcePacksRequired());
 		$event->call();
-		$this->setHandler(new ResourcePacksPacketHandler($this, $event->getResourcePacks(), $event->getEncryptionKeys(), $event->mustAccept(), function() : void{
+		$this->setHandler(new ResourcePacksPacketHandler($this, $event->getResourcePacks(), $event->getEncryptionKeys(), $event->mustAccept(), $event->forceDisableVibrantVisuals(), function() : void{
 			$this->createPlayer();
 		}));
 	}

--- a/src/network/mcpe/handler/ResourcePacksPacketHandler.php
+++ b/src/network/mcpe/handler/ResourcePacksPacketHandler.php
@@ -87,6 +87,7 @@ class ResourcePacksPacketHandler extends PacketHandler{
 		private array $resourcePackStack,
 		private array $encryptionKeys,
 		private bool $mustAccept,
+		private bool $forceDisableVibrantVisuals,
 		private \Closure $completionCallback
 	){
 		$this->requestQueue = new \SplQueue();
@@ -121,7 +122,7 @@ class ResourcePacksPacketHandler extends PacketHandler{
 			hasScripts: false,
 			worldTemplateId: Uuid::fromString(Uuid::NIL),
 			worldTemplateVersion: "",
-			forceDisableVibrantVisuals: true,
+			forceDisableVibrantVisuals: $this->forceDisableVibrantVisuals,
 		));
 		$this->session->getLogger()->debug("Waiting for client to accept resource packs");
 	}


### PR DESCRIPTION
### Related issues & PRs
* Resolves #6739 

## Changes
### API changes
Added:
```PlayerResourcePackOfferEvent->setForceDisableVibrantVisuals(bool $forceDisable) :  void{}```
```PlayerResourcePackOfferEvent->forceDisableVibrantVisuals() : bool{}```
```ResourcePacksPacketHandler__construct()``` now accepts new parameter ```$forceDisableVibrantVisuals```

### Behavioural changes
You can now enable vibrant visuals 🎉

## Backwards compatibility
None

## Tests
```php
final class Test extends PluginBase implements Listener{
	protected function onEnable(): void{
		$this->getServer()->getPluginManager()->registerEvent(PlayerResourcePackOfferEvent::class, function(PlayerResourcePackOfferEvent $event): void{
                       $event->setForceDisableVibrantVisuals(false);
		}, EventPriority::NORMAL, $this);
	}
}