### PR TITLE
Fixed hanging signs placement criteria

### DIFF
--- a/src/block/BlockTypeTags.php
+++ b/src/block/BlockTypeTags.php
@@ -31,4 +31,5 @@ final class BlockTypeTags{
 	public const SAND = self::PREFIX . "sand";
 	public const POTTABLE_PLANTS = self::PREFIX . "pottable";
 	public const FIRE = self::PREFIX . "fire";
+	public const HANGING_SIGN = self::PREFIX . "hanging_sign";
 }

--- a/src/block/CeilingCenterHangingSign.php
+++ b/src/block/CeilingCenterHangingSign.php
@@ -25,6 +25,7 @@ namespace pocketmine\block;
 
 use pocketmine\block\utils\SignLikeRotation;
 use pocketmine\block\utils\SignLikeRotationTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\item\Item;
 use pocketmine\math\Facing;
 use pocketmine\math\Vector3;
@@ -33,6 +34,7 @@ use pocketmine\world\BlockTransaction;
 
 final class CeilingCenterHangingSign extends BaseSign implements SignLikeRotation{
 	use SignLikeRotationTrait;
+	use StaticSupportTrait;
 
 	protected function getSupportingFace() : int{
 		return Facing::UP;
@@ -44,19 +46,18 @@ final class CeilingCenterHangingSign extends BaseSign implements SignLikeRotatio
 			return false;
 		}
 
-		$supportBlock = $blockReplace->getSide(Facing::UP);
-		if(
-			!$supportBlock->getSupportType(Facing::UP)->hasCenterSupport() &&
-			!$supportBlock instanceof WallHangingSign &&
-			!$supportBlock instanceof CeilingEdgesHangingSign &&
-			!$supportBlock instanceof CeilingCenterHangingSign
-		){
-			return false;
-		}
-
 		if($player !== null){
 			$this->rotation = self::getRotationFromYaw($player->getLocation()->getYaw());
 		}
 		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
+	}
+
+	private function canBeSupportedAt(Block $block) : bool{
+		$supportBlock = $block->getSide(Facing::UP);
+		return
+			$supportBlock->getSupportType(Facing::DOWN)->hasCenterSupport() ||
+			$supportBlock instanceof WallHangingSign ||
+			$supportBlock instanceof CeilingEdgesHangingSign ||
+			$supportBlock instanceof CeilingCenterHangingSign;
 	}
 }

--- a/src/block/CeilingCenterHangingSign.php
+++ b/src/block/CeilingCenterHangingSign.php
@@ -44,6 +44,15 @@ final class CeilingCenterHangingSign extends BaseSign implements SignLikeRotatio
 			return false;
 		}
 
+		$supportBlock = $blockReplace->getSide(Facing::UP);
+		if(
+			!$supportBlock->getSupportType(Facing::UP)->hasCenterSupport() &&
+			!$supportBlock instanceof CeilingEdgesHangingSign &&
+			!$supportBlock instanceof CeilingCenterHangingSign
+		){
+			return false;
+		}
+
 		if($player !== null){
 			$this->rotation = self::getRotationFromYaw($player->getLocation()->getYaw());
 		}

--- a/src/block/CeilingCenterHangingSign.php
+++ b/src/block/CeilingCenterHangingSign.php
@@ -56,8 +56,6 @@ final class CeilingCenterHangingSign extends BaseSign implements SignLikeRotatio
 		$supportBlock = $block->getSide(Facing::UP);
 		return
 			$supportBlock->getSupportType(Facing::DOWN)->hasCenterSupport() ||
-			$supportBlock instanceof WallHangingSign ||
-			$supportBlock instanceof CeilingEdgesHangingSign ||
-			$supportBlock instanceof CeilingCenterHangingSign;
+			$supportBlock->hasTypeTag(BlockTypeTags::HANGING_SIGN);
 	}
 }

