### PR TITLE
fixed sneak pressed

### DIFF
--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -226,7 +226,7 @@ class InGamePacketHandler extends PacketHandler{
 			$gliding = $this->resolveOnOffInputFlags($inputFlags, PlayerAuthInputFlags::START_GLIDING, PlayerAuthInputFlags::STOP_GLIDING);
 			$flying = $this->resolveOnOffInputFlags($inputFlags, PlayerAuthInputFlags::START_FLYING, PlayerAuthInputFlags::STOP_FLYING);
 			$mismatch =
-				($sneaking !== null && !$this->player->toggleSneak($sneaking, $sneakPressed)) |
+				(!$this->player->toggleSneak($sneaking, $sneakPressed)) |
 				($sprinting !== null && !$this->player->toggleSprint($sprinting)) |
 				($swimming !== null && !$this->player->toggleSwim($swimming)) |
 				($gliding !== null && !$this->player->toggleGlide($gliding)) |

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -226,7 +226,7 @@ class InGamePacketHandler extends PacketHandler{
 			$gliding = $this->resolveOnOffInputFlags($inputFlags, PlayerAuthInputFlags::START_GLIDING, PlayerAuthInputFlags::STOP_GLIDING);
 			$flying = $this->resolveOnOffInputFlags($inputFlags, PlayerAuthInputFlags::START_FLYING, PlayerAuthInputFlags::STOP_FLYING);
 			$mismatch =
-				(!$this->player->toggleSneak($sneaking, $sneakPressed)) |
+				(!$this->player->toggleSneak($sneaking ?? $this->player->isSneaking(), $sneakPressed)) |
 				($sprinting !== null && !$this->player->toggleSprint($sprinting)) |
 				($swimming !== null && !$this->player->toggleSwim($swimming)) |
 				($gliding !== null && !$this->player->toggleGlide($gliding)) |

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -2106,7 +2106,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 		}
 		$this->setSneakPressed($sneakPressed);
 
-		$ev = new PlayerToggleSneakEvent($this, $sneak ?? $this->sneaking, $sneakPressed);
+		$ev = new PlayerToggleSneakEvent($this, $sneak, $sneakPressed);
 		if(!$sneakChanged){
 			$ev->cancel();
 		}

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -2099,14 +2099,15 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 		return true;
 	}
 
-	public function toggleSneak(bool $sneak, bool $sneakPressed = true) : bool{
-		if($sneak === $this->sneaking && $sneakPressed === $this->sneakPressed){
+	public function toggleSneak(?bool $sneak, bool $sneakPressed = true) : bool{
+		$sneakChanged = ($sneak === !$this->sneaking);
+		if(!$sneakChanged && $sneakPressed === $this->sneakPressed){
 			return true;
 		}
 		$this->setSneakPressed($sneakPressed);
 
-		$ev = new PlayerToggleSneakEvent($this, $sneak, $sneakPressed);
-		if($sneak === $this->sneaking){
+		$ev = new PlayerToggleSneakEvent($this, $sneak ?? $this->sneaking, $sneakPressed);
+		if(!$sneakChanged){
 			$ev->cancel();
 		}
 		$ev->call();
@@ -2114,7 +2115,9 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 		if($ev->isCancelled()){
 			return false;
 		}
-		$this->setSneaking($sneak);
+		if($sneakChanged){
+			$this->setSneaking($sneak);
+		}
 		return true;
 	}
 

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -2099,8 +2099,8 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 		return true;
 	}
 
-	public function toggleSneak(?bool $sneak, bool $sneakPressed = true) : bool{
-		$sneakChanged = ($sneak === !$this->sneaking);
+	public function toggleSneak(bool $sneak, bool $sneakPressed = true) : bool{
+		$sneakChanged = ($sneak !== $this->sneaking);
 		if(!$sneakChanged && $sneakPressed === $this->sneakPressed){
 			return true;
 		}

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -2100,14 +2100,13 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 	}
 
 	public function toggleSneak(bool $sneak, bool $sneakPressed = true) : bool{
-		$sneakChanged = ($sneak !== $this->sneaking);
-		if(!$sneakChanged && $sneakPressed === $this->sneakPressed){
+		if($sneak === $this->sneaking && $sneakPressed === $this->sneakPressed){
 			return true;
 		}
 		$this->setSneakPressed($sneakPressed);
 
 		$ev = new PlayerToggleSneakEvent($this, $sneak, $sneakPressed);
-		if(!$sneakChanged){
+		if($sneak === $this->sneaking){
 			$ev->cancel();
 		}
 		$ev->call();
@@ -2115,9 +2114,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 		if($ev->isCancelled()){
 			return false;
 		}
-		if($sneakChanged){
-			$this->setSneaking($sneak);
-		}
+		$this->setSneaking($sneak);
 		return true;
 	}
 


### PR DESCRIPTION
<!-- Summarize your PR here. Keep it short and simple. -->
<!-- Explain existing problems or why this pull request is necessary -->

### Related issues & PRs
Related to #6867 

https://github.com/pmmp/PocketMine-MP/pull/6867/files#diff-f405c0ec75b0721cb66a250d6938b9267fd68285ffa443dfe8e0e156afac04e0R229

if both START_SNEAKING and STOP_SNEAKING are always false, any changes of SNEAKING is never handled and Player->isSneakPressed() is never changed
this happened when a player is holding shift to enter a 1.5 block space and then release shift

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
<!-- If not, you can delete this section -->
~~`Player->toggleSneak(bool $sneak, bool $sneakPressed = true) : bool` -> `Player->toggleSneak(?bool $sneak, bool $sneakPressed = true) : bool`~~

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
<!-- If not, you can delete this section -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
<!-- If not, you can delete this section -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!-- For example, future changes that this PR lays the groundwork for -->

## Tests
<!--
If this PR affects gameplay or user experience in some way, it must be manually tested.
Include any screenshots or videos of manual testing here.
Any test plugin code should also be pasted here if it can't be adapted to a PHPUnit test.
-->
i just tested the 4 states on #6548 with my own branch and haven't tested for PlayerToggleSneakEvent