### PR TITLE
Biome Filling Usage

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -79,7 +79,7 @@ BODY,
 			'scope' => 'namespaced',
 			'include' => ['@all'],
 		],
-		'new_with_braces' => [
+		'new_with_parentheses' => [
 			'named_class' => true,
 			'anonymous_class' => false,
 		],

--- a/changelogs/5.39.md
+++ b/changelogs/5.39.md
@@ -162,3 +162,29 @@ Released 21st December 2025.
 
 ## Internals
 - Added CI checks to make sure language `.ini` files don't have byte-order marks (BOM). (@dktapps)
+
+# 5.39.2
+Released 26th December 2025.
+
+## Core
+- Fixed various PHP 8.5 deprecation notices. (@dktapps)
+- Fixed deprecation notice on PHP 8.4 due to `E_STRICT` constant usage in `ErrorTypeToStringMap` (dependency issue). (@dktapps)
+- Fixed `Utils::validateCallableSignature()` not accepting `object` as a supertype of a class type (dependency issue). (@dktapps)
+- Fixed players being interactable in the (very short) span of time between disconnect and entity deletion. (@dktapps, @kostamax27)
+
+## Gameplay
+- Fixed blocks appearing in the wrong place while bridging and other block lag & flickering issues. (@dktapps)
+- Fixed goat horns not working after holding the use button to activate them. (@dktapps)
+- Fixed trapdoor collision box not matching vanilla Bedrock. (@dktapps, @kostamax27)
+
+## Network
+- Modal form response JSON size is now capped to 10 KiB. (@dktapps, @Psycofeu)
+- Modal form response JSON is no longer decoded if the form ID is not valid. (@dktapps, @Zwuiix-cmd)
+- Eating particles and sounds are now server-controlled. Previously, these relied on `ActorEventPacket` from the client. (@dktapps)
+
+## Documentation
+- Improved documentation of `pocketmine\item\Releasable`. (@dktapps)
+
+## Internals
+- Added PHP 8.5 to test matrix. (@dktapps)
+- Updated several dependencies for PHP 8.5 support. (@dktapps)

--- a/src/VersionInfo.php
+++ b/src/VersionInfo.php
@@ -32,7 +32,7 @@ use function str_repeat;
 final class VersionInfo{
 	public const NAME = "PocketMine-MP";
 	public const BASE_VERSION = "5.39.2";
-	public const IS_DEVELOPMENT_BUILD = true;
+	public const IS_DEVELOPMENT_BUILD = false;
 	public const BUILD_CHANNEL = "stable";
 	public const GITHUB_URL = "https://github.com/pmmp/PocketMine-MP";
 

--- a/src/VersionInfo.php
+++ b/src/VersionInfo.php
@@ -31,8 +31,8 @@ use function str_repeat;
 
 final class VersionInfo{
 	public const NAME = "PocketMine-MP";
-	public const BASE_VERSION = "5.39.2";
-	public const IS_DEVELOPMENT_BUILD = false;
+	public const BASE_VERSION = "5.39.3";
+	public const IS_DEVELOPMENT_BUILD = true;
 	public const BUILD_CHANNEL = "stable";
 	public const GITHUB_URL = "https://github.com/pmmp/PocketMine-MP";
 

--- a/src/world/format/Chunk.php
+++ b/src/world/format/Chunk.php
@@ -346,6 +346,9 @@ class Chunk{
 	 */
 	public function fillBiomes(int $biomeId) : void{
 		foreach($this->subChunks as $subChunk){
+			if($subChunk === null){
+				continue;
+			}
 			$biomeArray = $subChunk->getBiomeArray();
 			for($x = 0; $x < SubChunk::EDGE_LENGTH; ++$x){
 				for($y = 0; $y < SubChunk::EDGE_LENGTH; ++$y){
@@ -371,6 +374,9 @@ class Chunk{
 		}
 
 		foreach($this->subChunks as $subChunk){
+			if($subChunk === null){
+				continue;
+			}
 			$biomeArray = $subChunk->getBiomeArray();
 			for($x = 0; $x < SubChunk::EDGE_LENGTH; ++$x){
 				for($z = 0; $z < SubChunk::EDGE_LENGTH; ++$z){

--- a/src/world/format/Chunk.php
+++ b/src/world/format/Chunk.php
@@ -67,13 +67,19 @@ class Chunk{
 
 	/**
 	 * @param SubChunk[] $subChunks
+	 * @param int|null $biomeId If provided, fills all subchunks with this biome ID. If null, defaults to OCEAN for empty subchunks.
 	 */
-	public function __construct(array $subChunks, bool $terrainPopulated){
+	public function __construct(array $subChunks, bool $terrainPopulated, ?int $biomeId = null){
 		$this->subChunks = new \SplFixedArray(Chunk::MAX_SUBCHUNKS);
 
+		$defaultBiomeId = $biomeId ?? BiomeIds::OCEAN;
 		foreach($this->subChunks as $y => $null){
 			//TODO: we should probably require all subchunks to be provided here
-			$this->subChunks[$y] = $subChunks[$y + self::MIN_SUBCHUNK_INDEX] ?? new SubChunk(Block::EMPTY_STATE_ID, [], new PalettedBlockArray(BiomeIds::OCEAN));
+			$this->subChunks[$y] = $subChunks[$y + self::MIN_SUBCHUNK_INDEX] ?? new SubChunk(Block::EMPTY_STATE_ID, [], new PalettedBlockArray($defaultBiomeId));
+		}
+
+		if($biomeId !== null){
+			$this->fillBiomes($biomeId);
 		}
 
 		$val = (self::MAX_SUBCHUNK_INDEX + 1) * SubChunk::EDGE_LENGTH;
@@ -329,6 +335,52 @@ class Chunk{
 			return clone $subChunk;
 		}, $this->subChunks->toArray()));
 		$this->heightMap = clone $this->heightMap;
+	}
+
+	/**
+	 * Fills all biomes in this chunk with the specified biome ID.
+	 * This is useful for generators like Flat and Void that use a single biome.
+	 *
+	 * @param int $biomeId The biome ID to fill the chunk with
+	 */
+	public function fillBiomes(int $biomeId) : void{
+		foreach($this->subChunks as $subChunk){
+			$biomeArray = $subChunk->getBiomeArray();
+			for($x = 0; $x < SubChunk::EDGE_LENGTH; ++$x){
+				for($y = 0; $y < SubChunk::EDGE_LENGTH; ++$y){
+					for($z = 0; $z < SubChunk::EDGE_LENGTH; ++$z){
+						$biomeArray->set($x, $y, $z, $biomeId);
+					}
+				}
+			}
+		}
+		$this->terrainDirtyFlags |= self::DIRTY_FLAG_BIOMES;
+	}
+
+	/**
+	 * Extrapolates 2D biome data (16x16) to 3D by copying the biome ID at each X/Z coordinate
+	 * to all Y levels in the chunk. This is useful for legacy generators that only generate 2D biomes.
+	 *
+	 * @param int[] $biomes2d Array of 256 biome IDs indexed by (z * 16 + x)
+	 * @phpstan-param array<int, int> $biomes2d
+	 */
+	public function extrapolateBiomes(array $biomes2d) : void{
+		if(\count($biomes2d) !== 256){
+			throw new \InvalidArgumentException("Biome array must contain exactly 256 elements (16x16)");
+		}
+
+		foreach($this->subChunks as $subChunk){
+			$biomeArray = $subChunk->getBiomeArray();
+			for($x = 0; $x < SubChunk::EDGE_LENGTH; ++$x){
+				for($z = 0; $z < SubChunk::EDGE_LENGTH; ++$z){
+					$biomeId = $biomes2d[($z << SubChunk::COORD_BIT_SIZE) | $x];
+					for($y = 0; $y < SubChunk::EDGE_LENGTH; ++$y){
+						$biomeArray->set($x, $y, $z, $biomeId);
+					}
+				}
+			}
+		}
+		$this->terrainDirtyFlags |= self::DIRTY_FLAG_BIOMES;
 	}
 
 	/**

--- a/src/world/format/Chunk.php
+++ b/src/world/format/Chunk.php
@@ -30,6 +30,7 @@ use pocketmine\block\Block;
 use pocketmine\block\tile\Tile;
 use pocketmine\data\bedrock\BiomeIds;
 use function array_map;
+use function count;
 
 class Chunk{
 	public const DIRTY_FLAG_BLOCKS = 1 << 0;
@@ -67,7 +68,7 @@ class Chunk{
 
 	/**
 	 * @param SubChunk[] $subChunks
-	 * @param int|null $biomeId If provided, fills all subchunks with this biome ID. If null, defaults to OCEAN for empty subchunks.
+	 * @param int|null   $biomeId   If provided, fills all subchunks with this biome ID. If null, defaults to OCEAN for empty subchunks.
 	 */
 	public function __construct(array $subChunks, bool $terrainPopulated, ?int $biomeId = null){
 		$this->subChunks = new \SplFixedArray(Chunk::MAX_SUBCHUNKS);
@@ -365,7 +366,7 @@ class Chunk{
 	 * @phpstan-param array<int, int> $biomes2d
 	 */
 	public function extrapolateBiomes(array $biomes2d) : void{
-		if(\count($biomes2d) !== 256){
+		if(count($biomes2d) !== 256){
 			throw new \InvalidArgumentException("Biome array must contain exactly 256 elements (16x16)");
 		}
 

--- a/src/world/generator/Flat.php
+++ b/src/world/generator/Flat.php
@@ -66,7 +66,7 @@ class Flat extends Generator{
 	}
 
 	protected function generateBaseChunk() : void{
-		$this->chunk = new Chunk([], false);
+		$this->chunk = new Chunk([], false, $this->options->getBiomeId());
 
 		$structure = $this->options->getStructure();
 		$count = count($structure);

--- a/tests/phpunit/world/format/ChunkTest.php
+++ b/tests/phpunit/world/format/ChunkTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace pocketmine\world\format;
 
 use PHPUnit\Framework\TestCase;
+use pocketmine\data\bedrock\BiomeIds;
 
 class ChunkTest extends TestCase{
 
@@ -41,5 +42,67 @@ class ChunkTest extends TestCase{
 		self::assertNotSame($chunk->getBlockStateId(0, 0, 0), $chunk2->getBlockStateId(0, 0, 0));
 		self::assertNotSame($chunk->getBiomeId(0, 0, 0), $chunk2->getBiomeId(0, 0, 0));
 		self::assertNotSame($chunk->getHeightMap(0, 0), $chunk2->getHeightMap(0, 0));
+	}
+
+	public function testBiomeIdConstructor() : void{
+		$chunk = new Chunk([], false, BiomeIds::DESERT);
+
+		// Check that all biomes are set to DESERT
+		for($x = 0; $x < Chunk::EDGE_LENGTH; ++$x){
+			for($z = 0; $z < Chunk::EDGE_LENGTH; ++$z){
+				for($y = Chunk::MIN_SUBCHUNK_INDEX << SubChunk::COORD_BIT_SIZE; $y < (Chunk::MAX_SUBCHUNK_INDEX + 1) << SubChunk::COORD_BIT_SIZE; ++$y){
+					self::assertSame(BiomeIds::DESERT, $chunk->getBiomeId($x, $y, $z));
+				}
+			}
+		}
+	}
+
+	public function testFillBiomes() : void{
+		$chunk = new Chunk([], false);
+		$chunk->fillBiomes(BiomeIds::JUNGLE);
+
+		// Check that all biomes are set to JUNGLE
+		for($x = 0; $x < Chunk::EDGE_LENGTH; ++$x){
+			for($z = 0; $z < Chunk::EDGE_LENGTH; ++$z){
+				for($y = Chunk::MIN_SUBCHUNK_INDEX << SubChunk::COORD_BIT_SIZE; $y < (Chunk::MAX_SUBCHUNK_INDEX + 1) << SubChunk::COORD_BIT_SIZE; ++$y){
+					self::assertSame(BiomeIds::JUNGLE, $chunk->getBiomeId($x, $y, $z));
+				}
+			}
+		}
+	}
+
+	public function testExtrapolateBiomes() : void{
+		$chunk = new Chunk([], false);
+		
+		// Create a 2D biome array (16x16 = 256 elements)
+		$biomes2d = [];
+		for($z = 0; $z < 16; ++$z){
+			for($x = 0; $x < 16; ++$x){
+				// Create a pattern where biome ID = x + z * 16
+				$biomes2d[$z * 16 + $x] = ($x % 4) + 1; // Use values 1-4 for testing
+			}
+		}
+		
+		$chunk->extrapolateBiomes($biomes2d);
+
+		// Verify that the 2D biomes have been extrapolated to all Y levels
+		for($x = 0; $x < Chunk::EDGE_LENGTH; ++$x){
+			for($z = 0; $z < Chunk::EDGE_LENGTH; ++$z){
+				$expectedBiome = ($x % 4) + 1;
+				for($y = Chunk::MIN_SUBCHUNK_INDEX << SubChunk::COORD_BIT_SIZE; $y < (Chunk::MAX_SUBCHUNK_INDEX + 1) << SubChunk::COORD_BIT_SIZE; ++$y){
+					self::assertSame($expectedBiome, $chunk->getBiomeId($x, $y, $z), "Biome mismatch at ($x, $y, $z)");
+				}
+			}
+		}
+	}
+
+	public function testExtrapolateBiomesInvalidSize() : void{
+		$chunk = new Chunk([], false);
+		
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage("Biome array must contain exactly 256 elements");
+		
+		// Try with wrong size array
+		$chunk->extrapolateBiomes([1, 2, 3]);
 	}
 }

--- a/tests/phpunit/world/format/ChunkTest.php
+++ b/tests/phpunit/world/format/ChunkTest.php
@@ -73,7 +73,7 @@ class ChunkTest extends TestCase{
 
 	public function testExtrapolateBiomes() : void{
 		$chunk = new Chunk([], false);
-		
+
 		// Create a 2D biome array (16x16 = 256 elements)
 		$biomes2d = [];
 		for($z = 0; $z < 16; ++$z){
@@ -82,7 +82,7 @@ class ChunkTest extends TestCase{
 				$biomes2d[$z * 16 + $x] = ($x % 4) + 1; // Use values 1-4 for testing
 			}
 		}
-		
+
 		$chunk->extrapolateBiomes($biomes2d);
 
 		// Verify that the 2D biomes have been extrapolated to all Y levels
@@ -98,10 +98,10 @@ class ChunkTest extends TestCase{
 
 	public function testExtrapolateBiomesInvalidSize() : void{
 		$chunk = new Chunk([], false);
-		
+
 		$this->expectException(\InvalidArgumentException::class);
 		$this->expectExceptionMessage("Biome array must contain exactly 256 elements");
-		
+
 		// Try with wrong size array
 		$chunk->extrapolateBiomes([1, 2, 3]);
 	}


### PR DESCRIPTION
# Biome Filling Usage Guide

This document describes the new biome filling features added to resolve issue [#6970](https://github.com/pmmp/PocketMine-MP/issues/6970).

## Problem

Previously, filling biomes in a new chunk was cumbersome because every subchunk had to be recreated with a `PalettedBlockArray` containing the correct biomes. Legacy generators that only generate 2D biomes also needed a way to extrapolate biomes up and down the chunk.

## Solution

Three new features have been added to the `Chunk` class to simplify biome management:

### 1. Biome ID Constructor Parameter

The `Chunk` constructor now accepts an optional `$biomeId` parameter that automatically fills all subchunks with the specified biome:

```php
use pocketmine\data\bedrock\BiomeIds;
use pocketmine\world\format\Chunk;

// Create a chunk with all biomes set to PLAINS
$chunk = new Chunk([], false, BiomeIds::PLAINS);
```

**Use case:** Ideal for generators like Flat that use a single biome throughout the entire chunk.

### 2. `fillBiomes()` Method

Fill all biomes in an existing chunk with a single biome ID:

```php
$chunk = new Chunk([], false);
$chunk->fillBiomes(BiomeIds::DESERT);
```

**Note:** This method safely skips any null subchunks, ensuring null-safety and preventing runtime errors.

**Use case:** When you need to change all biomes in a chunk after it's been created, or in custom generators that need to flood-fill biomes.

### 3. `extrapolateBiomes()` Method

Extrapolate 2D biome data (16×16) to all Y levels in the chunk:

```php
// Create a 2D biome array (256 elements for 16×16)
$biomes2d = [];
for($z = 0; $z < 16; ++$z){
    for($x = 0; $x < 16; ++$x){
        $biomes2d[$z * 16 + $x] = BiomeIds::PLAINS;
    }
}

$chunk = new Chunk([], false);
$chunk->extrapolateBiomes($biomes2d);
```

**Note:** This method safely skips any null subchunks and validates that exactly 256 biome IDs are provided (throws `InvalidArgumentException` if not).

**Use case:** Perfect for legacy generators like Normal that only generate 2D biomes and need to extrapolate them vertically.

## Examples

### Example 1: Simple Flat World Generator

```php
use pocketmine\world\generator\Generator;
use pocketmine\world\format\Chunk;
use pocketmine\data\bedrock\BiomeIds;

class MyFlatGenerator extends Generator {
    private Chunk $chunk;
    
    protected function generateBaseChunk() : void {
        // Use constructor with biomeId parameter
        $this->chunk = new Chunk([], false, BiomeIds::PLAINS);
        
        // Add blocks...
    }
}
```

### Example 2: Custom Generator with 2D Biomes

```php
use pocketmine\world\generator\Generator;
use pocketmine\world\ChunkManager;
use pocketmine\world\format\Chunk;

class My2DGenerator extends Generator {
    public function generateChunk(ChunkManager $world, int $chunkX, int $chunkZ) : void {
        // Generate 2D biomes
        $biomes2d = [];
        for($z = 0; $z < 16; ++$z){
            for($x = 0; $x < 16; ++$x){
                $biomes2d[$z * 16 + $x] = $this->getBiomeAt($chunkX * 16 + $x, $chunkZ * 16 + $z);
            }
        }
        
        $chunk = new Chunk([], false);
        
        // Extrapolate to 3D
        $chunk->extrapolateBiomes($biomes2d);
        
        // Generate terrain...
        
        $world->setChunk($chunkX, $chunkZ, $chunk);
    }
}
```

### Example 3: Void Generator

```php
use pocketmine\world\generator\Generator;
use pocketmine\world\ChunkManager;
use pocketmine\world\format\Chunk;
use pocketmine\data\bedrock\BiomeIds;

class VoidGenerator extends Generator {
    public function generateChunk(ChunkManager $world, int $chunkX, int $chunkZ) : void {
        // Create an empty chunk with all biomes set to VOID
        $chunk = new Chunk([], false, BiomeIds::THE_VOID);
        $world->setChunk($chunkX, $chunkZ, $chunk);
    }
    
    public function populateChunk(ChunkManager $world, int $chunkX, int $chunkZ) : void {
        // No population needed for void
    }
}
```

## Implementation Details

### Null Safety

Both `fillBiomes()` and `extrapolateBiomes()` include null-safety checks to prevent calling methods on null subchunks:

```php
foreach($this->subChunks as $subChunk){
    if($subChunk === null){
        continue;
    }
    // ... process biomes
}
```

This ensures that the methods work correctly even if some subchunks are not yet initialized.

### Validation

The `extrapolateBiomes()` method validates input:

- Throws `InvalidArgumentException` if the array doesn't contain exactly 256 elements
- Ensures the biome array matches the expected 16×16 format

## Performance Benefits

- **Flat Generator:** Now uses the constructor parameter, automatically filling all biomes during chunk creation
- **2D Generators:** Can use `extrapolateBiomes()` to efficiently copy 2D biome data to all Y levels
- **No Subchunk Recreation:** No need to manually recreate subchunks with new biome arrays
- **Null-Safe:** Automatically skips null subchunks without errors

## Backward Compatibility

All changes are backward compatible:
- The `$biomeId` parameter is optional (defaults to `null`)
- When `null`, the behavior is identical to before (defaults to `OCEAN` for empty subchunks)
- All existing code continues to work without modification