### PR TITLE
Support editing the back side of signs

### DIFF
--- a/src/block/BaseSign.php
+++ b/src/block/BaseSign.php
@@ -135,11 +135,11 @@ abstract class BaseSign extends Transparent implements WoodMaterial{
 		}
 	}
 
-	private function doSignChange(SignText $newText, Player $player, Item $item, bool $frontSide) : bool{
-		$ev = new SignChangeEvent($this, $player, $newText, $frontSide);
+	private function doSignChange(SignText $newText, Player $player, Item $item, bool $frontFace) : bool{
+		$ev = new SignChangeEvent($this, $player, $newText, $frontFace);
 		$ev->call();
 		if(!$ev->isCancelled()){
-			$frontSide ? $this->setText($ev->getNewText()) : $this->setBackText($ev->getNewText());
+			$this->setFaceText($frontFace, $ev->getNewText());
 			$this->position->getWorld()->setBlock($this->position, $this);
 			$item->pop();
 			return true;
@@ -148,9 +148,9 @@ abstract class BaseSign extends Transparent implements WoodMaterial{
 		return false;
 	}
 
-	private function changeSignGlowingState(bool $glowing, Player $player, Item $item, bool $frontSide) : bool{
-		$text = $frontSide ? $this->text : $this->backText;
-		if($text->isGlowing() !== $glowing && $this->doSignChange(new SignText($text->getLines(), $text->getBaseColor(), $glowing), $player, $item, $frontSide)){
+	private function changeSignGlowingState(bool $glowing, Player $player, Item $item, bool $frontFace) : bool{
+		$text = $this->getFaceText($frontFace);
+		if($text->isGlowing() !== $glowing && $this->doSignChange(new SignText($text->getLines(), $text->getBaseColor(), $glowing), $player, $item, $frontFace)){
 			$this->position->getWorld()->addSound($this->position, new InkSacUseSound());
 			return true;
 		}
@@ -177,7 +177,7 @@ abstract class BaseSign extends Transparent implements WoodMaterial{
 			return true;
 		}
 
-		$clickedFront = $this->interactsFront($this->getHitboxCenter(), $player->getPosition(), $this->getFacingDegrees());
+		$frontFace = $this->interactsFront($this->getHitboxCenter(), $player->getPosition(), $this->getFacingDegrees());
 
 		$dyeColor = $item instanceof Dye ? $item->getColor() : match($item->getTypeId()){
 			ItemTypeIds::BONE_MEAL => DyeColor::WHITE,
@@ -187,24 +187,24 @@ abstract class BaseSign extends Transparent implements WoodMaterial{
 		};
 		if($dyeColor !== null){
 			$color = $dyeColor === DyeColor::BLACK ? new Color(0, 0, 0) : $dyeColor->getRgbValue();
-			$text = $clickedFront ? $this->text : $this->backText;
+			$text = $this->getFaceText($frontFace);
 			if(
 				$color->toARGB() !== $text->getBaseColor()->toARGB() &&
-				$this->doSignChange(new SignText($text->getLines(), $color, $text->isGlowing()), $player, $item, $clickedFront)
+				$this->doSignChange(new SignText($text->getLines(), $color, $text->isGlowing()), $player, $item, $frontFace)
 			){
 				$this->position->getWorld()->addSound($this->position, new DyeUseSound());
 				return true;
 			}
 		}elseif(match($item->getTypeId()){
-			ItemTypeIds::INK_SAC => $this->changeSignGlowingState(false, $player, $item, $clickedFront),
-			ItemTypeIds::GLOW_INK_SAC => $this->changeSignGlowingState(true, $player, $item, $clickedFront),
+			ItemTypeIds::INK_SAC => $this->changeSignGlowingState(false, $player, $item, $frontFace),
+			ItemTypeIds::GLOW_INK_SAC => $this->changeSignGlowingState(true, $player, $item, $frontFace),
 			ItemTypeIds::HONEYCOMB => $this->wax($player, $item),
 			default => false
 		}){
 			return true;
 		}
 
-		$player->openSignEditor($this->position, $clickedFront);
+		$player->openSignEditor($this->position, $frontFace);
 
 		return true;
 	}
@@ -221,7 +221,7 @@ abstract class BaseSign extends Transparent implements WoodMaterial{
 	}
 
 	/**
-	 * Returns the center of the sign's hitbox. Used to decide which side of the sign to open when a player interacts.
+	 * Returns the center of the sign's hitbox. Used to decide which face of the sign to open when a player interacts.
 	 */
 	protected function getHitboxCenter() : Vector3{
 		return $this->position->add(0.5, 0.5, 0.5);
@@ -236,22 +236,30 @@ abstract class BaseSign extends Transparent implements WoodMaterial{
 
 	/**
 	 * Returns an object containing information about the sign text.
+	 * @deprecated
+	 * @see self::getFaceText()
 	 */
 	public function getText() : SignText{
 		return $this->text;
 	}
 
-	/** @return $this */
+	/**
+	 * @deprecated
+	 * @see self::setFaceText()
+	 * @return $this
+	 */
 	public function setText(SignText $text) : self{
 		$this->text = $text;
 		return $this;
 	}
 
-	public function getBackText() : SignText{ return $this->backText; }
+	public function getFaceText(bool $frontFace) : SignText{
+		return $frontFace ? $this->text : $this->backText;
+	}
 
 	/** @return $this */
-	public function setBackText(SignText $backText) : self{
-		$this->backText = $backText;
+	public function setFaceText(bool $frontFace, SignText $text) : self{
+		$frontFace ? $this->text = $text : $this->backText = $text;
 		return $this;
 	}
 
@@ -285,7 +293,7 @@ abstract class BaseSign extends Transparent implements WoodMaterial{
 	 * @return bool if the sign update was successful.
 	 * @throws \UnexpectedValueException if the text payload is too large
 	 */
-	public function updateText(Player $author, SignText $text, bool $frontSide = true) : bool{
+	public function updateText(Player $author, SignText $text, bool $frontFace = true) : bool{
 		$size = 0;
 		foreach($text->getLines() as $line){
 			$size += strlen($line);
@@ -293,16 +301,16 @@ abstract class BaseSign extends Transparent implements WoodMaterial{
 		if($size > 1000){
 			throw new \UnexpectedValueException($author->getName() . " tried to write $size bytes of text onto a sign (bigger than max 1000)");
 		}
-		$oldText = $frontSide ? $this->text : $this->backText;
+		$oldText = $this->getFaceText($frontFace);
 		$ev = new SignChangeEvent($this, $author, new SignText(array_map(function(string $line) : string{
 			return TextFormat::clean($line, false);
-		}, $text->getLines()), $oldText->getBaseColor(), $oldText->isGlowing()), $frontSide);
+		}, $text->getLines()), $oldText->getBaseColor(), $oldText->isGlowing()), $frontFace);
 		if($this->waxed || $this->editorEntityRuntimeId !== $author->getId()){
 			$ev->cancel();
 		}
 		$ev->call();
 		if(!$ev->isCancelled()){
-			$frontSide ? $this->setText($ev->getNewText()) : $this->setBackText($ev->getNewText());
+			$this->setFaceText($frontFace, $text);
 			$this->setEditorEntityRuntimeId(null);
 			$this->position->getWorld()->setBlock($this->position, $this);
 			return true;

--- a/src/block/BaseSign.php
+++ b/src/block/BaseSign.php
@@ -41,14 +41,19 @@ use pocketmine\utils\TextFormat;
 use pocketmine\world\BlockTransaction;
 use pocketmine\world\sound\DyeUseSound;
 use pocketmine\world\sound\InkSacUseSound;
+use function abs;
 use function array_map;
 use function assert;
+use function atan2;
+use function fmod;
+use function rad2deg;
 use function strlen;
 
 abstract class BaseSign extends Transparent implements WoodMaterial{
 	use WoodTypeTrait;
 
 	protected SignText $text;
+	protected SignText $backText;
 	private bool $waxed = false;
 
 	protected ?int $editorEntityRuntimeId = null;
@@ -63,6 +68,7 @@ abstract class BaseSign extends Transparent implements WoodMaterial{
 		$this->woodType = $woodType;
 		parent::__construct($idInfo, $name, $typeInfo);
 		$this->text = new SignText();
+		$this->backText = new SignText();
 		$this->asItemCallback = $asItemCallback;
 	}
 
@@ -71,6 +77,7 @@ abstract class BaseSign extends Transparent implements WoodMaterial{
 		$tile = $this->position->getWorld()->getTile($this->position);
 		if($tile instanceof TileSign){
 			$this->text = $tile->getText();
+			$this->backText = $tile->getBackText();
 			$this->waxed = $tile->isWaxed();
 			$this->editorEntityRuntimeId = $tile->getEditorEntityRuntimeId();
 		}
@@ -83,6 +90,7 @@ abstract class BaseSign extends Transparent implements WoodMaterial{
 		$tile = $this->position->getWorld()->getTile($this->position);
 		assert($tile instanceof TileSign);
 		$tile->setText($this->text);
+		$tile->setBackText($this->backText);
 		$tile->setWaxed($this->waxed);
 		$tile->setEditorEntityRuntimeId($this->editorEntityRuntimeId);
 	}
@@ -144,11 +152,11 @@ abstract class BaseSign extends Transparent implements WoodMaterial{
 		}
 	}
 
-	private function doSignChange(SignText $newText, Player $player, Item $item) : bool{
-		$ev = new SignChangeEvent($this, $player, $newText);
+	private function doSignChange(SignText $newText, Player $player, Item $item, bool $frontSide) : bool{
+		$ev = new SignChangeEvent($this, $player, $newText, $frontSide);
 		$ev->call();
 		if(!$ev->isCancelled()){
-			$this->text = $ev->getNewText();
+			$ev->isFrontSide() ? $this->setText($ev->getNewText()) : $this->setBackText($ev->getNewText());
 			$this->position->getWorld()->setBlock($this->position, $this);
 			$item->pop();
 			return true;
@@ -157,8 +165,9 @@ abstract class BaseSign extends Transparent implements WoodMaterial{
 		return false;
 	}
 
-	private function changeSignGlowingState(bool $glowing, Player $player, Item $item) : bool{
-		if($this->text->isGlowing() !== $glowing && $this->doSignChange(new SignText($this->text->getLines(), $this->text->getBaseColor(), $glowing), $player, $item)){
+	private function changeSignGlowingState(bool $glowing, Player $player, Item $item, bool $frontSide) : bool{
+		$text = $frontSide ? $this->text : $this->backText;
+		if($text->isGlowing() !== $glowing && $this->doSignChange(new SignText($text->getLines(), $text->getBaseColor(), $glowing), $player, $item, $frontSide)){
 			$this->position->getWorld()->addSound($this->position, new InkSacUseSound());
 			return true;
 		}
@@ -185,6 +194,8 @@ abstract class BaseSign extends Transparent implements WoodMaterial{
 			return true;
 		}
 
+		$clickedFront = $this->interactsFront($this->getHitboxCenter(), $player->getPosition(), $this->getFacingDegrees());
+
 		$dyeColor = $item instanceof Dye ? $item->getColor() : match($item->getTypeId()){
 			ItemTypeIds::BONE_MEAL => DyeColor::WHITE,
 			ItemTypeIds::LAPIS_LAZULI => DyeColor::BLUE,
@@ -193,25 +204,51 @@ abstract class BaseSign extends Transparent implements WoodMaterial{
 		};
 		if($dyeColor !== null){
 			$color = $dyeColor === DyeColor::BLACK ? new Color(0, 0, 0) : $dyeColor->getRgbValue();
+			$text = $clickedFront ? $this->text : $this->backText;
 			if(
-				$color->toARGB() !== $this->text->getBaseColor()->toARGB() &&
-				$this->doSignChange(new SignText($this->text->getLines(), $color, $this->text->isGlowing()), $player, $item)
+				$color->toARGB() !== $text->getBaseColor()->toARGB() &&
+				$this->doSignChange(new SignText($text->getLines(), $color, $text->isGlowing()), $player, $item, $clickedFront)
 			){
 				$this->position->getWorld()->addSound($this->position, new DyeUseSound());
 				return true;
 			}
 		}elseif(match($item->getTypeId()){
-			ItemTypeIds::INK_SAC => $this->changeSignGlowingState(false, $player, $item),
-			ItemTypeIds::GLOW_INK_SAC => $this->changeSignGlowingState(true, $player, $item),
+			ItemTypeIds::INK_SAC => $this->changeSignGlowingState(false, $player, $item, $clickedFront),
+			ItemTypeIds::GLOW_INK_SAC => $this->changeSignGlowingState(true, $player, $item, $clickedFront),
 			ItemTypeIds::HONEYCOMB => $this->wax($player, $item),
 			default => false
 		}){
 			return true;
 		}
 
-		$player->openSignEditor($this->position);
+		$player->openSignEditor($this->position, $clickedFront);
 
 		return true;
+	}
+
+	private function interactsFront(Vector3 $hitboxCenter, Vector3 $playerPosition, float $signFacingDegrees) : bool{
+		$playerCenterDiffX = $playerPosition->x - $hitboxCenter->x;
+		$playerCenterDiffZ = $playerPosition->z - $hitboxCenter->z;
+
+		$f1 = rad2deg(atan2($playerCenterDiffZ, $playerCenterDiffX)) - 90.0;
+
+		$rotationDiff = $signFacingDegrees - $f1;
+		$rotation = fmod($rotationDiff + 180.0, 360.0) - 180.0; // Normalize to [-180, 180]
+		return abs($rotation) <= 90.0;
+	}
+
+	/**
+	 * Returns the center of the sign's hitbox. Used to decide which side of the sign to open when a player interacts.
+	 */
+	protected function getHitboxCenter() : Vector3{
+		return $this->position->add(0.5, 0.5, 0.5);
+	}
+
+	/**
+	 * TODO: make this abstract (BC break)
+	 */
+	protected function getFacingDegrees() : float{
+		return 0;
 	}
 
 	/**
@@ -224,6 +261,14 @@ abstract class BaseSign extends Transparent implements WoodMaterial{
 	/** @return $this */
 	public function setText(SignText $text) : self{
 		$this->text = $text;
+		return $this;
+	}
+
+	public function getBackText() : SignText{ return $this->backText; }
+
+	/** @return $this */
+	public function setBackText(SignText $backText) : self{
+		$this->backText = $backText;
 		return $this;
 	}
 
@@ -257,7 +302,7 @@ abstract class BaseSign extends Transparent implements WoodMaterial{
 	 * @return bool if the sign update was successful.
 	 * @throws \UnexpectedValueException if the text payload is too large
 	 */
-	public function updateText(Player $author, SignText $text) : bool{
+	public function updateText(Player $author, SignText $text, bool $frontSide = true) : bool{
 		$size = 0;
 		foreach($text->getLines() as $line){
 			$size += strlen($line);
@@ -265,15 +310,16 @@ abstract class BaseSign extends Transparent implements WoodMaterial{
 		if($size > 1000){
 			throw new \UnexpectedValueException($author->getName() . " tried to write $size bytes of text onto a sign (bigger than max 1000)");
 		}
+		$oldText = $frontSide ? $this->text : $this->backText;
 		$ev = new SignChangeEvent($this, $author, new SignText(array_map(function(string $line) : string{
 			return TextFormat::clean($line, false);
-		}, $text->getLines()), $this->text->getBaseColor(), $this->text->isGlowing()));
+		}, $text->getLines()), $oldText->getBaseColor(), $oldText->isGlowing()), $frontSide);
 		if($this->waxed || $this->editorEntityRuntimeId !== $author->getId()){
 			$ev->cancel();
 		}
 		$ev->call();
 		if(!$ev->isCancelled()){
-			$this->setText($ev->getNewText());
+			$ev->isFrontSide() ? $this->setText($ev->getNewText()) : $this->setBackText($ev->getNewText());
 			$this->setEditorEntityRuntimeId(null);
 			$this->position->getWorld()->setBlock($this->position, $this);
 			return true;

--- a/src/block/BaseSign.php
+++ b/src/block/BaseSign.php
@@ -52,7 +52,7 @@ use function strlen;
 abstract class BaseSign extends Transparent implements WoodMaterial{
 	use WoodTypeTrait;
 
-	protected SignText $text;
+	protected SignText $text; //TODO: rename this (BC break)
 	protected SignText $backText;
 	private bool $waxed = false;
 

--- a/src/block/BaseSign.php
+++ b/src/block/BaseSign.php
@@ -139,7 +139,7 @@ abstract class BaseSign extends Transparent implements WoodMaterial{
 		$ev = new SignChangeEvent($this, $player, $newText, $frontSide);
 		$ev->call();
 		if(!$ev->isCancelled()){
-			$ev->isFrontSide() ? $this->setText($ev->getNewText()) : $this->setBackText($ev->getNewText());
+			$frontSide ? $this->setText($ev->getNewText()) : $this->setBackText($ev->getNewText());
 			$this->position->getWorld()->setBlock($this->position, $this);
 			$item->pop();
 			return true;
@@ -302,7 +302,7 @@ abstract class BaseSign extends Transparent implements WoodMaterial{
 		}
 		$ev->call();
 		if(!$ev->isCancelled()){
-			$ev->isFrontSide() ? $this->setText($ev->getNewText()) : $this->setBackText($ev->getNewText());
+			$frontSide ? $this->setText($ev->getNewText()) : $this->setBackText($ev->getNewText());
 			$this->setEditorEntityRuntimeId(null);
 			$this->position->getWorld()->setBlock($this->position, $this);
 			return true;

--- a/src/block/BaseSign.php
+++ b/src/block/BaseSign.php
@@ -288,12 +288,20 @@ abstract class BaseSign extends Transparent implements WoodMaterial{
 	}
 
 	/**
+	 * @deprecated
+	 * @see self::updateFaceText()
+	 */
+	public function updateText(Player $author, SignText $text) : bool{
+		return $this->updateFaceText($author, true, $text);
+	}
+
+	/**
 	 * Called by the player controller (network session) to update the sign text, firing events as appropriate.
 	 *
 	 * @return bool if the sign update was successful.
 	 * @throws \UnexpectedValueException if the text payload is too large
 	 */
-	public function updateText(Player $author, SignText $text, bool $frontFace = true) : bool{
+	public function updateFaceText(Player $author, bool $frontFace, SignText $text) : bool{
 		$size = 0;
 		foreach($text->getLines() as $line){
 			$size += strlen($line);

--- a/src/block/BaseSign.php
+++ b/src/block/BaseSign.php
@@ -318,7 +318,7 @@ abstract class BaseSign extends Transparent implements WoodMaterial{
 		}
 		$ev->call();
 		if(!$ev->isCancelled()){
-			$this->setFaceText($frontFace, $text);
+			$this->setFaceText($frontFace, $ev->getNewText());
 			$this->setEditorEntityRuntimeId(null);
 			$this->position->getWorld()->setBlock($this->position, $this);
 			return true;

--- a/src/block/CeilingCenterHangingSign.php
+++ b/src/block/CeilingCenterHangingSign.php
@@ -49,4 +49,8 @@ final class CeilingCenterHangingSign extends BaseSign implements SignLikeRotatio
 		}
 		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
 	}
+
+	protected function getFacingDegrees() : float{
+		return $this->rotation * 22.5;
+	}
 }

--- a/src/block/CeilingEdgesHangingSign.php
+++ b/src/block/CeilingEdgesHangingSign.php
@@ -73,7 +73,7 @@ final class CeilingEdgesHangingSign extends BaseSign implements HorizontalFacing
 			Facing::WEST => 90,
 			Facing::NORTH => 180,
 			Facing::EAST => 270,
-			default => throw new AssumptionFailedError("Invalid facing direction for WallSign: " . $this->facing),
+			default => throw new AssumptionFailedError("Invalid facing direction: " . $this->facing),
 		};
 	}
 }

--- a/src/block/CeilingEdgesHangingSign.php
+++ b/src/block/CeilingEdgesHangingSign.php
@@ -68,7 +68,7 @@ final class CeilingEdgesHangingSign extends BaseSign implements HorizontalFacing
 	}
 
 	protected function getFacingDegrees() : float{
-		return match ($this->facing) {
+		return match($this->facing){
 			Facing::SOUTH => 0,
 			Facing::WEST => 90,
 			Facing::NORTH => 180,

--- a/src/block/CeilingEdgesHangingSign.php
+++ b/src/block/CeilingEdgesHangingSign.php
@@ -29,6 +29,7 @@ use pocketmine\item\Item;
 use pocketmine\math\Facing;
 use pocketmine\math\Vector3;
 use pocketmine\player\Player;
+use pocketmine\utils\AssumptionFailedError;
 use pocketmine\world\BlockTransaction;
 
 final class CeilingEdgesHangingSign extends BaseSign implements HorizontalFacing{
@@ -47,5 +48,15 @@ final class CeilingEdgesHangingSign extends BaseSign implements HorizontalFacing
 		}
 
 		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
+	}
+
+	protected function getFacingDegrees() : float{
+		return match ($this->facing) {
+			Facing::SOUTH => 0,
+			Facing::WEST => 90,
+			Facing::NORTH => 180,
+			Facing::EAST => 270,
+			default => throw new AssumptionFailedError("Invalid facing direction for WallSign: " . $this->facing),
+		};
 	}
 }

--- a/src/block/FloorSign.php
+++ b/src/block/FloorSign.php
@@ -48,4 +48,8 @@ final class FloorSign extends BaseSign implements SignLikeRotation{
 		}
 		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
 	}
+
+	protected function getFacingDegrees() : float{
+		return $this->rotation * 22.5;
+	}
 }

--- a/src/block/WallHangingSign.php
+++ b/src/block/WallHangingSign.php
@@ -30,6 +30,7 @@ use pocketmine\math\Axis;
 use pocketmine\math\Facing;
 use pocketmine\math\Vector3;
 use pocketmine\player\Player;
+use pocketmine\utils\AssumptionFailedError;
 use pocketmine\world\BlockTransaction;
 
 final class WallHangingSign extends BaseSign implements HorizontalFacing{
@@ -59,5 +60,15 @@ final class WallHangingSign extends BaseSign implements HorizontalFacing{
 		}
 
 		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
+	}
+
+	protected function getFacingDegrees() : float{
+		return match ($this->facing) {
+			Facing::SOUTH => 0,
+			Facing::WEST => 90,
+			Facing::NORTH => 180,
+			Facing::EAST => 270,
+			default => throw new AssumptionFailedError("Invalid facing direction for WallSign: " . $this->facing),
+		};
 	}
 }

--- a/src/block/WallHangingSign.php
+++ b/src/block/WallHangingSign.php
@@ -86,7 +86,7 @@ final class WallHangingSign extends BaseSign implements HorizontalFacing{
 			Facing::WEST => 90,
 			Facing::NORTH => 180,
 			Facing::EAST => 270,
-			default => throw new AssumptionFailedError("Invalid facing direction for WallSign: " . $this->facing),
+			default => throw new AssumptionFailedError("Invalid facing direction: " . $this->facing),
 		};
 	}
 }

--- a/src/block/WallHangingSign.php
+++ b/src/block/WallHangingSign.php
@@ -81,7 +81,7 @@ final class WallHangingSign extends BaseSign implements HorizontalFacing{
 	}
 
 	protected function getFacingDegrees() : float{
-		return match ($this->facing) {
+		return match($this->facing){
 			Facing::SOUTH => 0,
 			Facing::WEST => 90,
 			Facing::NORTH => 180,

--- a/src/block/WallSign.php
+++ b/src/block/WallSign.php
@@ -30,6 +30,7 @@ use pocketmine\math\Axis;
 use pocketmine\math\Facing;
 use pocketmine\math\Vector3;
 use pocketmine\player\Player;
+use pocketmine\utils\AssumptionFailedError;
 use pocketmine\world\BlockTransaction;
 
 final class WallSign extends BaseSign implements HorizontalFacing{
@@ -45,5 +46,26 @@ final class WallSign extends BaseSign implements HorizontalFacing{
 		}
 		$this->facing = $face;
 		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
+	}
+
+	protected function getHitboxCenter() : Vector3{
+		[$xOffset, $zOffset] = match($this->facing){
+			Facing::NORTH => [0, 15 / 16],
+			Facing::SOUTH => [0, 1 / 16],
+			Facing::WEST => [15 / 16, 0],
+			Facing::EAST => [1 / 16, 0],
+			default => throw new AssumptionFailedError("Invalid facing direction for WallSign: " . $this->facing),
+		};
+		return $this->position->add($xOffset, 0.5, $zOffset);
+	}
+
+	protected function getFacingDegrees() : float{
+		return match($this->facing){
+			Facing::SOUTH => 0,
+			Facing::WEST => 90,
+			Facing::NORTH => 180,
+			Facing::EAST => 270,
+			default => throw new AssumptionFailedError("Invalid facing direction for WallSign: " . $this->facing),
+		};
 	}
 }

--- a/src/block/WallSign.php
+++ b/src/block/WallSign.php
@@ -54,7 +54,7 @@ final class WallSign extends BaseSign implements HorizontalFacing{
 			Facing::SOUTH => [0, 1 / 16],
 			Facing::WEST => [15 / 16, 0],
 			Facing::EAST => [1 / 16, 0],
-			default => throw new AssumptionFailedError("Invalid facing direction for WallSign: " . $this->facing),
+			default => throw new AssumptionFailedError("Invalid facing direction: " . $this->facing),
 		};
 		return $this->position->add($xOffset, 0.5, $zOffset);
 	}
@@ -65,7 +65,7 @@ final class WallSign extends BaseSign implements HorizontalFacing{
 			Facing::WEST => 90,
 			Facing::NORTH => 180,
 			Facing::EAST => 270,
-			default => throw new AssumptionFailedError("Invalid facing direction for WallSign: " . $this->facing),
+			default => throw new AssumptionFailedError("Invalid facing direction: " . $this->facing),
 		};
 	}
 }

--- a/src/block/tile/Sign.php
+++ b/src/block/tile/Sign.php
@@ -70,16 +70,18 @@ class Sign extends Spawnable{
 	}
 
 	protected SignText $text;
+	protected SignText $backText;
 	private bool $waxed = false;
 
 	protected ?int $editorEntityRuntimeId = null;
 
 	public function __construct(World $world, Vector3 $pos){
 		$this->text = new SignText();
+		$this->backText = new SignText();
 		parent::__construct($world, $pos);
 	}
 
-	private function readTextTag(CompoundTag $nbt, bool $lightingBugResolved) : void{
+	private function readTextTag(CompoundTag $nbt, bool $lightingBugResolved) : SignText{
 		$baseColor = new Color(0, 0, 0);
 		$glowingText = false;
 		if(($baseColorTag = $nbt->getTag(self::TAG_TEXT_COLOR)) instanceof IntTag){
@@ -90,19 +92,27 @@ class Sign extends Spawnable{
 			//see https://bugs.mojang.com/browse/MCPE-117835
 			$glowingText = $glowingTextTag->getValue() !== 0;
 		}
-		$this->text = SignText::fromBlob(mb_scrub($nbt->getString(self::TAG_TEXT_BLOB), 'UTF-8'), $baseColor, $glowingText);
+		return SignText::fromBlob(mb_scrub($nbt->getString(self::TAG_TEXT_BLOB), 'UTF-8'), $baseColor, $glowingText);
+	}
+
+	private function writeTextTag(SignText $text) : CompoundTag{
+		return CompoundTag::create()
+			->setString(self::TAG_TEXT_BLOB, rtrim(implode("\n", $text->getLines()), "\n"))
+			->setInt(self::TAG_TEXT_COLOR, Binary::signInt($text->getBaseColor()->toARGB()))
+			->setByte(self::TAG_GLOWING_TEXT, $text->isGlowing() ? 1 : 0)
+			->setByte(self::TAG_PERSIST_FORMATTING, 1);
 	}
 
 	public function readSaveData(CompoundTag $nbt) : void{
 		$frontTextTag = $nbt->getTag(self::TAG_FRONT_TEXT);
 		if($frontTextTag instanceof CompoundTag){
-			$this->readTextTag($frontTextTag, true);
+			$this->text = $this->readTextTag($frontTextTag, true);
 		}elseif($nbt->getTag(self::TAG_TEXT_BLOB) instanceof StringTag){ //MCPE 1.2 save format
 			$lightingBugResolved = false;
 			if(($lightingBugResolvedTag = $nbt->getTag(self::TAG_LEGACY_BUG_RESOLVE)) instanceof ByteTag){
 				$lightingBugResolved = $lightingBugResolvedTag->getValue() !== 0;
 			}
-			$this->readTextTag($nbt, $lightingBugResolved);
+			$this->text = $this->readTextTag($nbt, $lightingBugResolved);
 		}else{
 			$text = [];
 			for($i = 0; $i < SignText::LINE_COUNT; ++$i){
@@ -113,22 +123,14 @@ class Sign extends Spawnable{
 			}
 			$this->text = new SignText($text);
 		}
+		$backTextTag = $nbt->getTag(self::TAG_BACK_TEXT);
+		$this->backText = $backTextTag instanceof CompoundTag ? $this->readTextTag($backTextTag, true) : new SignText();
 		$this->waxed = $nbt->getByte(self::TAG_WAXED, 0) !== 0;
 	}
 
 	protected function writeSaveData(CompoundTag $nbt) : void{
-		$nbt->setTag(self::TAG_FRONT_TEXT, CompoundTag::create()
-			->setString(self::TAG_TEXT_BLOB, rtrim(implode("\n", $this->text->getLines()), "\n"))
-			->setInt(self::TAG_TEXT_COLOR, Binary::signInt($this->text->getBaseColor()->toARGB()))
-			->setByte(self::TAG_GLOWING_TEXT, $this->text->isGlowing() ? 1 : 0)
-			->setByte(self::TAG_PERSIST_FORMATTING, 1)
-		);
-		$nbt->setTag(self::TAG_BACK_TEXT, CompoundTag::create()
-			->setString(self::TAG_TEXT_BLOB, "")
-			->setInt(self::TAG_TEXT_COLOR, Binary::signInt(0xff_00_00_00))
-			->setByte(self::TAG_GLOWING_TEXT, 0)
-			->setByte(self::TAG_PERSIST_FORMATTING, 1)
-		);
+		$nbt->setTag(self::TAG_FRONT_TEXT, $this->writeTextTag($this->text));
+		$nbt->setTag(self::TAG_BACK_TEXT, $this->writeTextTag($this->backText));
 
 		$nbt->setByte(self::TAG_WAXED, $this->waxed ? 1 : 0);
 	}
@@ -140,6 +142,10 @@ class Sign extends Spawnable{
 	public function setText(SignText $text) : void{
 		$this->text = $text;
 	}
+
+	public function getBackText() : SignText{ return $this->backText; }
+
+	public function setBackText(SignText $backText) : void{ $this->backText = $backText; }
 
 	public function isWaxed() : bool{ return $this->waxed; }
 
@@ -162,19 +168,8 @@ class Sign extends Spawnable{
 	}
 
 	protected function addAdditionalSpawnData(CompoundTag $nbt) : void{
-		$nbt->setTag(self::TAG_FRONT_TEXT, CompoundTag::create()
-			->setString(self::TAG_TEXT_BLOB, rtrim(implode("\n", $this->text->getLines()), "\n"))
-			->setInt(self::TAG_TEXT_COLOR, Binary::signInt($this->text->getBaseColor()->toARGB()))
-			->setByte(self::TAG_GLOWING_TEXT, $this->text->isGlowing() ? 1 : 0)
-			->setByte(self::TAG_PERSIST_FORMATTING, 1) //TODO: not sure what this is used for
-		);
-		//TODO: this is not yet used by the server, but needed to rollback any client-side changes to the back text
-		$nbt->setTag(self::TAG_BACK_TEXT, CompoundTag::create()
-			->setString(self::TAG_TEXT_BLOB, "")
-			->setInt(self::TAG_TEXT_COLOR, Binary::signInt(0xff_00_00_00))
-			->setByte(self::TAG_GLOWING_TEXT, 0)
-			->setByte(self::TAG_PERSIST_FORMATTING, 1)
-		);
+		$nbt->setTag(self::TAG_FRONT_TEXT, $this->writeTextTag($this->text));
+		$nbt->setTag(self::TAG_BACK_TEXT, $this->writeTextTag($this->backText));
 		$nbt->setByte(self::TAG_WAXED, $this->waxed ? 1 : 0);
 		$nbt->setLong(self::TAG_LOCKED_FOR_EDITING_BY, $this->editorEntityRuntimeId ?? -1);
 	}

--- a/src/event/block/SignChangeEvent.php
+++ b/src/event/block/SignChangeEvent.php
@@ -41,9 +41,9 @@ class SignChangeEvent extends BlockEvent implements Cancellable{
 		private BaseSign $sign,
 		private Player $player,
 		private SignText $text,
-		private bool $frontSide = true
+		private bool $frontFace = true
 	){
-		$this->oldText = $this->frontSide ? $sign->getText() : $sign->getBackText();
+		$this->oldText = $this->sign->getFaceText($this->frontFace);
 		parent::__construct($sign);
 	}
 
@@ -76,5 +76,5 @@ class SignChangeEvent extends BlockEvent implements Cancellable{
 		$this->text = $text;
 	}
 
-	public function isFrontSide() : bool{ return $this->frontSide; }
+	public function isFrontFace() : bool{ return $this->frontFace; }
 }

--- a/src/event/block/SignChangeEvent.php
+++ b/src/event/block/SignChangeEvent.php
@@ -77,6 +77,4 @@ class SignChangeEvent extends BlockEvent implements Cancellable{
 	}
 
 	public function isFrontSide() : bool{ return $this->frontSide; }
-
-	public function setFrontSide(bool $frontSide) : void{ $this->frontSide = $frontSide; }
 }

--- a/src/event/block/SignChangeEvent.php
+++ b/src/event/block/SignChangeEvent.php
@@ -35,11 +35,15 @@ use pocketmine\player\Player;
 class SignChangeEvent extends BlockEvent implements Cancellable{
 	use CancellableTrait;
 
+	private SignText $oldText;
+
 	public function __construct(
 		private BaseSign $sign,
 		private Player $player,
-		private SignText $text
+		private SignText $text,
+		private bool $frontSide = true
 	){
+		$this->oldText = $this->frontSide ? $sign->getText() : $sign->getBackText();
 		parent::__construct($sign);
 	}
 
@@ -55,7 +59,7 @@ class SignChangeEvent extends BlockEvent implements Cancellable{
 	 * Returns the text currently on the sign.
 	 */
 	public function getOldText() : SignText{
-		return $this->sign->getText();
+		return $this->oldText;
 	}
 
 	/**
@@ -71,4 +75,8 @@ class SignChangeEvent extends BlockEvent implements Cancellable{
 	public function setNewText(SignText $text) : void{
 		$this->text = $text;
 	}
+
+	public function isFrontSide() : bool{ return $this->frontSide; }
+
+	public function setFrontSide(bool $frontSide) : void{ $this->frontSide = $frontSide; }
 }

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -758,7 +758,7 @@ class InGamePacketHandler extends PacketHandler{
 	/**
 	 * @throws PacketHandlingException
 	 */
-	private function updateSignText(CompoundTag $nbt, string $tagName, bool $isFront, BaseSign $block, Vector3 $pos) : bool{
+	private function updateSignText(CompoundTag $nbt, string $tagName, bool $frontFace, BaseSign $block, Vector3 $pos) : bool{
 		$textTag = $nbt->getTag($tagName);
 		if(!$textTag instanceof CompoundTag){
 			throw new PacketHandlingException("Invalid tag type " . get_debug_type($textTag) . " for tag \"$tagName\" in sign update data");
@@ -774,13 +774,13 @@ class InGamePacketHandler extends PacketHandler{
 			throw PacketHandlingException::wrap($e, "Invalid sign text update");
 		}
 
-		$oldText = $isFront ? $block->getText() : $block->getBackText();
+		$oldText = $block->getFaceText($frontFace);
 		if($text->getLines() === $oldText->getLines()){
 			return false;
 		}
 
 		try{
-			if(!$block->updateText($this->player, $text, $isFront)){
+			if(!$block->updateText($this->player, $text, $frontFace)){
 				foreach($this->player->getWorld()->createBlockUpdatePackets([$pos]) as $updatePacket){
 					$this->session->sendDataPacket($updatePacket);
 				}

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -780,7 +780,7 @@ class InGamePacketHandler extends PacketHandler{
 		}
 
 		try{
-			if(!$block->updateText($this->player, $text, $frontFace)){
+			if(!$block->updateFaceText($this->player, $frontFace, $text)){
 				foreach($this->player->getWorld()->createBlockUpdatePackets([$pos]) as $updatePacket){
 					$this->session->sendDataPacket($updatePacket);
 				}

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -755,6 +755,43 @@ class InGamePacketHandler extends PacketHandler{
 		return true; //this packet is useless
 	}
 
+	/**
+	 * @throws PacketHandlingException
+	 */
+	private function updateSignText(CompoundTag $nbt, string $tagName, bool $isFront, BaseSign $block, Vector3 $pos) : bool{
+		$frontTextTag = $nbt->getTag($tagName);
+		if(!$frontTextTag instanceof CompoundTag){
+			throw new PacketHandlingException("Invalid tag type " . get_debug_type($frontTextTag) . " for tag \"$tagName\" in sign update data");
+		}
+		$textBlobTag = $frontTextTag->getTag(Sign::TAG_TEXT_BLOB);
+		if(!$textBlobTag instanceof StringTag){
+			throw new PacketHandlingException("Invalid tag type " . get_debug_type($textBlobTag) . " for tag \"" . Sign::TAG_TEXT_BLOB . "\" in sign update data");
+		}
+
+		try{
+			$text = SignText::fromBlob($textBlobTag->getValue());
+		}catch(\InvalidArgumentException $e){
+			throw PacketHandlingException::wrap($e, "Invalid sign text update");
+		}
+
+		$oldText = $isFront ? $block->getText() : $block->getBackText();
+		if($text->getLines() === $oldText->getLines()){
+			return false;
+		}
+
+		try{
+			if(!$block->updateText($this->player, $text, $isFront)){
+				foreach($this->player->getWorld()->createBlockUpdatePackets([$pos]) as $updatePacket){
+					$this->session->sendDataPacket($updatePacket);
+				}
+				return false;
+			}
+			return true;
+		}catch(\UnexpectedValueException $e){
+			throw PacketHandlingException::wrap($e);
+		}
+	}
+
 	public function handleBlockActorData(BlockActorDataPacket $packet) : bool{
 		$pos = new Vector3($packet->blockPosition->getX(), $packet->blockPosition->getY(), $packet->blockPosition->getZ());
 		if($pos->distanceSquared($this->player->getLocation()) > 10000){
@@ -766,29 +803,9 @@ class InGamePacketHandler extends PacketHandler{
 		if(!($nbt instanceof CompoundTag)) throw new AssumptionFailedError("PHPStan should ensure this is a CompoundTag"); //for phpstorm's benefit
 
 		if($block instanceof BaseSign){
-			$frontTextTag = $nbt->getTag(Sign::TAG_FRONT_TEXT);
-			if(!$frontTextTag instanceof CompoundTag){
-				throw new PacketHandlingException("Invalid tag type " . get_debug_type($frontTextTag) . " for tag \"" . Sign::TAG_FRONT_TEXT . "\" in sign update data");
-			}
-			$textBlobTag = $frontTextTag->getTag(Sign::TAG_TEXT_BLOB);
-			if(!$textBlobTag instanceof StringTag){
-				throw new PacketHandlingException("Invalid tag type " . get_debug_type($textBlobTag) . " for tag \"" . Sign::TAG_TEXT_BLOB . "\" in sign update data");
-			}
-
-			try{
-				$text = SignText::fromBlob($textBlobTag->getValue());
-			}catch(\InvalidArgumentException $e){
-				throw PacketHandlingException::wrap($e, "Invalid sign text update");
-			}
-
-			try{
-				if(!$block->updateText($this->player, $text)){
-					foreach($this->player->getWorld()->createBlockUpdatePackets([$pos]) as $updatePacket){
-						$this->session->sendDataPacket($updatePacket);
-					}
-				}
-			}catch(\UnexpectedValueException $e){
-				throw PacketHandlingException::wrap($e);
+			if(!$this->updateSignText($nbt, Sign::TAG_FRONT_TEXT, true, $block, $pos)){
+				//only one side can be updated at a time
+				$this->updateSignText($nbt, Sign::TAG_BACK_TEXT, false, $block, $pos);
 			}
 
 			return true;

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -759,11 +759,11 @@ class InGamePacketHandler extends PacketHandler{
 	 * @throws PacketHandlingException
 	 */
 	private function updateSignText(CompoundTag $nbt, string $tagName, bool $isFront, BaseSign $block, Vector3 $pos) : bool{
-		$frontTextTag = $nbt->getTag($tagName);
-		if(!$frontTextTag instanceof CompoundTag){
-			throw new PacketHandlingException("Invalid tag type " . get_debug_type($frontTextTag) . " for tag \"$tagName\" in sign update data");
+		$textTag = $nbt->getTag($tagName);
+		if(!$textTag instanceof CompoundTag){
+			throw new PacketHandlingException("Invalid tag type " . get_debug_type($textTag) . " for tag \"$tagName\" in sign update data");
 		}
-		$textBlobTag = $frontTextTag->getTag(Sign::TAG_TEXT_BLOB);
+		$textBlobTag = $textTag->getTag(Sign::TAG_TEXT_BLOB);
 		if(!$textBlobTag instanceof StringTag){
 			throw new PacketHandlingException("Invalid tag type " . get_debug_type($textBlobTag) . " for tag \"" . Sign::TAG_TEXT_BLOB . "\" in sign update data");
 		}

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -2838,7 +2838,6 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 
 	/**
 	 * Opens the player's sign editor GUI for the sign at the given position.
-	 * TODO: add support for editing the rear side of the sign (not currently supported due to technical limitations)
 	 */
 	public function openSignEditor(Vector3 $position, bool $frontSide = true) : void{
 		$block = $this->getWorld()->getBlock($position);

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -2839,11 +2839,11 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 	/**
 	 * Opens the player's sign editor GUI for the sign at the given position.
 	 */
-	public function openSignEditor(Vector3 $position, bool $frontSide = true) : void{
+	public function openSignEditor(Vector3 $position, bool $frontFace = true) : void{
 		$block = $this->getWorld()->getBlock($position);
 		if($block instanceof BaseSign){
 			$this->getWorld()->setBlock($position, $block->setEditorEntityRuntimeId($this->getId()));
-			$this->getNetworkSession()->onOpenSignEditor($position, $frontSide);
+			$this->getNetworkSession()->onOpenSignEditor($position, $frontFace);
 		}else{
 			throw new \InvalidArgumentException("Block at this position is not a sign");
 		}

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -2840,11 +2840,11 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 	 * Opens the player's sign editor GUI for the sign at the given position.
 	 * TODO: add support for editing the rear side of the sign (not currently supported due to technical limitations)
 	 */
-	public function openSignEditor(Vector3 $position) : void{
+	public function openSignEditor(Vector3 $position, bool $frontSide = true) : void{
 		$block = $this->getWorld()->getBlock($position);
 		if($block instanceof BaseSign){
 			$this->getWorld()->setBlock($position, $block->setEditorEntityRuntimeId($this->getId()));
-			$this->getNetworkSession()->onOpenSignEditor($position, true);
+			$this->getNetworkSession()->onOpenSignEditor($position, $frontSide);
 		}else{
 			throw new \InvalidArgumentException("Block at this position is not a sign");
 		}


### PR DESCRIPTION
Working, but could be 10% cleaner if I was able to make BC breaks.

Preexisting `text` properties of sign-related objects refers to the front side; new `backText` properties have been added where appropriate.

## API changes
- `SignChangeEvent` now fires when the back side of a sign is edited (check `isFrontSide()`)
- `BaseSign->updateText()` now accepts an optional `bool $frontSide = true` parameter
- `Player->openSignEditor()` now accepts an optional `bool $frontSide = true` parameter
- Added `BaseSign->getBackText()` and `BaseSign->setBackText()`
- `BaseSign` inheritors should implement `getFacingDegrees()` and may need to implement `getHitboxCenter()` for sign editor to open the correct side when right-clicking on the block

## Issues
- Duplication of code for `getFacingDegrees()` in different types of sign classes
- `getFacingDegrees()` should be abstract, but limited by requirement for backwards compatibility
- Various usages of read/write text now have to do `$frontSide ? $text : $backText` or similar, which is prone to bugs