### PR TITLE
Adjust collision box calculation for `SnowLayer` blocks

### DIFF
--- a/src/block/SnowLayer.php
+++ b/src/block/SnowLayer.php
@@ -66,8 +66,10 @@ class SnowLayer extends Flowable implements Fallable{
 	}
 
 	protected function recalculateCollisionBoxes() : array{
-		//TODO: this zero-height BB is intended to stay in lockstep with a MCPE bug
-		return [AxisAlignedBB::one()->trim(Facing::UP, $this->layers >= 4 ? 0.5 : 1)];
+		if($this->layers === self::MIN_LAYERS){
+			return [];
+		}
+		return [AxisAlignedBB::one()->trim(Facing::UP, 1 - ($this->layers * 0.125))];
 	}
 
 	public function getSupportType(int $facing) : SupportType{

--- a/src/block/SnowLayer.php
+++ b/src/block/SnowLayer.php
@@ -66,10 +66,7 @@ class SnowLayer extends Flowable implements Fallable{
 	}
 
 	protected function recalculateCollisionBoxes() : array{
-		if($this->layers === self::MIN_LAYERS){
-			return [];
-		}
-		return [AxisAlignedBB::one()->trim(Facing::UP, 1 - ($this->layers * 0.125))];
+		return [AxisAlignedBB::one()->trim(Facing::UP, (self::MAX_LAYERS - $this->layers + 1) / 8)];
 	}
 
 	public function getSupportType(int $facing) : SupportType{


### PR DESCRIPTION
## Changes
### Behavioural changes
The collision height now correctly matches the number of snow layers.

## Backwards compatibility
Changes are backward-compatible, except in cases where code relied on the previous collision height for the minimal layer.

## Tests
This has been tested in-game.

Vanilla:
<img width="1752" height="805" alt="image" src="https://github.com/user-attachments/assets/0ac4a281-04a5-4356-9832-e981a4544b7c" />

Before:
<img width="1591" height="605" alt="image" src="https://github.com/user-attachments/assets/3c168591-72a5-49e1-b14f-418d5e4a7e46" />

After:
<img width="1561" height="573" alt="image" src="https://github.com/user-attachments/assets/34c7997f-0c22-44b8-b232-44284cf92081" />

