### PR TITLE
Strip unnecessary NBT from network items

### DIFF
--- a/src/network/mcpe/convert/TypeConverter.php
+++ b/src/network/mcpe/convert/TypeConverter.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace pocketmine\network\mcpe\convert;
 
+use pocketmine\block\tile\Container;
 use pocketmine\block\VanillaBlocks;
 use pocketmine\crafting\ExactRecipeIngredient;
 use pocketmine\crafting\MetaWildcardRecipeIngredient;
@@ -31,10 +32,16 @@ use pocketmine\crafting\TagWildcardRecipeIngredient;
 use pocketmine\data\bedrock\BedrockDataFiles;
 use pocketmine\data\bedrock\item\BlockItemIdMap;
 use pocketmine\data\bedrock\item\ItemTypeNames;
+use pocketmine\data\SavedDataLoadingException;
 use pocketmine\item\Item;
 use pocketmine\item\VanillaItems;
+use pocketmine\nbt\LittleEndianNbtSerializer;
+use pocketmine\nbt\NBT;
 use pocketmine\nbt\NbtException;
 use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\nbt\tag\ListTag;
+use pocketmine\nbt\tag\Tag;
+use pocketmine\nbt\TreeRoot;
 use pocketmine\network\mcpe\protocol\serializer\ItemTypeDictionary;
 use pocketmine\network\mcpe\protocol\serializer\PacketSerializer;
 use pocketmine\network\mcpe\protocol\types\GameMode as ProtocolGameMode;
@@ -52,11 +59,13 @@ use pocketmine\utils\SingletonTrait;
 use pocketmine\world\format\io\GlobalBlockStateHandlers;
 use pocketmine\world\format\io\GlobalItemDataHandlers;
 use function get_class;
