### PR TITLE
Fix sneaking hitbox height

### DIFF
--- a/src/entity/Human.php
+++ b/src/entity/Human.php
@@ -247,6 +247,10 @@ class Human extends Living implements ProjectileSource, InventoryHolder{
 		return $this->enderInventory;
 	}
 
+	public function getSneakOffset() : float{
+		return 1.49;
+	}
+
 	/**
 	 * For Human entities which are not players, sets their properties such as nametag, skin and UUID from NBT.
 	 */

--- a/src/entity/Human.php
+++ b/src/entity/Human.php
@@ -248,7 +248,7 @@ class Human extends Living implements ProjectileSource, InventoryHolder{
 	}
 
 	public function getSneakOffset() : float{
-		return 1.49;
+		return 0.31;
 	}
 
 	/**

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -296,7 +296,7 @@ abstract class Living extends Entity{
 			$width = $size->getWidth();
 			$this->setSize((new EntitySizeInfo($width, $width, $width * 0.9))->scale($this->getScale()));
 		}elseif($this->isSneaking()){
-			$this->setSize((new EntitySizeInfo($size->getHeight() - $this->getSneakOffset(), $size->getWidth(), 3 / 4 * $size->getEyeHeight()))->scale($this->getScale()));
+			$this->setSize((new EntitySizeInfo($size->getHeight() - $this->getSneakOffset(), $size->getWidth(), $size->getEyeHeight() - $this->getSneakOffset()))->scale($this->getScale()));
 		}else{
 			$this->setSize($size->scale($this->getScale()));
 		}

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -243,7 +243,7 @@ abstract class Living extends Entity{
 	}
 
 	public function getSneakOffset() : float{
-		return 0.0
+		return 0.0;
 	}
 
 	public function isSneaking() : bool{

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -292,7 +292,7 @@ abstract class Living extends Entity{
 			$width = $size->getWidth();
 			$this->setSize((new EntitySizeInfo($width, $width, $width * 0.9))->scale($this->getScale()));
 		}elseif($this->isSneaking()){
-			$this->setSize((new EntitySizeInfo(53 / 64 * $size->getHeight(), $size->getWidth(), 3 / 4 * $size->getEyeHeight()))->scale($this->getScale()));
+			$this->setSize((new EntitySizeInfo(53 / 64 * $size->getHeight(), $size->getWidth(), 53 / 64 * $size->getEyeHeight()))->scale($this->getScale()));
 		}else{
 			$this->setSize($size->scale($this->getScale()));
 		}

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -292,7 +292,7 @@ abstract class Living extends Entity{
 			$width = $size->getWidth();
 			$this->setSize((new EntitySizeInfo($width, $width, $width * 0.9))->scale($this->getScale()));
 		}elseif($this->isSneaking()){
-			$this->setSize((new EntitySizeInfo(3 / 4 * $size->getHeight(), $size->getWidth(), 3 / 4 * $size->getEyeHeight()))->scale($this->getScale()));
+			$this->setSize((new EntitySizeInfo(53 / 64 * $size->getHeight(), $size->getWidth(), 3 / 4 * $size->getEyeHeight()))->scale($this->getScale()));
 		}else{
 			$this->setSize($size->scale($this->getScale()));
 		}

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -242,6 +242,10 @@ abstract class Living extends Entity{
 		$this->absorptionAttr->setValue($absorption);
 	}
 
+	public function getSneakOffset() : float{
+		return 0.0
+	}
+
 	public function isSneaking() : bool{
 		return $this->sneaking;
 	}
@@ -292,7 +296,7 @@ abstract class Living extends Entity{
 			$width = $size->getWidth();
 			$this->setSize((new EntitySizeInfo($width, $width, $width * 0.9))->scale($this->getScale()));
 		}elseif($this->isSneaking()){
-			$this->setSize((new EntitySizeInfo(53 / 64 * $size->getHeight(), $size->getWidth(), 53 / 64 * $size->getEyeHeight()))->scale($this->getScale()));
+			$this->setSize((new EntitySizeInfo($size->getHeight() - $this->getSneakOffset(), $size->getWidth(), 3 / 4 * $size->getEyeHeight()))->scale($this->getScale()));
 		}else{
 			$this->setSize($size->scale($this->getScale()));
 		}


### PR DESCRIPTION
BDS sends 1.49, so 53/64 (0.828125) gonna be good for it.  Reference: https://github.com/df-mc/dragonfly/pull/1000

<!-- Summarize your PR here. Keep it short and simple. -->
<!-- Explain existing problems or why this pull request is necessary -->

## Changes
### API changes
- `Living` now has  `getSneakOffset()`  to define hitbox height offset while sneaking.

## Tests
Tested

https://github.com/user-attachments/assets/6f59cdbc-2a78-407c-84f6-c79540bf13f9

