### PR TITLE
Implemented native spectator mode

### DIFF
--- a/generated/lang/KnownTranslationFactory.php
+++ b/generated/lang/KnownTranslationFactory.php
@@ -982,6 +982,10 @@ final class KnownTranslationFactory{
 		return new Translatable(KnownTranslationKeys::GAMEMODE_CREATIVE, []);
 	}
 
+	public static function gameMode_native_spectator() : Translatable{
+		return new Translatable(KnownTranslationKeys::GAMEMODE_NATIVE_SPECTATOR, []);
+	}
+
 	public static function gameMode_spectator() : Translatable{
 		return new Translatable(KnownTranslationKeys::GAMEMODE_SPECTATOR, []);
 	}

--- a/generated/lang/KnownTranslationKeys.php
+++ b/generated/lang/KnownTranslationKeys.php
@@ -215,6 +215,7 @@ final class KnownTranslationKeys{
 	public const GAMEMODE_ADVENTURE = "gameMode.adventure";
 	public const GAMEMODE_CHANGED = "gameMode.changed";
 	public const GAMEMODE_CREATIVE = "gameMode.creative";
+	public const GAMEMODE_NATIVE_SPECTATOR = "gameMode.nativeSpectator";
 	public const GAMEMODE_SPECTATOR = "gameMode.spectator";
 	public const GAMEMODE_SURVIVAL = "gameMode.survival";
 	public const GAMEMODE_INFO = "gamemode_info";

--- a/generated/lang/KnownTranslationParameterInfo.php
+++ b/generated/lang/KnownTranslationParameterInfo.php
@@ -218,6 +218,7 @@ final class KnownTranslationParameterInfo{
 		Keys::GAMEMODE_ADVENTURE => [],
 		Keys::GAMEMODE_CHANGED => ["0"],
 		Keys::GAMEMODE_CREATIVE => [],
+		Keys::GAMEMODE_NATIVE_SPECTATOR => [],
 		Keys::GAMEMODE_SPECTATOR => [],
 		Keys::GAMEMODE_SURVIVAL => [],
 		Keys::GAMEMODE_INFO => [],

--- a/resources/translations/eng.ini
+++ b/resources/translations/eng.ini
@@ -189,6 +189,7 @@ enchantment.tridentImpaling=Impaling
 gameMode.adventure=Adventure Mode
 gameMode.changed=Your game mode has been updated to {%0}
 gameMode.creative=Creative Mode
+gameMode.nativeSpectator=Native Spectator Mode
 gameMode.spectator=Spectator Mode
 gameMode.survival=Survival Mode
 item.record_11.desc=C418 - 11

--- a/src/data/java/GameModeIdMap.php
+++ b/src/data/java/GameModeIdMap.php
@@ -49,7 +49,7 @@ final class GameModeIdMap{
 				GameMode::SURVIVAL => 0,
 				GameMode::CREATIVE => 1,
 				GameMode::ADVENTURE => 2,
-				GameMode::SPECTATOR => 3,
+				GameMode::SPECTATOR, GameMode::NATIVE_SPECTATOR => 3,
 			}, $case);
 		}
 	}

--- a/src/network/mcpe/convert/TypeConverter.php
+++ b/src/network/mcpe/convert/TypeConverter.php
@@ -38,7 +38,6 @@ use pocketmine\data\SavedDataLoadingException;
 use pocketmine\item\Item;
 use pocketmine\item\VanillaItems;
 use pocketmine\nbt\LittleEndianNbtSerializer;
-use pocketmine\nbt\NBT;
 use pocketmine\nbt\NbtException;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\ListTag;
@@ -125,8 +124,8 @@ class TypeConverter{
 	public function coreGameModeToProtocol(GameMode $gamemode) : int{
 		return match($gamemode){
 			GameMode::SURVIVAL => ProtocolGameMode::SURVIVAL,
-			//TODO: native spectator support
-			GameMode::CREATIVE, GameMode::SPECTATOR => ProtocolGameMode::CREATIVE,
+			GameMode::SPECTATOR => ProtocolGameMode::SPECTATOR,
+			GameMode::CREATIVE => ProtocolGameMode::CREATIVE,
 			GameMode::ADVENTURE => ProtocolGameMode::ADVENTURE,
 		};
 	}
@@ -136,8 +135,7 @@ class TypeConverter{
 			ProtocolGameMode::SURVIVAL => GameMode::SURVIVAL,
 			ProtocolGameMode::CREATIVE => GameMode::CREATIVE,
 			ProtocolGameMode::ADVENTURE => GameMode::ADVENTURE,
-			ProtocolGameMode::SURVIVAL_VIEWER, ProtocolGameMode::CREATIVE_VIEWER => GameMode::SPECTATOR,
-			//TODO: native spectator support
+			ProtocolGameMode::SPECTATOR => GameMode::SPECTATOR,
 			default => null,
 		};
 	}