+use function hash;
 
 class TypeConverter{
 	use SingletonTrait;
 
 	private const PM_ID_TAG = "___Id___";
+	private const PM_FULL_NBT_HASH_TAG = "___FullNbtHash___";
 
 	private const RECIPE_INPUT_WILDCARD_META = 0x7fff;
 
@@ -197,6 +206,90 @@ class TypeConverter{
 		return new ExactRecipeIngredient($result);
 	}
 
+	/**
+	 * Strips unnecessary block actor NBT from items that have it.
+	 * This tag can potentially be extremely large, and is not read by the client anyway.
+	 */
+	protected function stripBlockEntityNBT(CompoundTag $tag) : bool{
+		if(
+			($blockEntityTag = $tag->getTag(Item::TAG_BLOCK_ENTITY_TAG)) !== null &&
+			$blockEntityTag instanceof CompoundTag &&
+			$blockEntityTag->count() > 0
+		){
+			//prevent stacking unless data was the same
+			//client doesn't use this tag, so it's fine to delete completely
+			$tag->removeTag(Item::TAG_BLOCK_ENTITY_TAG);
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Strips non-viewable data from shulker boxes and similar blocks
+	 * The lore for shulker boxes only requires knowing the type & count of items and possibly custom name
+	 * We don't need to, and should not allow, sending nested inventories across the network.
+	 */
+	protected function stripContainedItemNonVisualNBT(CompoundTag $tag) : bool{
+		if(
+			($blockEntityInventoryTag = $tag->getTag(Container::TAG_ITEMS)) !== null &&
+			$blockEntityInventoryTag instanceof ListTag &&
+			$blockEntityInventoryTag->getTagType() === NBT::TAG_Compound &&
+			$blockEntityInventoryTag->count() > 0
+		){
+			$stripped = new ListTag();
+
+			/** @var CompoundTag $itemTag */
+			foreach($blockEntityInventoryTag as $itemTag){
+				try{
+					$containedItem = Item::nbtDeserialize($itemTag);
+					$customName = $containedItem->getCustomName();
+					$containedItem->clearNamedTag();
+					$containedItem->setCustomName($customName);
+					$stripped->push($containedItem->nbtSerialize());
+				}catch(SavedDataLoadingException){
+					continue;
+				}
+			}
+			$tag->setTag(Container::TAG_ITEMS, $stripped);
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Computes a hash of an item's server-side NBT.
+	 * This is baked into an item's network NBT to make sure the client doesn't try to stack items with the same network
+	 * NBT but different server-side NBT.
+	 */
+	protected function hashNBT(Tag $tag) : string{
+		$encoded = (new LittleEndianNbtSerializer())->write(new TreeRoot($tag));
+		return hash('sha256', $encoded, binary: true);
+	}
+
+	/**
+	 * TODO: HACK!
+	 * Strips non-viewable data from the NBT of an item.
+	 * This is a pretty yucky hack that's mainly needed because of inventories inside blockitems containing blockentity
+	 * data. There isn't really a good way to deal with this due to the way tiles currently require a position,
+	 * otherwise we could just keep a copy of the tile context and ask it for persistent vs network NBT as needed.
+	 * Unfortunately, making this nice will require significant BC breaks, so this will have to do for now.
+	 */
+	protected function cleanupUnnecessaryItemNBT(CompoundTag $original) : CompoundTag{
+		$tag = clone $original;
+		$anythingStripped = false;
+		foreach([
+			$this->stripContainedItemNonVisualNBT($tag),
+			$this->stripBlockEntityNBT($tag)
+		] as $stripped){
+			$anythingStripped = $anythingStripped || $stripped;
+		}
+
+		if($anythingStripped){
+			$tag->setByteArray(self::PM_FULL_NBT_HASH_TAG, $this->hashNBT($original));
+		}
+		return $tag;
+	}
+
 	public function coreItemStackToNet(Item $itemStack) : ItemStack{
 		if($itemStack->isNull()){
 			return ItemStack::null();
@@ -205,7 +298,7 @@ class TypeConverter{
 		if($nbt->count() === 0){
 			$nbt = null;
 		}else{
-			$nbt = clone $nbt;
+			$nbt = $this->cleanupUnnecessaryItemNBT($nbt);
 		}
 
 		$idMeta = $this->itemTranslator->toNetworkIdQuiet($itemStack);

--- a/src/network/mcpe/convert/TypeConverter.php
+++ b/src/network/mcpe/convert/TypeConverter.php
@@ -211,12 +211,7 @@ class TypeConverter{
 	 * This tag can potentially be extremely large, and is not read by the client anyway.
 	 */
 	protected function stripBlockEntityNBT(CompoundTag $tag) : bool{
-		if(
-			($blockEntityTag = $tag->getTag(Item::TAG_BLOCK_ENTITY_TAG)) !== null &&
-			$blockEntityTag instanceof CompoundTag &&
-			$blockEntityTag->count() > 0
-		){
-			//prevent stacking unless data was the same
+		if(($tag->getTag(Item::TAG_BLOCK_ENTITY_TAG)) !== null){
 			//client doesn't use this tag, so it's fine to delete completely
 			$tag->removeTag(Item::TAG_BLOCK_ENTITY_TAG);
 			return true;

--- a/src/network/mcpe/convert/TypeConverter.php
+++ b/src/network/mcpe/convert/TypeConverter.php
@@ -268,7 +268,7 @@ class TypeConverter{
 
 	/**
 	 * TODO: HACK!
-	 * Strips non-viewable data from the NBT of an item.
+	 * Creates a copy of an item's NBT with non-viewable data stripped.
 	 * This is a pretty yucky hack that's mainly needed because of inventories inside blockitems containing blockentity
 	 * data. There isn't really a good way to deal with this due to the way tiles currently require a position,
 	 * otherwise we could just keep a copy of the tile context and ask it for persistent vs network NBT as needed.


### PR DESCRIPTION
Item containers like shulker boxes, or chests with block entity data obtained with ctrl+middle click, will often have extremely large NBT payloads. This problem gets exponentially worse in cases where it's possible to nest inventories, as in #4665.

We can't easily address this at the core level, because tiles are not able to exist within items (due to position requirement) so we don't have a good way to avoid this useless NBT in the first place. However, we can strip it before the item is sent to the client, which dramatically reduces the network costs of such items, as well as removing any reason the client could have to send such enormous items to the server.

A fully loaded shulker box with written books now takes only 5-6 KB on the wire instead of ~1 MB, which is a substantial improvement.

Dealing with this in a less hacky way is currently blocked on #6147.

<!-- Summarize your PR here. Keep it short and simple. -->
<!-- Explain existing problems or why this pull request is necessary -->

### Related issues & PRs
- Fixes #4665 
- Fixes, kinda, #6649 , although this needs to be redone in a better way once #6147 is dealt with

## Changes
### API changes
None

### Behavioural changes
Significant network performance improvement when dealing with items containing inventories or block entity data (containing inventories)
Pains were taken to ensure that the lore of shulker boxes doesn't break with this change, however it is possible I may have missed something. Nonetheless, I think this change is worth it.

## Backwards compatibility
Backwards compatible

## Follow-up
Redo this in PM6 once #6149 is done

## Tests
Playtested with shulkerboxes and nested chests