### PR TITLE
Fix entities having incorrect hitbox sizes

### DIFF
--- a/src/entity/Squid.php
+++ b/src/entity/Squid.php
@@ -45,7 +45,7 @@ class Squid extends WaterAnimal{
 
 	private int $switchDirectionTicker = 0;
 
-	protected function getInitialSizeInfo() : EntitySizeInfo{ return new EntitySizeInfo(0.95, 0.95); }
+	protected function getInitialSizeInfo() : EntitySizeInfo{ return new EntitySizeInfo(0.8, 0.8); }
 
 	public function initEntity(CompoundTag $nbt) : void{
 		$this->setMaxHealth(10);

--- a/src/entity/Villager.php
+++ b/src/entity/Villager.php
@@ -46,7 +46,7 @@ class Villager extends Living implements Ageable{
 	private int $profession = self::PROFESSION_FARMER;
 
 	protected function getInitialSizeInfo() : EntitySizeInfo{
-		return new EntitySizeInfo(1.8, 0.6); //TODO: eye height??
+		return new EntitySizeInfo(1.9, 0.6); //TODO: eye height??
 	}
 
 	public function getName() : string{

--- a/src/entity/Zombie.php
+++ b/src/entity/Zombie.php
@@ -33,7 +33,7 @@ class Zombie extends Living{
 	public static function getNetworkTypeId() : string{ return EntityIds::ZOMBIE; }
 
 	protected function getInitialSizeInfo() : EntitySizeInfo{
-		return new EntitySizeInfo(1.8, 0.6); //TODO: eye height ??
+		return new EntitySizeInfo(1.9, 0.6); //TODO: eye height ??
 	}
 
 	public function getName() : string{


### PR DESCRIPTION

This PR adjusts a few entity hitbox sizes to better match vanilla behaviour.
Some values were slightly off compared to vanilla.


## Changes
### Entity Size Changes
* **Squid:** `0.95, 0.95` → `0.8, 0.8`
  [Reference](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/entities/squid.json#L36-L39)

* **Villager:** `1.8, 0.6` → `1.9, 0.6`
  [Reference](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/entities/villager.json#L378-L381)

* **Zombie:** `1.8, 0.6` → `1.9, 0.6`
  [Reference](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/entities/zombie.json#L139-L142)
