### PR TITLE
Fix for "block lag" while placing blocks on higher latency clients

### DIFF
--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -498,11 +498,6 @@ class InGamePacketHandler extends PacketHandler{
 				$blockPos = $data->getBlockPosition();
 				$vBlockPos = new Vector3($blockPos->getX(), $blockPos->getY(), $blockPos->getZ());
 				$this->player->interactBlock($vBlockPos, $data->getFace(), $clickPos);
-				//always sync this in case plugins caused a different result than the client expected
-				//we *could* try to enhance detection of plugin-altered behaviour, but this would require propagating
-				//more information up the stack. For now I think this is good enough.
-				//if only the client would tell us what blocks it thinks changed...
-				$this->syncBlocksNearby($vBlockPos, $data->getFace());
 				return true;
 			case UseItemTransactionData::ACTION_CLICK_AIR:
 				if($this->player->isUsingItem()){

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1938,10 +1938,23 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer{
 				return true;
 			}
 		}else{
+			$this->syncBlocks([$pos, $pos->getSide($face)]);
 			$this->logger->debug("Cancelled interaction of block at $pos due to not currently being interactable");
 		}
 
 		return false;
+	}
+
+	/**
+	 * Sync blocks sends block updates to the player at the block positions.
+	 *
+	 * @param Vector3[] $blocks
+	 */
+	public function syncBlocks(array $blocks) : void {
+		$blocks = array_filter($blocks, fn(Vector3 $block) => $block->distanceSquared($this->getLocation()) < 10000);
+		foreach ($this->getWorld()->createBlockUpdatePackets($blocks) as $packet) {
+			$this->getNetworkSession()->sendDataPacket($packet);
+		}
 	}
 
 	/**

--- a/src/world/World.php
+++ b/src/world/World.php
@@ -2341,7 +2341,6 @@ class World implements ChunkManager{
 				$playerCollision = false;
 				if ($player !== null && $player->getBoundingBox()->intersectsWith($collisionBox)) {
 					$allowed = false;
-					$needsSync = !$blockPos->equals($clickedBlockPos) && !$blockPos->equals($sideClickPos);
 					$playerCollision = true;
 				}
 				if (count($this->getCollidingEntities($collisionBox)) > 0) {

--- a/src/world/World.php
+++ b/src/world/World.php
@@ -122,7 +122,6 @@ use function count;
 use function floor;
 use function get_class;
 use function gettype;
-use function in_array;
 use function is_a;
 use function is_object;
 use function max;
@@ -2239,10 +2238,10 @@ class World implements ChunkManager{
 	 * @param bool        $playSound      Whether to play a block-place sound if the block was placed successfully.
 	 * @param Item[]      &$returnedItems Items to be added to the target's inventory (or dropped if the inventory is full)
 	 */