--- a/src/network/mcpe/convert/TypeConverter.php
+++ b/src/network/mcpe/convert/TypeConverter.php
@@ -135,7 +135,8 @@ class TypeConverter{
 			ProtocolGameMode::SURVIVAL => GameMode::SURVIVAL,
 			ProtocolGameMode::CREATIVE => GameMode::CREATIVE,
 			ProtocolGameMode::ADVENTURE => GameMode::ADVENTURE,
-			ProtocolGameMode::SURVIVAL_VIEWER, ProtocolGameMode::CREATIVE_VIEWER, ProtocolGameMode::SPECTATOR => GameMode::SPECTATOR,
+			ProtocolGameMode::SURVIVAL_VIEWER, ProtocolGameMode::CREATIVE_VIEWER => GameMode::SPECTATOR,
+			ProtocolGameMode::SPECTATOR => GameMode::NATIVE_SPECTATOR,
 			default => null,
 		};
 	}

--- a/src/network/mcpe/convert/TypeConverter.php
+++ b/src/network/mcpe/convert/TypeConverter.php
@@ -124,8 +124,8 @@ class TypeConverter{
 	public function coreGameModeToProtocol(GameMode $gamemode) : int{
 		return match($gamemode){
 			GameMode::SURVIVAL => ProtocolGameMode::SURVIVAL,
-			GameMode::SPECTATOR => ProtocolGameMode::SPECTATOR,
-			GameMode::CREATIVE => ProtocolGameMode::CREATIVE,
+			GameMode::NATIVE_SPECTATOR => ProtocolGameMode::SPECTATOR,
+			GameMode::CREATIVE, GameMode::SPECTATOR => ProtocolGameMode::CREATIVE,
 			GameMode::ADVENTURE => ProtocolGameMode::ADVENTURE,
 		};
 	}
@@ -135,7 +135,7 @@ class TypeConverter{
 			ProtocolGameMode::SURVIVAL => GameMode::SURVIVAL,
 			ProtocolGameMode::CREATIVE => GameMode::CREATIVE,
 			ProtocolGameMode::ADVENTURE => GameMode::ADVENTURE,
-			ProtocolGameMode::SPECTATOR => GameMode::SPECTATOR,
+			ProtocolGameMode::SURVIVAL_VIEWER, ProtocolGameMode::CREATIVE_VIEWER, ProtocolGameMode::SPECTATOR => GameMode::SPECTATOR,
 			default => null,
 		};
 	}

--- a/src/player/GameMode.php
+++ b/src/player/GameMode.php
@@ -36,6 +36,7 @@ use function spl_object_id;
  * @method static GameMode ADVENTURE()
  * @method static GameMode CREATIVE()
  * @method static GameMode SPECTATOR()
+ * @method static GameMode NATIVE_SPECTATOR()
  * @method static GameMode SURVIVAL()
  *
  * @phpstan-type TMetadata array{0: string, 1: Translatable, 2: list<string>}