--- a/src/block/CeilingCenterHangingSign.php
+++ b/src/block/CeilingCenterHangingSign.php
@@ -47,6 +47,7 @@ final class CeilingCenterHangingSign extends BaseSign implements SignLikeRotatio
 		$supportBlock = $blockReplace->getSide(Facing::UP);
 		if(
 			!$supportBlock->getSupportType(Facing::UP)->hasCenterSupport() &&
+			!$supportBlock instanceof WallHangingSign &&
 			!$supportBlock instanceof CeilingEdgesHangingSign &&
 			!$supportBlock instanceof CeilingCenterHangingSign
 		){

--- a/src/block/CeilingEdgesHangingSign.php
+++ b/src/block/CeilingEdgesHangingSign.php
@@ -43,7 +43,6 @@ final class CeilingEdgesHangingSign extends BaseSign implements HorizontalFacing
 		if($face !== Facing::DOWN){
 			return false;
 		}
-
 		if($player !== null){
 			$this->facing = Facing::opposite($player->getHorizontalFacing());
 		}

--- a/src/block/CeilingEdgesHangingSign.php
+++ b/src/block/CeilingEdgesHangingSign.php
@@ -25,7 +25,6 @@ namespace pocketmine\block;
 
 use pocketmine\block\utils\HorizontalFacing;
 use pocketmine\block\utils\HorizontalFacingTrait;
-use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\block\utils\SupportType;
 use pocketmine\item\Item;
 use pocketmine\math\Facing;
@@ -35,7 +34,6 @@ use pocketmine\world\BlockTransaction;
 
 final class CeilingEdgesHangingSign extends BaseSign implements HorizontalFacing{
 	use HorizontalFacingTrait;
-	use StaticSupportTrait;
 
 	protected function getSupportingFace() : int{
 		return Facing::UP;
@@ -48,15 +46,23 @@ final class CeilingEdgesHangingSign extends BaseSign implements HorizontalFacing
 		if($player !== null){
 			$this->facing = Facing::opposite($player->getHorizontalFacing());
 		}
+		if(!$this->canBeSupportedAt($blockReplace)){
+			return false;
+		}
 
 		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
+	}
+
+	public function onNearbyBlockChange() : void{
+		if(!$this->canBeSupportedAt($this)){
+			$this->position->getWorld()->useBreakOn($this->position);
+		}
 	}
 
 	private function canBeSupportedAt(Block $block) : bool{
 		$supportBlock = $block->getSide(Facing::UP);
 		return
 			$supportBlock->getSupportType(Facing::DOWN) === SupportType::FULL ||
-			($supportBlock instanceof WallHangingSign && Facing::axis($supportBlock->getFacing()) === Facing::axis($this->facing)) ||
-			$supportBlock instanceof CeilingEdgesHangingSign;
+			(($supportBlock instanceof WallHangingSign || $supportBlock instanceof CeilingEdgesHangingSign) && Facing::axis($supportBlock->getFacing()) === Facing::axis($this->facing));
 	}
 }

--- a/src/block/CeilingEdgesHangingSign.php
+++ b/src/block/CeilingEdgesHangingSign.php
@@ -25,6 +25,7 @@ namespace pocketmine\block;
 
 use pocketmine\block\utils\HorizontalFacing;
 use pocketmine\block\utils\HorizontalFacingTrait;
+use pocketmine\block\utils\StaticSupportTrait;
 use pocketmine\block\utils\SupportType;
 use pocketmine\item\Item;
 use pocketmine\math\Facing;
@@ -34,6 +35,7 @@ use pocketmine\world\BlockTransaction;
 
 final class CeilingEdgesHangingSign extends BaseSign implements HorizontalFacing{
 	use HorizontalFacingTrait;
+	use StaticSupportTrait;
 
 	protected function getSupportingFace() : int{
 		return Facing::UP;
@@ -47,15 +49,14 @@ final class CeilingEdgesHangingSign extends BaseSign implements HorizontalFacing
 			$this->facing = Facing::opposite($player->getHorizontalFacing());
 		}
 
-		$supportBlock = $blockReplace->getSide(Facing::UP);
-		if(
-			$supportBlock->getSupportType(Facing::UP) !== SupportType::FULL &&
-			(!$supportBlock instanceof WallHangingSign || Facing::axis($supportBlock->getFacing()) !== Facing::axis($this->facing)) &&
-			!$supportBlock instanceof CeilingEdgesHangingSign
-		){
-			return false;
-		}
-
 		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
+	}
+
+	private function canBeSupportedAt(Block $block) : bool{
+		$supportBlock = $block->getSide(Facing::UP);
+		return
+			$supportBlock->getSupportType(Facing::DOWN) === SupportType::FULL ||
+			($supportBlock instanceof WallHangingSign && Facing::axis($supportBlock->getFacing()) === Facing::axis($this->facing)) ||
+			$supportBlock instanceof CeilingEdgesHangingSign;
 	}
 }

