### PR TITLE
Add an API to remove a player's item cooldown

### DIFF
--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -779,6 +779,16 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 		}
 	}
 
+	/**
+	 * Removes the player's cooldown time for the given item.
+	 */
+	public function removeItemCooldown(Item $item) : void{
+		if($this->hasItemCooldown($item)){
+			unset($this->usedItemsCooldown[$item->getCooldownTag() ?? $item->getStateId()]);
+			$this->getNetworkSession()->onItemCooldownChanged($item, 0);
+		}
+	}
+
 	protected function checkItemCooldowns() : void{
 		$serverTick = $this->server->getTick();
 		foreach($this->usedItemsCooldown as $itemId => $cooldownUntil){


### PR DESCRIPTION
<!-- Summarize your PR here. Keep it short and simple. -->
<!-- Explain existing problems or why this pull request is necessary -->
Currently, plugins cannot remove a player's server-side item cooldown. The only publicly available API is [`Player->resetItemCooldown(Item $item, ?int $ticks = null)`](https://github.com/pmmp/PocketMine-MP/blob/4bda8738834730bd0be194d0a488229aa89d6d0e/src/player/Player.php#L774), which intentionally only supports cooldown values greater than 0.

## Changes
### API changes
- The following API methods have been added:
  - `public Player->removeItemCooldown(Item $item) : void` - removes the player's cooldown time for the given item

## Tests
This testing plugin removes the cooldown on ender pearls and goat horns after 10 and 40 ticks respectively.
Video: https://github.com/user-attachments/assets/0f716c52-1369-486b-8062-902f97504a24
```php
<?php

declare(strict_types=1);

namespace Max\Test;

use pocketmine\event\Listener;
use pocketmine\event\player\PlayerItemUseEvent;
use pocketmine\item\EnderPearl;
use pocketmine\item\GoatHorn;
use pocketmine\plugin\PluginBase;
use pocketmine\scheduler\ClosureTask;

class Test extends PluginBase implements Listener {
    public function onEnable(): void {
        $this->getServer()->getPluginManager()->registerEvents($this, $this);
    }

    public function onItemUse(PlayerItemUseEvent $event): void {
        $item = $event->getItem();
        if ($item instanceof EnderPearl) {
            $delay = 10;
        } elseif ($item instanceof GoatHorn) {
            $delay = 40;
        } else {
            return;
        }
        $player = $event->getPlayer();
        $this->getScheduler()->scheduleDelayedTask(new ClosureTask(function() use ($player, $item) {
            $player->removeItemCooldown($item);
        }), $delay);
    }
}
```