### PR TITLE
Fix critical animation particles not displaying

### DIFF
--- a/src/entity/animation/CriticalHitAnimation.php
+++ b/src/entity/animation/CriticalHitAnimation.php
@@ -28,11 +28,11 @@ use pocketmine\network\mcpe\protocol\AnimatePacket;
 
 final class CriticalHitAnimation implements Animation{
 
-	public function __construct(private Living $entity){}
+	public function __construct(private Living $entity, private int $particleCount = 55){}
 
 	public function encode() : array{
 		return [
-			AnimatePacket::create($this->entity->getId(), AnimatePacket::ACTION_CRITICAL_HIT, 55)
+			AnimatePacket::create($this->entity->getId(), AnimatePacket::ACTION_CRITICAL_HIT, $this->particleCount),
 		];
 	}
 }

--- a/src/entity/animation/CriticalHitAnimation.php
+++ b/src/entity/animation/CriticalHitAnimation.php
@@ -32,7 +32,7 @@ final class CriticalHitAnimation implements Animation{
 
 	public function encode() : array{
 		return [
-			AnimatePacket::create($this->entity->getId(), AnimatePacket::ACTION_CRITICAL_HIT)
+			AnimatePacket::create($this->entity->getId(), AnimatePacket::ACTION_CRITICAL_HIT, 55)
 		];
 	}
 }


### PR DESCRIPTION
Reference: https://github.com/df-mc/dragonfly/pull/1127

Since 1.21.120, just sending AnimatePacket with AnimatePacket::ACTION_CRITICAL_HIT is not enough, must fill the `data` field as well

Magic value is dumped from BDS
