### PR TITLE
Feature #6869: Add VoidGenerator

### DIFF
--- a/src/world/generator/GeneratorManager.php
+++ b/src/world/generator/GeneratorManager.php
@@ -39,7 +39,7 @@ final class GeneratorManager{
 	 */
 	private array $list = [];
 
-	public function __construct(){
+  public function __construct(){
 		$this->addGenerator(Flat::class, "flat", function(string $preset) : ?InvalidGeneratorOptionsException{
 			if($preset === ""){
 				return null;
@@ -54,7 +54,8 @@ final class GeneratorManager{
 		$this->addGenerator(Normal::class, "normal", fn() => null);
 		$this->addAlias("normal", "default");
 		$this->addGenerator(Nether::class, "nether", fn() => null);
-		$this->addAlias("nether", "hell");
+	$this->addAlias("nether", "hell");
+	$this->addGenerator(VoidGenerator::class, "void", fn() => null);
 	}
 
 	/**

--- a/src/world/generator/VoidGenerator.php
+++ b/src/world/generator/VoidGenerator.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\world\generator;
+
+use pocketmine\world\ChunkManager;
+use pocketmine\world\format\Chunk;
+
+class VoidGenerator extends Generator{
+	private Chunk $chunk;
+
+	public function __construct(int $seed, string $preset){
+		parent::__construct($seed, $preset);
+		$this->generateBaseChunk();
+	}
+
+  protected function generateBaseChunk() : void{
+	$this->chunk = new Chunk([], false);
+	}
+
+	public function generateChunk(ChunkManager $world, int $chunkX, int $chunkZ) : void{
+		$world->setChunk($chunkX, $chunkZ, clone $this->chunk);
+	}
+
+	public function populateChunk(ChunkManager $world, int $chunkX, int $chunkZ) : void{
+	}
+}


### PR DESCRIPTION
Closes #6869.

This PR adds a new `VoidGenerator` to the `GeneratorManager`, implementing completely empty worlds.

I registered the alias as `"void"` in `GeneratorManager`.

You can try it by deleting all the worlds in `worlds/` and setting `level-type=void` in `server.properties`.