### PR TITLE
Implement exposure calculation for explosions

### DIFF
--- a/src/world/Explosion.php
+++ b/src/world/Explosion.php
@@ -280,8 +280,8 @@ class Explosion{
 		$diff = (new Vector3($bb->getXLength(), $bb->getYLength(), $bb->getZLength()))->multiply(2)->add(1, 1, 1);
 		$step = new Vector3(1.0 / $diff->x, 1.0 / $diff->y, 1.0 / $diff->z);
 
-		$xOffset = (1.0 - floor($diff->x) / $diff->x) / 2.0;
-		$zOffset = (1.0 - floor($diff->z) / $diff->z) / 2.0;
+		$xOffset = (1.0 - (floor($diff->x) / $diff->x)) / 2.0;
+		$zOffset = (1.0 - (floor($diff->z) / $diff->z)) / 2.0;
 
 		$checks = 0.0;
 		$misses = 0.0;

--- a/src/world/Explosion.php
+++ b/src/world/Explosion.php
@@ -277,7 +277,7 @@ class Explosion{
 	public function getExposure(World $world, Vector3 $origin, Entity $entity) : float{
 		$bb = $entity->getBoundingBox();
 
-		$diff = new Vector3($bb->getXLength(), $bb->getYLength(), $bb->getZLength())->multiply(2)->add(1, 1, 1);
+		$diff = (new Vector3($bb->getXLength(), $bb->getYLength(), $bb->getZLength()))->multiply(2)->add(1, 1, 1);
 		$step = new Vector3(1.0 / $diff->x, 1.0 / $diff->y, 1.0 / $diff->z);
 
 		$xOffset = (1.0 - floor($diff->x) / $diff->x) / 2.0;

--- a/src/world/Explosion.php
+++ b/src/world/Explosion.php
@@ -38,6 +38,7 @@ use pocketmine\item\VanillaItems;
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Facing;
 use pocketmine\math\Vector3;
+use pocketmine\math\VoxelRayTrace;
 use pocketmine\utils\AssumptionFailedError;
 use pocketmine\utils\Utils;
 use pocketmine\world\format\SubChunk;
@@ -218,13 +219,14 @@ class Explosion{
 
 			if($distance <= 1){
 				$motion = $entityPos->subtractVector($this->source)->normalize();
+				$exposure = $this->getExposure($this->world, $this->source, $entity);
 
-				$impact = (1 - $distance) * ($exposure = 1);
+				$impact = (1 - $distance) * $exposure;
 
 				$damage = (int) ((($impact * $impact + $impact) / 2) * 8 * $explosionSize + 1);
 
 				if($this->what instanceof Entity){
-					$ev = new EntityDamageByEntityEvent($this->what, $entity, EntityDamageEvent::CAUSE_ENTITY_EXPLOSION, $damage);
+					$ev = new EntityDamageByEntityEvent($this->what, $entity, EntityDamageEvent::CAUSE_ENTITY_EXPLOSION, $damage, [], $exposure);
 				}elseif($this->what instanceof Block){
 					$ev = new EntityDamageByBlockEvent($this->what, $entity, EntityDamageEvent::CAUSE_BLOCK_EXPLOSION, $damage);
 				}else{
@@ -270,6 +272,63 @@ class Explosion{
 	}
 
 	/**
+	 * Returns the explosion exposure of an entity, used to calculate explosion impact.
+	 */
+	public function getExposure(World $world, Vector3 $origin, Entity $entity) : float{
+		$bb = $entity->getBoundingBox();
+
+		$boxMin = new Vector3($bb->minX, $bb->minY, $bb->minZ);
+		$boxMax = new Vector3($bb->maxX, $bb->maxY, $bb->maxZ);
+
+		$diff = $boxMax->subtractVector($boxMin)->multiply(2)->add(1, 1, 1);
+
+		if($diff->x <= 0.0 || $diff->y <= 0.0 || $diff->z <= 0.0){
+			return 0.0;
+		}
+
+		$step = new Vector3(1.0 / $diff->x, 1.0 / $diff->y, 1.0 / $diff->z);
+
+		if($step->x < 0.0 || $step->y < 0.0 || $step->z < 0.0){
+			return 0.0;
+		}
+
+		$xOffset = (1.0 - floor($diff->x) / $diff->x) / 2.0;
+		$zOffset = (1.0 - floor($diff->z) / $diff->z) / 2.0;
+
+		$checks = 0.0;
+		$misses = 0.0;
+
+		for($x = 0.0; $x <= 1.0; $x += $step->x){
+			for($y = 0.0; $y <= 1.0; $y += $step->y){
+				for($z = 0.0; $z <= 1.0; $z += $step->z){
+					$point = new Vector3(
+						$this->lerp($x, $boxMin->x, $boxMax->x) + $xOffset,
+						$this->lerp($y, $boxMin->y, $boxMax->y),
+						$this->lerp($z, $boxMin->z, $boxMax->z) + $zOffset
+					);
+
+					$collided = false;
+
+					foreach(VoxelRayTrace::betweenPoints($origin, $point) as $pos){
+						$block = $world->getBlock($pos);
+						if($block->calculateIntercept($origin, $point) !== null){
+							$collided = true;
+							break;
+						}
+					}
+
+					if(!$collided){
+						$misses++;
+					}
+					$checks++;
+				}
+			}
+		}
+
+		return $checks > 0.0 ? $misses / $checks : 0.0;
+	}
+
+	/**
 	 * Sets a chance between 0 and 1 of creating a fire.
 	 * For example, if the chance is 1/3, then that amount of affected blocks will be ignited.
 	 *
@@ -281,5 +340,9 @@ class Explosion{
 			throw new \InvalidArgumentException("Fire chance must be a number between 0 and 1.");
 		}
 		$this->fireChance = $fireChance;
+	}
+
+	private function lerp(float $t, float $a, float $b) : float{
+		return $a + $t * ($b - $a);
 	}
 }

--- a/src/world/Explosion.php
+++ b/src/world/Explosion.php
@@ -277,20 +277,8 @@ class Explosion{
 	public function getExposure(World $world, Vector3 $origin, Entity $entity) : float{
 		$bb = $entity->getBoundingBox();
 
-		$boxMin = new Vector3($bb->minX, $bb->minY, $bb->minZ);
-		$boxMax = new Vector3($bb->maxX, $bb->maxY, $bb->maxZ);
-
-		$diff = $boxMax->subtractVector($boxMin)->multiply(2)->add(1, 1, 1);
-
-		if($diff->x <= 0.0 || $diff->y <= 0.0 || $diff->z <= 0.0){
-			return 0.0;
-		}
-
+		$diff = new Vector3($bb->getXLength(), $bb->getYLength(), $bb->getZLength())->multiply(2)->add(1, 1, 1);
 		$step = new Vector3(1.0 / $diff->x, 1.0 / $diff->y, 1.0 / $diff->z);
-
-		if($step->x < 0.0 || $step->y < 0.0 || $step->z < 0.0){
-			return 0.0;
-		}
 
 		$xOffset = (1.0 - floor($diff->x) / $diff->x) / 2.0;
 		$zOffset = (1.0 - floor($diff->z) / $diff->z) / 2.0;
@@ -302,9 +290,9 @@ class Explosion{
 			for($y = 0.0; $y <= 1.0; $y += $step->y){
 				for($z = 0.0; $z <= 1.0; $z += $step->z){
 					$point = new Vector3(
-						$this->lerp($x, $boxMin->x, $boxMax->x) + $xOffset,
-						$this->lerp($y, $boxMin->y, $boxMax->y),
-						$this->lerp($z, $boxMin->z, $boxMax->z) + $zOffset
+						$this->lerp($x, $bb->minX, $bb->maxX) + $xOffset,
+						$this->lerp($y, $bb->minY, $bb->maxY),
+						$this->lerp($z, $bb->minZ, $bb->maxZ) + $zOffset
 					);
 
 					$collided = false;

--- a/src/world/Explosion.php
+++ b/src/world/Explosion.php
@@ -284,7 +284,7 @@ class Explosion{
 		$zOffset = (1.0 - (floor($diff->z) / $diff->z)) / 2.0;
 
 		$checks = 0.0;
-		$misses = 0.0;
+		$hits = 0.0;
 
 		for($x = 0.0; $x <= 1.0; $x += $step->x){
 			for($y = 0.0; $y <= 1.0; $y += $step->y){
@@ -306,14 +306,14 @@ class Explosion{
 					}
 
 					if(!$intercepted){
-						$misses++;
+						$hits++;
 					}
 					$checks++;
 				}
 			}
 		}
 
-		return $checks > 0.0 ? $misses / $checks : 0.0;
+		return $checks > 0.0 ? $hits / $checks : 0.0;
 	}
 
 	/**

--- a/src/world/Explosion.php
+++ b/src/world/Explosion.php
@@ -226,7 +226,7 @@ class Explosion{
 				$damage = (int) ((($impact * $impact + $impact) / 2) * 8 * $explosionSize + 1);
 
 				if($this->what instanceof Entity){
-					$ev = new EntityDamageByEntityEvent($this->what, $entity, EntityDamageEvent::CAUSE_ENTITY_EXPLOSION, $damage, [], $exposure);
+					$ev = new EntityDamageByEntityEvent($this->what, $entity, EntityDamageEvent::CAUSE_ENTITY_EXPLOSION, $damage);
 				}elseif($this->what instanceof Block){
 					$ev = new EntityDamageByBlockEvent($this->what, $entity, EntityDamageEvent::CAUSE_BLOCK_EXPLOSION, $damage);
 				}else{

--- a/src/world/Explosion.php
+++ b/src/world/Explosion.php
@@ -219,7 +219,7 @@ class Explosion{
 
 			if($distance <= 1){
 				$motion = $entityPos->subtractVector($this->source)->normalize();
-				$exposure = $this->getExposure($this->world, $this->source, $entity);
+				$exposure = $this->getExposure($this->source, $entity);
 
 				$impact = (1 - $distance) * $exposure;
 
@@ -274,7 +274,7 @@ class Explosion{
 	/**
 	 * Returns the explosion exposure of an entity, used to calculate explosion impact.
 	 */
-	public function getExposure(World $world, Vector3 $origin, Entity $entity) : float{
+	private function getExposure(Vector3 $origin, Entity $entity) : float{
 		$bb = $entity->getBoundingBox();
 
 		$diff = (new Vector3($bb->getXLength(), $bb->getYLength(), $bb->getZLength()))->multiply(2)->add(1, 1, 1);
@@ -295,17 +295,17 @@ class Explosion{
 						$this->lerp($z, $bb->minZ, $bb->maxZ) + $zOffset
 					);
 
-					$collided = false;
+					$intercepted = false;
 
 					foreach(VoxelRayTrace::betweenPoints($origin, $point) as $pos){
-						$block = $world->getBlock($pos);
+						$block = $this->world->getBlock($pos);
 						if($block->calculateIntercept($origin, $point) !== null){
-							$collided = true;
+							$intercepted = true;
 							break;
 						}
 					}
 
-					if(!$collided){
+					if(!$intercepted){
 						$misses++;
 					}
 					$checks++;
@@ -330,7 +330,7 @@ class Explosion{
 		$this->fireChance = $fireChance;
 	}
 
-	private function lerp(float $t, float $a, float $b) : float{
-		return $a + $t * ($b - $a);
+	private static function lerp(float $scale, float $a, float $b) : float{
+		return $a + $scale * ($b - $a);
 	}
 }

--- a/src/world/Explosion.php
+++ b/src/world/Explosion.php
@@ -290,9 +290,9 @@ class Explosion{
 			for($y = 0.0; $y <= 1.0; $y += $step->y){
 				for($z = 0.0; $z <= 1.0; $z += $step->z){
 					$point = new Vector3(
-						$this->lerp($x, $bb->minX, $bb->maxX) + $xOffset,
-						$this->lerp($y, $bb->minY, $bb->maxY),
-						$this->lerp($z, $bb->minZ, $bb->maxZ) + $zOffset
+						self::lerp($x, $bb->minX, $bb->maxX) + $xOffset,
+						self::lerp($y, $bb->minY, $bb->maxY),
+						self::lerp($z, $bb->minZ, $bb->maxZ) + $zOffset
 					);
 
 					$intercepted = false;


### PR DESCRIPTION
Right now in PM, explosion damage is always calculated as if players have full exposure, which causes odd situations like taking damage through walls. This PR adds proper exposure checks using raycasts to make explosions behave more accurately and realistically.

A lot of the logic for this was referenced from [Dragonfly](https://github.com/df-mc/dragonfly/blob/master/server/block/explosion.go#L183). 

## Changes

### Behavioural changes
Explosion damage now accurately matches vanilla behavior by using a new `getExposure()` method in the `Explosion` class to calculate real exposure.

## Follow-up
One thing I wasn’t completely sure about while making this PR was whether the `lerp()` method belongs inside `Explosion`. It might make more sense to move it to `Math` instead.

## Tests
Here’s a video demonstrating the behavior before and after the changes.

https://github.com/user-attachments/assets/5498dbdc-ea00-4a9f-a7b4-40482f0d4158

