### PR TITLE
Implement `Releaseable::getMinUseDuration()`

### DIFF
--- a/src/item/Bow.php
+++ b/src/item/Bow.php
@@ -127,4 +127,8 @@ class Bow extends Tool implements Releasable{
 	public function canStartUsingItem(Player $player) : bool{
 		return !$player->hasFiniteResources() || $player->getOffHandInventory()->contains($arrow = VanillaItems::ARROW()) || $player->getInventory()->contains($arrow);
 	}
+
+	public function getMinUseDuration() : int{
+		return 5;
+	}
 }

--- a/src/item/DriedKelp.php
+++ b/src/item/DriedKelp.php
@@ -32,4 +32,8 @@ class DriedKelp extends Food{
 	public function getSaturationRestore() : float{
 		return 0.6;
 	}
+
+	public function getMinUseDuration() : int{
+		return 16;
+	}
 }

--- a/src/item/Food.php
+++ b/src/item/Food.php
@@ -46,4 +46,8 @@ abstract class Food extends Item implements FoodSourceItem{
 	public function canStartUsingItem(Player $player) : bool{
 		return !$this->requiresHunger() || $player->canEat();
 	}
+
+	public function getMinUseDuration() : int{
+		return 32;
+	}
 }

--- a/src/item/GoatHorn.php
+++ b/src/item/GoatHorn.php
@@ -68,4 +68,8 @@ class GoatHorn extends Item implements Releasable{
 
 		return ItemUseResult::SUCCESS;
 	}
+
+	public function getMinUseDuration() : int{
+		return 0;
+	}
 }

--- a/src/item/Medicine.php
+++ b/src/item/Medicine.php
@@ -64,4 +64,8 @@ class Medicine extends Item implements ConsumableItem{
 	public function canStartUsingItem(Player $player) : bool{
 		return $player->getEffects()->has($this->getType()->getCuredEffect());
 	}
+
+	public function getMinUseDuration() : int{
+		return 32;
+	}
 }

--- a/src/item/MilkBucket.php
+++ b/src/item/MilkBucket.php
@@ -47,4 +47,8 @@ class MilkBucket extends Item implements ConsumableItem{
 	public function canStartUsingItem(Player $player) : bool{
 		return true;
 	}
+
+	public function getMinUseDuration() : int{
+		return 32;
+	}
 }

--- a/src/item/Potion.php
+++ b/src/item/Potion.php
@@ -66,4 +66,8 @@ class Potion extends Item implements ConsumableItem{
 	public function canStartUsingItem(Player $player) : bool{
 		return true;
 	}
+
+	public function getMinUseDuration() : int{
+		return 32;
+	}
 }

--- a/src/item/Releasable.php
+++ b/src/item/Releasable.php
@@ -35,5 +35,5 @@ interface Releasable{
 	/**
 	 * Returns the minimum use time in ticks
 	 */
-	public function getMinUseDuration(): int;
+	public function getMinUseDuration() : int;
 }

--- a/src/item/Releasable.php
+++ b/src/item/Releasable.php
@@ -32,4 +32,8 @@ interface Releasable{
 
 	public function canStartUsingItem(Player $player) : bool;
 
+	/**
+	 * Returns the minimum use time in ticks
+	 */
+	public function getMinUseDuration(): int;
 }

--- a/src/item/Spyglass.php
+++ b/src/item/Spyglass.php
@@ -34,4 +34,8 @@ class Spyglass extends Item implements Releasable{
 	public function canStartUsingItem(Player $player) : bool{
 		return true;
 	}
+
+	public function getMinUseDuration() : int{
+		return 0;
+	}
 }

--- a/src/item/Trident.php
+++ b/src/item/Trident.php
@@ -43,9 +43,6 @@ class Trident extends Tool implements Releasable{
 		$location = $player->getLocation();
 
 		$diff = $player->getItemUseDuration();
-		if($diff < 14){
-			return ItemUseResult::FAIL;
-		}
 
 		$item = $this->pop();
 		if($player->hasFiniteResources()){
@@ -95,5 +92,9 @@ class Trident extends Tool implements Releasable{
 			return $this->applyDamage(2);
 		}
 		return false;
+	}
+
+	public function getMinUseDuration() : int{
+		return 14;
 	}
 }

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1738,6 +1738,10 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 	public function consumeHeldItem() : bool{
 		$slot = $this->inventory->getItemInHand();
 		if($slot instanceof ConsumableItem){
+			if($this->getItemUseDuration() < $slot->getMinUseDuration()){
+				return false;
+			}
+
 			$oldItem = clone $slot;
 
 			$ev = new PlayerItemConsumeEvent($this, $slot);
@@ -1771,6 +1775,10 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 		try{
 			$item = $this->inventory->getItemInHand();
 			if(!$this->isUsingItem() || $this->hasItemCooldown($item)){
+				return false;
+			}
+
+			if($item instanceof Releasable && $this->getItemUseDuration() < $item->getMinUseDuration()){
 				return false;
 			}
 


### PR DESCRIPTION
Implemented a new function `getMinUseDuration` in the `Releaseable` interface which will return the minimum needed ticks to use the item for an action to occur.

Also, regarding the Bow, should it be 5 ticks, or 0?
### Related issues & PRs
* Fixes https://github.com/pmmp/PocketMine-MP/issues/6653

## Changes
### API changes
* Added `Releaseable::getMinUseDuration`

## Backwards compatibility
Nope, It's BC Breaking. good for major-next branch

## Tests
Works 👍
https://streamable.com/2l8zru
