### PR TITLE
Thread-safe block and item type ID assignment

### DIFF
--- a/src/block/BlockIdentifier.php
+++ b/src/block/BlockIdentifier.php
@@ -28,14 +28,17 @@ use pocketmine\utils\Utils;
 
 class BlockIdentifier{
 	/**
+	 * TODO: in the future it would be simpler to just accept the unique identifier directly here, instead of requiring
+	 * the caller to call BlockTypeIds::claimId()
+	 *
 	 * @phpstan-param class-string<Tile>|null $tileClass
 	 */
 	public function __construct(
 		private int $blockTypeId,
 		private ?string $tileClass = null
 	){
-		if($blockTypeId < 0){
-			throw new \InvalidArgumentException("Block type ID may not be negative");
+		if(BlockTypeIds::getClaimant($blockTypeId) === null){
+			throw new \InvalidArgumentException("Type IDs must be claimed using BlockTypeIds::claimId()");
 		}
 		if($tileClass !== null){
 			Utils::testValidInstance($tileClass, Tile::class);

--- a/src/block/BlockTypeIds.php
+++ b/src/block/BlockTypeIds.php
@@ -23,6 +23,15 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pmmp\thread\ThreadSafe;
+use pmmp\thread\ThreadSafeArray;
+use pocketmine\utils\ThreadSafeSingletonTrait;
+use pocketmine\utils\Utils;
+use function is_int;
+use function mb_strtolower;
+use function trigger_error;
+use const E_USER_DEPRECATED;
+
 /**
  * Every block in {@link VanillaBlocks} has a corresponding constant in this class. These constants can be used to
  * identify and compare block types efficiently using {@link Block::getTypeId()}.
@@ -33,11 +42,8 @@ namespace pocketmine\block;
  * WARNING: These are NOT a replacement for Minecraft legacy IDs. Do **NOT** hardcode their values, or store them in
  * configs or databases. They will change without warning.
  */
-final class BlockTypeIds{
-
-	private function __construct(){
-		//NOOP
-	}
+final class BlockTypeIds extends ThreadSafe{
+	use ThreadSafeSingletonTrait;
 
 	public const AIR = 10000;
 
@@ -857,12 +863,70 @@ final class BlockTypeIds{
 
 	public const FIRST_UNUSED_BLOCK_ID = 10827;
 
+	/**
+	 * @deprecated This preserves the old, flawed thread-local type ID assignment behaviour when a unique ID isn't
+	 * provided to newId(). To be removed in PM6.
+	 */
 	private static int $nextDynamicId = self::FIRST_UNUSED_BLOCK_ID;
 
 	/**
-	 * Returns a new runtime block type ID, e.g. for use by a custom block.
+	 * @deprecated This function is not thread-safe. If blocks are registered in a different order on different threads,
+	 * their type IDs will conflict when moving data between threads.
 	 */
 	public static function newId() : int{
+		trigger_error("newId() is not thread-safe, use claimId() instead", E_USER_DEPRECATED);
 		return self::$nextDynamicId++;
+	}
+
+	private int $nextFreeId = 100_000;
+
+	/** @phpstan-var ThreadSafeArray<string, int> */
+	private ThreadSafeArray $dynamicIdLookup;
+	/** @phpstan-var ThreadSafeArray<int, string> */
+	private ThreadSafeArray $claimedIds;
+
+	private function __construct(){
+		$this->dynamicIdLookup = new ThreadSafeArray();
+		$this->claimedIds = new ThreadSafeArray();
+
+		foreach(Utils::stringifyKeys((new \ReflectionClass($this))->getConstants()) as $name => $value){
+			if($name === "FIRST_UNUSED_BLOCK_ID" || !is_int($value)){
+				continue;
+			}
+			$uniqueId = VanillaBlocksInputs::class . "::" . mb_strtolower($name, 'UTF-8');
+			$this->claimedIds[$value] = $uniqueId;
+			$this->dynamicIdLookup[$uniqueId] = $value;
+		}
+	}
+
+	private function fetchOrAssignId(string $uniqueId) : int{
+		return $this->synchronized(function() use ($uniqueId) : int{
+			$existing = $this->dynamicIdLookup[$uniqueId];
+			if($existing !== null){
+				return $existing;
+			}
+			$numericId = $this->nextFreeId++;
+			$this->claimedIds[$numericId] = $uniqueId;
+			return $this->dynamicIdLookup[$uniqueId] = $numericId;
+		});
+	}
+
+	/**
+	 * Returns a new runtime block type ID, e.g. for use by a custom block.
+	 *
+	 * @param string $uniqueId Any string unique to the block type to ensure it gets the same ID on all threads
+	 */
+	public static function claimId(string $uniqueId) : int{
+		return self::getInstance()->fetchOrAssignId($uniqueId);
+	}
+
+	/**
+	 * Returns the unique string ID used to claim the given type ID.
+	 */
+	public static function getClaimant(int $typeId) : ?string{
+		if($typeId >= self::FIRST_UNUSED_BLOCK_ID && $typeId < self::$nextDynamicId){
+			return "deprecated:anonymous_thread_local";
+		}
+		return self::getInstance()->claimedIds[$typeId];
 	}
 }

--- a/src/block/VanillaBlocksInputs.php
+++ b/src/block/VanillaBlocksInputs.php
@@ -70,9 +70,7 @@ use pocketmine\item\VanillaItems;
 use pocketmine\math\Facing;
 use pocketmine\utils\RegistrySource;
 use pocketmine\world\generator\object\TreeType;
-use function is_int;
 use function mb_strtolower;
-use function mb_strtoupper;
 use function strtolower;
 
 /**
@@ -101,18 +99,7 @@ final class VanillaBlocksInputs extends RegistrySource{
 	 * @phpstan-param class-string<covariant Tile> $tileClass
 	 */
 	private static function makeBID(string $name, ?string $tileClass = null) : BID{
-		//this sketchy hack allows us to avoid manually writing the constants inline
-		//since type IDs are generated from this class anyway, I'm OK with this hack
-		//nonetheless, we should try to get rid of it in a future major version (e.g by using string type IDs)
-		$reflect = new \ReflectionClass(BlockTypeIds::class);
-		$typeId = $reflect->getConstant(mb_strtoupper($name));
-		if(!is_int($typeId)){
-			//this allows registering new stuff without adding new type ID constants
-			//this reduces the number of mandatory steps to test new features in local development
-			\GlobalLogger::get()->error(self::class . ": No constant type ID found for $name, generating a new one");
-			$typeId = BlockTypeIds::newId();
-		}
-		return new BID($typeId, $tileClass);
+		return new BID(BlockTypeIds::claimId(self::class . "::" . $name), $tileClass);
 	}
 
 	/**

--- a/src/item/ItemIdentifier.php
+++ b/src/item/ItemIdentifier.php
@@ -24,11 +24,21 @@ declare(strict_types=1);
 namespace pocketmine\item;
 
 use pocketmine\block\Block;
+use pocketmine\block\BlockTypeIds;
 
 class ItemIdentifier{
 	public function __construct(
 		private int $typeId
-	){}
+	){
+		$blockTypeId = ItemTypeIds::toBlockTypeId($this->typeId);
+		if($blockTypeId !== null){
+			if(BlockTypeIds::getClaimant($blockTypeId) === null){
+				throw new \InvalidArgumentException("Block type IDs must be claimed using BlockTypeIds::claimId()");
+			}
+		}elseif(ItemTypeIds::getClaimant($typeId) === null){
+			throw new \InvalidArgumentException("Type IDs must be claimed using ItemTypeIds::claimId()");
+		}
+	}
 
 	public static function fromBlock(Block $block) : self{
 		//TODO: maybe an ItemBlockIdentifier is in order?

--- a/src/item/ItemTypeIds.php
+++ b/src/item/ItemTypeIds.php
@@ -23,6 +23,15 @@ declare(strict_types=1);
 
 namespace pocketmine\item;
 
+use pmmp\thread\ThreadSafe;
+use pmmp\thread\ThreadSafeArray;
+use pocketmine\utils\ThreadSafeSingletonTrait;
+use pocketmine\utils\Utils;
+use function is_int;
+use function mb_strtolower;
+use function trigger_error;
+use const E_USER_DEPRECATED;
+
 /**
  * Every item in {@link VanillaItems} has a corresponding constant in this class. These constants can be used to
  * identify and compare item types efficiently using {@link Item::getTypeId()}.
@@ -30,11 +39,8 @@ namespace pocketmine\item;
  * WARNING: These are NOT a replacement for Minecraft legacy IDs. Do **NOT** hardcode their values, or store them in
  * configs or databases. They will change without warning.
  */
-final class ItemTypeIds{
-
-	private function __construct(){
-		//NOOP
-	}
+final class ItemTypeIds extends ThreadSafe{
+	use ThreadSafeSingletonTrait;
 
 	public const ACACIA_BOAT = 20000;
 	public const ACACIA_SIGN = 20001;
@@ -365,13 +371,71 @@ final class ItemTypeIds{
 
 	public const FIRST_UNUSED_ITEM_ID = 20326;
 
+	/**
+	 * @deprecated This preserves the old, flawed thread-local type ID assignment behaviour when a unique ID isn't
+	 * provided to newId(). To be removed in PM6.
+	 */
 	private static int $nextDynamicId = self::FIRST_UNUSED_ITEM_ID;
 
 	/**
-	 * Returns a new runtime item type ID, e.g. for use by a custom item.
+	 * @deprecated This function is not thread-safe. If items are registered in a different order on different threads,
+	 * their type IDs will conflict when moving data between threads.
 	 */
 	public static function newId() : int{
+		trigger_error("newId() is not thread-safe, use claimId() instead", E_USER_DEPRECATED);
 		return self::$nextDynamicId++;
+	}
+
+	private int $nextFreeId = 100_000;
+
+	/** @phpstan-var ThreadSafeArray<string, int> */
+	private ThreadSafeArray $dynamicIdLookup;
+	/** @phpstan-var ThreadSafeArray<int, string> */
+	private ThreadSafeArray $claimedIds;
+
+	private function __construct(){
+		$this->dynamicIdLookup = new ThreadSafeArray();
+		$this->claimedIds = new ThreadSafeArray();
+
+		foreach(Utils::stringifyKeys((new \ReflectionClass($this))->getConstants()) as $name => $value){
+			if($name === "FIRST_UNUSED_ITEM_ID" || !is_int($value)){
+				continue;
+			}
+			$uniqueId = VanillaItemsInputs::class . "::" . mb_strtolower($name, 'UTF-8');
+			$this->claimedIds[$value] = $uniqueId;
+			$this->dynamicIdLookup[$uniqueId] = $value;
+		}
+	}
+
+	private function fetchOrAssignId(string $uniqueId) : int{
+		return $this->synchronized(function() use ($uniqueId) : int{
+			$existing = $this->dynamicIdLookup[$uniqueId];
+			if($existing !== null){
+				return $existing;
+			}
+			$numericId = $this->nextFreeId++;
+			$this->claimedIds[$numericId] = $uniqueId;
+			return $this->dynamicIdLookup[$uniqueId] = $numericId;
+		});
+	}
+
+	/**
+	 * Returns a new runtime item type ID, e.g. for use by a custom item.
+	 *
+	 * @param string $uniqueId Any string unique to the item type to ensure it gets the same ID on all threads
+	 */
+	public static function claimId(string $uniqueId) : int{
+		return self::getInstance()->fetchOrAssignId($uniqueId);
+	}
+
+	/**
+	 * Returns the unique string ID used to claim the given type ID.
+	 */
+	public static function getClaimant(int $typeId) : ?string{
+		if($typeId >= self::FIRST_UNUSED_ITEM_ID && $typeId < self::$nextDynamicId){
+			return "deprecated:anonymous_thread_local";
+		}
+		return self::getInstance()->claimedIds[$typeId];
 	}
 
 	public static function fromBlockTypeId(int $blockTypeId) : int{

--- a/src/item/VanillaItemsInputs.php
+++ b/src/item/VanillaItemsInputs.php
@@ -37,8 +37,6 @@ use pocketmine\item\VanillaArmorMaterials as ArmorMaterials;
 use pocketmine\math\Vector3;
 use pocketmine\utils\RegistrySource;
 use pocketmine\world\World;
-use function is_int;
-use function mb_strtoupper;
 use function strtolower;
 
 /**
@@ -60,19 +58,7 @@ final class VanillaItemsInputs extends RegistrySource{
 	public function cloneResults() : bool{ return true; }
 
 	private static function makeIID(string $name) : IID{
-		//this sketchy hack allows us to avoid manually writing the constants inline
-		//since type IDs are generated from this class anyway, I'm OK with this hack
-		//nonetheless, we should try to get rid of it in a future major version (e.g by using string type IDs)
-		$reflect = new \ReflectionClass(ItemTypeIds::class);
-		$typeId = $reflect->getConstant(mb_strtoupper($name));
-		if(!is_int($typeId)){
-			//this allows registering new stuff without adding new type ID constants
-			//this reduces the number of mandatory steps to test new features in local development
-			\GlobalLogger::get()->error(self::class . ": No constant type ID found for $name, generating a new one");
-			$typeId = ItemTypeIds::newId();
-		}
-
-		return new IID($typeId);
+		return new IID(ItemTypeIds::claimId(self::class . "::" . $name));
 	}
 
 	/**

--- a/src/utils/ThreadSafeSingletonTrait.php
+++ b/src/utils/ThreadSafeSingletonTrait.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ *
+ *  ____            _        _   __  __ _                  __  __ ____
+ * |  _ \ ___   ___| | _____| |_|  \/  (_)_ __   ___      |  \/  |  _ \
+ * | |_) / _ \ / __| |/ / _ \ __| |\/| | | '_ \ / _ \_____| |\/| | |_) |
+ * |  __/ (_) | (__|   <  __/ |_| |  | | | | | |  __/_____| |  | |  __/
+ * |_|   \___/ \___|_|\_\___|\__|_|  |_|_|_| |_|\___|     |_|  |_|_|
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author PocketMine Team
+ * @link http://www.pocketmine.net/
+ *
+ *
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\utils;
+
+use pmmp\thread\Thread;
+use pmmp\thread\ThreadSafe;
+use function get_debug_type;
+
+/**
+ * Used by singletons which have a common instance accessible on all threads for process-global state.
+ * Note that the using class must extend {@link ThreadSafe} for this to work.
+ */
+trait ThreadSafeSingletonTrait{
+	private static ?self $instanceCache = null;
+
+	private static function make() : self{
+		return new self();
+	}
+
+	public static function getInstance() : self{
+		if(self::$instanceCache !== null){
+			return self::$instanceCache;
+		}
+
+		$threadSafeGlobals = Thread::getSharedGlobals();
+		return self::$instanceCache = $threadSafeGlobals->synchronized(function() use ($threadSafeGlobals) : self{
+			$key = self::getProcessGlobalStateKey();
+			$processGlobal = $threadSafeGlobals[$key];
+			if($processGlobal === null){
+				return $threadSafeGlobals[$key] = new self();
+			}elseif($processGlobal instanceof self){
+				return $processGlobal;
+			}
+			throw new \LogicException("Dynamic ID processGlobal in superglobals is of wrong type, expected " . self::class . ", but got " . get_debug_type($processGlobal));
+		});
+	}
+
+	public static function setInstance(self $instance) : void{
+		Thread::getSharedGlobals()->synchronized(function() use ($instance) : void{
+			Thread::getSharedGlobals()[self::getProcessGlobalStateKey()] = $instance;
+			self::$instanceCache = $instance;
+		});
+	}
+
+	public static function reset() : void{
+		Thread::getSharedGlobals()->synchronized(function() : void{
+			unset(Thread::getSharedGlobals()[self::getProcessGlobalStateKey()]);
+			self::$instanceCache = null;
+		});
+	}
+
+	final protected static function getProcessGlobalStateKey() : string{
+		return self::class . "::processGlobalState";
+	}
+}

--- a/src/utils/ThreadSafeSingletonTrait.php
+++ b/src/utils/ThreadSafeSingletonTrait.php
@@ -56,20 +56,6 @@ trait ThreadSafeSingletonTrait{
 		});
 	}
 
-	public static function setInstance(self $instance) : void{
-		Thread::getSharedGlobals()->synchronized(function() use ($instance) : void{
-			Thread::getSharedGlobals()[self::getProcessGlobalStateKey()] = $instance;
-			self::$instanceCache = $instance;
-		});
-	}
-
-	public static function reset() : void{
-		Thread::getSharedGlobals()->synchronized(function() : void{
-			unset(Thread::getSharedGlobals()[self::getProcessGlobalStateKey()]);
-			self::$instanceCache = null;
-		});
-	}
-
 	final protected static function getProcessGlobalStateKey() : string{
 		return self::class . "::processGlobalState";
 	}

--- a/tests/phpunit/block/BlockTest.php
+++ b/tests/phpunit/block/BlockTest.php
@@ -64,7 +64,7 @@ class BlockTest extends TestCase{
 	 * Test registering a new block which does not yet exist
 	 */
 	public function testRegisterNewBlock() : void{
-		$b = new StrangeNewBlock(new BlockIdentifier(BlockTypeIds::newId()), "Strange New Block", new BlockTypeInfo(BlockBreakInfo::instant()));
+		$b = new StrangeNewBlock(new BlockIdentifier(BlockTypeIds::claimId("pocketmine:strange_new_block")), "Strange New Block", new BlockTypeInfo(BlockBreakInfo::instant()));
 		$this->blockFactory->register($b);
 		self::assertInstanceOf(StrangeNewBlock::class, $this->blockFactory->fromStateId($b->getStateId()));
 	}
@@ -75,6 +75,23 @@ class BlockTest extends TestCase{
 	public function testRegisterIdTooSmall() : void{
 		self::expectException(\InvalidArgumentException::class);
 		$this->blockFactory->register(new OutOfBoundsBlock(new BlockIdentifier(-1), "Out Of Bounds Block", new BlockTypeInfo(BlockBreakInfo::instant())));
+	}
+
+	/**
+	 * Verifies that block type IDs must be claimed before being given to a BlockIdentifier
+	 */
+	public function testRegisterUnclaimedId() : void{
+		self::expectException(\InvalidArgumentException::class);
+		$this->blockFactory->register(new OutOfBoundsBlock(new BlockIdentifier(200_000), "Out Of Bounds Block", new BlockTypeInfo(BlockBreakInfo::instant())));
+	}
+
+	/**
+	 * Test that deprecated BlockTypeIds::newId() works as expected
+	 */
+	public function testDeprecatedNewId() : void{
+		$b = new StrangeNewBlock(new BlockIdentifier(@BlockTypeIds::newId()), "Strange New Block 2", new BlockTypeInfo(BlockBreakInfo::instant()));
+		$this->blockFactory->register($b);
+		self::assertInstanceOf(StrangeNewBlock::class, $this->blockFactory->fromStateId($b->getStateId()));
 	}
 
 	/**


### PR DESCRIPTION
I realised the PR #6786 was trying too hard to avoid sharing any data between threads, but it looks like the performance impact of trying to do so is much greater than the performance impact of just sharing ID registration tables.

A new method of claiming type IDs has been implemented. Using a string unique to the block type, such as the block's Minecraft string ID, blocks can ensure they always get to claim the same ID on all threads. This ID is not guaranteed to be the same across different runs, but it at least permits moving block and item type/state IDs across threads without ridiculous serialization hacks.

There may be other places where we could benefit from a system like this. Basically anywhere plugins might need to fight over ID assignment.

Checks have also been added to ensure that plugins can't just use a random unassigned type ID, as this may cause conflicts with other plugins. This isn't foolproof, but we can't do better than this without breaking BC and stopping plugins from providing numeric type IDs entirely (thereby stopping them from being hardcoded).

<!-- Summarize your PR here. Keep it short and simple. -->
<!-- Explain existing problems or why this pull request is necessary -->

<!-- DO NOT submit AI generated code or use AI to generate PR descriptions. -->
<!-- These are a waste of our team's time and your PR will be closed immediately. -->

### Related issues & PRs
- fixes #6062 

## Changes
### API changes
- added `BlockTypeIds::claimId()` and `BlockTypeIds::getClaimant()`
- added `ItemTypeIds::claimId()` and `ItemTypeIds::getClaimant()`
- deprecated `BlockTypeIds::newId()` and `ItemTypeIds::newId()`
- added new `ThreadSafeSingletonTrait`

### Behavioural changes
Unless plugins use these new APIs, none are expected, bar some deprecation notices.

## Follow-up
`BlockIdentifier` and `ItemIdentifier` to accept strings directly instead of ints (and have numeric type IDs internally claimed)

## Tests
tests are green