### PR TITLE
fix query token comparison

### DIFF
--- a/src/network/query/QueryHandler.php
+++ b/src/network/query/QueryHandler.php
@@ -104,7 +104,7 @@ class QueryHandler implements RawPacketHandler{
 
 					return true;
 				case self::STATISTICS: //Stat
-					$token = BE::readUnsignedInt($stream);
+					$token = BE::readSignedInt($stream);
 					if($token !== ($t1 = self::getTokenString($this->token, $address)) && $token !== ($t2 = self::getTokenString($this->lastToken, $address))){
 						$this->logger->debug("Bad token $token from $address $port, expected $t1 or $t2");
 


### PR DESCRIPTION
Fix query token validation by using signed integers consistently

## Changes
Changed `$token = BE::readUnsignedInt($stream);` to `$token = BE::readSignedInt($stream);` as `$this->token` can be negative 

## Tests
Used a known working Python library ([mcquery](https://pypi.org/project/mcquery/)) to query a PocketMine-MP server.
Before the patch, mcquery was unable to query the server when it had a negative token (approximately 60% of the time)
After the patch, rebooted the server multiple times to regenerate tokens and mcquery successfully retrieved query information regardless of whether the token was positive or negative.