@@ -47,6 +48,7 @@ enum GameMode{
 	case CREATIVE;
 	case ADVENTURE;
 	case SPECTATOR;
+	case NATIVE_SPECTATOR;
 
 	public static function fromString(string $str) : ?self{
 		/**
@@ -78,7 +80,8 @@ enum GameMode{
 			self::SURVIVAL => ["Survival", KnownTranslationFactory::gameMode_survival(), ["survival", "s", "0"]],
 			self::CREATIVE => ["Creative", KnownTranslationFactory::gameMode_creative(), ["creative", "c", "1"]],
 			self::ADVENTURE => ["Adventure", KnownTranslationFactory::gameMode_adventure(), ["adventure", "a", "2"]],
-			self::SPECTATOR => ["Spectator", KnownTranslationFactory::gameMode_spectator(), ["spectator", "v", "view", "3"]]
+			self::SPECTATOR => ["Spectator", KnownTranslationFactory::gameMode_spectator(), ["spectator", "v", "view", "3"]],
+			self::NATIVE_SPECTATOR => throw new \Exception('To be implemented')
 		};
 	}
 

--- a/src/player/GameMode.php
+++ b/src/player/GameMode.php
@@ -80,7 +80,8 @@ enum GameMode{
 			self::SURVIVAL => ["Survival", KnownTranslationFactory::gameMode_survival(), ["survival", "s", "0"]],
 			self::CREATIVE => ["Creative", KnownTranslationFactory::gameMode_creative(), ["creative", "c", "1"]],
 			self::ADVENTURE => ["Adventure", KnownTranslationFactory::gameMode_adventure(), ["adventure", "a", "2"]],
-			self::SPECTATOR, self::NATIVE_SPECTATOR => ["Spectator", KnownTranslationFactory::gameMode_spectator(), ["spectator", "v", "view", "3"]]
+			self::SPECTATOR => ["Spectator", KnownTranslationFactory::gameMode_spectator(), ["spectator", "v", "view", "3"]],
+			self::NATIVE_SPECTATOR => ["Native Spectator", KnownTranslationFactory::gameMode_native_spectator(), ["native_spectator"]]
 		};
 	}
 

--- a/src/player/GameMode.php
+++ b/src/player/GameMode.php
@@ -80,8 +80,7 @@ enum GameMode{
 			self::SURVIVAL => ["Survival", KnownTranslationFactory::gameMode_survival(), ["survival", "s", "0"]],
 			self::CREATIVE => ["Creative", KnownTranslationFactory::gameMode_creative(), ["creative", "c", "1"]],
 			self::ADVENTURE => ["Adventure", KnownTranslationFactory::gameMode_adventure(), ["adventure", "a", "2"]],
-			self::SPECTATOR => ["Spectator", KnownTranslationFactory::gameMode_spectator(), ["spectator", "v", "view", "3"]],
-			self::NATIVE_SPECTATOR => throw new \Exception('To be implemented')
+			self::SPECTATOR, self::NATIVE_SPECTATOR => ["Spectator", KnownTranslationFactory::gameMode_spectator(), ["spectator", "v", "view", "3"]]
 		};
 	}
 

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -1266,7 +1266,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 	 * @param bool $literal whether a literal check should be performed
 	 */
 	public function isCreative(bool $literal = false) : bool{
-		return $this->gamemode === GameMode::CREATIVE || (!$literal && $this->gamemode === GameMode::SPECTATOR);
+		return $this->gamemode === GameMode::CREATIVE || (!$literal && ($this->gamemode === GameMode::SPECTATOR || $this->gamemode === GameMode::NATIVE_SPECTATOR));
 	}
 
 	/**
@@ -1276,11 +1276,11 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 	 * @param bool $literal whether a literal check should be performed
 	 */
 	public function isAdventure(bool $literal = false) : bool{
-		return $this->gamemode === GameMode::ADVENTURE || (!$literal && $this->gamemode === GameMode::SPECTATOR);
+		return $this->gamemode === GameMode::ADVENTURE || (!$literal && ($this->gamemode === GameMode::SPECTATOR || $this->gamemode === GameMode::NATIVE_SPECTATOR));
 	}
 
 	public function isSpectator() : bool{
-		return $this->gamemode === GameMode::SPECTATOR;
+		return $this->gamemode === GameMode::SPECTATOR || $this->gamemode === GameMode::NATIVE_SPECTATOR;
 	}
 
 	public function setSneakPressed(bool $sneakPressed) : void{


### PR DESCRIPTION
## Changes
### API Changes
- Added GameMode::NATIVE_SPECTATOR
### Behavioural changes
- Implemented native spectator mode

NOTE: It needs a new release for bedrock protocol in packagist because of PR [#](https://github.com/pmmp/BedrockProtocol/pull/340)[340](https://github.com/pmmp/BedrockProtocol/pull/340). I couldn't update it so we can't merge it without the release. Also thats why it doesn't pass PHPStan CI i guess