--- a/src/block/CeilingEdgesHangingSign.php
+++ b/src/block/CeilingEdgesHangingSign.php
@@ -44,13 +44,17 @@ final class CeilingEdgesHangingSign extends BaseSign implements HorizontalFacing
 			return false;
 		}
 
-		$supportBlock = $blockReplace->getSide(Facing::UP);
-		if($supportBlock->getSupportType(Facing::UP) !== SupportType::FULL && !$supportBlock instanceof CeilingEdgesHangingSign){
-			return false;
-		}
-
 		if($player !== null){
 			$this->facing = Facing::opposite($player->getHorizontalFacing());
+		}
+
+		$supportBlock = $blockReplace->getSide(Facing::UP);
+		if(
+			$supportBlock->getSupportType(Facing::UP) !== SupportType::FULL &&
+			(!$supportBlock instanceof WallHangingSign || Facing::axis($supportBlock->getFacing()) !== Facing::axis($this->facing)) &&
+			!$supportBlock instanceof CeilingEdgesHangingSign
+		){
+			return false;
 		}
 
 		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);

--- a/src/block/CeilingEdgesHangingSign.php
+++ b/src/block/CeilingEdgesHangingSign.php
@@ -25,6 +25,7 @@ namespace pocketmine\block;
 
 use pocketmine\block\utils\HorizontalFacing;
 use pocketmine\block\utils\HorizontalFacingTrait;
+use pocketmine\block\utils\SupportType;
 use pocketmine\item\Item;
 use pocketmine\math\Facing;
 use pocketmine\math\Vector3;
@@ -42,6 +43,12 @@ final class CeilingEdgesHangingSign extends BaseSign implements HorizontalFacing
 		if($face !== Facing::DOWN){
 			return false;
 		}
+
+		$supportBlock = $blockReplace->getSide(Facing::UP);
+		if($supportBlock->getSupportType(Facing::UP) !== SupportType::FULL && !$supportBlock instanceof CeilingEdgesHangingSign){
+			return false;
+		}
+
 		if($player !== null){
 			$this->facing = Facing::opposite($player->getHorizontalFacing());
 		}