-	public function useItemOn(Vector3 $vector, Item &$item, int $face, ?Vector3 $clickVector = null, ?Player $player = null, bool $playSound = false, array &$returnedItems = []) : bool{
-		$blockClicked = $this->getBlock($vector);
+	public function useItemOn(Vector3 $clickedBlockPos, Item &$item, int $face, ?Vector3 $clickVector = null, ?Player $player = null, bool $playSound = false, array &$returnedItems = []) : bool{
+		$blockClicked = $this->getBlock($clickedBlockPos);
 		$blockReplace = $blockClicked->getSide($face);
-		$mainBlocks = [$vector, ($sideVector = $vector->getSide($face))];
+		$mainBlocks = [$clickedBlockPos, ($sideClickPos = $clickedBlockPos->getSide($face))];
 
 		if($clickVector === null){
 			$clickVector = new Vector3(0.0, 0.0, 0.0);
@@ -2285,13 +2284,13 @@ class World implements ChunkManager{
 			if(!$ev->isCancelled()){
 				if($ev->useBlock() && $blockClicked->onInteract($item, $face, $clickVector, $player, $returnedItems)){
 					$aroundBlocks = [];
-					foreach ($vector->sidesArray() as $otherVector) {
-						if ($sideVector !== $otherVector) {
+					foreach ($clickedBlockPos->sidesArray() as $otherVector) {
+						if ($sideClickPos !== $otherVector) {
 							$aroundBlocks[] = $otherVector;
 						}
 					}
-					foreach ($sideVector->sidesArray() as $otherVector) {
-						if ($vector !== $otherVector) {
+					foreach ($sideClickPos->sidesArray() as $otherVector) {
+						if ($clickedBlockPos !== $otherVector) {
 							$aroundBlocks[] = $otherVector;
 						}
 					}
@@ -2331,19 +2330,32 @@ class World implements ChunkManager{
 		}
 
 		/** @var Vector3[] $originalBlocks */
-		$originalBlocks = [];
-		foreach($tx->getBlocks() as [$x, $y, $z, $block]){
-			$originalBlocks[] = new Vector3($x, $y, $z);
+		$placementSyncBlocks = [];
+		$allowed = true;
+		$needsSync = false;
+		foreach($tx->getBlocks() as [$x, $y, $z, $block]) {
+			$blockPos = new Vector3($x, $y, $z);
+			$placementSyncBlocks[] = $blockPos;
 			$block->position($this, $x, $y, $z);
-			foreach($block->getCollisionBoxes() as $collisionBox){
+			foreach($block->getCollisionBoxes() as $collisionBox) {
+				$playerCollision = false;
 				if ($player !== null && $player->getBoundingBox()->intersectsWith($collisionBox)) {
-					return false;
+					$allowed = false;
+					$needsSync = !$blockPos->equals($clickedBlockPos) && !$blockPos->equals($sideClickPos);
+					$playerCollision = true;
 				}
-				if(count($this->getCollidingEntities($collisionBox)) > 0){
-					$player?->syncBlocks($mainBlocks);
-					return false;
+				if (count($this->getCollidingEntities($collisionBox)) > 0) {
+					$allowed = false;
+					$needsSync = $needsSync || !$playerCollision;
 				}
 			}
+		}
+
+		if (!$allowed) {
+			if ($needsSync) {
+				$player?->syncBlocks($placementSyncBlocks);
+			}
+			return false;
 		}
 
 		if($player !== null){
@@ -2351,7 +2363,6 @@ class World implements ChunkManager{
 			if($player->isSpectator()){
 				$ev->cancel();
 			}
-
 			if($player->isAdventure(true) && !$ev->isCancelled()){
 				$canPlace = false;
 				$itemParser = LegacyStringToItemParser::getInstance();
@@ -2370,22 +2381,17 @@ class World implements ChunkManager{
 
 			$ev->call();
 			if($ev->isCancelled()){
-				$player->syncBlocks($mainBlocks);
+				$player->syncBlocks($placementSyncBlocks);
 				return false;
 			}
 		}
 
 		if(!$tx->apply()){
-			$player?->syncBlocks($mainBlocks);
+			$player?->syncBlocks($placementSyncBlocks);
 			return false;
 		}
 		$first = true;
-		$newBlocks = [];
 		foreach($tx->getBlocks() as [$x, $y, $z, $_]){
-			$blockPos = new Vector3($x, $y, $z);
-			if (!in_array($blockPos, $originalBlocks, true)) {
-				$newBlocks[] = $blockPos;
-			}
 			$tile = $this->getTileAt($x, $y, $z);
 			if($tile !== null){
 				//TODO: seal this up inside block placement
@@ -2401,10 +2407,8 @@ class World implements ChunkManager{
 		}
 
 		$item->pop();
-		if ($player !== null && count($newBlocks) > 0) {
-			$player->syncBlocks($newBlocks);
-		}
-
+		// As long as we are only syncing the relevant blocks to the actual placement, this should be fine.
+		$player?->syncBlocks($placementSyncBlocks);
 		return true;
 	}
 

--- a/src/world/World.php
+++ b/src/world/World.php
@@ -2329,7 +2329,7 @@ class World implements ChunkManager{
 			return false;
 		}
 
-		/** @var Vector3[] $originalBlocks */
+		/** @var Vector3[] $placementSyncBlocks */
 		$placementSyncBlocks = [];
 		$allowed = true;
 		$needsSync = false;

--- a/src/world/World.php
+++ b/src/world/World.php
@@ -122,6 +122,7 @@ use function count;
 use function floor;
 use function get_class;
 use function gettype;
+use function in_array;
 use function is_a;
 use function is_object;
 use function max;
@@ -2241,6 +2242,7 @@ class World implements ChunkManager{
 	public function useItemOn(Vector3 $vector, Item &$item, int $face, ?Vector3 $clickVector = null, ?Player $player = null, bool $playSound = false, array &$returnedItems = []) : bool{
 		$blockClicked = $this->getBlock($vector);
 		$blockReplace = $blockClicked->getSide($face);
+		$mainBlocks = [$vector, ($sideVector = $vector->getSide($face))];
 
 		if($clickVector === null){
 			$clickVector = new Vector3(0.0, 0.0, 0.0);
@@ -2254,15 +2256,18 @@ class World implements ChunkManager{
 
 		if(!$this->isInWorld($blockReplace->getPosition()->x, $blockReplace->getPosition()->y, $blockReplace->getPosition()->z)){
 			//TODO: build height limit messages for custom world heights and mcregion cap
+			$player?->syncBlocks($mainBlocks);
 			return false;
 		}
 		$chunkX = $blockReplace->getPosition()->getFloorX() >> Chunk::COORD_BIT_SIZE;
 		$chunkZ = $blockReplace->getPosition()->getFloorZ() >> Chunk::COORD_BIT_SIZE;
 		if(!$this->isChunkLoaded($chunkX, $chunkZ) || $this->isChunkLocked($chunkX, $chunkZ)){
+			$player?->syncBlocks($mainBlocks);
 			return false;
 		}
 
 		if($blockClicked->getTypeId() === BlockTypeIds::AIR){
+			$player?->syncBlocks($mainBlocks);
 			return false;
 		}
 
@@ -2279,6 +2284,18 @@ class World implements ChunkManager{
 			$ev->call();
 			if(!$ev->isCancelled()){
 				if($ev->useBlock() && $blockClicked->onInteract($item, $face, $clickVector, $player, $returnedItems)){
+					$aroundBlocks = [];
+					foreach ($vector->sidesArray() as $otherVector) {
+						if ($sideVector !== $otherVector) {
+							$aroundBlocks[] = $otherVector;
+						}
+					}
+					foreach ($sideVector->sidesArray() as $otherVector) {
+						if ($vector !== $otherVector) {
+							$aroundBlocks[] = $otherVector;
+						}
+					}
+					$player->syncBlocks($aroundBlocks);
 					return true;
 				}
 
@@ -2289,6 +2306,7 @@ class World implements ChunkManager{
 					}
 				}
 			}else{
+				$player->syncBlocks($mainBlocks);
 				return false;
 			}
 		}elseif($blockClicked->onInteract($item, $face, $clickVector, $player, $returnedItems)){
@@ -2296,6 +2314,7 @@ class World implements ChunkManager{
 		}
 
 		if($item->isNull() || !$item->canBePlaced()){
+			$player?->syncBlocks($mainBlocks);
 			return false;
 		}
 
@@ -2307,14 +2326,22 @@ class World implements ChunkManager{
 			$item->getPlacementTransaction($blockReplace, $blockClicked, $face, $clickVector, $player);
 		if($tx === null){
 			//no placement options available
+			$player?->syncBlocks($mainBlocks);
 			return false;
 		}
 
+		/** @var Vector3[] $originalBlocks */
+		$originalBlocks = [];
 		foreach($tx->getBlocks() as [$x, $y, $z, $block]){
+			$originalBlocks[] = new Vector3($x, $y, $z);
 			$block->position($this, $x, $y, $z);
 			foreach($block->getCollisionBoxes() as $collisionBox){
+				if ($player !== null && $player->getBoundingBox()->intersectsWith($collisionBox)) {
+					return false;
+				}
 				if(count($this->getCollidingEntities($collisionBox)) > 0){
-					return false;  //Entity in block
+					$player?->syncBlocks($mainBlocks);
+					return false;
 				}
 			}
 		}
@@ -2343,15 +2370,22 @@ class World implements ChunkManager{
 
 			$ev->call();
 			if($ev->isCancelled()){
+				$player->syncBlocks($mainBlocks);
 				return false;
 			}
 		}
 
 		if(!$tx->apply()){
+			$player?->syncBlocks($mainBlocks);
 			return false;
 		}
 		$first = true;
+		$newBlocks = [];
 		foreach($tx->getBlocks() as [$x, $y, $z, $_]){
+			$blockPos = new Vector3($x, $y, $z);
+			if (!in_array($blockPos, $originalBlocks, true)) {
+				$newBlocks[] = $blockPos;
+			}
 			$tile = $this->getTileAt($x, $y, $z);
 			if($tile !== null){
 				//TODO: seal this up inside block placement
@@ -2367,6 +2401,9 @@ class World implements ChunkManager{
 		}
 
 		$item->pop();
+		if ($player !== null && count($newBlocks) > 0) {
+			$player->syncBlocks($newBlocks);
+		}
 
 		return true;
 	}


### PR DESCRIPTION
<!-- Summarize your PR here. Keep it short and simple. -->
<!-- Explain existing problems or why this pull request is necessary -->

### Related issues & PRs
<!--
* Fixes #1
* Related to #2
-->
#4725 
#4924 
#3811 

## Changes
### API changes
* Added `Player->syncBlocks`

### Behavioural changes
This PR aims to fix a long-known issue where placing two or more blocks consecutively near each other will cause them to "flicker" on the client, and cause issues with bridging mechanics on higher latency clients. Instead of syncing all nearby blocks every time a player clicks a block, we move the logic directly to `World->useItemOn`, so that we only synchronize blocks the client needs.

## Backwards compatibility
N/A

## Tests
<!--
If this PR affects gameplay or user experience in some way, it must be manually tested.
Include any screenshots or videos of manual testing here.
Any test plugin code should also be pasted here if it can't be adapted to a PHPUnit test.
-->
After changes in this PR:
https://streamable.com/vochsr

Before changes in this PR:
https://streamable.com/id65yg


