### PR TITLE
Separate sneak keydown flag from crouching flag

### DIFF
--- a/src/event/player/PlayerToggleSneakEvent.php
+++ b/src/event/player/PlayerToggleSneakEvent.php
@@ -47,7 +47,8 @@ class PlayerToggleSneakEvent extends PlayerEvent implements Cancellable{
 	 * isSneakPressed is different from isSneaking because is responsible for interaction limitation and don't change visual player state.
 	 * isSneaking is responsible for visual player state (hitbox height, sneaking).
 	 *
-	 * Returns true when the player is actually holding the sneak key.
+	 * Returns whether the player is pressing the sneak key.
+	 * The player may still be sneaking even if this is false due to gameplay mechanics (e.g. releasing sneak while in a 1.5 block high space).
 	 */
 	public function isSneakPressed() : bool{
 		return $this->isSneakPressed;

--- a/src/event/player/PlayerToggleSneakEvent.php
+++ b/src/event/player/PlayerToggleSneakEvent.php
@@ -43,10 +43,6 @@ class PlayerToggleSneakEvent extends PlayerEvent implements Cancellable{
 	}
 
 	/**
-	 * Since 1.20.10, sneaking has multiple states that affects interacting with items/blocks.
-	 * isSneakPressed is different from isSneaking because is responsible for interaction limitation and don't change visual player state.
-	 * isSneaking is responsible for visual player state (hitbox height, sneaking).
-	 *
 	 * Returns whether the player is pressing the sneak key.
 	 * The player may still be sneaking even if this is false due to gameplay mechanics (e.g. releasing sneak while in a 1.5 block high space).
 	 */

--- a/src/event/player/PlayerToggleSneakEvent.php
+++ b/src/event/player/PlayerToggleSneakEvent.php
@@ -32,12 +32,17 @@ class PlayerToggleSneakEvent extends PlayerEvent implements Cancellable{
 
 	public function __construct(
 		Player $player,
-		protected bool $isSneaking
+		protected bool $isSneaking,
+		protected bool $isSneakBindPressed,
 	){
 		$this->player = $player;
 	}
 
 	public function isSneaking() : bool{
 		return $this->isSneaking;
+	}
+
+	public function isSneakBindPressed() : bool{
+		return $this->isSneakBindPressed;
 	}
 }

--- a/src/event/player/PlayerToggleSneakEvent.php
+++ b/src/event/player/PlayerToggleSneakEvent.php
@@ -33,7 +33,7 @@ class PlayerToggleSneakEvent extends PlayerEvent implements Cancellable{
 	public function __construct(
 		Player $player,
 		protected bool $isSneaking,
-		protected bool $isSneakBindPressed,
+		protected bool $isSneakBindPressed
 	){
 		$this->player = $player;
 	}

--- a/src/event/player/PlayerToggleSneakEvent.php
+++ b/src/event/player/PlayerToggleSneakEvent.php
@@ -33,7 +33,7 @@ class PlayerToggleSneakEvent extends PlayerEvent implements Cancellable{
 	public function __construct(
 		Player $player,
 		protected bool $isSneaking,
-		protected bool $isSneakBindPressed
+		protected bool $isSneakPressed
 	){
 		$this->player = $player;
 	}
@@ -42,7 +42,7 @@ class PlayerToggleSneakEvent extends PlayerEvent implements Cancellable{
 		return $this->isSneaking;
 	}
 
-	public function isSneakBindPressed() : bool{
-		return $this->isSneakBindPressed;
+	public function isSneakPressed() : bool{
+		return $this->isSneakPressed;
 	}
 }

--- a/src/event/player/PlayerToggleSneakEvent.php
+++ b/src/event/player/PlayerToggleSneakEvent.php
@@ -42,6 +42,13 @@ class PlayerToggleSneakEvent extends PlayerEvent implements Cancellable{
 		return $this->isSneaking;
 	}
 
+	/**
+	 * Since 1.20.10, sneaking has multiple states that affects interacting with items/blocks.
+	 * isSneakPressed is different from isSneaking because is responsible for interaction limitation and don't change visual player state.
+	 * isSneaking is responsible for visual player state (hitbox height, sneaking).
+	 *
+	 * Returns true when the player is actually holding the sneak key.
+	 */
 	public function isSneakPressed() : bool{
 		return $this->isSneakPressed;
 	}

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -218,7 +218,7 @@ class InGamePacketHandler extends PacketHandler{
 		if($this->lastPlayerAuthInputFlags === null || !$inputFlags->equals($this->lastPlayerAuthInputFlags)){
 			$this->lastPlayerAuthInputFlags = $inputFlags;
 
-			$sneakBind = $inputFlags->get(PlayerAuthInputFlags::SNEAKING);
+			$sneakPressed = $inputFlags->get(PlayerAuthInputFlags::SNEAKING);
 
 			$sneaking = $this->resolveOnOffInputFlags($inputFlags, PlayerAuthInputFlags::START_SNEAKING, PlayerAuthInputFlags::STOP_SNEAKING);
 			$sprinting = $this->resolveOnOffInputFlags($inputFlags, PlayerAuthInputFlags::START_SPRINTING, PlayerAuthInputFlags::STOP_SPRINTING);
@@ -226,7 +226,7 @@ class InGamePacketHandler extends PacketHandler{
 			$gliding = $this->resolveOnOffInputFlags($inputFlags, PlayerAuthInputFlags::START_GLIDING, PlayerAuthInputFlags::STOP_GLIDING);
 			$flying = $this->resolveOnOffInputFlags($inputFlags, PlayerAuthInputFlags::START_FLYING, PlayerAuthInputFlags::STOP_FLYING);
 			$mismatch =
-				($sneaking !== null && !$this->player->toggleSneak($sneaking, $sneakBind)) |
+				($sneaking !== null && !$this->player->toggleSneak($sneaking, $sneakPressed)) |
 				($sprinting !== null && !$this->player->toggleSprint($sprinting)) |
 				($swimming !== null && !$this->player->toggleSwim($swimming)) |
 				($gliding !== null && !$this->player->toggleGlide($gliding)) |

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -148,7 +148,8 @@ class InGamePacketHandler extends PacketHandler{
 		private Player $player,
 		private NetworkSession $session,
 		private InventoryManager $inventoryManager
-	){}
+	){
+	}
 
 	public function handleText(TextPacket $packet) : bool{
 		if($packet->type === TextPacket::TYPE_CHAT){
@@ -229,8 +230,8 @@ class InGamePacketHandler extends PacketHandler{
 			$gliding = $this->resolveOnOffInputFlags($inputFlags, PlayerAuthInputFlags::START_GLIDING, PlayerAuthInputFlags::STOP_GLIDING);
 			$flying = $this->resolveOnOffInputFlags($inputFlags, PlayerAuthInputFlags::START_FLYING, PlayerAuthInputFlags::STOP_FLYING);
 			$mismatch =
-				($sneaking !== null && !$this->player->toggleSneak($sneaking)) |
-				($sneakBind !== null && !$this->player->toggleSneakBindPressed($sneakBind)) |
+				(($sneaking !== null || $sneakBind !== null) &&
+					!$this->player->toggleSneak($sneaking ?? $this->player->isSneaking(), $sneakBind ?? $this->player->isSneakBindPressed())) |
 				($sprinting !== null && !$this->player->toggleSprint($sprinting)) |
 				($swimming !== null && !$this->player->toggleSwim($swimming)) |
 				($gliding !== null && !$this->player->toggleGlide($gliding)) |
@@ -969,7 +970,7 @@ class InGamePacketHandler extends PacketHandler{
 		}
 
 		//for redundancy, in case of protocol changes, we don't want to pass these directly
-		$action = match($packet->type){
+		$action = match ($packet->type) {
 			BookEditPacket::TYPE_REPLACE_PAGE => PlayerEditBookEvent::ACTION_REPLACE_PAGE,
 			BookEditPacket::TYPE_ADD_PAGE => PlayerEditBookEvent::ACTION_ADD_PAGE,
 			BookEditPacket::TYPE_DELETE_PAGE => PlayerEditBookEvent::ACTION_DELETE_PAGE,

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -220,9 +220,6 @@ class InGamePacketHandler extends PacketHandler{
 			$this->lastPlayerAuthInputFlags = $inputFlags;
 
 			$sneakBind = $inputFlags->get(PlayerAuthInputFlags::SNEAKING);
-			if($this->player->isSneakBindPressed() === $sneakBind){
-				$sneakBind = null;
-			}
 
 			$sneaking = $this->resolveOnOffInputFlags($inputFlags, PlayerAuthInputFlags::START_SNEAKING, PlayerAuthInputFlags::STOP_SNEAKING);
 			$sprinting = $this->resolveOnOffInputFlags($inputFlags, PlayerAuthInputFlags::START_SPRINTING, PlayerAuthInputFlags::STOP_SPRINTING);
@@ -230,8 +227,7 @@ class InGamePacketHandler extends PacketHandler{
 			$gliding = $this->resolveOnOffInputFlags($inputFlags, PlayerAuthInputFlags::START_GLIDING, PlayerAuthInputFlags::STOP_GLIDING);
 			$flying = $this->resolveOnOffInputFlags($inputFlags, PlayerAuthInputFlags::START_FLYING, PlayerAuthInputFlags::STOP_FLYING);
 			$mismatch =
-				(($sneaking !== null || $sneakBind !== null) &&
-					!$this->player->toggleSneak($sneaking ?? $this->player->isSneaking(), $sneakBind ?? $this->player->isSneakBindPressed())) |
+				($sneaking !== null && !$this->player->toggleSneak($sneaking, $sneakBind)) |
 				($sprinting !== null && !$this->player->toggleSprint($sprinting)) |
 				($swimming !== null && !$this->player->toggleSwim($swimming)) |
 				($gliding !== null && !$this->player->toggleGlide($gliding)) |

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -218,16 +218,19 @@ class InGamePacketHandler extends PacketHandler{
 		if($this->lastPlayerAuthInputFlags === null || !$inputFlags->equals($this->lastPlayerAuthInputFlags)){
 			$this->lastPlayerAuthInputFlags = $inputFlags;
 
-			$sneaking = $inputFlags->get(PlayerAuthInputFlags::SNEAKING);
-			if($this->player->isSneaking() === $sneaking){
-				$sneaking = null;
+			$sneakBind = $inputFlags->get(PlayerAuthInputFlags::SNEAKING);
+			if($this->player->isSneakBindPressed() === $sneakBind){
+				$sneakBind = null;
 			}
+
+			$sneaking = $this->resolveOnOffInputFlags($inputFlags, PlayerAuthInputFlags::START_SNEAKING, PlayerAuthInputFlags::STOP_SNEAKING);
 			$sprinting = $this->resolveOnOffInputFlags($inputFlags, PlayerAuthInputFlags::START_SPRINTING, PlayerAuthInputFlags::STOP_SPRINTING);
 			$swimming = $this->resolveOnOffInputFlags($inputFlags, PlayerAuthInputFlags::START_SWIMMING, PlayerAuthInputFlags::STOP_SWIMMING);
 			$gliding = $this->resolveOnOffInputFlags($inputFlags, PlayerAuthInputFlags::START_GLIDING, PlayerAuthInputFlags::STOP_GLIDING);
 			$flying = $this->resolveOnOffInputFlags($inputFlags, PlayerAuthInputFlags::START_FLYING, PlayerAuthInputFlags::STOP_FLYING);
 			$mismatch =
 				($sneaking !== null && !$this->player->toggleSneak($sneaking)) |
+				($sneakBind !== null && !$this->player->toggleSneakBindPressed($sneakBind)) |
 				($sprinting !== null && !$this->player->toggleSprint($sprinting)) |
 				($swimming !== null && !$this->player->toggleSwim($swimming)) |
 				($gliding !== null && !$this->player->toggleGlide($gliding)) |

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -148,8 +148,7 @@ class InGamePacketHandler extends PacketHandler{
 		private Player $player,
 		private NetworkSession $session,
 		private InventoryManager $inventoryManager
-	){
-	}
+	){}
 
 	public function handleText(TextPacket $packet) : bool{
 		if($packet->type === TextPacket::TYPE_CHAT){
@@ -966,7 +965,7 @@ class InGamePacketHandler extends PacketHandler{
 		}
 
 		//for redundancy, in case of protocol changes, we don't want to pass these directly
-		$action = match ($packet->type) {
+		$action = match($packet->type){
 			BookEditPacket::TYPE_REPLACE_PAGE => PlayerEditBookEvent::ACTION_REPLACE_PAGE,
 			BookEditPacket::TYPE_ADD_PAGE => PlayerEditBookEvent::ACTION_ADD_PAGE,
 			BookEditPacket::TYPE_DELETE_PAGE => PlayerEditBookEvent::ACTION_DELETE_PAGE,

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1285,6 +1285,13 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 		$this->sneakPressed = $sneakPressed;
 	}
 
+	/**
+	 * Since 1.20.10, sneaking has multiple states that affects interacting with items/blocks.
+	 * isSneakPressed is different from isSneaking because is responsible for interaction limitation and don't change visual player state.
+	 * isSneaking is responsible for visual player state (hitbox height, sneaking).
+	 *
+	 * Returns true when the player is actually holding the sneak key.
+	 */
 	public function isSneakPressed() : bool{
 		return $this->sneakPressed;
 	}

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -294,7 +294,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 
 	protected float $flightSpeedMultiplier = self::DEFAULT_FLIGHT_SPEED_MULTIPLIER;
 
-	/** @phpstan-var positive-int|null  */
+	/** @phpstan-var positive-int|null */
 	protected ?int $lineHeight = null;
 	protected string $locale = "en_US";
 
@@ -343,7 +343,8 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 		$this->spawnThreshold = (int) (($this->server->getConfigGroup()->getPropertyInt(YmlServerProperties::CHUNK_SENDING_SPAWN_RADIUS, 4) ** 2) * M_PI);
 		$this->chunkSelector = new ChunkSelector();
 
-		$this->chunkLoader = new class implements ChunkLoader{};
+		$this->chunkLoader = new class implements ChunkLoader{
+		};
 		$this->chunkTicker = new ChunkTicker();
 		$world = $spawnLocation->getWorld();
 		//load the spawn chunk so we can see the terrain
@@ -966,8 +967,8 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 	}
 
 	/**
-	 * @param true[] $oldTickingChunks
-	 * @param true[] $newTickingChunks
+	 * @param true[]                   $oldTickingChunks
+	 * @param true[]                   $newTickingChunks
 	 *
 	 * @phpstan-param array<int, true> $oldTickingChunks
 	 * @phpstan-param array<int, true> $newTickingChunks
@@ -2080,24 +2081,22 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 		return true;
 	}
 
-	public function toggleSneak(bool $sneak) : bool{
-		if($sneak === $this->sneaking){
+	public function toggleSneak(bool $sneak, bool $sneakBindPressed) : bool{
+		if($sneak === $this->sneaking && $sneakBindPressed === $this->sneakBindPressed){
 			return true;
 		}
-		$ev = new PlayerToggleSneakEvent($this, $sneak);
+
+		$ev = new PlayerToggleSneakEvent($this, $sneak, $sneakBindPressed);
+		if($sneak == $this->sneaking) {
+			$ev->cancel();
+		}
+		$this->sneakBindPressed = $sneakBindPressed;
+
 		$ev->call();
 		if($ev->isCancelled()){
 			return false;
 		}
 		$this->setSneaking($sneak);
-		return true;
-	}
-
-	public function toggleSneakBindPressed(bool $bind) : bool{
-		if($bind === $this->sneakBindPressed) {
-			return true;
-		}
-		$this->sneakBindPressed = $bind;
 		return true;
 	}
 
@@ -2167,8 +2166,8 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 	/**
 	 * Adds a title text to the user's screen, with an optional subtitle.
 	 *
-	 * @param int $fadeIn  Duration in ticks for fade-in. If -1 is given, client-sided defaults will be used.
-	 * @param int $stay    Duration in ticks to stay on screen for
+	 * @param int $fadeIn Duration in ticks for fade-in. If -1 is given, client-sided defaults will be used.
+	 * @param int $stay Duration in ticks to stay on screen for
 	 * @param int $fadeOut Duration in ticks for fade-out.
 	 */
 	public function sendTitle(string $title, string $subtitle = "", int $fadeIn = -1, int $stay = -1, int $fadeOut = -1) : void{
@@ -2210,8 +2209,8 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 	/**
 	 * Sets the title duration.
 	 *
-	 * @param int $fadeIn  Title fade-in time in ticks.
-	 * @param int $stay    Title stay time in ticks.
+	 * @param int $fadeIn Title fade-in time in ticks.
+	 * @param int $stay Title stay time in ticks.
 	 * @param int $fadeOut Title fade-out time in ticks.
 	 */
 	public function setTitleDuration(int $fadeIn, int $stay, int $fadeOut) : void{
@@ -2292,7 +2291,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 	 * Transfers a player to another server.
 	 *
 	 * @param string                   $address The IP address or hostname of the destination server
-	 * @param int                      $port    The destination port, defaults to 19132
+	 * @param int                      $port The destination port, defaults to 19132
 	 * @param Translatable|string|null $message Message to show in the console when closing the player, null will use the default message
 	 *
 	 * @return bool if transfer was successful.
@@ -2311,8 +2310,8 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 	/**
 	 * Kicks a player from the server
 	 *
-	 * @param Translatable|string      $reason                  Shown in the server log - this should be a short one-line message
-	 * @param Translatable|string|null $quitMessage             Message to broadcast to online players (null will use default)
+	 * @param Translatable|string      $reason Shown in the server log - this should be a short one-line message
+	 * @param Translatable|string|null $quitMessage Message to broadcast to online players (null will use default)
 	 * @param Translatable|string|null $disconnectScreenMessage Shown on the player's disconnection screen (null will use the reason)
 	 */
 	public function kick(Translatable|string $reason = "", Translatable|string|null $quitMessage = null, Translatable|string|null $disconnectScreenMessage = null) : bool{
@@ -2344,8 +2343,8 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 	 *
 	 * Note for internals developers: Do not call this from network sessions. It will cause a feedback loop.
 	 *
-	 * @param Translatable|string      $reason                  Shown in the server log - this should be a short one-line message
-	 * @param Translatable|string|null $quitMessage             Message to broadcast to online players (null will use default)
+	 * @param Translatable|string      $reason Shown in the server log - this should be a short one-line message
+	 * @param Translatable|string|null $quitMessage Message to broadcast to online players (null will use default)
 	 * @param Translatable|string|null $disconnectScreenMessage Shown on the player's disconnection screen (null will use the reason)
 	 */
 	public function disconnect(Translatable|string $reason, Translatable|string|null $quitMessage = null, Translatable|string|null $disconnectScreenMessage = null) : void{
@@ -2358,11 +2357,12 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 	}
 
 	/**
+	 * @param Translatable|string      $reason Shown in the server log - this should be a short one-line message
+	 * @param Translatable|string|null $quitMessage Message to broadcast to online players (null will use default)
+	 *
 	 * @internal
 	 * This method executes post-disconnect actions and cleanups.
 	 *
-	 * @param Translatable|string      $reason      Shown in the server log - this should be a short one-line message
-	 * @param Translatable|string|null $quitMessage Message to broadcast to online players (null will use default)
 	 */
 	public function onPostDisconnect(Translatable|string $reason, Translatable|string|null $quitMessage) : void{
 		if($this->isConnected()){

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1286,10 +1286,6 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 	}
 
 	/**
-	 * Since 1.20.10, sneaking has multiple states that affects interacting with items/blocks.
-	 * isSneakPressed is different from isSneaking because is responsible for interaction limitation and don't change visual player state.
-	 * isSneaking is responsible for visual player state (hitbox height, sneaking).
-	 *
 	 * Returns whether the player is pressing the sneak key.
 	 * The player may still be sneaking even if this is false due to gameplay mechanics (e.g. releasing sneak while in a 1.5 block high space).
 	 */

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -2095,7 +2095,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 		$this->setSneakPressed($sneakPressed);
 
 		$ev = new PlayerToggleSneakEvent($this, $sneak, $sneakPressed);
-		if($sneak === $this->sneaking) {
+		if($sneak === $this->sneaking){
 			$ev->cancel();
 		}
 		$ev->call();

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1290,7 +1290,8 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 	 * isSneakPressed is different from isSneaking because is responsible for interaction limitation and don't change visual player state.
 	 * isSneaking is responsible for visual player state (hitbox height, sneaking).
 	 *
-	 * Returns true when the player is actually holding the sneak key.
+	 * Returns whether the player is pressing the sneak key.
+	 * The player may still be sneaking even if this is false due to gameplay mechanics (e.g. releasing sneak while in a 1.5 block high space).
 	 */
 	public function isSneakPressed() : bool{
 		return $this->sneakPressed;

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -290,6 +290,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 	protected bool $allowFlight = false;
 	protected bool $blockCollision = true;
 	protected bool $flying = false;
+	protected bool $sneakBindPressed = false;
 
 	protected float $flightSpeedMultiplier = self::DEFAULT_FLIGHT_SPEED_MULTIPLIER;
 
@@ -1280,6 +1281,10 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 		return $this->gamemode === GameMode::SPECTATOR;
 	}
 
+	public function isSneakBindPressed() : bool{
+		return $this->sneakBindPressed;
+	}
+
 	/**
 	 * TODO: make this a dynamic ability instead of being hardcoded
 	 */
@@ -2085,6 +2090,14 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 			return false;
 		}
 		$this->setSneaking($sneak);
+		return true;
+	}
+
+	public function toggleSneakBindPressed(bool $bind) : bool{
+		if($bind === $this->sneakBindPressed) {
+			return true;
+		}
+		$this->sneakBindPressed = $bind;
 		return true;
 	}
 

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -2080,7 +2080,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 		return true;
 	}
 
-	public function toggleSneak(bool $sneak, bool $sneakPressed) : bool{
+	public function toggleSneak(bool $sneak, bool $sneakPressed = true) : bool{
 		if($sneak === $this->sneaking && $sneakPressed === $this->sneakPressed){
 			return true;
 		}

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1486,6 +1486,10 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 		return false;
 	}
 
+	public function setSneakPressed(bool $sneakPressed) : void{
+		$this->sneakPressed = $sneakPressed;
+	}
+
 	protected function updateMovement(bool $teleport = false) : void{
 
 	}
@@ -2089,9 +2093,9 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 		if($sneak === $this->sneaking) {
 			$ev->cancel();
 		}
-		$this->sneakPressed = $sneakPressed;
-
 		$ev->call();
+
+		$this->setSneakPressed($sneakPressed);
 		if($ev->isCancelled()){
 			return false;
 		}

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -290,7 +290,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 	protected bool $allowFlight = false;
 	protected bool $blockCollision = true;
 	protected bool $flying = false;
-	protected bool $sneakBindPressed = false;
+	protected bool $sneakPressed = false;
 
 	protected float $flightSpeedMultiplier = self::DEFAULT_FLIGHT_SPEED_MULTIPLIER;
 
@@ -1281,8 +1281,8 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 		return $this->gamemode === GameMode::SPECTATOR;
 	}
 
-	public function isSneakBindPressed() : bool{
-		return $this->sneakBindPressed;
+	public function isSneakPressed() : bool{
+		return $this->sneakPressed;
 	}
 
 	/**
@@ -2080,16 +2080,16 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 		return true;
 	}
 
-	public function toggleSneak(bool $sneak, bool $sneakBindPressed) : bool{
-		if($sneak === $this->sneaking && $sneakBindPressed === $this->sneakBindPressed){
+	public function toggleSneak(bool $sneak, bool $sneakPressed) : bool{
+		if($sneak === $this->sneaking && $sneakPressed === $this->sneakPressed){
 			return true;
 		}
 
-		$ev = new PlayerToggleSneakEvent($this, $sneak, $sneakBindPressed);
+		$ev = new PlayerToggleSneakEvent($this, $sneak, $sneakPressed);
 		if($sneak === $this->sneaking) {
 			$ev->cancel();
 		}
-		$this->sneakBindPressed = $sneakBindPressed;
+		$this->sneakPressed = $sneakPressed;
 
 		$ev->call();
 		if($ev->isCancelled()){

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -294,7 +294,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 
 	protected float $flightSpeedMultiplier = self::DEFAULT_FLIGHT_SPEED_MULTIPLIER;
 
-	/** @phpstan-var positive-int|null */
+	/** @phpstan-var positive-int|null  */
 	protected ?int $lineHeight = null;
 	protected string $locale = "en_US";
 
@@ -343,8 +343,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 		$this->spawnThreshold = (int) (($this->server->getConfigGroup()->getPropertyInt(YmlServerProperties::CHUNK_SENDING_SPAWN_RADIUS, 4) ** 2) * M_PI);
 		$this->chunkSelector = new ChunkSelector();
 
-		$this->chunkLoader = new class implements ChunkLoader{
-		};
+		$this->chunkLoader = new class implements ChunkLoader{};
 		$this->chunkTicker = new ChunkTicker();
 		$world = $spawnLocation->getWorld();
 		//load the spawn chunk so we can see the terrain
@@ -967,8 +966,8 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 	}
 
 	/**
-	 * @param true[]                   $oldTickingChunks
-	 * @param true[]                   $newTickingChunks
+	 * @param true[] $oldTickingChunks
+	 * @param true[] $newTickingChunks
 	 *
 	 * @phpstan-param array<int, true> $oldTickingChunks
 	 * @phpstan-param array<int, true> $newTickingChunks
@@ -2166,8 +2165,8 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 	/**
 	 * Adds a title text to the user's screen, with an optional subtitle.
 	 *
-	 * @param int $fadeIn Duration in ticks for fade-in. If -1 is given, client-sided defaults will be used.
-	 * @param int $stay Duration in ticks to stay on screen for
+	 * @param int $fadeIn  Duration in ticks for fade-in. If -1 is given, client-sided defaults will be used.
+	 * @param int $stay    Duration in ticks to stay on screen for
 	 * @param int $fadeOut Duration in ticks for fade-out.
 	 */
 	public function sendTitle(string $title, string $subtitle = "", int $fadeIn = -1, int $stay = -1, int $fadeOut = -1) : void{
@@ -2209,8 +2208,8 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 	/**
 	 * Sets the title duration.
 	 *
-	 * @param int $fadeIn Title fade-in time in ticks.
-	 * @param int $stay Title stay time in ticks.
+	 * @param int $fadeIn  Title fade-in time in ticks.
+	 * @param int $stay    Title stay time in ticks.
 	 * @param int $fadeOut Title fade-out time in ticks.
 	 */
 	public function setTitleDuration(int $fadeIn, int $stay, int $fadeOut) : void{
@@ -2291,7 +2290,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 	 * Transfers a player to another server.
 	 *
 	 * @param string                   $address The IP address or hostname of the destination server
-	 * @param int                      $port The destination port, defaults to 19132
+	 * @param int                      $port    The destination port, defaults to 19132
 	 * @param Translatable|string|null $message Message to show in the console when closing the player, null will use the default message
 	 *
 	 * @return bool if transfer was successful.
@@ -2310,8 +2309,8 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 	/**
 	 * Kicks a player from the server
 	 *
-	 * @param Translatable|string      $reason Shown in the server log - this should be a short one-line message
-	 * @param Translatable|string|null $quitMessage Message to broadcast to online players (null will use default)
+	 * @param Translatable|string      $reason                  Shown in the server log - this should be a short one-line message
+	 * @param Translatable|string|null $quitMessage             Message to broadcast to online players (null will use default)
 	 * @param Translatable|string|null $disconnectScreenMessage Shown on the player's disconnection screen (null will use the reason)
 	 */
 	public function kick(Translatable|string $reason = "", Translatable|string|null $quitMessage = null, Translatable|string|null $disconnectScreenMessage = null) : bool{
@@ -2343,8 +2342,8 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 	 *
 	 * Note for internals developers: Do not call this from network sessions. It will cause a feedback loop.
 	 *
-	 * @param Translatable|string      $reason Shown in the server log - this should be a short one-line message
-	 * @param Translatable|string|null $quitMessage Message to broadcast to online players (null will use default)
+	 * @param Translatable|string      $reason                  Shown in the server log - this should be a short one-line message
+	 * @param Translatable|string|null $quitMessage             Message to broadcast to online players (null will use default)
 	 * @param Translatable|string|null $disconnectScreenMessage Shown on the player's disconnection screen (null will use the reason)
 	 */
 	public function disconnect(Translatable|string $reason, Translatable|string|null $quitMessage = null, Translatable|string|null $disconnectScreenMessage = null) : void{
@@ -2357,12 +2356,11 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 	}
 
 	/**
-	 * @param Translatable|string      $reason Shown in the server log - this should be a short one-line message
-	 * @param Translatable|string|null $quitMessage Message to broadcast to online players (null will use default)
-	 *
 	 * @internal
 	 * This method executes post-disconnect actions and cleanups.
 	 *
+	 * @param Translatable|string      $reason      Shown in the server log - this should be a short one-line message
+	 * @param Translatable|string|null $quitMessage Message to broadcast to online players (null will use default)
 	 */
 	public function onPostDisconnect(Translatable|string $reason, Translatable|string|null $quitMessage) : void{
 		if($this->isConnected()){

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -2086,7 +2086,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 		}
 
 		$ev = new PlayerToggleSneakEvent($this, $sneak, $sneakBindPressed);
-		if($sneak == $this->sneaking) {
+		if($sneak === $this->sneaking) {
 			$ev->cancel();
 		}
 		$this->sneakBindPressed = $sneakBindPressed;

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1281,6 +1281,10 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 		return $this->gamemode === GameMode::SPECTATOR;
 	}
 
+	public function setSneakPressed(bool $sneakPressed) : void{
+		$this->sneakPressed = $sneakPressed;
+	}
+
 	public function isSneakPressed() : bool{
 		return $this->sneakPressed;
 	}
@@ -1484,10 +1488,6 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 			return true;
 		}
 		return false;
-	}
-
-	public function setSneakPressed(bool $sneakPressed) : void{
-		$this->sneakPressed = $sneakPressed;
 	}
 
 	protected function updateMovement(bool $teleport = false) : void{

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -2088,6 +2088,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 		if($sneak === $this->sneaking && $sneakPressed === $this->sneakPressed){
 			return true;
 		}
+		$this->setSneakPressed($sneakPressed);
 
 		$ev = new PlayerToggleSneakEvent($this, $sneak, $sneakPressed);
 		if($sneak === $this->sneaking) {
@@ -2095,7 +2096,6 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 		}
 		$ev->call();
 
-		$this->setSneakPressed($sneakPressed);
 		if($ev->isCancelled()){
 			return false;
 		}

--- a/src/world/World.php
+++ b/src/world/World.php
@@ -2269,7 +2269,7 @@ class World implements ChunkManager{
 
 		if($player !== null){
 			$ev = new PlayerInteractEvent($player, $item, $blockClicked, $clickVector, $face, PlayerInteractEvent::RIGHT_CLICK_BLOCK);
-			if($player->isSneaking()){
+			if($player->isSneakBindPressed()){
 				$ev->setUseItem(false);
 				$ev->setUseBlock($item->isNull()); //opening doors is still possible when sneaking if using an empty hand
 			}

--- a/src/world/World.php
+++ b/src/world/World.php
@@ -2269,7 +2269,7 @@ class World implements ChunkManager{
 
 		if($player !== null){
 			$ev = new PlayerInteractEvent($player, $item, $blockClicked, $clickVector, $face, PlayerInteractEvent::RIGHT_CLICK_BLOCK);
-			if($player->isSneakBindPressed()){
+			if($player->isSneakPressed()){
 				$ev->setUseItem(false);
 				$ev->setUseBlock($item->isNull()); //opening doors is still possible when sneaking if using an empty hand
 			}


### PR DESCRIPTION
<!-- Summarize your PR here. Keep it short and simple. -->
<!-- Explain existing problems or why this pull request is necessary -->

### Related issues & PRs
fixes #6066
fixes #6733

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
<!-- If not, you can delete this section -->
- `Player` now has `toggleSneakBindPressed` method to toggle sneak bind state
- `Player` now has `isSneakBindPressed` method to get toggle sneak bind state

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
<!-- If not, you can delete this section -->
To determine whether player is actually sneaking for item/block interactions, BDS uses `PlayerAuthInputFlags::SNEAKING` , for player sneaking state only `PlayerAuthInputFlags::START_SNEAKING` and `PlayerAuthInputFlags::STOP_SNEAKING`.

This PR reverts #6544 changes due to incorrect flag usage

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
<!-- If not, you can delete this section -->
I don't know whether it can entail some BC break but it changes the `use item on` logic in `World` class

## Tests
<!--
If this PR affects gameplay or user experience in some way, it must be manually tested.
Include any screenshots or videos of manual testing here.
Any test plugin code should also be pasted here if it can't be adapted to a PHPUnit test.
-->

First test: press crouch bind and release when you're forced to crouch
Be sure that you're not experiencing #6066 and #6733

https://github.com/user-attachments/assets/969bb4d1-ab5e-47a6-942b-c888d9171e88

Second test: press crouch bind while flying and place some interactable blocks
Be sure that you're experiencing #6544

https://github.com/user-attachments/assets/47b7dc71-0e01-407d-9fae-178d14e80a03

Third last test: carry some item in hand, press crouch bind and release when you're forced to crouch
- be sure that you can interact with door in that state
- press crouch bind
- you shouldn't be able to open and close the door
- select free slot
- you can interact with the door again (open and close)

https://github.com/user-attachments/assets/0f83189a-e2d6-46fb-acc4-68952a8178cd