--- a/src/block/VanillaBlocks.php
+++ b/src/block/VanillaBlocks.php
@@ -1391,6 +1391,7 @@ final class VanillaBlocks{
 	private static function registerWoodenBlocks() : void{
 		$planksBreakInfo = new Info(BreakInfo::axe(2.0, null, 15.0));
 		$signBreakInfo = new Info(BreakInfo::axe(1.0));
+		$hangingSignBreakInfo = new Info(BreakInfo::axe(1.0), [Tags::HANGING_SIGN]);
 		$logBreakInfo = new Info(BreakInfo::axe(2.0));
 		$woodenDoorBreakInfo = new Info(BreakInfo::axe(3.0, null, 15.0));
 		$woodenButtonBreakInfo = new Info(BreakInfo::axe(0.5));
@@ -1444,9 +1445,9 @@ final class VanillaBlocks{
 				WoodType::CHERRY => VanillaItems::CHERRY_HANGING_SIGN(...),
 				WoodType::PALE_OAK => VanillaItems::PALE_OAK_HANGING_SIGN(...),
 			};
-			self::register($idName("ceiling_center_hanging_sign"), fn(BID $id) => new CeilingCenterHangingSign($id, $name . "Center Hanging Sign", $signBreakInfo, $woodType, $hangingSignAsItem), TileHangingSign::class);
-			self::register($idName("ceiling_edges_hanging_sign"), fn(BID $id) => new CeilingEdgesHangingSign($id, $name . "Edges Hanging Sign", $signBreakInfo, $woodType, $hangingSignAsItem), TileHangingSign::class);
-			self::register($idName("wall_hanging_sign"), fn(BID $id) => new WallHangingSign($id, $name . " Wall Hanging Sign", $signBreakInfo, $woodType, $hangingSignAsItem), TileHangingSign::class);
+			self::register($idName("ceiling_center_hanging_sign"), fn(BID $id) => new CeilingCenterHangingSign($id, $name . "Center Hanging Sign", $hangingSignBreakInfo, $woodType, $hangingSignAsItem), TileHangingSign::class);
+			self::register($idName("ceiling_edges_hanging_sign"), fn(BID $id) => new CeilingEdgesHangingSign($id, $name . "Edges Hanging Sign", $hangingSignBreakInfo, $woodType, $hangingSignAsItem), TileHangingSign::class);
+			self::register($idName("wall_hanging_sign"), fn(BID $id) => new WallHangingSign($id, $name . " Wall Hanging Sign", $hangingSignBreakInfo, $woodType, $hangingSignAsItem), TileHangingSign::class);
 		}
 	}
 

--- a/src/block/WallHangingSign.php
+++ b/src/block/WallHangingSign.php
@@ -25,6 +25,7 @@ namespace pocketmine\block;
 
 use pocketmine\block\utils\HorizontalFacing;
 use pocketmine\block\utils\HorizontalFacingTrait;
+use pocketmine\block\utils\SupportType;
 use pocketmine\item\Item;
 use pocketmine\math\Axis;
 use pocketmine\math\AxisAlignedBB;
@@ -50,16 +51,38 @@ final class WallHangingSign extends BaseSign implements HorizontalFacing{
 	}
 
 	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		if(Facing::axis($face) === Axis::Y){
+		if(Facing::axis($face) === Axis::Y && $player === null){
+			return false;
+		}
+		$attachFace = Facing::axis($face) === Axis::Y ? Facing::rotateY($player->getHorizontalFacing(), clockwise: true) : $face;
+		$direction = null;
+
+		foreach([
+			$attachFace,
+			Facing::opposite($attachFace)
+		] as $side){
+			if($this->canBeSupportedAt($blockReplace->getSide($side), $side)){
+				$direction = $side;
+				break;
+			}
+		}
+
+		if($direction === null){
 			return false;
 		}
 
-		$this->facing = Facing::rotateY($face, clockwise: true);
+		$this->facing = Facing::rotateY(Facing::opposite($direction), clockwise: true);
 		//the front should always face the player if possible
 		if($player !== null && $this->facing === $player->getHorizontalFacing()){
 			$this->facing = Facing::opposite($this->facing);
 		}
 
 		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
+	}
+
+	private function canBeSupportedAt(Block $block, int $face) : bool{
+		return
+			($block instanceof WallHangingSign && Facing::axis(Facing::rotateY($block->getFacing(), clockwise: true)) === Facing::axis($face)) ||
+			$block->getSupportType(Facing::opposite($face)) === SupportType::FULL;
 	}
 }

--- a/src/block/WallHangingSign.php
+++ b/src/block/WallHangingSign.php
@@ -51,7 +51,7 @@ final class WallHangingSign extends BaseSign implements HorizontalFacing{
 	}
 
 	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
