### PR TITLE
Introduce Effect::getApplyInterval()

### DIFF
--- a/src/entity/effect/Effect.php
+++ b/src/entity/effect/Effect.php
@@ -86,9 +86,20 @@ class Effect{
 
 	/**
 	 * Returns whether the effect will do something on the current tick.
+	 * @deprecated Implement {@link getApplyInterval()} instead
 	 */
 	public function canTick(EffectInstance $instance) : bool{
-		return false;
+		$interval = $this->getApplyInterval($instance);
+		return $interval > 0 && $instance->getDuration() % $interval === 0;
+	}
+
+	/**
+	 * Returns after how many ticks {@link applyEffect()} will be called.
+	 * If this returns 0, the effect will not be ticked.
+	 * If it returns 1, it will be ticked every tick.
+	 */
+	public function getApplyInterval(EffectInstance $instance) : int{
+		return 0;
 	}
 
 	/**

--- a/src/entity/effect/HungerEffect.php
+++ b/src/entity/effect/HungerEffect.php
@@ -30,8 +30,8 @@ use pocketmine\event\player\PlayerExhaustEvent;
 
 class HungerEffect extends Effect{
 
-	public function canTick(EffectInstance $instance) : bool{
-		return true;
+	public function getApplyInterval(EffectInstance $instance) : int{
+		return 1;
 	}
 
 	public function applyEffect(Living $entity, EffectInstance $instance, float $potency = 1.0, ?Entity $source = null) : void{

--- a/src/entity/effect/InstantEffect.php
+++ b/src/entity/effect/InstantEffect.php
@@ -32,7 +32,7 @@ abstract class InstantEffect extends Effect{
 		parent::__construct($name, $color, $bad, 1, $hasBubbles);
 	}
 
-	public function canTick(EffectInstance $instance) : bool{
-		return true; //If forced to last longer than 1 tick, these apply every tick.
+	public function getApplyInterval(EffectInstance $instance) : int{
+		return 1; //If forced to last longer than 1 tick, these apply every tick.
 	}
 }

--- a/src/entity/effect/LevitationEffect.php
+++ b/src/entity/effect/LevitationEffect.php
@@ -29,8 +29,8 @@ use pocketmine\player\Player;
 
 class LevitationEffect extends Effect{
 
-	public function canTick(EffectInstance $instance) : bool{
-		return true;
+	public function getApplyInterval(EffectInstance $instance) : int{
+		return 1;
 	}
 
 	public function applyEffect(Living $entity, EffectInstance $instance, float $potency = 1.0, ?Entity $source = null) : void{

--- a/src/entity/effect/PoisonEffect.php
+++ b/src/entity/effect/PoisonEffect.php
@@ -28,6 +28,7 @@ use pocketmine\entity\Entity;
 use pocketmine\entity\Living;
 use pocketmine\event\entity\EntityDamageEvent;
 use pocketmine\lang\Translatable;
+use function max;
 
 class PoisonEffect extends Effect{
 	private bool $fatal;

--- a/src/entity/effect/PoisonEffect.php
+++ b/src/entity/effect/PoisonEffect.php
@@ -37,11 +37,8 @@ class PoisonEffect extends Effect{
 		$this->fatal = $fatal;
 	}
 
-	public function canTick(EffectInstance $instance) : bool{
-		if(($interval = (25 >> $instance->getAmplifier())) > 0){
-			return ($instance->getDuration() % $interval) === 0;
-		}
-		return true;
+	public function getApplyInterval(EffectInstance $instance) : int{
+		return max(1, 25 >> $instance->getAmplifier());
 	}
 
 	public function applyEffect(Living $entity, EffectInstance $instance, float $potency = 1.0, ?Entity $source = null) : void{

--- a/src/entity/effect/RegenerationEffect.php
+++ b/src/entity/effect/RegenerationEffect.php
@@ -26,6 +26,7 @@ namespace pocketmine\entity\effect;
 use pocketmine\entity\Entity;
 use pocketmine\entity\Living;
 use pocketmine\event\entity\EntityRegainHealthEvent;
+use function max;
 
 class RegenerationEffect extends Effect{
 

--- a/src/entity/effect/RegenerationEffect.php
+++ b/src/entity/effect/RegenerationEffect.php
@@ -29,11 +29,8 @@ use pocketmine\event\entity\EntityRegainHealthEvent;
 
 class RegenerationEffect extends Effect{
 
-	public function canTick(EffectInstance $instance) : bool{
-		if(($interval = (50 >> $instance->getAmplifier())) > 0){
-			return ($instance->getDuration() % $interval) === 0;
-		}
-		return true;
+	public function getApplyInterval(EffectInstance $instance) : int{
+		return max(1, 50 >> $instance->getAmplifier());
 	}
 
 	public function applyEffect(Living $entity, EffectInstance $instance, float $potency = 1.0, ?Entity $source = null) : void{

--- a/src/entity/effect/WitherEffect.php
+++ b/src/entity/effect/WitherEffect.php
@@ -26,6 +26,7 @@ namespace pocketmine\entity\effect;
 use pocketmine\entity\Entity;
 use pocketmine\entity\Living;
 use pocketmine\event\entity\EntityDamageEvent;
+use function max;
 
 class WitherEffect extends Effect{
 

--- a/src/entity/effect/WitherEffect.php
+++ b/src/entity/effect/WitherEffect.php
@@ -29,11 +29,8 @@ use pocketmine\event\entity\EntityDamageEvent;
 
 class WitherEffect extends Effect{
 
-	public function canTick(EffectInstance $instance) : bool{
-		if(($interval = (40 >> $instance->getAmplifier())) > 0){
-			return ($instance->getDuration() % $interval) === 0;
-		}
-		return true;
+	public function getApplyInterval(EffectInstance $instance) : int{
+		return max(1, 40 >> $instance->getAmplifier());
 	}
 
 	public function applyEffect(Living $entity, EffectInstance $instance, float $potency = 1.0, ?Entity $source = null) : void{


### PR DESCRIPTION
This allows implementing effect ticking mechanisms that don't depend on the effect duration, as well as exposing more useful metadata to plugins.

### Related issues & PRs
closes #6880

## Changes
### API changes
- `Effect->canTick()` deprecated
- `Effect->getApplyInterval()` added

### Behavioural changes
None expected

## Backwards compatibility
Backwards compatible

## Follow-up
`Effect->canTick()` should be removed in PM6.
`EffectManager` should use `getApplyInterval()` in conjunction with a ticker (e.g. `ticksLived` or some other mechanism) to tick effects instead of using their duration.

## Tests
TBD, but CI is green (or will be, once the CS check stops complaining)
