### PR TITLE
Fix: Prevent Frosted Ice from being dropped with Silk Touch

### DIFF
--- a/src/block/FrostedIce.php
+++ b/src/block/FrostedIce.php
@@ -92,4 +92,8 @@ class FrostedIce extends Ice implements Ageable{
 		$world->scheduleDelayedBlockUpdate($this->position, mt_rand(20, 40));
 		return false;
 	}
+
+	public function isAffectedBySilkTouch() : bool{
+		return false;
+	}
 }


### PR DESCRIPTION
Implemented isAffectedBySilkTouch() in FrostedIce class to return false, ensuring that frosted ice blocks do not drop as items when mined with Silk Touch tools, matching vanilla behavior.

### Related issues & PRs
## Changes
### API changes
* Added `isAffectedBySilkTouch()` method to `FrostedIce` class.
### Behavioural changes
* Players can no longer obtain Frosted Ice blocks using Silk Touch tools; the block will now correctly break without dropping anything, matching vanilla mechanics.
## Follow-up
## Tests
not testing 😥