-		if(Facing::axis($face) === Axis::Y && $player === null){
+		if($player === null){
 			return false;
 		}
 		$attachFace = Facing::axis($face) === Axis::Y ? Facing::rotateY($player->getHorizontalFacing(), clockwise: true) : $face;
@@ -73,7 +73,7 @@ final class WallHangingSign extends BaseSign implements HorizontalFacing{
 
 		$this->facing = Facing::rotateY(Facing::opposite($direction), clockwise: true);
 		//the front should always face the player if possible
-		if($player !== null && $this->facing === $player->getHorizontalFacing()){
+		if($this->facing === $player->getHorizontalFacing()){
 			$this->facing = Facing::opposite($this->facing);
 		}
 

--- a/src/block/WallHangingSign.php
+++ b/src/block/WallHangingSign.php
@@ -55,19 +55,12 @@ final class WallHangingSign extends BaseSign implements HorizontalFacing{
 			return false;
 		}
 		$attachFace = Facing::axis($face) === Axis::Y ? Facing::rotateY($player->getHorizontalFacing(), clockwise: true) : $face;
-		$direction = null;
 
-		foreach([
-			$attachFace,
-			Facing::opposite($attachFace)
-		] as $side){
-			if($this->canBeSupportedAt($blockReplace->getSide($side), $side)){
-				$direction = $side;
-				break;
-			}
-		}
-
-		if($direction === null){
+		if($this->canBeSupportedAt($blockReplace->getSide($attachFace), $attachFace)){
+			$direction = $attachFace;
+		}elseif($this->canBeSupportedAt($blockReplace->getSide($opposite = Facing::opposite($attachFace)), $opposite)){
+			$direction = $opposite;
+		}else{
 			return false;
 		}
 

--- a/src/item/HangingSign.php
+++ b/src/item/HangingSign.php
@@ -26,6 +26,7 @@ namespace pocketmine\item;
 use pocketmine\block\Block;
 use pocketmine\block\CeilingEdgesHangingSign;
 use pocketmine\block\utils\SupportType;
+use pocketmine\block\WallHangingSign;
 use pocketmine\math\Facing;
 use pocketmine\math\Vector3;
 use pocketmine\player\Player;
@@ -50,7 +51,7 @@ final class HangingSign extends Item{
 			}
 
 			$support = $blockReplace->getSide(Facing::UP);
-			$result = ($support instanceof CeilingEdgesHangingSign && $player?->getHorizontalFacing() !== $support->getFacing()) ||
+			$result = (($support instanceof CeilingEdgesHangingSign || $support instanceof WallHangingSign) && ($player === null || Facing::axis($player->getHorizontalFacing()) !== Facing::axis($support->getFacing()))) ||
 			$support->getSupportType(Facing::DOWN) === SupportType::CENTER ?
 				$this->centerPointCeilingVariant :
 				$this->edgePointCeilingVariant;

--- a/src/item/HangingSign.php
+++ b/src/item/HangingSign.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace pocketmine\item;
 
 use pocketmine\block\Block;
+use pocketmine\block\CeilingCenterHangingSign;
 use pocketmine\block\CeilingEdgesHangingSign;
 use pocketmine\block\utils\SupportType;
 use pocketmine\block\WallHangingSign;
@@ -50,11 +51,16 @@ final class HangingSign extends Item{
 				return clone $this->centerPointCeilingVariant;
 			}
 
+			//we select the center variant when support is edge/wall sign with perpendicular player facing,
+			//support is a center sign itself, or support provides center support.
+			//otherwise use the edge variant.
 			$support = $blockReplace->getSide(Facing::UP);
-			$result = (($support instanceof CeilingEdgesHangingSign || $support instanceof WallHangingSign) && ($player === null || Facing::axis($player->getHorizontalFacing()) !== Facing::axis($support->getFacing()))) ||
-			$support->getSupportType(Facing::DOWN) === SupportType::CENTER ?
-				$this->centerPointCeilingVariant :
-				$this->edgePointCeilingVariant;
+			$result =
+				(($support instanceof CeilingEdgesHangingSign || $support instanceof WallHangingSign) && ($player === null || Facing::axis($player->getHorizontalFacing()) !== Facing::axis($support->getFacing()))) ||
+				$support instanceof CeilingCenterHangingSign ||
+				$support->getSupportType(Facing::DOWN) === SupportType::CENTER ?
+					$this->centerPointCeilingVariant :
+					$this->edgePointCeilingVariant;
 		}else{
 			$result = $this->wallVariant;
 		}

--- a/src/item/HangingSign.php
+++ b/src/item/HangingSign.php
@@ -24,9 +24,11 @@ declare(strict_types=1);
 namespace pocketmine\item;
 
 use pocketmine\block\Block;
+use pocketmine\block\CeilingEdgesHangingSign;
 use pocketmine\block\utils\SupportType;
 use pocketmine\math\Facing;
 use pocketmine\math\Vector3;
+use pocketmine\player\Player;
 
 final class HangingSign extends Item{
 
@@ -40,13 +42,21 @@ final class HangingSign extends Item{
 		parent::__construct($identifier, $name);
 	}
 
-	public function getPlacementBlock(Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector) : Block{
+	public function getPlacementBlock(?Player $player, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector) : Block{
 		//we don't verify valid placement conditions here, only decide which block to return
-		$result = $face === Facing::DOWN ?
-			$blockReplace->getSide(Facing::UP)->getSupportType(Facing::DOWN) === SupportType::CENTER ?
+		if($face === Facing::DOWN){
+			if($player !== null && $player->isSneaking()){
+				return clone $this->centerPointCeilingVariant;
+			}
+
+			$support = $blockReplace->getSide(Facing::UP);
+			$result = ($support instanceof CeilingEdgesHangingSign && $player?->getHorizontalFacing() !== $support->getFacing()) ||
+			$support->getSupportType(Facing::DOWN) === SupportType::CENTER ?
 				$this->centerPointCeilingVariant :
-				$this->edgePointCeilingVariant
-			: $this->wallVariant;
+				$this->edgePointCeilingVariant;
+		}else{
+			$result = $this->wallVariant;
+		}
 		return clone $result;
 	}
 

--- a/src/item/Item.php
+++ b/src/item/Item.php
@@ -485,7 +485,7 @@ class Item implements \JsonSerializable{
 		return $this->getBlock()->canBePlaced();
 	}
 
-	public function getPlacementBlock(Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector) : Block{
+	public function getPlacementBlock(?Player $player, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector) : Block{
 		return $this->getBlock($face);
 	}
 

--- a/src/world/World.php
+++ b/src/world/World.php
@@ -2298,7 +2298,7 @@ class World implements ChunkManager{
 		if($item->isNull() || !$item->canBePlaced()){
 			return false;
 		}
-		$hand = $item->getPlacementBlock($blockReplace, $blockClicked, $face, $clickVector);
+		$hand = $item->getPlacementBlock($player, $blockReplace, $blockClicked, $face, $clickVector);
 		$hand->position($this, $blockReplace->getPosition()->x, $blockReplace->getPosition()->y, $blockReplace->getPosition()->z);
 
 		if($hand->canBePlacedAt($blockClicked, $clickVector, $face, true)){


### PR DESCRIPTION
### In Bedrock, hanging signs have the following placement criteria. They are not documented on the wiki, but can be observed in the game:
#### Wall:
 - Wall hanging signs require full support type (they can't be placed on leaves, etc).
 - Wall hanging signs can provide support to each other, but only if have matching axis.
 - Wall hanging signs can be still placed when clicked axis is Y. In that case they try to find support based on player's horizontal facing.
 
 #### Ceiling:
  - Sneaking will always result in placing center variant.
  - Edge variant can be placed on blocks with full support or on a wall/edge hanging sign with the same axis.
  - Center variant can be placed on blocks with center support or on a wall/edge/center hanging signs with different facings.


## Changes
### API changes
Added `?Player` parameter to `getPlacementBlock()`. Not a BC Break since it's not on a stable yet.

## Follow-up
There is still one bug remains. Vanilla doesn't open the sign editor menu when placing hanging sign on another hanging sign. Not sure how to fix that without huge code duplication.

## Tests
https://youtu.be/njGMGLCZhSI
