### PR TITLE
Fix StringToItemParser::override() not fully overriding aliases

### DIFF
--- a/src/item/StringToItemParser.php
+++ b/src/item/StringToItemParser.php
@@ -1602,15 +1602,10 @@ final class StringToItemParser extends StringToTParser{
 		if($oldItem !== null){
 			$oldStateId = $oldItem->getStateId();
 			unset($this->reverseMap[$oldStateId][$alias]);
-			if($this->reverseMap[$oldStateId] === []){
-				unset($this->reverseMap[$oldStateId]);
-			}
 		}
 		parent::override($alias, $callback);
-		$newItem = $this->parse($alias);
-		if($newItem !== null){
-			$this->reverseMap[$newItem->getStateId()][$alias] = true;
-		}
+		$newItem = $callback($alias);
+		$this->reverseMap[$newItem->getStateId()][$alias] = true;
 	}
 
 	/** @phpstan-param \Closure(string $input) : Block $callback */

--- a/src/item/StringToItemParser.php
+++ b/src/item/StringToItemParser.php
@@ -38,6 +38,7 @@ use pocketmine\item\VanillaItems as Items;
 use pocketmine\utils\SingletonTrait;
 use pocketmine\utils\StringToTParser;
 use function array_keys;
+use function count;
 use function strtolower;
 
 /**

--- a/src/item/StringToItemParser.php
+++ b/src/item/StringToItemParser.php
@@ -1597,6 +1597,16 @@ final class StringToItemParser extends StringToTParser{
 		$this->reverseMap[$item->getStateId()][$alias] = true;
 	}
 
+	public function override(string $alias, \Closure $callback) : void{
+		// Remove the alias from the old item's reverse map
+		foreach($this->reverseMap as $stateId => $aliases){
+			unset($this->reverseMap[$stateId][$alias]);
+		}
+		parent::override($alias, $callback);
+		$item = $callback($alias);
+		$this->reverseMap[$item->getStateId()][$alias] = true;
+	}
+
 	/** @phpstan-param \Closure(string $input) : Block $callback */
 	public function registerBlock(string $alias, \Closure $callback) : void{
 		$this->register($alias, fn(string $input) => $callback($input)->asItem());

--- a/src/item/StringToItemParser.php
+++ b/src/item/StringToItemParser.php
@@ -1598,9 +1598,13 @@ final class StringToItemParser extends StringToTParser{
 	}
 
 	public function override(string $alias, \Closure $callback) : void{
-		// Remove the alias from the old item's reverse map
-		foreach($this->reverseMap as $stateId => $aliases){
-			unset($this->reverseMap[$stateId][$alias]);
+		$oldItem = $this->parse($alias);
+		if($oldItem !== null){
+			$oldStateId = $oldItem->getStateId();
+			unset($this->reverseMap[$oldStateId][$alias]);
+			if(count($this->reverseMap[$oldStateId]) === 0){
+				unset($this->reverseMap[$oldStateId]);
+			}
 		}
 		parent::override($alias, $callback);
 		$item = $callback($alias);

--- a/src/item/StringToItemParser.php
+++ b/src/item/StringToItemParser.php
@@ -38,7 +38,6 @@ use pocketmine\item\VanillaItems as Items;
 use pocketmine\utils\SingletonTrait;
 use pocketmine\utils\StringToTParser;
 use function array_keys;
-use function count;
 use function strtolower;
 
 /**
@@ -1603,13 +1602,15 @@ final class StringToItemParser extends StringToTParser{
 		if($oldItem !== null){
 			$oldStateId = $oldItem->getStateId();
 			unset($this->reverseMap[$oldStateId][$alias]);
-			if(count($this->reverseMap[$oldStateId]) === 0){
+			if($this->reverseMap[$oldStateId] === []){
 				unset($this->reverseMap[$oldStateId]);
 			}
 		}
 		parent::override($alias, $callback);
-		$item = $callback($alias);
-		$this->reverseMap[$item->getStateId()][$alias] = true;
+		$newItem = $this->parse($alias);
+		if($newItem !== null){
+			$this->reverseMap[$newItem->getStateId()][$alias] = true;
+		}
 	}
 
 	/** @phpstan-param \Closure(string $input) : Block $callback */

--- a/src/item/StringToItemParser.php
+++ b/src/item/StringToItemParser.php
@@ -1602,8 +1602,15 @@ final class StringToItemParser extends StringToTParser{
 		if($oldItem !== null){
 			$oldStateId = $oldItem->getStateId();
 			unset($this->reverseMap[$oldStateId][$alias]);
+			if($this->reverseMap[$oldStateId] === []){
+				unset($this->reverseMap[$oldStateId]);
+			}
 		}
 		parent::override($alias, $callback);
+		$newItem = $this->parse($alias);
+		if($newItem !== null){
+			$this->reverseMap[$newItem->getStateId()][$alias] = true;
+		}
 	}
 
 	/** @phpstan-param \Closure(string $input) : Block $callback */

--- a/src/item/StringToItemParser.php
+++ b/src/item/StringToItemParser.php
@@ -1602,15 +1602,8 @@ final class StringToItemParser extends StringToTParser{
 		if($oldItem !== null){
 			$oldStateId = $oldItem->getStateId();
 			unset($this->reverseMap[$oldStateId][$alias]);
-			if($this->reverseMap[$oldStateId] === []){
-				unset($this->reverseMap[$oldStateId]);
-			}
 		}
 		parent::override($alias, $callback);
-		$newItem = $this->parse($alias);
-		if($newItem !== null){
-			$this->reverseMap[$newItem->getStateId()][$alias] = true;
-		}
 	}
 
 	/** @phpstan-param \Closure(string $input) : Block $callback */

--- a/src/item/StringToItemParser.php
+++ b/src/item/StringToItemParser.php
@@ -38,6 +38,7 @@ use pocketmine\item\VanillaItems as Items;
 use pocketmine\utils\SingletonTrait;
 use pocketmine\utils\StringToTParser;
 use function array_keys;
+use function count;
 use function strtolower;
 
 /**
@@ -1602,6 +1603,9 @@ final class StringToItemParser extends StringToTParser{
 		if($oldItem !== null){
 			$oldStateId = $oldItem->getStateId();
 			unset($this->reverseMap[$oldStateId][$alias]);
+			if(count($this->reverseMap[$oldStateId]) === 0){
+				unset($this->reverseMap[$oldStateId]);
+			}
 		}
 		parent::override($alias, $callback);
 		$newItem = $callback($alias);

--- a/tests/phpunit/item/StringToItemParserTest.php
+++ b/tests/phpunit/item/StringToItemParserTest.php
@@ -5,7 +5,7 @@
  *  ____            _        _   __  __ _                  __  __ ____
  * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
  * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
- * |  __/ (_) | (__|   <  __/ |_| |  | | | | |  __/_____| |  | |  __/
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
  * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
  *
  * This program is free software: you can redistribute it and/or modify
@@ -16,6 +16,7 @@
  * @author PocketMine Team
  * @link http://www.pocketmine.net/
  *
+ *
  */
 
 declare(strict_types=1);
@@ -23,8 +24,6 @@ declare(strict_types=1);
 namespace pocketmine\item;
 
 use PHPUnit\Framework\TestCase;
-use pocketmine\item\VanillaItems;
-use pocketmine\item\StringToItemParser;
 
 class StringToItemParserTest extends TestCase{
 

--- a/tests/phpunit/item/StringToItemParserTest.php
+++ b/tests/phpunit/item/StringToItemParserTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\item;
+
+use PHPUnit\Framework\TestCase;
+use pocketmine\item\VanillaItems;
+use pocketmine\item\StringToItemParser;
+
+class StringToItemParserTest extends TestCase{
+
+	public function testOverrideRemovesOldAlias() : void{
+		$parser = new StringToItemParser();
+
+		$item1 = VanillaItems::DIAMOND();
+		$item2 = VanillaItems::EMERALD();
+
+		$parser->register("test_alias", fn() => $item1);
+
+		self::assertContains("test_alias", $parser->lookupAliases($item1));
+		self::assertNotContains("test_alias", $parser->lookupAliases($item2));
+
+		$parser->override("test_alias", fn() => $item2);
+
+		self::assertNotContains("test_alias", $parser->lookupAliases($item1));
+		self::assertContains("test_alias", $parser->lookupAliases($item2));
+	}
+
+	public function testOverrideWithNewAlias() : void{
+		$parser = new StringToItemParser();
+
+		$item = VanillaItems::DIAMOND();
+
+		$parser->override("new_alias", fn() => $item);
+
+		self::assertContains("new_alias", $parser->lookupAliases($item));
+		self::assertSame($item, $parser->parse("new_alias"));
+	}
+
+	public function testOverrideMultipleAliases() : void{
+		$parser = new StringToItemParser();
+
+		$item1 = VanillaItems::DIAMOND();
+		$item2 = VanillaItems::EMERALD();
+
+		$parser->register("alias1", fn() => $item1);
+		$parser->register("alias2", fn() => $item1);
+		$parser->register("alias3", fn() => $item1);
+
+		self::assertCount(3, $parser->lookupAliases($item1));
+
+		$parser->override("alias2", fn() => $item2);
+
+		self::assertCount(2, $parser->lookupAliases($item1));
+		self::assertContains("alias1", $parser->lookupAliases($item1));
+		self::assertContains("alias3", $parser->lookupAliases($item1));
+		self::assertNotContains("alias2", $parser->lookupAliases($item1));
+
+		self::assertCount(1, $parser->lookupAliases($item2));
+		self::assertContains("alias2", $parser->lookupAliases($item2));
+	}
+}


### PR DESCRIPTION
Fixes #6815

This PR fixes an issue where `StringToItemParser::override()` did not fully override aliases,
causing `lookupAliases()` to return incorrect results.