### PR TITLE
Fix #4830: Correct slime block physics for items and sneaking players

### DIFF
--- a/src/block/Slime.php
+++ b/src/block/Slime.php
@@ -33,8 +33,8 @@ final class Slime extends Transparent{
 	}
 
 	public function onEntityLand(Entity $entity) : ?float{
-    		$entity->resetFallDistance();
-    		if($entity instanceof Living && $entity->isSneaking()){
+			$entity->resetFallDistance();
+			if($entity instanceof Living && $entity->isSneaking()){
 			return null;
 		}
 		return -$entity->getMotion()->y;

--- a/src/block/Slime.php
+++ b/src/block/Slime.php
@@ -33,8 +33,8 @@ final class Slime extends Transparent{
 	}
 
 	public function onEntityLand(Entity $entity) : ?float{
-    $entity->resetFallDistance();
-    if($entity instanceof Living && $entity->isSneaking()){
+    		$entity->resetFallDistance();
+    		if($entity instanceof Living && $entity->isSneaking()){
 			return null;
 		}
 		return -$entity->getMotion()->y;

--- a/src/block/Slime.php
+++ b/src/block/Slime.php
@@ -33,10 +33,10 @@ final class Slime extends Transparent{
 	}
 
 	public function onEntityLand(Entity $entity) : ?float{
-		if($entity instanceof Living && $entity->isSneaking()){
+    $entity->resetFallDistance();
+    if($entity instanceof Living && $entity->isSneaking()){
 			return null;
 		}
-		$entity->resetFallDistance();
 		return -$entity->getMotion()->y;
 	}
 

--- a/src/entity/Entity.php
+++ b/src/entity/Entity.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 namespace pocketmine\entity;
 
 use pocketmine\block\Block;
+use pocketmine\block\BlockTypeIds;
 use pocketmine\block\Water;
 use pocketmine\entity\animation\Animation;
 use pocketmine\event\entity\EntityDamageEvent;
@@ -66,6 +67,7 @@ use pocketmine\utils\Utils;
 use pocketmine\VersionInfo;
 use pocketmine\world\format\Chunk;
 use pocketmine\world\Position;
+use pocketmine\world\sound\EntityLandSound;
 use pocketmine\world\sound\Sound;
 use pocketmine\world\World;
 use function abs;
@@ -1111,7 +1113,18 @@ abstract class Entity{
 	 * Called when a falling entity hits the ground.
 	 */
 	protected function onHitGround() : ?float{
-		return null;
+    $fallBlockPos = $this->location->floor();
+    $fallBlock = $this->getWorld()->getBlock($fallBlockPos);
+    if(count($fallBlock->getCollisionBoxes()) === 0){
+        $fallBlockPos = $fallBlockPos->down();
+        $fallBlock = $this->getWorld()->getBlock($fallBlockPos);
+    }
+    $newVerticalVelocity = $fallBlock->onEntityLand($this);
+
+    if($fallBlock->getTypeId() !== BlockTypeIds::AIR){
+        $this->broadcastSound(new EntityLandSound($this, $fallBlock));
+    }
+    return $newVerticalVelocity;
 	}
 
 	public function getEyeHeight() : float{

--- a/src/entity/Entity.php
+++ b/src/entity/Entity.php
@@ -1113,18 +1113,18 @@ abstract class Entity{
 	 * Called when a falling entity hits the ground.
 	 */
 	protected function onHitGround() : ?float{
-    $fallBlockPos = $this->location->floor();
-    $fallBlock = $this->getWorld()->getBlock($fallBlockPos);
-    if(count($fallBlock->getCollisionBoxes()) === 0){
-        $fallBlockPos = $fallBlockPos->down();
-        $fallBlock = $this->getWorld()->getBlock($fallBlockPos);
-    }
-    $newVerticalVelocity = $fallBlock->onEntityLand($this);
+    		$fallBlockPos = $this->location->floor();
+    		$fallBlock = $this->getWorld()->getBlock($fallBlockPos);
+    		if(count($fallBlock->getCollisionBoxes()) === 0){
+        		$fallBlockPos = $fallBlockPos->down();
+        		$fallBlock = $this->getWorld()->getBlock($fallBlockPos);
+    		}
+    		$newVerticalVelocity = $fallBlock->onEntityLand($this);
 
-    if($fallBlock->getTypeId() !== BlockTypeIds::AIR){
-        $this->broadcastSound(new EntityLandSound($this, $fallBlock));
-    }
-    return $newVerticalVelocity;
+    		if($fallBlock->getTypeId() !== BlockTypeIds::AIR){
+        		$this->broadcastSound(new EntityLandSound($this, $fallBlock));
+    		}
+    		return $newVerticalVelocity;
 	}
 
 	public function getEyeHeight() : float{

--- a/src/entity/Entity.php
+++ b/src/entity/Entity.php
@@ -1113,18 +1113,18 @@ abstract class Entity{
 	 * Called when a falling entity hits the ground.
 	 */
 	protected function onHitGround() : ?float{
-    		$fallBlockPos = $this->location->floor();
-    		$fallBlock = $this->getWorld()->getBlock($fallBlockPos);
-    		if(count($fallBlock->getCollisionBoxes()) === 0){
-        		$fallBlockPos = $fallBlockPos->down();
-        		$fallBlock = $this->getWorld()->getBlock($fallBlockPos);
-    		}
-    		$newVerticalVelocity = $fallBlock->onEntityLand($this);
+			$fallBlockPos = $this->location->floor();
+			$fallBlock = $this->getWorld()->getBlock($fallBlockPos);
+			if(count($fallBlock->getCollisionBoxes()) === 0){
+				$fallBlockPos = $fallBlockPos->down();
+				$fallBlock = $this->getWorld()->getBlock($fallBlockPos);
+			}
+			$newVerticalVelocity = $fallBlock->onEntityLand($this);
 
-    		if($fallBlock->getTypeId() !== BlockTypeIds::AIR){
-        		$this->broadcastSound(new EntityLandSound($this, $fallBlock));
-    		}
-    		return $newVerticalVelocity;
+			if($fallBlock->getTypeId() !== BlockTypeIds::AIR){
+				$this->broadcastSound(new EntityLandSound($this, $fallBlock));
+			}
+			return $newVerticalVelocity;
 	}
 
 	public function getEyeHeight() : float{

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -64,7 +64,6 @@ use pocketmine\timings\Timings;
 use pocketmine\utils\Binary;
 use pocketmine\utils\Utils;
 use pocketmine\world\sound\BurpSound;
-use pocketmine\world\sound\EntityLandSound;
 use pocketmine\world\sound\EntityLongFallSound;
 use pocketmine\world\sound\EntityShortFallSound;
 use pocketmine\world\sound\ItemBreakSound;
@@ -381,25 +380,16 @@ abstract class Living extends Entity{
 	}
 
 	protected function onHitGround() : ?float{
-		$fallBlockPos = $this->location->floor();
-		$fallBlock = $this->getWorld()->getBlock($fallBlockPos);
-		if(count($fallBlock->getCollisionBoxes()) === 0){
-			$fallBlockPos = $fallBlockPos->down();
-			$fallBlock = $this->getWorld()->getBlock($fallBlockPos);
-		}
-		$newVerticalVelocity = $fallBlock->onEntityLand($this);
-
-		$damage = $this->calculateFallDamage($this->fallDistance);
+    $newVerticalVelocity = parent::onHitGround();
+    $damage = $this->calculateFallDamage($this->fallDistance);
 		if($damage > 0){
 			$ev = new EntityDamageEvent($this, EntityDamageEvent::CAUSE_FALL, $damage);
 			$this->attack($ev);
 
 			$this->broadcastSound($damage > 4 ?
 				new EntityLongFallSound($this) :
-				new EntityShortFallSound($this)
+        new EntityShortFallSound($this)
 			);
-		}elseif($fallBlock->getTypeId() !== BlockTypeIds::AIR){
-			$this->broadcastSound(new EntityLandSound($this, $fallBlock));
 		}
 		return $newVerticalVelocity;
 	}

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -380,15 +380,15 @@ abstract class Living extends Entity{
 	}
 
 	protected function onHitGround() : ?float{
-    		$newVerticalVelocity = parent::onHitGround();
-    		$damage = $this->calculateFallDamage($this->fallDistance);
+			$newVerticalVelocity = parent::onHitGround();
+			$damage = $this->calculateFallDamage($this->fallDistance);
 		if($damage > 0){
 			$ev = new EntityDamageEvent($this, EntityDamageEvent::CAUSE_FALL, $damage);
 			$this->attack($ev);
 
 			$this->broadcastSound($damage > 4 ?
 				new EntityLongFallSound($this) :
-        new EntityShortFallSound($this)
+		new EntityShortFallSound($this)
 			);
 		}
 		return $newVerticalVelocity;

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -380,8 +380,8 @@ abstract class Living extends Entity{
 	}
 
 	protected function onHitGround() : ?float{
-    $newVerticalVelocity = parent::onHitGround();
-    $damage = $this->calculateFallDamage($this->fallDistance);
+    		$newVerticalVelocity = parent::onHitGround();
+    		$damage = $this->calculateFallDamage($this->fallDistance);
 		if($damage > 0){
 			$ev = new EntityDamageEvent($this, EntityDamageEvent::CAUSE_FALL, $damage);
 			$this->attack($ev);


### PR DESCRIPTION
Closes #4830. This PR moves part of `onHitGround` logic (which only applied to `Living`) to `Entity` so `ItemEntity` can use it.

The `Living::onHitGround` method was updated to call the parent method first, ensuring fall damage is only calculated after a block (like `Slime`) has a chance to reset the fall distance.

I also fixed a logic bug in `Slime` where sneaking players would not bounce (correct) but would still take fall damage (incorrect).

I have tested the following in-game scenarios:
* `ItemEntity` (dropped items) now correctly bounce on slime blocks.
* Players correctly bounce on slime blocks and take no fall damage.
* Players holding "sneak" land on slime blocks without bouncing and without taking fall damage.
* Players still take normal fall damage when landing on any other block.
* Players who bounce off a slime block and then land on a normal block correctly take fall damage (confirming `fallDistance` resets and re-accumulates properly after the bounce).
* Arrows, Snowballs, and Eggs correctly break or stick on Slime blocks (they do not bounce).