### PR TITLE
Fix typo in changelog

### DIFF
--- a/changelogs/5.30.md
+++ b/changelogs/5.30.md
@@ -67,7 +67,7 @@ Consider using the `mcpe-protocol` directive in `plugin.yml` as a constraint if 
 Released 23rd June 2025.
 
 ## Fixes
-- Fixed accidental break of backwards compatability in `EntityExplodeEvent` introduced in the previous release.
+- Fixed accidental break of backwards compatibility in `EntityExplodeEvent` introduced in the previous release.
 - Fixed placement of player holding block when exploding respawn anchor.
 - Updated BedrockProtocol to fix incorrect encoding of `ServerScriptDebugDrawerPacket`.
 - Disabled client-side locator bar, allowing plugins to write their own implementations.


### PR DESCRIPTION
The word ```compatability``` should be compatibility