### PR TITLE
Fixed held block placement after respawn anchor explosion

### DIFF
--- a/src/block/RespawnAnchor.php
+++ b/src/block/RespawnAnchor.php
@@ -85,7 +85,7 @@ final class RespawnAnchor extends Opaque{
 			switch($ev->getAction()){
 				case PlayerRespawnAnchorUseEvent::ACTION_EXPLODE:
 					$this->explode($player);
-					return false;
+					return true;
 
 				case PlayerRespawnAnchorUseEvent::ACTION_SET_SPAWN:
 					if($player->getSpawn() !== null && $player->getSpawn()->equals($this->position)){


### PR DESCRIPTION
Vanilla doesn't place the player held block when exploding respawn anchor.

## Tests
https://github.com/user-attachments/assets/fa8562e7-b404-44b7-969c-efb1e1dd1a0c

