### PR TITLE
Fix glowstone count not decreasing when charging respawn anchors

### DIFF
--- a/src/block/RespawnAnchor.php
+++ b/src/block/RespawnAnchor.php
@@ -68,6 +68,7 @@ final class RespawnAnchor extends Opaque{
 		if($item->getTypeId() === ItemTypeIds::fromBlockTypeId(BlockTypeIds::GLOWSTONE) && $this->charges < self::MAX_CHARGES){
 			$this->position->getWorld()->setBlock($this->position, $this->setCharges($this->charges + 1));
 			$this->position->getWorld()->addSound($this->position, new RespawnAnchorChargeSound());
+			$item->pop();
 			return true;
 		}
 


### PR DESCRIPTION
Fixes an issue where glowstone was not being consumed when charging a respawn anchor.
Behavior now matches vanilla Minecraft.

https://minecraft.fandom.com/wiki/Respawn_Anchor